### PR TITLE
plugins/lsp/hls: add missing --lsp cmd flag

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -194,7 +194,7 @@ with lib; let
       name = "hls";
       description = "Enable haskell language server";
       package = pkgs.haskell-language-server;
-      cmd = cfg: ["haskell-language-server-wrapper"];
+      cmd = cfg: ["haskell-language-server-wrapper" "--lsp"];
     }
     {
       name = "html";


### PR DESCRIPTION
hls just crashed everytime i tried to use it, because it's missing the `--lsp` flag to work correctly.
