### PR TITLE
wrappers/nixos: set wrapRc to true

### DIFF
--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -4,7 +4,7 @@ modules: {
   lib,
   ...
 } @ args: let
-  inherit (lib) mkEnableOption mkOption mkOptionType mkMerge mkIf types;
+  inherit (lib) mkEnableOption mkOption mkOptionType mkForce mkMerge mkIf types;
   shared = import ./_shared.nix modules args;
   cfg = config.programs.nixvim;
   files =
@@ -19,6 +19,7 @@ in {
       type = types.submodule ([
           {
             options.enable = mkEnableOption "nixvim";
+            config.wrapRc = mkForce true;
           }
         ]
         ++ shared.topLevelModules);


### PR DESCRIPTION
When using nixvim through the NixOS module, it seems that the config is not properly loaded.
This is not surprising as nixvim places the config in `/etc/nvim/sysinit.lua` which is not supported (https://github.com/neovim/neovim/issues/22595).
Hence, setting `wrapRc` to `true` is a working solution to overcome this situation.

Fixes https://github.com/nix-community/nixvim/issues/79 and https://github.com/nix-community/nixvim/issues/508