### PR TITLE
fix(docs): typo + line wrap

### DIFF
--- a/templates/simple/README.md
+++ b/templates/simple/README.md
@@ -4,7 +4,9 @@ This template gives you a good starting point for configuring nixvim standalone.
 
 ## Configuring
 
-To start configuring, just add or modify the nix files in `./config`. If you add a new configuration file, remember to add it to the [`congig/default.nix`](./config/default.nix) file
+To start configuring, just add or modify the nix files in `./config`.
+If you add a new configuration file, remember to add it to the
+[`config/default.nix`](./config/default.nix) file
 
 ## Testing your new configuration
 
@@ -13,4 +15,3 @@ To test your configuration simply run the following command
 ```
 nix run .
 ```
-


### PR DESCRIPTION
1. `congig/default.nix` -> `config/default.nix`
2. Wrap at 80 chars