### PR TITLE
plugins/ts-context-commentstring: use new setup-based init

### DIFF
--- a/plugins/languages/treesitter/ts-context-commentstring.nix
+++ b/plugins/languages/treesitter/ts-context-commentstring.nix
@@ -15,6 +15,36 @@ with lib; {
         helpers.mkPackageOption
         "ts-context-commentstring"
         pkgs.vimPlugins.nvim-ts-context-commentstring;
+
+      skipTsContextCommentStringModule = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whethter to skip backwards compatibility routines and speed up loading.
+        '';
+        example = false;
+      };
+
+      disableAutoInitialization = helpers.defaultNullOpts.mkBool false ''
+        Whether to disable auto-initialization.
+      '';
+
+      languages =
+        helpers.mkNullOrOption
+        (
+          with types;
+            attrsOf
+            (
+              either
+              str
+              (attrsOf str)
+            )
+        )
+        ''
+          Allows you to add support for more languages.
+
+          See `:h ts-context-commentstring-commentstring-configuration` for more information.
+        '';
     };
 
   config = let
@@ -27,10 +57,19 @@ with lib; {
 
       extraPlugins = [cfg.package];
 
-      plugins.treesitter.moduleConfig.context_commentstring =
-        {
-          enable = true;
-        }
-        // cfg.extraOptions;
+      globals = with cfg; {
+        skip_ts_context_commentstring_module = skipTsContextCommentStringModule;
+        loaded_ts_context_commentstring = disableAutoInitialization;
+      };
+
+      extraConfigLua = let
+        setupOptions = with cfg;
+          {
+            inherit languages;
+          }
+          // cfg.extraOptions;
+      in ''
+        require('ts_context_commentstring').setup(${helpers.toLuaObject setupOptions})
+      '';
     };
 }


### PR DESCRIPTION
This TS module has changed the way it should be initialized.
With this patch, we follow their latest setup guidelines.

Fixes #748