### PR TITLE
misc: change cachix namespace to nix-community

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: cachix/cachix-action@v12
         with:
-          name: nixvim
+          name: nix-community
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix flake check
       - run: nix flake check ./templates/_wrapper/simple

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,4 +108,6 @@ The tests are then runnable with `nix flake check`.
 
 There are a second set of tests, unit tests for nixvim itself, defined in `tests/lib-tests.nix` that use the `pkgs.lib.runTests` framework.
 
-If you want to speed up tests, we have set up a Cachix for nixvim. This way, only tests whose dependencies have changed will be re-run, speeding things up considerably. To use it, just install cachix and run `cachix use nixvim`.
+If you want to speed up tests, we have set up a Cachix for nixvim.
+This way, only tests whose dependencies have changed will be re-run, speeding things up
+considerably. To use it, just install cachix and run `cachix use nix-community`.


### PR DESCRIPTION
We are now relying on the [nix-community cachix](https://app.cachix.org/cache/nix-community).