### PR TITLE
misc: fix defaultEditor option for HM and NixOS modules

### DIFF
--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -37,7 +37,8 @@ in {
         xdg.configFile = files;
       })
       {
-        inherit (cfg) warnings assertions defaultEditor;
+        inherit (cfg) warnings assertions;
+        home.sessionVariables = mkIf cfg.defaultEditor {EDITOR = "nvim";};
       }
     ]);
 }

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -39,7 +39,9 @@ in {
         environment.variables."VIM" = "/etc/nvim";
       })
       {
-        inherit (cfg) warnings assertions defaultEditor;
+        inherit (cfg) warnings assertions;
+        programs.neovim.defaultEditor = cfg.defaultEditor;
+        environment.variables.EDITOR = mkIf cfg.defaultEditor (lib.mkOverride 900 "nvim");
       }
     ]);
 }


### PR DESCRIPTION
Currently, the HM module (and probably the NixOS one too) fails with:
```
error:
       … while calling the 'head' builtin

         at /nix/store/6s86padm2iikrwhlq8nwfv0lw9d1sbvq-source/lib/attrsets.nix:820:11:

          819|         || pred here (elemAt values 1) (head values) then
          820|           head values
             |           ^
          821|         else

       … while evaluating the attribute 'value'

         at /nix/store/6s86padm2iikrwhlq8nwfv0lw9d1sbvq-source/lib/modules.nix:800:9:

          799|     in warnDeprecation opt //
          800|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          801|         inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: The option `home-manager.users.gaetan.defaultEditor' does not exist. Definition values:
       - In `/nix/store/6s86padm2iikrwhlq8nwfv0lw9d1sbvq-source/flake.nix':
           {
             _type = "if";
             condition = true;
             content = false;
           }
```

This patch should be correct (at least there is no more error).

@mrtnvgr could you confirm that this is the expected behavior ?