### PR TITLE
plugins/neo-tree: fix incorrect option - filtered_items

### DIFF
--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -1162,7 +1162,7 @@ in {
             scan_mode = scanMode;
             bind_to_cwd = bindToCwd;
             cwd_target = cwdTarget;
-            filteredItems = with filteredItems;
+            filtered_items = with filteredItems;
               ifNonNull' cfg.filesystem.filteredItems {
                 inherit visible;
                 force_visible_in_empty_folder = forceVisibleInEmptyFolder;


### PR DESCRIPTION
The `plugins.neo-tree.filesystem.filteredItems` is creating the respective option in the neovim config incorrectly. it should be `filtered_items` instead of `filteredItems`. This PR fixes that.