### PR TITLE
plugins/telescope: allow key mappings to be attrs

### DIFF
--- a/tests/test-sources/plugins/telescope/default.nix
+++ b/tests/test-sources/plugins/telescope/default.nix
@@ -1,0 +1,21 @@
+{
+  empty = {
+    plugins.telescope.enable = true;
+  };
+
+  example = {
+    plugins.telescope = {
+      enable = true;
+
+      keymaps = {
+        "<leader>fg" = "live_grep";
+        "<C-p>" = {
+          action = "git_files";
+          desc = "Telescope Git Files";
+        };
+      };
+      keymapsSilent = true;
+      highlightTheme = "gruvbox";
+    };
+  };
+}


### PR DESCRIPTION
Allow more flexibility in keymaps declared in `telescope`.
Also adds a test case for the `telescope` plugin.