### PR TITLE
plugins/dap-go: add buildFlags option

### DIFF
--- a/plugins/dap/dap-go.nix
+++ b/plugins/dap/dap-go.nix
@@ -31,6 +31,8 @@ in {
       '';
 
       args = helpers.mkNullOrOption (types.listOf types.str) "Additional args to pass to dlv.";
+
+      buildFlags = helpers.defaultNullOpts.mkStr "" "Build flags to pass to dlv.";
     };
   };
 
@@ -41,6 +43,7 @@ in {
       delve = with delve; {
         inherit path port args;
         initialize_timeout_sec = initializeTimeoutSec;
+        build_flags = buildFlags;
       };
     };
   in

--- a/tests/test-sources/plugins/dap/dap-go.nix
+++ b/tests/test-sources/plugins/dap/dap-go.nix
@@ -21,6 +21,7 @@
         initializeTimeoutSec = 20;
         port = "$\{port}";
         args = [];
+        buildFlags = "-tags=unit";
       };
     };
   };


### PR DESCRIPTION
We are missing the `build_flags` config option, https://github.com/leoluz/nvim-dap-go#configuring