### PR TITLE
fsautocomplete: init

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -176,6 +176,11 @@ with lib; let
       cmd = cfg: ["${cfg.package}/bin/elixir-ls"];
     }
     {
+      name = "fsautocomplete";
+      description = "Enable fsautocomplete, for F#";
+      package = pkgs.fsautocomplete;
+    }
+    {
       name = "futhark-lsp";
       description = "Enable Futhark lsp, for Futhark";
       package = pkgs.futhark;

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -87,6 +87,7 @@
         elmls.enable = true;
         eslint.enable = true;
         elixirls.enable = true;
+        fsautocomplete.enable = true;
         futhark-lsp.enable = true;
         gopls.enable = true;
         hls.enable = true;


### PR DESCRIPTION
### Changes
 * Add fsautocomplete from the unstable channel as a language server.
 * Add test enabling fsautocomplete.

#### Result of `nix fmt`
```
Checking style in 316 files using 6 threads.


Congratulations! Your code complies with the Alejandra style.

⭐ If Alejandra is useful to you, please add your star to the repository.
Thank you! https://github.com/kamadorueda/alejandra
```

#### Result of `nix flake check`
```
Please, use the new `keymaps` option which works as follows:

keymaps = [
  {
    # Default mode is "" which means normal-visual-op
    key = "<C-m>";
    action = ":!make<CR>";
  }
  {
    # Mode can be a string or a list of strings
    mode = "n";
    key = "<leader>p";
    action = "require('my-plugin').do_stuff";
    lua = true;
    # Note that all of the mapping options are now under the `options` attrs
    options = {
      silent = true;
      desc = "My plugin does stuff";
    };
  }
];

trace: warning: The `maps` option will be deprecated in the near future.
Please, use the new `keymaps` option which works as follows:

keymaps = [
  {
    # Default mode is "" which means normal-visual-op
    key = "<C-m>";
    action = ":!make<CR>";
  }
  {
    # Mode can be a string or a list of strings
    mode = "n";
    key = "<leader>p";
    action = "require('my-plugin').do_stuff";
    lua = true;
    # Note that all of the mapping options are now under the `options` attrs
    options = {
      silent = true;
      desc = "My plugin does stuff";
    };
  }
];

trace: warning: The `maps` option will be deprecated in the near future.
Please, use the new `keymaps` option which works as follows:

keymaps = [
  {
    # Default mode is "" which means normal-visual-op
    key = "<C-m>";
    action = ":!make<CR>";
  }
  {
    # Mode can be a string or a list of strings
    mode = "n";
    key = "<leader>p";
    action = "require('my-plugin').do_stuff";
    lua = true;
    # Note that all of the mapping options are now under the `options` attrs
    options = {
      silent = true;
      desc = "My plugin does stuff";
    };
  }
];

warning: unknown flake output 'homeManagerModules'
warning: unknown flake output 'nixDarwinModules'
warning: unknown flake output 'rawModules'
warning: The check omitted these incompatible systems: aarch64-darwin, aarch64-linux, x86_64-darwin
Use '--all-systems' to check all.
```