### PR TITLE
plugins/harpoon: fix busted keybind

### DIFF
--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -241,7 +241,7 @@ in {
             toggleQuickMenu = "require('harpoon.ui').toggle_quick_menu";
             navNext = "require('harpoon.ui').nav_next";
             navPrev = "require('harpoon.ui').nav_prev";
-            cmdToggleQuickMenu = "require('harpoon.cmd-ui').toggle_quick_menu()";
+            cmdToggleQuickMenu = "require('harpoon.cmd-ui').toggle_quick_menu";
           }
         );
 


### PR DESCRIPTION
fix keybinding where the action was being called at the time of creation of the keybind instead of when the keybind was triggered