### PR TITLE
plugins/none-ls: add enableLspFormat option

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -272,9 +272,9 @@ with lib; rec {
   };
 
   mkRaw = r:
-    ifNonNull'
-    r
-    {__raw = r;};
+    if (isString r && (r != ""))
+    then {__raw = r;}
+    else null;
 
   wrapDo = string: ''
     do

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -14,9 +14,21 @@
   #   };
   # };
 
+  with-lsp-format = {
+    plugins = {
+      lsp-format.enable = true;
+      none-ls = {
+        enable = true;
+        enableLspFormat = true;
+      };
+    };
+  };
+
   default = {
     plugins.none-ls = {
       enable = true;
+
+      enableLspFormat = false;
       border = null;
       cmd = ["nvim"];
       debounce = 250;


### PR DESCRIPTION
This PR adds an option in `none-ls` to configure the use of `lsp-format` with it.

I also changed the behavior of `mkRaw` to ensure that `mkRaw ""` gives `null` instead of `""`.

Fixes #755 