### PR TITLE
docs: terminate build on shell-script error

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -236,7 +236,7 @@ with lib; let
 
     # Copy the generated MD docs into the build directory
     # Using pkgs.writeShellScript helps to avoid the "bash: argument list too long" error
-    ${pkgs.writeShellScript "copy_docs" docs.commands}
+    bash -e ${pkgs.writeShellScript "copy_docs" docs.commands}
 
     # Prepare SUMMARY.md for mdBook
     # Using pkgs.writeText helps to avoid the same error as above


### PR DESCRIPTION
This makes the script generated by `pkgs.writeShellScript` terminate documentation build on error