### PR TITLE
Add flakehub workflow

### DIFF
--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -1,0 +1,19 @@
+name: "Publish every Git push to main to FlakeHub"
+on:
+  push:
+    branches:
+      - "main"
+jobs:
+  flakehub-publish:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "DeterminateSystems/nix-installer-action@main"
+      - uses: "DeterminateSystems/flakehub-push@main"
+        with:
+          name: "nix-community/nixvim"
+          rolling: true
+          visibility: "public"


### PR DESCRIPTION
Following our discussion in https://github.com/nix-community/nixvim/issues/538, I propose that we publish nixvim to Flakehub.
As is, it could enhance our visibility without any drawbacks.
Other factual benefits are not clear to me, but this does not constraint us to anything, so I don't see any downside.