### PR TITLE
fix: Enable `helpers` to be passed as an argument in nixvim

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
           packages =
             {
               docs = pkgs-unfree.callPackage (import ./docs) {
-                modules = nixvimModules;
+                modules = modules pkgs;
               };
             }
             // (import ./helpers pkgs);


### PR DESCRIPTION
With this change `helpers` can be imported using `{pkgs, lib, helpers, ...}` instead of requiring to `import` it.