### PR TITLE
plugins/lsp: enable auto-installing rustc and cargo

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -528,6 +528,7 @@ in {
       ./efmls-configs.nix
       ./nixd.nix
       ./pylsp.nix
+      ./rust-analyzer.nix
       ./svelte.nix
     ];
 }

--- a/plugins/lsp/language-servers/rust-analyzer.nix
+++ b/plugins/lsp/language-servers/rust-analyzer.nix
@@ -1,0 +1,81 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.lsp.servers.rust-analyzer;
+in {
+  options.plugins.lsp.servers.rust-analyzer = {
+    # https://github.com/nix-community/nixvim/issues/674
+    installCargo = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = true;
+      description = "Whether to install `cargo`.";
+    };
+
+    cargoPackage = mkOption {
+      type = types.package;
+      default = pkgs.cargo;
+      description = "Which package to use for `cargo`.";
+    };
+
+    installRustc = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = true;
+      description = "Whether to install `rustc`.";
+    };
+
+    rustcPackage = mkOption {
+      type = types.package;
+      default = pkgs.rustc;
+      description = "Which package to use for `rustc`.";
+    };
+  };
+  config = mkIf cfg.enable {
+    warnings =
+      (
+        optional
+        (cfg.installCargo == null)
+        ''
+          `rust_analyzer` relies on `cargo`.
+          - Set `plugins.lsp.servers.rust-analyzer.installCargo = true` to install it automatically
+            with Nixvim.
+            You can customize which package to install by changing
+            `plugins.lsp.servers.rust-analyzer.cargoPackage`.
+          - Set `plugins.lsp.servers.rust-analyzer.installCargo = false` to not have it install
+            through Nixvim.
+            By doing so, you will dismiss this warning.
+        ''
+      )
+      ++ (
+        optional
+        (cfg.installRustc == null)
+        ''
+          `rust_analyzer` relies on `rustc`.
+          - Set `plugins.lsp.servers.rust-analyzer.installRustc = true` to install it automatically
+            with Nixvim.
+            You can customize which package to install by changing
+            `plugins.lsp.servers.rust-analyzer.rustcPackage`.
+          - Set `plugins.lsp.servers.rust-analyzer.installRustc = false` to not have it install
+            through Nixvim.
+            By doing so, you will dismiss this warning.
+        ''
+      );
+
+    extraPackages = with pkgs;
+      (
+        optional
+        ((isBool cfg.installCargo) && cfg.installCargo)
+        cfg.cargoPackage
+      )
+      ++ (
+        optional
+        ((isBool cfg.installRustc) && cfg.installRustc)
+        cfg.rustcPackage
+      );
+  };
+}

--- a/tests/test-sources/example-configurations/issues.nix
+++ b/tests/test-sources/example-configurations/issues.nix
@@ -28,7 +28,11 @@
       lsp = {
         enable = true;
         servers = {
-          rust-analyzer.enable = true;
+          rust-analyzer = {
+            enable = true;
+            installCargo = true;
+            installRustc = true;
+          };
           rnix-lsp.enable = true;
         };
       };
@@ -75,7 +79,11 @@
         enable = true;
         servers = {
           rnix-lsp.enable = true;
-          rust-analyzer.enable = true;
+          rust-analyzer = {
+            enable = true;
+            installCargo = true;
+            installRustc = true;
+          };
           jsonls.enable = true;
         };
       };

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -43,7 +43,11 @@
           installLanguageServer = false;
         };
         nil_ls.enable = true;
-        rust-analyzer.enable = true;
+        rust-analyzer = {
+          enable = true;
+          installCargo = true;
+          installRustc = true;
+        };
         ruff-lsp = {
           enable = true;
           extraOptions = {
@@ -112,7 +116,11 @@
         pyright.enable = true;
         rnix-lsp.enable = true;
         ruff-lsp.enable = true;
-        rust-analyzer.enable = true;
+        rust-analyzer = {
+          enable = true;
+          installCargo = true;
+          installRustc = true;
+        };
         sourcekit.enable = true;
         svelte.enable = true;
         tailwindcss.enable = true;


### PR DESCRIPTION
`rust_analyzer` relies on both `cargo` and `rustc`.
This patch adds the `installCargo` and `installRustc` options which can have 3 values:
- `null` (default): does not install the package but show a warning.
- `false`: explicitly disables installing the packages.
- `true`: explicitly enables installing the packages (the user might then eventually use the `cargoPackage`/`rustcPackage` option).

Fixes #674 