### PR TITLE
github-workflow: add a timeout for jobs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -25,6 +25,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,7 @@ jobs:
   check:
     name: Check that the module is valid
     runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v20

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   lockfile:
     runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    timeout-minutes: 40
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Sometimes jobs get stuck for hours.
Avoid wasting resources by setting a timeout.