### PR TITLE
plugins/null-ls: migrate `null-ls` to `none-ls`

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -72,7 +72,7 @@
     ./lsp/nvim-lightbulb.nix
     ./lsp/trouble.nix
 
-    ./null-ls
+    ./none-ls
 
     ./dap
 

--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -5,22 +5,27 @@
   ...
 }:
 with lib; let
-  cfg = config.plugins.null-ls;
+  cfg = config.plugins.none-ls;
   helpers = import ../helpers.nix {inherit lib;};
 in {
   imports = [
     ./servers.nix
+    (
+      mkRenamedOptionModule
+      ["plugins" "null-ls"]
+      ["plugins" "none-ls"]
+    )
   ];
 
-  options.plugins.null-ls =
+  options.plugins.none-ls =
     helpers.extraOptionsOptions
     // {
-      enable = mkEnableOption "null-ls";
+      enable = mkEnableOption "none-ls";
 
       package = mkOption {
         type = types.package;
-        default = pkgs.vimPlugins.null-ls-nvim;
-        description = "Plugin to use for null-ls";
+        default = pkgs.vimPlugins.none-ls-nvim;
+        description = "Plugin to use for none-ls";
       };
 
       border = helpers.defaultNullOpts.mkBorder "null" "`:NullLsInfo` UI window." ''

--- a/plugins/none-ls/helpers.nix
+++ b/plugins/none-ls/helpers.nix
@@ -7,7 +7,7 @@
   mkServer = {
     name,
     sourceType,
-    description ? "${name} source, for null-ls.",
+    description ? "${name} source, for none-ls.",
     package ? null,
     extraPackages ? [],
     ...
@@ -21,7 +21,7 @@
   } @ args:
     with lib; let
       helpers = import ../helpers.nix args;
-      cfg = config.plugins.null-ls.sources.${sourceType}.${name};
+      cfg = config.plugins.none-ls.sources.${sourceType}.${name};
       # does this evaluate package?
       packageOption =
         if package == null
@@ -30,11 +30,11 @@
           package = mkOption {
             type = types.package;
             default = package;
-            description = "Package to use for ${name} by null-ls";
+            description = "Package to use for ${name} by none-ls";
           };
         };
     in {
-      options.plugins.null-ls.sources.${sourceType}.${name} =
+      options.plugins.none-ls.sources.${sourceType}.${name} =
         {
           enable = mkEnableOption description;
 
@@ -56,7 +56,7 @@
         extraPackages = extraPackages ++ optional (package != null) cfg.package;
 
         # Add source to list of sources
-        plugins.null-ls.sourcesItems = let
+        plugins.none-ls.sourcesItems = let
           sourceItem = "${sourceType}.${name}";
           withArgs =
             if (cfg.withArgs == null)

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -161,7 +161,7 @@ in {
   imports = lib.lists.map helpers.mkServer dataFlattened;
 
   config = let
-    cfg = config.plugins.null-ls;
+    cfg = config.plugins.none-ls;
     gitsignsEnabled = cfg.sources.code_actions.gitsigns.enable;
   in
     lib.mkIf cfg.enable {

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -1,21 +1,21 @@
 {
   # Empty configuration
   empty = {
-    plugins.null-ls.enable = true;
+    plugins.none-ls.enable = true;
   };
 
   # Broken:
-  # error: The option `plugins.null-ls.sources.formatting.beautysh' does not exist.
+  # error: The option `plugins.none-ls.sources.formatting.beautysh' does not exist.
   #
   # beautysh = {
-  #   plugins.null-ls = {
+  #   plugins.none-ls = {
   #     enable = true;
   #     sources.formatting.beautysh.enable = true;
   #   };
   # };
 
   default = {
-    plugins.null-ls = {
+    plugins.none-ls = {
       enable = true;
       border = null;
       cmd = ["nvim"];


### PR DESCRIPTION
`null-ls` was archived [some time ago](https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1621) and [`none-ls`](https://github.com/nvimtools/none-ls.nvim) is a fork and a drop-in replacement.

`none-ls` is packaged but not merged onto unstable yet (https://nixpk.gs/pr-tracker.html?pr=258774), so I am marking this as a draft.

This pr just replaces the default package with `none-ls`. I don't think this requires any deprecations or warnings because it doesn't make any breaking changes, plus the package is still configurable. From the `none-ls` readme:
```
Only the repo name is changed for compatibility concerns.
All the API and future changes will keep in place as-is.
```

FWIW, `LazyVim` has also migrated to `none-ls`: https://github.com/LazyVim/LazyVim/pull/1517