### PR TITLE
module/keymaps: no need to set options = {}

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -129,17 +129,13 @@ in {
             (keyMapping)
             mode
             key
+            options
             ;
 
           action =
             if keyMapping.lua
             then helpers.mkRaw keyMapping.action
             else keyMapping.action;
-
-          options =
-            if keyMapping.options == {}
-            then helpers.emptyTable
-            else keyMapping.options;
         };
       in
         map normalizeMapping


### PR DESCRIPTION
We do not have to bother to set `options` to `"{}"` as if the attribute is missing, `nil` will be used.