### PR TITLE
feat(options): add `defaultEditor` option

### DIFF
--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -18,7 +18,10 @@ in {
       default = {};
       type = types.submodule ([
           {
-            options.enable = mkEnableOption "nixvim";
+            options = {
+              enable = mkEnableOption "nixvim";
+              defaultEditor = mkEnableOption "Set nixvim as the default editor";
+            };
           }
         ]
         ++ shared.topLevelModules);

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -34,7 +34,7 @@ in {
         xdg.configFile = files;
       })
       {
-        inherit (cfg) warnings assertions;
+        inherit (cfg) warnings assertions defaultEditor;
       }
     ]);
 }

--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -94,7 +94,7 @@ in {
     config.extraPlugins;
 
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig ({
-        inherit (config) viAlias vimAlias defaultEditor;
+        inherit (config) viAlias vimAlias;
         # inherit customRC;
         plugins = normalizedPlugins;
       }

--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -31,7 +31,7 @@ in {
       type = types.bool;
       default = false;
       description = ''
-        Symlink <command>vi</command> to <command>nvim</command> binary.
+        Symlink `vi` to `nvim` binary.
       '';
     };
 
@@ -39,7 +39,7 @@ in {
       type = types.bool;
       default = false;
       description = ''
-        Symlink <command>vim</command> to <command>nvim</command> binary.
+        Symlink `vim` to `nvim` binary.
       '';
     };
 
@@ -47,7 +47,7 @@ in {
       type = types.bool;
       default = false;
       description = ''
-        Configure <command>nvim</command> as the default editor using the EDITOR environment variable
+        Configure `nvim` as the default editor using the EDITOR environment variable
       '';
     };
 

--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -43,6 +43,14 @@ in {
       '';
     };
 
+    defaultEditor = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Configure <command>nvim</command> as the default editor using the EDITOR environment variable
+      '';
+    };
+
     package = mkOption {
       type = types.package;
       default = pkgs.neovim-unwrapped;
@@ -86,7 +94,7 @@ in {
     config.extraPlugins;
 
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig ({
-        inherit (config) viAlias vimAlias;
+        inherit (config) viAlias vimAlias defaultEditor;
         # inherit customRC;
         plugins = normalizedPlugins;
       }

--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -43,14 +43,6 @@ in {
       '';
     };
 
-    defaultEditor = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Configure `nvim` as the default editor using the EDITOR environment variable
-      '';
-    };
-
     package = mkOption {
       type = types.package;
       default = pkgs.neovim-unwrapped;

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -18,7 +18,10 @@ in {
       default = {};
       type = types.submodule ([
           {
-            options.enable = mkEnableOption "nixvim";
+            options = {
+              enable = mkEnableOption "nixvim";
+              defaultEditor = mkEnableOption "Set nixvim as the default editor";
+            };
             config.wrapRc = mkForce true;
           }
         ]
@@ -36,7 +39,7 @@ in {
         environment.variables."VIM" = "/etc/nvim";
       })
       {
-        inherit (cfg) warnings assertions;
+        inherit (cfg) warnings assertions defaultEditor;
       }
     ]);
 }


### PR DESCRIPTION
This PR adds `defaultEditor` option from home-manager's `neovim` module