### PR TITLE
plugins/ui/noice: fix typo

### DIFF
--- a/plugins/ui/noice.nix
+++ b/plugins/ui/noice.nix
@@ -312,7 +312,7 @@ in {
           hover = helpers.ifNonNull' cfgL.hover {
             inherit (cfgL.hover) enabled view opts;
           };
-          sigature = let
+          signature = let
             cfgLS = cfgL.signature;
           in
             helpers.ifNonNull' cfgLS {


### PR DESCRIPTION
This PR fixes a typo in noice (`sigature` -> `signature`)