### PR TITLE
docs: fix grammar, spelling, and text for `enable` options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This can then be passed to `pkgs.wrapNeovimUnstable` to generate a derivation th
 
 All the options that nixvim expose end up in those three places. This is done in the `modules/output.nix` file.
 
-The guiding principle of nixvim is too only add to the `init.lua` what the user added to the configuration. This means that we must trim out all the options that were not set.
+The guiding principle of nixvim is to only add to the `init.lua` what the user added to the configuration. This means that we must trim out all the options that were not set.
 
 This is done by making most of the options of the type `types.nullOr ....`, and not setting any option that is null.
 

--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -16,7 +16,7 @@ in {
       package = helpers.mkPackageOption "gruvbox" pkgs.vimPlugins.gruvbox-nvim;
 
       italics = mkEnableOption "italics";
-      bold = mkEnableOption "bold";
+      bold = mkEnableOption "bold text";
       underline = mkEnableOption "underlined text";
       undercurl = mkEnableOption "undercurled text";
 

--- a/plugins/completion/coq.nix
+++ b/plugins/completion/coq.nix
@@ -14,7 +14,7 @@ in {
 
       package = helpers.mkPackageOption "coq-nvim" pkgs.vimPlugins.coq_nvim;
 
-      installArtifacts = mkEnableOption "Install coq-artifacts";
+      installArtifacts = mkEnableOption "and install coq-artifacts";
 
       autoStart = mkOption {
         type = with types; nullOr (oneOf [bool (enum ["shut-up"])]);

--- a/plugins/git/gitmessenger.nix
+++ b/plugins/git/gitmessenger.nix
@@ -8,7 +8,7 @@ with lib; let
   helpers = import ../helpers.nix args;
 in {
   options.plugins.gitmessenger = {
-    enable = mkEnableOption "Enable the gitmessenger plugin";
+    enable = mkEnableOption "gitmessenger";
 
     package = helpers.mkPackageOption "git-messenger" pkgs.vimPlugins.git-messenger-vim;
 

--- a/plugins/git/gitsigns.nix
+++ b/plugins/git/gitsigns.nix
@@ -36,7 +36,7 @@ with lib; let
   };
 in {
   options.plugins.gitsigns = {
-    enable = mkEnableOption "Enable gitsigns plugin";
+    enable = mkEnableOption "gitsigns plugin";
     package = helpers.mkPackageOption "gitsigns" pkgs.vimPlugins.gitsigns-nvim;
     signs = {
       add = signOptions {

--- a/plugins/languages/clangd-extensions.nix
+++ b/plugins/languages/clangd-extensions.nix
@@ -58,7 +58,7 @@ in {
   options.plugins.clangd-extensions =
     helpers.extraOptionsOptions
     // {
-      enable = mkEnableOption "clangd_extensions, plugin implementing clangd LSP extensions";
+      enable = mkEnableOption "clangd_extensions, plugins implementing clangd LSP extensions";
 
       package =
         helpers.mkPackageOption "clangd_extensions.nvim" pkgs.vimPlugins.clangd_extensions-nvim;

--- a/plugins/languages/treesitter/treesitter-refactor.nix
+++ b/plugins/languages/treesitter/treesitter-refactor.nix
@@ -36,7 +36,7 @@ in {
     };
     highlightCurrentScope = {
       inherit disable;
-      enable = mkEnableOption "highlights the block from the current scope where the cursor is.";
+      enable = mkEnableOption "highlighting the block from the current scope where the cursor is";
     };
     smartRename = {
       inherit disable;

--- a/plugins/lsp/fidget.nix
+++ b/plugins/lsp/fidget.nix
@@ -12,7 +12,7 @@ in {
     plugins.fidget =
       helpers.extraOptionsOptions
       // {
-        enable = mkEnableOption "Enable fidget.";
+        enable = mkEnableOption "fidget";
 
         package = helpers.mkPackageOption "fidget" pkgs.vimPlugins.fidget-nvim;
 

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -9,7 +9,7 @@ with lib; let
   helpers = import ../../helpers.nix {inherit lib;};
 in {
   options.plugins.luasnip = {
-    enable = mkEnableOption "Enable luasnip";
+    enable = mkEnableOption "luasnip";
 
     package = helpers.mkPackageOption "luasnip" pkgs.vimPlugins.luasnip;
 

--- a/plugins/telescope/file-browser.nix
+++ b/plugins/telescope/file-browser.nix
@@ -25,7 +25,7 @@ with lib; let
   };
 in {
   options.plugins.telescope.extensions.file_browser = {
-    enable = mkEnableOption "File browser extension for telescope";
+    enable = mkEnableOption "file browser extension for telescope";
 
     package = helpers.mkPackageOption "telescope file_browser" pkgs.vimPlugins.telescope-file-browser-nvim;
 

--- a/plugins/telescope/fzf-native.nix
+++ b/plugins/telescope/fzf-native.nix
@@ -9,7 +9,7 @@ with lib; let
   helpers = import ../helpers.nix {inherit lib;};
 in {
   options.plugins.telescope.extensions.fzf-native = {
-    enable = mkEnableOption "Enable fzf-native";
+    enable = mkEnableOption "fzf-native";
 
     package = helpers.mkPackageOption "telescope extension fzf-native" pkgs.vimPlugins.telescope-fzf-native-nvim;
 

--- a/plugins/telescope/fzy-native.nix
+++ b/plugins/telescope/fzy-native.nix
@@ -8,7 +8,7 @@ with lib; let
   cfg = config.plugins.telescope.extensions.fzy-native;
 in {
   options.plugins.telescope.extensions.fzy-native = {
-    enable = mkEnableOption "Enable fzy-native";
+    enable = mkEnableOption "fzy-native";
 
     overrideGenericSorter = mkOption {
       type = types.nullOr types.bool;

--- a/plugins/telescope/media-files.nix
+++ b/plugins/telescope/media-files.nix
@@ -9,7 +9,7 @@ with lib; let
   helpers = import ../helpers.nix {inherit lib;};
 in {
   options.plugins.telescope.extensions.media_files = {
-    enable = mkEnableOption "Enable media_files extension for telescope";
+    enable = mkEnableOption "media_files extension for telescope";
 
     package = helpers.mkPackageOption "telescope extension media_files" pkgs.vimPlugins.telescope-media-files-nvim;
 

--- a/plugins/utils/comment-nvim.nix
+++ b/plugins/utils/comment-nvim.nix
@@ -10,7 +10,7 @@ with lib; let
 in {
   options = {
     plugins.comment-nvim = {
-      enable = mkEnableOption "Enable comment-nvim";
+      enable = mkEnableOption "comment-nvim";
 
       package = helpers.mkPackageOption "comment-nvim" pkgs.vimPlugins.comment-nvim;
 

--- a/plugins/utils/easyescape.nix
+++ b/plugins/utils/easyescape.nix
@@ -10,7 +10,7 @@ with lib; let
 in {
   options = {
     plugins.easyescape = {
-      enable = mkEnableOption "Enable easyescape";
+      enable = mkEnableOption "easyescape";
 
       package = helpers.mkPackageOption "easyescape" pkgs.vimPlugins.vim-easyescape;
     };

--- a/plugins/utils/hardtime.nix
+++ b/plugins/utils/hardtime.nix
@@ -12,7 +12,7 @@ in {
     plugins.hardtime =
       helpers.extraOptionsOptions
       // {
-        enable = mkEnableOption "Enable hardtime.";
+        enable = mkEnableOption "hardtime";
 
         package = helpers.mkPackageOption "hardtime" pkgs.vimPlugins.hardtime-nvim;
 

--- a/plugins/utils/presence-nvim.nix
+++ b/plugins/utils/presence-nvim.nix
@@ -12,7 +12,7 @@ in {
     plugins.presence-nvim =
       helpers.extraOptionsOptions
       // {
-        enable = mkEnableOption "Enable presence-nvim.";
+        enable = mkEnableOption "presence-nvim";
         package = helpers.mkPackageOption "presence-nvim" pkgs.vimPlugins.presence-nvim;
 
         # General options.

--- a/plugins/utils/tmux-navigator.nix
+++ b/plugins/utils/tmux-navigator.nix
@@ -9,7 +9,7 @@ with lib; let
   helpers = import ../helpers.nix {inherit lib;};
 in {
   options.plugins.tmux-navigator = {
-    enable = mkEnableOption "Enable Tmux-Navigator (see https://github.com/christoomey/vim-tmux-navigator for tmux installation instruction)";
+    enable = mkEnableOption "Tmux-Navigator (see https://github.com/christoomey/vim-tmux-navigator for tmux installation instruction)";
 
     package = helpers.mkPackageOption "tmux-navigator" pkgs.vimPlugins.tmux-navigator;
 

--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -19,7 +19,7 @@ in {
     plugins.todo-comments =
       helpers.extraOptionsOptions
       // {
-        enable = mkEnableOption "Enable todo-comments.";
+        enable = mkEnableOption "todo-comments";
 
         package =
           helpers.mkPackageOption

--- a/plugins/utils/undotree.nix
+++ b/plugins/utils/undotree.nix
@@ -10,7 +10,7 @@ with lib; let
 in {
   options = {
     plugins.undotree = {
-      enable = mkEnableOption "Enable undotree";
+      enable = mkEnableOption "undotree";
 
       package = helpers.mkPackageOption "undotree" pkgs.vimPlugins.undotree;
 

--- a/plugins/utils/vim-matchup.nix
+++ b/plugins/utils/vim-matchup.nix
@@ -8,12 +8,12 @@ with lib; let
   helpers = import ../helpers.nix args;
 in {
   options.plugins.vim-matchup = {
-    enable = mkEnableOption "Enable vim-matchup";
+    enable = mkEnableOption "vim-matchup";
 
     package = helpers.mkPackageOption "vim-matchup" pkgs.vimPlugins.vim-matchup;
 
     treesitterIntegration = {
-      enable = mkEnableOption "Enable treesitter integration";
+      enable = mkEnableOption "treesitter integration";
       disable =
         helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]"
         "Languages for each to disable this module";

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -20,7 +20,7 @@ in {
           {
             options = {
               enable = mkEnableOption "nixvim";
-              defaultEditor = mkEnableOption "Set nixvim as the default editor";
+              defaultEditor = mkEnableOption "nixvim as the default editor";
             };
           }
         ]

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -20,7 +20,7 @@ in {
           {
             options = {
               enable = mkEnableOption "nixvim";
-              defaultEditor = mkEnableOption "Set nixvim as the default editor";
+              defaultEditor = mkEnableOption "nixvim as the default editor";
             };
             config.wrapRc = mkForce true;
           }


### PR DESCRIPTION
noticed some grammatical discrepancies throughout the repo and decided to fix them :)