### PR TITLE
Allow defining setup options in extraPlugins (WIP)

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -7,17 +7,23 @@
 with lib; let
   pluginWithConfigType = types.submodule {
     options = {
-      config = mkOption {
-        type = types.lines;
-        description = "vimscript for this plugin to be placed in init.vim";
-        default = "";
+      packageName = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "lua package name for require";
       };
 
-      optional =
-        mkEnableOption "optional"
-        // {
-          description = "Don't load by default (load with :packadd)";
-        };
+      setupTable = mkOption {
+        type = types.nullOr types.attrs;
+        default = null;
+        description = "lua table to be passed to setup";
+      };
+
+      setupFunction = mkOption {
+        type = types.str;
+        default = "setup";
+        description = "lua function to be called with setupTable";
+      };
 
       plugin = mkOption {
         type = types.package;


### PR DESCRIPTION
## Description

Often times, I want to add some plugin that is not present on nixvim. To do this, I'd end up adding the plugin package to `extraPlugins`, and then set the config options somewhere else.

With this PR I am aiming to allow things to be more centralized, initially by making it possible to automatically call the `setup` function.

## Example

### Before
```nix
{
  extraPlugins = [ pkgs.vimPlugins.orgmode ];
  extraConfigLua = ''
    require('orgmode').setup({
      org_agenda_files = {'~/org/**/*'},
      org_default_notes_file = '~/org/refile.org'
    })
  '';
}
```

### After
```nix
{
  extraPlugins = with pkgs.vimPlugins; [{
    package = orgmode;
    packageName = "orgmode";
    setup = {
      org_agenda_files = [ "~/org/**/*" ];
      org_default_notes_file = "~/org/refile.org";
    };
  }];
}
```

Obviously, with only one plugin, this isn't that much help, but I hope you can see how this can come in handy when you have a lot of external plugins!

## Notes
This is _very much_ a WIP, I have only defined the options for now, but I wanted to get some feedback!

## TODO
- [X] Define options
- [ ] Generate lua code
- [ ] Allow adding arbitrary lua/vimscript code
- [ ] Allow setting lazy-loading options
- [ ] Allow setting keymaps
- [ ] Allow setting global variables
