### PR TITLE
ktlint: enable formatter and diagnostics

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -50,6 +50,9 @@
       hadolint = {
         package = pkgs.hadolint;
       };
+      ktlint = {
+        package = pkgs.ktlint;
+      };
       luacheck = {
         package = pkgs.luaPackages.luacheck;
       };
@@ -111,6 +114,9 @@
       };
       jq = {
         package = pkgs.jq;
+      };
+      ktlint = {
+        package = pkgs.ktlint;
       };
       markdownlint = {
         package = pkgs.nodePackages.markdownlint-cli;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -50,6 +50,7 @@
           flake8.enable = true;
           gitlint.enable = true;
           golangci_lint.enable = true;
+          ktlint.enable = true;
           shellcheck.enable = true;
           statix.enable = true;
           vale.enable = true;
@@ -71,6 +72,7 @@
           fnlfmt.enable = true;
           fourmolu.enable = true;
           gofmt.enable = true;
+          ktlint.enable = true;
           nixfmt.enable = true;
           nixpkgs_fmt.enable = true;
           phpcbf.enable = true;


### PR DESCRIPTION
### Changes
 * Enable ktlint as a none-ls formatter
 * Enable ktlint as a none-ls diagnostics tool
 * Add tests for both cases

### Checks
 - [x] Alejandra style
 - [x] Flake check 
