### PR TITLE
tests: Install all efmls-configs tools

### DIFF
--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -44,7 +44,13 @@
       then args
       else {
         # cases is a function
-        cases = cases {inherit pkgs helpers;};
+        cases = cases {
+          inherit pkgs helpers;
+          efmls-options = import ../plugins/lsp/language-servers/efmls-configs.nix {
+            inherit pkgs lib helpers;
+            config = {};
+          };
+        };
         inherit namespace;
       })
   testsList;

--- a/tests/test-sources/plugins/lsp/efmls-configs.nix
+++ b/tests/test-sources/plugins/lsp/efmls-configs.nix
@@ -1,6 +1,65 @@
-{
+{efmls-options, ...}: {
   empty = {
     plugins.efmls-configs.enable = true;
+  };
+
+  all = {
+    plugins.efmls-configs = let
+      options = efmls-options.options.plugins.efmls-configs;
+      # toolOptions is an attrsets of the form:
+      # { <lang> = { linter = tools; formatter = tools; }; }
+      # Where tools is the option type representing the valid tools for this language
+      toolOptions = (builtins.head options.setup.type.getSubModules).options;
+
+      brokenTools = [
+        #Broken as of 16 of November 2023
+        "phpstan"
+      ];
+
+      unpackaged = [
+        "blade_formatter"
+        "cspell"
+        "dartanalyzer"
+        "debride"
+        "fecs"
+        "fixjson"
+        "forge_fmt"
+        "gersemi"
+        "js_standard"
+        "pint"
+        "prettier_eslint"
+        "prettier_standard"
+        "redpen"
+        "reek"
+        "rome"
+        "slim_lint"
+        "solhint"
+        "sorbet"
+        "xo"
+      ];
+
+      # Fetch the valid enum members from the tool options
+      toolsFromOptions = opt: let
+        # tool options are a `either toolType (listOf toolType)`
+        # Look into `nestedTypes.left` to get a `toolType` option.
+        toolType = opt.type.nestedTypes.left;
+        # toolType is a `either (enum possible) helpers.rawType
+        # Look into `nestedTypes.left` for the enum
+        possible = toolType.nestedTypes.left;
+        # possible is an enum, look into functor.payload for the variants
+        toolList = possible.functor.payload;
+      in
+        builtins.filter (t: !builtins.elem t (brokenTools ++ unpackaged)) toolList;
+    in {
+      enable = true;
+
+      # Replace the { <lang> = { linter = tools; formatter = tools; } };
+      # With { <lang> = {
+      #          linter = [<all valid linters for lang>];
+      #          formatter = [<all valid formatters for lang>];
+      #       };}
+      setup = builtins.mapAttrs (_: builtins.mapAttrs (_: toolsFromOptions)) toolOptions;
+    };
   };
 
   example = {


### PR DESCRIPTION
This requires to pass the efmls-configs file to the derivation helpers, if we try to import it from the test file directly it fails.

We then look into the types to find the available languages & corresponding tools, to enable them all.

We then filter out the broken tools or the unpackaged tools, in order to detect more easily the introduction of future tools.