### PR TITLE
helpers: add highlightType and defaultNullOpts.mkHighlight

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -49,6 +49,39 @@ with lib; rec {
 
   emptyTable = {"__empty" = null;};
 
+  highlightType = with lib.types;
+    submodule {
+      # Adds flexibility for other keys
+      freeformType = types.attrs;
+
+      # :help nvim_set_hl()
+      options = {
+        fg = mkNullOrOption str "Color for the foreground (color name or '#RRGGBB').";
+        bg = mkNullOrOption str "Color for the background (color name or '#RRGGBB').";
+        sp = mkNullOrOption str "Special color (color name or '#RRGGBB').";
+        blend = mkNullOrOption (numbers.between 0 100) "Integer between 0 and 100.";
+        bold = mkNullOrOption bool "";
+        standout = mkNullOrOption bool "";
+        underline = mkNullOrOption bool "";
+        undercurl = mkNullOrOption bool "";
+        underdouble = mkNullOrOption bool "";
+        underdotted = mkNullOrOption bool "";
+        underdashed = mkNullOrOption bool "";
+        strikethrough = mkNullOrOption bool "";
+        italic = mkNullOrOption bool "";
+        reverse = mkNullOrOption bool "";
+        nocombine = mkNullOrOption bool "";
+        link = mkNullOrOption str "Name of another highlight group to link to.";
+        default = mkNullOrOption bool "Don't override existing definition.";
+        ctermfg = mkNullOrOption str "Sets foreground of cterm color.";
+        ctermbg = mkNullOrOption str "Sets background of cterm color.";
+        cterm = mkNullOrOption attrs ''
+          cterm attribute map, like |highlight-args|.
+          If not set, cterm attributes will match those from the attribute map documented above.
+        '';
+      };
+    };
+
   # Given an attrs of key mappings (for a single mode), applies the defaults to each one of them.
   #
   # Example:
@@ -167,6 +200,16 @@ with lib; rec {
           ${desc}
           ${defaultDesc}
         '');
+
+    mkHighlight = default: name: desc:
+      mkNullable
+      highlightType
+      default
+      (
+        if desc == ""
+        then "Highlight settings."
+        else desc
+      );
   };
 
   mkPackageOption = name: default:

--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -8,7 +8,7 @@ in
   with lib; {
     options = {
       highlight = mkOption {
-        type = types.attrsOf types.anything;
+        type = types.attrsOf helpers.highlightType;
         default = {};
         description = "Define highlight groups";
         example = ''


### PR DESCRIPTION
Many plugins expose options to define highlight groups.
In this case, we can now use the new `highlightType` which represents an `attrs` that will be later provided to `nvim_set_hl`.