### PR TITLE
fix(neo-tree): per-source window mappings had two table layers called "mappings"

### DIFF
--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -1022,7 +1022,7 @@ in {
 
     processWindowMappings = window:
       ifNonNull' window {
-        mappings = processMappings window;
+        mappings = processMappings window.mappings;
       };
 
     options = with cfg;


### PR DESCRIPTION
Currently, using e.g. `filesystem.window.mappings.ga = "git_add_file"` results in an invalid configuration which contains two layers of mappings:

```
 347   │     ["filesystem"] = {
 348   │         ["window"] = {
 349   │             ["mappings"] = { ["mappings"] = { ["ga"] = "git_add_file" } },
 350   │         },
```

This PR fixes that by correctly removing the mappings layer in the `processWindowMappings` function