### PR TITLE
[Colorscheme] Melange support

### DIFF
--- a/plugins/colorschemes/melange.nix
+++ b/plugins/colorschemes/melange.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: let
+  inherit (lib) mkEnableOption mkDefault mkIf;
+  inherit (import ../helpers.nix {inherit lib;}) mkPackageOption;
+  cfg = config.colorscheme.melange;
+in {
+  options = {
+    colorschemes.melange = {
+      enable = mkEnableOption "Melange colorscheme";
+      package = mkPackageOption "melange.nvim" pkgs.vimPlugins.melange-nvim;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    colorscheme = "melange";
+    extraPlugins = [cfg.package];
+    options = {
+      termguicolors = mkDefault true;
+    };
+  };
+}

--- a/plugins/colorschemes/melange.nix
+++ b/plugins/colorschemes/melange.nix
@@ -6,7 +6,7 @@
 }: let
   inherit (lib) mkEnableOption mkDefault mkIf;
   inherit (import ../helpers.nix {inherit lib;}) mkPackageOption;
-  cfg = config.colorscheme.melange;
+  cfg = config.colorschemes.melange;
 in {
   options = {
     colorschemes.melange = {

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -10,6 +10,7 @@
     ./colorschemes/dracula.nix
     ./colorschemes/gruvbox.nix
     ./colorschemes/kanagawa.nix
+    ./colorschemes/melange.nix
     ./colorschemes/nord.nix
     ./colorschemes/one.nix
     ./colorschemes/onedark.nix

--- a/tests/test-sources/plugins/colorschemes/melange.nix
+++ b/tests/test-sources/plugins/colorschemes/melange.nix
@@ -1,0 +1,9 @@
+{
+  empty = {
+    colorschemes.melange.enable = true;
+  };
+
+  defaults = {
+    colorschemes.melange.enable = true;
+  };
+}

--- a/tests/test-sources/plugins/colorschemes/melange.nix
+++ b/tests/test-sources/plugins/colorschemes/melange.nix
@@ -2,8 +2,4 @@
   empty = {
     colorschemes.melange.enable = true;
   };
-
-  defaults = {
-    colorschemes.melange.enable = true;
-  };
 }


### PR DESCRIPTION
Implement [melange](https://github.com/savq/melange-nvim) colorscheme for neovim. It's important to notice that to use the light variant the `set background=light` is needed. So the change between light and dark variant will be automatically if your terminal sets the `background` neovim option automatically.