### PR TITLE
flake: add overlay as an alternative to legacyPackages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,18 @@
         nixDarwinModules.nixvim = import ./wrappers/darwin.nix modules;
         rawModules.nixvim = nixvimModules;
 
+        overlays.default = final: prev: {
+          nixvim = rec {
+            makeNixvimWithModule = import ./wrappers/standalone.nix prev modules;
+            makeNixvim = configuration:
+              makeNixvimWithModule {
+                module = {
+                  config = configuration;
+                };
+              };
+          };
+        };
+
         templates = let
           simple = {
             path = ./templates/simple;


### PR DESCRIPTION
This adds an overlay containing both makeNixvim functions. This simplifies usage of the functions, as well as enabling you to use your own preinstantiated package set, instead of the one from this flake.