### PR TITLE
plugins/efmls-configs: Improve tool installation

### DIFF
--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -14,65 +14,91 @@ with lib; let
   toolPkgs = {
     inherit
       (pkgs)
+      actionlint
+      alejandra
       ameba
       astyle
       bashate
+      beautysh
+      biome
       black
       cbfmt
+      checkmake
       clazy
+      codespell
       cppcheck
       cpplint
+      dfmt
+      djlint
       dmd
       dprint
       fish
       flawfinder
       gcc
+      gitlint
+      gofumpt
       golines
       golint
       hadolint
+      isort
       joker
+      jq
       languagetool
       mypy
       nixfmt
       php
       prettierd
       proselint
+      protolint
       pylint
       rubocop
       ruff
       rustfmt
+      scalafmt
+      selene
       shellcheck
+      shellharden
       shfmt
       smlfmt
       statix
       stylua
+      taplo
       uncrustify
       vale
       yamllint
       yapf
       ;
-    inherit (pkgs.python3.pkgs) autopep8 flake8 vulture;
+    inherit (pkgs.python3.pkgs) autopep8 flake8 vulture mdformat;
     inherit (pkgs.nodePackages) eslint eslint_d prettier alex stylelint textlint write-good;
     inherit (pkgs.phpPackages) phpcbf phan phpcs phpstan psalm;
     inherit (pkgs.luaPackages) luacheck;
+    inherit (pkgs.haskellPackages) fourmolu;
     ansible_lint = pkgs.ansible-lint;
+    chktex = pkgs.texliveMedium;
     clang_format = pkgs.clang-tools;
     clang_tidy = pkgs.clang-tools;
     clj_kondo = pkgs.clj-kondo;
+    cmake_lint = pkgs.cmake-format;
     dartfmt = pkgs.dart;
     dotnet_format = pkgs.dotnet-runtime;
     fish_indent = pkgs.fish;
     gofmt = pkgs.go;
     goimports = pkgs.go-tools;
     golangci_lint = pkgs.golangci-lint;
+    google_java_format = pkgs.google-java-format;
     go_revive = pkgs.revive;
+    latexindent = pkgs.texliveMedium;
     lua_format = pkgs.luaformatter;
+    markdownlint = pkgs.markdownlint-cli;
     mcs = pkgs.mono;
     php_cs_fixer = pkgs.phpPackages.php-cs-fixer;
+    prettier_d = pkgs.prettierd;
     slither = pkgs.slither-analyzer;
     staticcheck = pkgs.go-tools;
     terraform_fmt = pkgs.terraform;
     vint = pkgs.vim-vint;
+    write_good = pkgs.write-good;
+    yq = pkgs.yq-go;
   };
 in {
   options.plugins.efmls-configs = {

--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -11,9 +11,8 @@ with lib; let
   languages = builtins.attrNames tools;
 
   # Mapping of tool name to the nixpkgs package (if any)
-  toolPkgs = {
+  toolPkgs = with pkgs; {
     inherit
-      (pkgs)
       actionlint
       alejandra
       ameba
@@ -68,37 +67,37 @@ with lib; let
       yamllint
       yapf
       ;
-    inherit (pkgs.python3.pkgs) autopep8 flake8 vulture mdformat;
-    inherit (pkgs.nodePackages) eslint eslint_d prettier alex stylelint textlint write-good;
-    inherit (pkgs.phpPackages) phpcbf phan phpcs phpstan psalm;
-    inherit (pkgs.luaPackages) luacheck;
-    inherit (pkgs.haskellPackages) fourmolu;
-    ansible_lint = pkgs.ansible-lint;
-    chktex = pkgs.texliveMedium;
-    clang_format = pkgs.clang-tools;
-    clang_tidy = pkgs.clang-tools;
-    clj_kondo = pkgs.clj-kondo;
-    cmake_lint = pkgs.cmake-format;
-    dartfmt = pkgs.dart;
-    dotnet_format = pkgs.dotnet-runtime;
-    fish_indent = pkgs.fish;
-    gofmt = pkgs.go;
-    goimports = pkgs.go-tools;
-    golangci_lint = pkgs.golangci-lint;
-    google_java_format = pkgs.google-java-format;
-    go_revive = pkgs.revive;
-    latexindent = pkgs.texliveMedium;
-    lua_format = pkgs.luaformatter;
-    markdownlint = pkgs.markdownlint-cli;
-    mcs = pkgs.mono;
-    php_cs_fixer = pkgs.phpPackages.php-cs-fixer;
-    prettier_d = pkgs.prettierd;
-    slither = pkgs.slither-analyzer;
-    staticcheck = pkgs.go-tools;
-    terraform_fmt = pkgs.terraform;
-    vint = pkgs.vim-vint;
-    write_good = pkgs.write-good;
-    yq = pkgs.yq-go;
+    inherit (python3.pkgs) autopep8 flake8 vulture mdformat;
+    inherit (nodePackages) eslint eslint_d prettier alex stylelint textlint write-good;
+    inherit (phpPackages) phpcbf phan phpcs phpstan psalm;
+    inherit (luaPackages) luacheck;
+    inherit (haskellPackages) fourmolu;
+    ansible_lint = ansible-lint;
+    chktex = texliveMedium;
+    clang_format = clang-tools;
+    clang_tidy = clang-tools;
+    clj_kondo = clj-kondo;
+    cmake_lint = cmake-format;
+    dartfmt = dart;
+    dotnet_format = dotnet-runtime;
+    fish_indent = fish;
+    gofmt = go;
+    goimports = go-tools;
+    golangci_lint = golangci-lint;
+    google_java_format = google-java-format;
+    go_revive = revive;
+    latexindent = texliveMedium;
+    lua_format = luaformatter;
+    markdownlint = markdownlint-cli;
+    mcs = mono;
+    php_cs_fixer = phpPackages.php-cs-fixer;
+    prettier_d = prettierd;
+    slither = slither-analyzer;
+    staticcheck = go-tools;
+    terraform_fmt = terraform;
+    vint = vim-vint;
+    write_good = write-good;
+    yq = yq-go;
   };
 in {
   options.plugins.efmls-configs = {

--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -9,11 +9,92 @@ with lib; let
   tools = trivial.importJSON "${pkgs.vimPlugins.efmls-configs-nvim.src}/doc/supported-list.json";
 
   languages = builtins.attrNames tools;
+
+  # Mapping of tool name to the nixpkgs package (if any)
+  toolPkgs = {
+    inherit
+      (pkgs)
+      ameba
+      astyle
+      bashate
+      black
+      cbfmt
+      clazy
+      cppcheck
+      cpplint
+      dmd
+      dprint
+      fish
+      flawfinder
+      gcc
+      golines
+      golint
+      hadolint
+      joker
+      languagetool
+      mypy
+      nixfmt
+      php
+      prettierd
+      proselint
+      pylint
+      rubocop
+      ruff
+      rustfmt
+      shellcheck
+      shfmt
+      smlfmt
+      statix
+      stylua
+      uncrustify
+      vale
+      yamllint
+      yapf
+      ;
+    inherit (pkgs.python3.pkgs) autopep8 flake8 vulture;
+    inherit (pkgs.nodePackages) eslint eslint_d prettier alex stylelint textlint write-good;
+    inherit (pkgs.phpPackages) phpcbf phan phpcs phpstan psalm;
+    inherit (pkgs.luaPackages) luacheck;
+    ansible_lint = pkgs.ansible-lint;
+    clang_format = pkgs.clang-tools;
+    clang_tidy = pkgs.clang-tools;
+    clj_kondo = pkgs.clj-kondo;
+    dartfmt = pkgs.dart;
+    dotnet_format = pkgs.dotnet-runtime;
+    fish_indent = pkgs.fish;
+    gofmt = pkgs.go;
+    goimports = pkgs.go-tools;
+    golangci_lint = pkgs.golangci-lint;
+    go_revive = pkgs.revive;
+    lua_format = pkgs.luaformatter;
+    mcs = pkgs.mono;
+    php_cs_fixer = pkgs.phpPackages.php-cs-fixer;
+    slither = pkgs.slither-analyzer;
+    staticcheck = pkgs.go-tools;
+    terraform_fmt = pkgs.terraform;
+    vint = pkgs.vim-vint;
+  };
 in {
   options.plugins.efmls-configs = {
     enable = mkEnableOption "efmls-configs, premade configurations for efm-langserver";
 
     package = helpers.mkPackageOption "efmls-configs-nvim" pkgs.vimPlugins.efmls-configs-nvim;
+
+    externallyManagedPackages = mkOption {
+      type = types.either (types.enum ["all"]) (types.listOf types.str);
+      description = ''
+        Linters/Formatters to skip installing with nixvim. Set to `all` to install no packages
+      '';
+      default = [];
+    };
+
+    toolPackages = attrsets.mapAttrs (tool: pkg:
+      mkOption {
+        type = types.package;
+        default = pkg;
+        description = "Package for ${tool}";
+      })
+    toolPkgs;
 
     /*
     Users can set the options as follows:
@@ -76,71 +157,6 @@ in {
   };
   config = let
     cfg = config.plugins.efmls-configs;
-
-    # Mapping of tool name to the nixpkgs package (if any)
-    toolPkgs = {
-      inherit
-        (pkgs)
-        ameba
-        astyle
-        bashate
-        black
-        cbfmt
-        clazy
-        cppcheck
-        cpplint
-        dmd
-        dprint
-        fish
-        flawfinder
-        gcc
-        golines
-        golint
-        hadolint
-        joker
-        languagetool
-        mypy
-        nixfmt
-        php
-        prettierd
-        proselint
-        pylint
-        rubocop
-        ruff
-        rustfmt
-        shellcheck
-        shfmt
-        smlfmt
-        statix
-        stylua
-        uncrustify
-        vale
-        yamllint
-        yapf
-        ;
-      inherit (pkgs.python3.pkgs) autopep8 flake8 vulture;
-      inherit (pkgs.nodePackages) eslint eslint_d prettier alex stylelint textlint write-good;
-      inherit (pkgs.phpPackages) phpcbf phan phpcs phpstan psalm;
-      inherit (pkgs.luaPackages) luacheck;
-      ansible_lint = pkgs.ansible-lint;
-      clang_format = pkgs.clang-tools;
-      clang_tidy = pkgs.clang-tools;
-      clj_kondo = pkgs.clj-kondo;
-      dartfmt = pkgs.dart;
-      dotnet_format = pkgs.dotnet-runtime;
-      fish_indent = pkgs.fish;
-      gofmt = pkgs.go;
-      goimports = pkgs.go-tools;
-      golangci_lint = pkgs.golangci-lint;
-      go_revive = pkgs.revive;
-      lua_format = pkgs.luaformatter;
-      mcs = pkgs.mono;
-      php_cs_fixer = pkgs.phpPackages.php-cs-fixer;
-      slither = pkgs.slither-analyzer;
-      staticcheck = pkgs.go-tools;
-      terraform_fmt = pkgs.terraform;
-      vint = pkgs.vim-vint;
-    };
     toolAsList = tools:
       if builtins.isList tools
       then tools
@@ -158,9 +174,18 @@ in {
       )
     ));
 
-    pkgsToInstall =
-      builtins.map (v: toolPkgs.${v})
-      (builtins.filter (v: builtins.hasAttr v toolPkgs) tools);
+    pkgsForTools = let
+      partitionFn =
+        if cfg.externallyManagedPackages == "all"
+        then _: false
+        else t: !(builtins.elem t cfg.externallyManagedPackages);
+      partition = lists.partition partitionFn tools;
+    in {
+      nixvim = partition.right;
+      external = partition.wrong;
+    };
+
+    nixvimPkgs = lists.partition (v: builtins.hasAttr v cfg.toolPackages) pkgsForTools.nixvim;
 
     mkToolOption = kind: opt:
       builtins.map
@@ -189,11 +214,16 @@ in {
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
 
+      warnings = optional ((builtins.length nixvimPkgs.wrong) > 0) ''
+        Following tools are not handled by nixvim, please add them to externallyManagedPackages to silence this:
+          ${builtins.concatStringsSep " " nixvimPkgs.wrong}
+      '';
+
       plugins.lsp.servers.efm = {
         enable = true;
         extraOptions.settings.languages = setupOptions;
       };
 
-      extraPackages = [pkgs.efm-langserver] ++ pkgsToInstall;
+      extraPackages = [pkgs.efm-langserver] ++ (builtins.map (v: toolPkgs.${v}) nixvimPkgs.right);
     };
 }


### PR DESCRIPTION
This adds a few missing tools, and adds the following behaviours: 
- Warning when selecting a tool nixvim is not able to install (it is either too new and was not added, or not packaged in nixpkgs)
- Allow to override tool packages (this is usefull for example for `mdformat` that can have plugins added to it)