### PR TITLE
nvim-tree: removes deprecated 'hideRootFolder' option

### DIFF
--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -365,10 +365,6 @@ in {
           Increase if you experience performance issues around screen refresh.
         '';
 
-        hideRootFolder = helpers.defaultNullOpts.mkBool false ''
-          Hide the path of the current working directory on top of the tree.
-        '';
-
         width =
           helpers.defaultNullOpts.mkNullable
           (types.oneOf [
@@ -471,13 +467,15 @@ in {
         rootFolderLabel =
           helpers.defaultNullOpts.mkNullable
           # Type
-          (types.either types.str helpers.rawType)
+          (with types; oneOf [str bool helpers.rawType])
           # Default
           ":~:s?$?/..?"
           # Description
           ''
             In what format to show root folder. See `:help filename-modifiers` for available `string`
             options.
+
+            Set to `false` to hide the root folder.
 
             This can also be a `function(root_cwd)` which is passed the absolute path of the root folder
             and should return a string.
@@ -949,7 +947,6 @@ in {
           centralize_selection = centralizeSelection;
           inherit cursorline;
           debounce_delay = debounceDelay;
-          hide_root_folder = hideRootFolder;
           inherit width;
           inherit side;
           preserve_window_proportions = preserveWindowProportions;

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -30,6 +30,12 @@ with lib; let
       They will be overridden to fit the file_popup content.
     '';
 in {
+  imports = [
+    (
+      mkRemovedOptionModule ["plugins" "nvim-tree" "view" "hideRootFolder"]
+      "Set `plugins.nvim-tree.renderer.rootFolderLabel` to `false` to hide the root folder."
+    )
+  ];
   options.plugins.nvim-tree =
     helpers.extraOptionsOptions
     // {

--- a/tests/test-sources/plugins/filetrees/nvim-tree.nix
+++ b/tests/test-sources/plugins/filetrees/nvim-tree.nix
@@ -79,7 +79,6 @@
         centralizeSelection = false;
         cursorline = true;
         debounceDelay = 15;
-        hideRootFolder = false;
         width = {
           min = 30;
           max = -1;


### PR DESCRIPTION
nvim-tree has [deprecated the `hide_root_folder` option](https://github.com/nvim-tree/nvim-tree.lua/pull/2431); it cannot be set anymore.

Also adds missing option to specify a boolean for `rootFolderLabel`. Setting it to `false` will do the same thing as what `hideRootFolder` used to do. 