### PR TITLE
fix-autocommand-description

### DIFF
--- a/modules/autocmd.nix
+++ b/modules/autocmd.nix
@@ -129,7 +129,7 @@ in {
                   group     = autocmd.group,
                   pattern   = autocmd.pattern,
                   buffer    = autocmd.buffer,
-                  desc      = autocmd.desc,
+                  desc      = autocmd.description,
                   callback  = autocmd.callback,
                   command   = autocmd.command,
                   once      = autocmd.once,


### PR DESCRIPTION
Hi. I notice that the auto commands were not getting the description set properly. After research I found that the issue was that the property is description but on the lua code is refer as desc. This was not generating an error on nix.
I think desc is a better name that align with the property name, and also with keymaps.
But changing to desc will break current usage and I don't think that is up to me to decide if that should do or not.

Let me know if you agree and approve the rename to desc, if not this will at least fis the current implementation.

Kind regards, and thanks for the project.