### PR TITLE
plugins/catppuccin: add `disableUnderline` option

### DIFF
--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -62,6 +62,8 @@ in {
 
       disableBold = helpers.defaultNullOpts.mkBool false "Force no bold";
 
+      disableUnderline = helpers.defaultNullOpts.mkBool false "Force no underline";
+
       styles = {
         comments =
           helpers.defaultNullOpts.mkNullable (types.listOf types.str)
@@ -326,6 +328,7 @@ in {
         dim_inactive = dimInactive;
         no_italic = disableItalic;
         no_bold = disableBold;
+        no_underline = disableUnderline;
         color_overrides = colorOverrides;
         custom_highlights =
           helpers.ifNonNull' cfg.customHighlights

--- a/tests/test-sources/plugins/colorschemes/catppuccin.nix
+++ b/tests/test-sources/plugins/colorschemes/catppuccin.nix
@@ -4,7 +4,7 @@
     colorschemes.catppuccin.enable = true;
   };
 
-  # All the upstream default options of catppuccin 
+  # All the upstream default options of catppuccin
   defaults = {
     colorschemes.catppuccin = {
       enable = true;

--- a/tests/test-sources/plugins/colorschemes/catppuccin.nix
+++ b/tests/test-sources/plugins/colorschemes/catppuccin.nix
@@ -4,7 +4,7 @@
     colorschemes.catppuccin.enable = true;
   };
 
-  # All the upstream default options of poimandres
+  # All the upstream default options of catppuccin 
   defaults = {
     colorschemes.catppuccin = {
       enable = true;
@@ -14,15 +14,13 @@
         dark = "mocha";
       };
       transparentBackground = false;
-      terminalColors = true;
+      terminalColors = false;
       showBufferEnd = false;
       dimInactive = {
         enabled = true;
         shade = "dark";
         percentage = 0.15;
       };
-      disableItalic = true;
-      disableBold = true;
       styles = {
         comments = ["italic"];
         conditionals = ["italic"];
@@ -57,6 +55,10 @@
       flavour = "mocha";
       terminalColors = true;
       colorOverrides.mocha.base = "#1e1e2f";
+
+      disableItalic = true;
+      disableBold = true;
+      disableUnderline = true;
 
       integrations = {
         barbar = true;


### PR DESCRIPTION
This PR adds support for `no_underline` option of catppuccin colorscheme.