### PR TITLE
fix: harpoon telescope integration

### DIFF
--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -29,6 +29,12 @@ in {
 
       enableTelescope = mkEnableOption "enable telescope integration";
 
+      keymapsSilent = mkOption {
+        type = types.bool;
+        description = "Whether harpoon keymaps should be silent.";
+        default = false;
+      };
+
       keymaps = {
         addFile = helpers.mkNullOrOption types.str ''
           Keymap for marking the current file.";

--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -27,7 +27,7 @@ in {
 
       package = helpers.mkPackageOption "harpoon" pkgs.vimPlugins.harpoon;
 
-      enableTelescope = mkEnableOption "enable telescope integration";
+      enableTelescope = mkEnableOption "telescope integration";
 
       keymapsSilent = mkOption {
         type = types.bool;

--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -27,7 +27,11 @@ in {
 
       package = helpers.mkPackageOption "harpoon" pkgs.vimPlugins.harpoon;
 
-      enableTelescope = mkEnableOption "Enable telescope integration";
+      enableTelescope = mkOption {
+        type = types.bool;
+        description = "Whether to enable telescope integration.";
+        default = false;
+      };
 
       keymapsSilent = mkOption {
         type = types.bool;

--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -27,17 +27,7 @@ in {
 
       package = helpers.mkPackageOption "harpoon" pkgs.vimPlugins.harpoon;
 
-      enableTelescope = mkOption {
-        type = types.bool;
-        description = "Whether to enable telescope integration.";
-        default = false;
-      };
-
-      keymapsSilent = mkOption {
-        type = types.bool;
-        description = "Whether harpoon keymaps should be silent.";
-        default = false;
-      };
+      enableTelescope = mkEnableOption "enable telescope integration";
 
       keymaps = {
         addFile = helpers.mkNullOrOption types.str ''
@@ -206,7 +196,7 @@ in {
     mkIf cfg.enable {
       assertions = [
         {
-          assertion = config.plugins.telescope.enable -> cfg.enableTelescope;
+          assertion = cfg.enableTelescope -> config.plugins.telescope.enable;
           message = ''Nixvim: The harpoon telescope integration needs telescope to function as intended'';
         }
       ];


### PR DESCRIPTION
At the moment if your config doesn't specify `enableTelescope` in the harpoon options you get the following:

Harpoon config:
```
      harpoon = {
        enable = true;
        tmuxAutocloseWindows = true;
        keymaps = {
          addFile = "<leader>ha";
          toggleQuickMenu = "<leader>ht";
          navNext = "<leader>hn";
          navPrev = "<leader>hp";
        };
      };
```

Error:
```bash
error:
       … while evaluating a branch condition

         at /nix/store/4smdp3v5a9bcg1hpdhl2hs70rq385ykq-source/lib/lists.nix:57:9:

           56|       fold' = n:
           57|         if n == len
             |         ^
           58|         then nul

       … while calling the 'length' builtin

         at /nix/store/4smdp3v5a9bcg1hpdhl2hs70rq385ykq-source/lib/lists.nix:55:13:

           54|     let
           55|       len = length list;
             |             ^
           56|       fold' = n:

       (stack trace truncated; use '--show-trace' to show the full trace)

       error:
       Failed assertions:
       - Nixvim: The harpoon telescope integration needs telescope to function as intended
```

I think we should default it to `false` and make users turn it on.