### PR TITLE
bug when paths does not exist build fails

### DIFF
--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -32,6 +32,6 @@ default_pkgs: {
 in
   config.finalPackage.overrideAttrs (oa: {
     paths =
-      oa.paths
+      oa.paths or []
       ++ (pkgs.lib.optional config.enableMan self.packages.${pkgs.system}.man-docs);
   })


### PR DESCRIPTION
When I try to build standalone I get this error:

`error: attribute 'paths' missing`

That change fixes the error, but I'm not totally sure how it works.