### PR TITLE
fix(helpers): use "__unkeyed" prefix instead of "@" in `toLuaObject`

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -21,7 +21,7 @@ with lib; rec {
         + (concatStringsSep ","
           (mapAttrsToList
             (n: v:
-              if head (stringToCharacters n) == "@"
+              if (builtins.match "__unkeyed.*" n) != null
               then toLuaObject v
               else if n == "__emptyString"
               then "[''] = " + (toLuaObject v)

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -990,7 +990,7 @@ in {
             name: value: {
               name =
                 if name == "name"
-                then "@"
+                then "__unkeyed"
                 else name;
               value =
                 if isList value
@@ -1011,7 +1011,7 @@ in {
         mapAttrs' (k: v: {
           name =
             if k == "command"
-            then "@"
+            then "__unkeyed"
             else k;
           value = v;
         })

--- a/plugins/pluginmanagers/packer.nix
+++ b/plugins/pluginmanagers/packer.nix
@@ -144,7 +144,7 @@ in {
           (k: v: {
             name =
               if k == "name"
-              then "@"
+              then "__unkeyed"
               else k;
             value = v;
           })
@@ -155,7 +155,7 @@ in {
       pluginToLua = plugin:
         if isAttrs plugin
         then {
-          "@" = plugin.name;
+          "__unkeyed" = plugin.name;
 
           inherit (plugin) disable as;
 

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -210,7 +210,7 @@ in {
     }:
       mergeAttrs
       {
-        "@" = name;
+        "__unkeyed" = name;
         inherit icons_enabled icon separator color padding;
       }
       extraConfig;

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -338,35 +338,35 @@ in {
       {
         columns = with cfg.columns;
           (optional type.enable {
-            "@" = "type";
+            "__unkeyed" = "type";
             inherit (type) highlight icons;
           })
           ++ (optional icon.enable {
-            "@" = "icon";
+            "__unkeyed" = "icon";
             inherit (icon) highlight defaultFile directory;
           })
           ++ (optional size.enable {
-            "@" = "size";
+            "__unkeyed" = "size";
             inherit (size) highlight;
           })
           ++ (optional permissions.enable {
-            "@" = "permissions";
+            "__unkeyed" = "permissions";
             inherit (permissions) highlight;
           })
           ++ (optional ctime.enable {
-            "@" = "ctime";
+            "__unkeyed" = "ctime";
             inherit (ctime) highlight format;
           })
           ++ (optional mtime.enable {
-            "@" = "mtime";
+            "__unkeyed" = "mtime";
             inherit (mtime) highlight format;
           })
           ++ (optional atime.enable {
-            "@" = "atime";
+            "__unkeyed" = "atime";
             inherit (atime) highlight format;
           })
           ++ (optional birthtime.enable {
-            "@" = "birthtime";
+            "__unkeyed" = "birthtime";
             inherit (birthtime) highlight format;
           });
         buf_opions = cfg.bufOptions;

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -23,7 +23,7 @@
 
     testToLuaObjectLuaTableMixingList = {
       expr = helpers.toLuaObject {
-        "@...." = "foo";
+        "__unkeyed...." = "foo";
         bar = "baz";
       };
       expected = ''{"foo",["bar"] = "baz"}'';


### PR DESCRIPTION
so that neovim (treesitter) highlight groups can start with "@".

this may break existing configs which use "@" for key-less table entries.

i'm open to other solutions or a different prefix name :)

closes #627 