### PR TITLE
[Notify] Add missing options

### DIFF
--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -74,6 +74,9 @@ with lib; let
     separator_visible = "separatorVisible";
     separator_selected = "separatorSelected";
 
+    tab_separator = "tabSeparator";
+    tab_separator_selected = "tabSeparatorSelected";
+
     indicator_selected = "indicatorSelected";
 
     pick = "pick";

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -32,9 +32,29 @@ in {
       description = "For stages that change opacity this is treated as the highlight between the window";
       default = null;
     };
+    maxWidth = mkOption {
+      type = types.nullOr types.int;
+      description = "Max number of columns for messages";
+      default = null;
+    };
+    maxHeight = mkOption {
+      type = types.nullOr types.int;
+      description = "Max number of rows for messages";
+      default = null;
+    };
     minimumWidth = mkOption {
       type = types.nullOr types.int;
       description = "Minimum width for notification windows";
+      default = null;
+    };
+    topDown = mkOption {
+      type = types.nullOr types.bool;
+      description = "Whether or not to position the notifications at the top or not";
+      default = null;
+    };
+    level = mkOption {
+      type = types.nullOr types.int;
+      description = "Log level. See vim.log.levels";
       default = null;
     };
     icons = mkOption {
@@ -54,9 +74,12 @@ in {
 
   config = let
     setupOptions = with cfg; {
-      inherit stages timeout;
+      inherit stages timeout level;
       background_colour = backgroundColour;
       minimum_width = minimumWidth;
+      top_down = topDown;
+      max_height = maxHeight;
+      max_width = maxWidth;
       icons = with icons; {
         ERROR = error;
         WARN = warn;


### PR DESCRIPTION
This commit adds missing options for `notify-nvim`.

Fixes #584 

Depends on #582