### PR TITLE
plugins/todo-comments: Allow to pass keymap options

### DIFF
--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -15,6 +15,13 @@ with lib; let
     todoTelescope = "TodoTelescope";
   };
 in {
+  imports = [
+    (
+      mkRemovedOptionModule
+      ["plugins" "todo-comments" "keymapsSilent"]
+      "Use `plugins.todo-comments.keymaps.<COMMAND>.options.silent`."
+    )
+  ];
   options = {
     plugins.todo-comments =
       helpers.extraOptionsOptions
@@ -182,16 +189,11 @@ in {
           '';
         };
 
-        # Keyboard shortcuts for :Todo* commands
-        keymapsSilent = mkOption {
-          type = types.bool;
-          description = "Whether todo-comments keymaps should be silent.";
-          default = false;
-        };
-
         keymaps = let
           mkKeymapOption = optionName: funcName:
-            helpers.mkCompositeOption "Keymap settings for the `:${funcName}` function." {
+            helpers.mkCompositeOption
+            "Keymap settings for the `:${funcName}` function."
+            {
               key = mkOption {
                 type = types.str;
                 description = "Key for the `${funcName}` function.";
@@ -213,6 +215,8 @@ in {
                 default = null;
                 example = "TODO,FIX";
               };
+
+              options = helpers.keymaps.mapConfigOptions;
             };
         in
           mapAttrs mkKeymapOption commands;
@@ -279,9 +283,12 @@ in {
               (keymap != null)
               {
                 mode = "n";
-                inherit (keymap) key;
+                inherit
+                  (keymap)
+                  key
+                  options
+                  ;
                 action = ":${funcName}${cwd}${keywords}<CR>";
-                options.silent = cfg.keymapsSilent;
               }
           )
           commands

--- a/tests/test-sources/plugins/utils/todo-comments.nix
+++ b/tests/test-sources/plugins/utils/todo-comments.nix
@@ -89,14 +89,13 @@
         pattern = ''\b(KEYWORDS):'';
       };
 
-      keymapsSilent = true;
-
       keymaps = {
         todoQuickFix.key = "<C-a>";
         todoLocList = {
           key = "<C-f>";
           cwd = "~/projects/foobar";
           keywords = "TODO,FIX";
+          options.silent = true;
         };
         todoTrouble = {
           key = "<C-t>";
@@ -105,6 +104,23 @@
         todoTelescope = {
           key = "<C-e>";
           cwd = "~/projects/foobar";
+        };
+      };
+    };
+  };
+
+  keymapsOptions = {
+    plugins.todo-comments = {
+      enable = true;
+
+      keymaps = {
+        todoTrouble = {
+          key = "<C-f>";
+          keywords = "TODO,FIX";
+          options = {
+            desc = "Description for todoTrouble";
+            silent = true;
+          };
         };
       };
     };


### PR DESCRIPTION
This re-uses the keymap options defined in the keymaps module to allow to define the options of todo-comments key mappings.

Fixes #598