### PR TITLE
plugins/dap: ensure extensions load after the main plugin

### DIFF
--- a/plugins/dap/dap-go.nix
+++ b/plugins/dap/dap-go.nix
@@ -47,10 +47,11 @@ in {
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
 
-      plugins.dap.enable = true;
-
-      extraConfigLua = ''
-        require("dap-go").setup(${helpers.toLuaObject options})
-      '';
+      plugins.dap = {
+        enable = true;
+        extensionConfigLua = ''
+          require("dap-go").setup(${helpers.toLuaObject options})
+        '';
+      };
     };
 }

--- a/plugins/dap/dap-python.nix
+++ b/plugins/dap/dap-python.nix
@@ -55,29 +55,31 @@ in {
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
 
-      plugins.dap.enable = true;
+      plugins.dap = {
+        enable = true;
 
-      extraConfigLua = with helpers;
-        ''
-          require("dap-python").setup("${cfg.adapterPythonPath}", ${toLuaObject options})
-        ''
-        + (optionalString (cfg.testRunners != null) ''
-          table.insert(require("dap-python").test_runners,
-          ${
-            toLuaObject
-            (
-              builtins.mapAttrs (_: mkRaw) cfg.testRunners
-            )
-          })
-        '')
-        + (optionalString (cfg.customConfigurations != null) ''
-          table.insert(require("dap").configurations.python, ${toLuaObject cfg.customConfigurations})
-        '')
-        + (optionalString (cfg.resolvePython != null) ''
-          require("dap-python").resolve_python = ${toLuaObject (mkRaw cfg.resolvePython)}
-        '')
-        + (optionalString (cfg.testRunner != null) ''
-          require("dap-python").test_runner = ${toLuaObject cfg.testRunner};
-        '');
+        extensionConfigLua = with helpers;
+          ''
+            require("dap-python").setup("${cfg.adapterPythonPath}", ${toLuaObject options})
+          ''
+          + (optionalString (cfg.testRunners != null) ''
+            table.insert(require("dap-python").test_runners,
+            ${
+              toLuaObject
+              (
+                builtins.mapAttrs (_: mkRaw) cfg.testRunners
+              )
+            })
+          '')
+          + (optionalString (cfg.customConfigurations != null) ''
+            table.insert(require("dap").configurations.python, ${toLuaObject cfg.customConfigurations})
+          '')
+          + (optionalString (cfg.resolvePython != null) ''
+            require("dap-python").resolve_python = ${toLuaObject (mkRaw cfg.resolvePython)}
+          '')
+          + (optionalString (cfg.testRunner != null) ''
+            require("dap-python").test_runner = ${toLuaObject cfg.testRunner};
+          '');
+      };
     };
 }

--- a/plugins/dap/dap-ui.nix
+++ b/plugins/dap/dap-ui.nix
@@ -219,10 +219,12 @@ in {
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
 
-      plugins.dap.enable = true;
+      plugins.dap = {
+        enable = true;
 
-      extraConfigLua = ''
-        require("dapui").setup(${helpers.toLuaObject options});
-      '';
+        extensionConfigLua = ''
+          require("dapui").setup(${helpers.toLuaObject options});
+        '';
+      };
     };
 }

--- a/plugins/dap/dap-virtual-text.nix
+++ b/plugins/dap/dap-virtual-text.nix
@@ -82,10 +82,12 @@ in {
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
 
-      plugins.dap.enable = true;
+      plugins.dap = {
+        enable = true;
 
-      extraConfigLua = ''
-        require("nvim-dap-virtual-text").setup(${helpers.toLuaObject options});
-      '';
+        extensionConfigLua = ''
+          require("nvim-dap-virtual-text").setup(${helpers.toLuaObject options});
+        '';
+      };
     };
 }

--- a/plugins/dap/default.nix
+++ b/plugins/dap/default.nix
@@ -45,7 +45,14 @@ in
           dapBreakpointRejected = mkSignOption "R" "Sign to indicate breakpoints rejected by the debug adapter.";
         };
 
-        extensionConfigLua = helpers.mkNullOrOption types.lines "Extension configuration for dap. Don't use this directly!";
+        extensionConfigLua = mkOption {
+          type = types.lines;
+          description = ''
+            Extension configuration for dap. Don't use this directly !
+          '';
+          default = "";
+          internal = true;
+        };
       };
 
     config = let

--- a/plugins/dap/default.nix
+++ b/plugins/dap/default.nix
@@ -44,6 +44,8 @@ in
 
           dapBreakpointRejected = mkSignOption "R" "Sign to indicate breakpoints rejected by the debug adapter.";
         };
+
+        extensionConfigLua = helpers.mkNullOrOption types.lines "Extension configuration for dap. Don't use this directly!";
       };
 
     config = let
@@ -86,6 +88,7 @@ in
             for sign_name, sign in pairs(__dap_signs) do
               vim.fn.sign_define(sign_name, sign)
             end
-          '');
+          '')
+          + (optionalString (cfg.extensionConfigLua != null) cfg.extensionConfigLua);
       };
   }

--- a/plugins/dap/default.nix
+++ b/plugins/dap/default.nix
@@ -96,6 +96,6 @@ in
               vim.fn.sign_define(sign_name, sign)
             end
           '')
-          + (optionalString (cfg.extensionConfigLua != null) cfg.extensionConfigLua);
+          + cfg.extensionConfigLua;
       };
   }


### PR DESCRIPTION
This pull request fixes issues with `nvim-dap` and extensions that add custom configurations/adapters to `nvim-dap`. All extensions now load after `nvim-dap` is initialized to prevent user-defined settings from overriding the configurations added by them.