### PR TITLE
ci/check: Run checks for all systems (not only x86_64-linux)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           name: nix-community
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix flake check
-      - run: nix flake check ./templates/_wrapper/simple
+      - run: nix flake check --all-systems
+      - run: nix flake check --all-systems ./templates/_wrapper/simple
       - run: nix build .#docs --show-trace

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lockfile:
     name: Update the flake inputs and generate options
-    runs-on: nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: self-hosted
     timeout-minutes: 40
     steps:
       - name: Checkout repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This document is mainly for contributors to nixvim, but it can also be useful fo
 In order to submit a change you must be careful of several points:
 
 - The code must be properly formatted. This can be done through `nix fmt`.
-- The tests must pass. This can be done through `nix flake check` (this also checks formatting).
+- The tests must pass. This can be done through `nix flake check --all-systems` (this also checks formatting).
 - The change should try to avoid breaking existing configurations.
 - If the change introduces a new feature it should add tests for it (see the architecture section for details).
 
@@ -104,7 +104,7 @@ You can specify the special `tests` attribute in the configuration that will not
 
 - `tests.dontRun`: avoid launching this test, simply build the configuration.
 
-The tests are then runnable with `nix flake check`.
+The tests are then runnable with `nix flake check --all-systems`.
 
 There are a second set of tests, unit tests for nixvim itself, defined in `tests/lib-tests.nix` that use the `pkgs.lib.runTests` framework.
 


### PR DESCRIPTION
Right now, the CI only performs checks for x86_64-linux.
However, bugs can occur on other platforms without impacting x86 linux.
Hence, we have nothing to lose by running checks for all systems.