### PR TITLE
fix(bufferline): add missing highlight groups

### DIFF
--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -74,6 +74,9 @@ with lib; let
     separator_visible = "separatorVisible";
     separator_selected = "separatorSelected";
 
+    tab_separator = "tabSeparator";
+    tab_separator_selected = "tabSeparatorSelected";
+
     indicator_selected = "indicatorSelected";
 
     pick = "pick";


### PR DESCRIPTION
This commit enables customization of the `tab_separator` and `tab_separator_selected` options for Bufferline. These allow for styling the tab entries that appear on the end of the bufferline.

fixes #581 