### PR TITLE
modules/keymaps: fix option

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -83,7 +83,6 @@ in rec {
     defaultMode ? "",
     withKeyOpt ? true,
     flatConfig ? false,
-    actionIsOptional ? false,
   }:
     with types;
       either
@@ -113,14 +112,10 @@ in rec {
               example = ["n" "v"];
             };
 
-            action =
-              if actionIsOptional
-              then helpers.mkNullOrOption str "The action to execute"
-              else
-                mkOption {
-                  type = str;
-                  description = "The action to execute.";
-                };
+            action = mkOption {
+              type = str;
+              description = "The action to execute.";
+            };
 
             lua = mkOption {
               type = bool;

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -84,10 +84,8 @@ in rec {
     withKeyOpt ? true,
     flatConfig ? false,
   }:
-    with types;
-      either
-      str
-      (submodule {
+    with types; let
+      mapOptionSubmodule = submodule {
         options =
           (
             if withKeyOpt
@@ -133,7 +131,11 @@ in rec {
               options = mapConfigOptions;
             }
           );
-      });
+      };
+    in
+      if flatConfig
+      then either str mapOptionSubmodule
+      else mapOptionSubmodule;
 
   # Correctly merge two attrs (partially) representing a mapping.
   mergeKeymap = defaults: keymap: let

--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -26,7 +26,6 @@ in {
                     defaultMode = modeProps.short;
                     withKeyOpt = false;
                     flatConfig = true;
-                    actionIsOptional = config.plugins.which-key.enable;
                   }
                 )
               );
@@ -38,9 +37,7 @@ in {
     keymaps = mkOption {
       type =
         types.listOf
-        (helpers.keymaps.mkMapOptionSubmodule {
-          actionIsOptional = config.plugins.which-key.enable;
-        });
+        (helpers.keymaps.mkMapOptionSubmodule {});
       default = [];
       example = [
         {


### PR DESCRIPTION
- remove possibility to add a str mapping to the `keymap` option
- remove possibility to add a keymap without an action