### PR TITLE
neo-tree: add window.mappings to document_symbol

### DIFF
--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -975,6 +975,7 @@ in {
             https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol
           '';
         };
+        window = mkWindowMappingsOption "{}";
       };
     };
 
@@ -1215,6 +1216,7 @@ in {
                 cfg.documentSymbols.customKinds
               ))
             + "}";
+          window = processWindowMappings cfg.documentSymbols.window;
         };
       }
       // cfg.extraOptions;


### PR DESCRIPTION
In current code, `filesystem.window.mappings`, when set, became `filesystem.window.mappings.mappings`.
`document_symbol` can also receive its own custom mappings.