### PR TITLE
plugins: remove mkCompositeOptions from implementation

### DIFF
--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -23,17 +23,15 @@ with lib; let
       "the button which is clicked to close / save a buffer, or indicate that it is pinned.";
 
     diagnostics =
-      helpers.mkCompositeOption "Diagnostics icons"
+      genAttrs
+      ["error" "warn" "info" "hint"]
       (
-        genAttrs
-        ["error" "warn" "info" "hint"]
-        (
-          name:
-            helpers.mkCompositeOption "${name} diagnostic icon" {
-              enable = helpers.defaultNullOpts.mkBool false "Enable the ${name} diagnostic symbol";
-              icon = helpers.mkNullOrOption types.str "${name} diagnostic symbol";
-            }
-        )
+        name:
+          helpers.mkCompositeOption "${name} diagnostic icon." {
+            enable = helpers.defaultNullOpts.mkBool false "Enable the ${name} diagnostic symbol";
+
+            icon = helpers.mkNullOrOption types.str "${name} diagnostic symbol";
+          }
       );
 
     filetype = {
@@ -250,7 +248,7 @@ in {
               buffer_index = bufferIndex;
               buffer_number = bufferNumber;
               inherit button;
-              diagnostics = helpers.ifNonNull' bufferOption.diagnostics (
+              diagnostics =
                 /*
                 Because the keys of this lua table are not strings (but
                 `vim.diagnostic.severity.XXXX`), we have to manualy build a raw lua string here.
@@ -277,8 +275,7 @@ in {
                       setIconsList
                     )
                     + "}"
-                  )
-              );
+                  );
               filetype = with filetype; {
                 custom_color = customColors;
                 enabled = enable;

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -240,19 +240,19 @@ in {
 
         offsets = helpers.defaultNullOpts.mkNullable (types.listOf types.attrs) "null" "offsets";
 
-        groups = helpers.mkCompositeOption "groups" {
+        groups = {
           items =
             helpers.defaultNullOpts.mkNullable (types.listOf types.attrs) "[]"
             "List of groups.";
 
-          options = helpers.mkCompositeOption "Group options" {
+          options = {
             toggleHiddenOnEnter =
               helpers.defaultNullOpts.mkBool true
               "Re-open hidden groups on bufenter.";
           };
         };
 
-        hover = helpers.mkCompositeOption "Hover" {
+        hover = {
           enabled = mkEnableOption "hover";
 
           reveal = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" "reveal";
@@ -260,7 +260,7 @@ in {
           delay = helpers.defaultNullOpts.mkInt 200 "delay";
         };
 
-        debug = helpers.mkCompositeOption "Debug options" {
+        debug = {
           logging = helpers.defaultNullOpts.mkBool false "Whether to enable logging";
         };
 
@@ -319,14 +319,23 @@ in {
           diagnostics_indicator = helpers.mkRaw diagnosticsIndicator;
           diagnostics_update_in_insert = diagnosticsUpdateInInsert;
           inherit offsets;
-          groups = helpers.ifNonNull' groups {
+          groups = {
             inherit (groups) items;
-            options = helpers.ifNonNull' groups.options {
+            options = {
               toggle_hidden_on_enter = groups.options.toggleHiddenOnEnter;
             };
           };
-          inherit hover;
-          inherit debug;
+          hover = {
+            inherit
+              (hover)
+              enabled
+              reveal
+              delay
+              ;
+          };
+          debug = {
+            inherit (debug) logging;
+          };
           custom_filter = helpers.mkRaw customFilter;
         }
         // cfg.extraOptions;

--- a/plugins/dap/dap-ui.nix
+++ b/plugins/dap/dap-ui.nix
@@ -58,7 +58,7 @@ in {
 
       package = helpers.mkPackageOption "dap-ui" pkgs.vimPlugins.nvim-dap-ui;
 
-      controls = helpers.mkCompositeOption "Options for dap-ui controls." {
+      controls = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable controls";
 
         element =
@@ -178,7 +178,7 @@ in {
         })
         "Keys to trigger actions in elements.";
 
-      render = helpers.mkCompositeOption "Rendering options which can be updated after initial setup." {
+      render = {
         indent = helpers.defaultNullOpts.mkInt 1 "Default indentation size.";
 
         maxTypeLength = helpers.mkNullOrOption types.int "Maximum number of characters to allow a type name to fill before trimming.";
@@ -206,11 +206,11 @@ in {
 
         force_buffers = forceBuffers;
 
-        render = helpers.ifNonNull' render (with render; {
+        render = with render; {
           inherit indent;
           max_type_length = maxTypeLength;
           max_value_lines = maxValueLines;
-        });
+        };
 
         select_window = helpers.mkRaw selectWindow;
       }

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -158,69 +158,60 @@ in {
         Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
       '';
 
-      hijackDirectories =
-        helpers.mkCompositeOption
-        "Hijacks new directory buffers when they are opened (`:e dir`)."
-        {
-          enable = helpers.defaultNullOpts.mkBool true ''
-            Enable the feature.
-            Disable this option if you use vim-dirvish or dirbuf.nvim.
-            If `hijackNetrw` and `disableNetrw` are `false`, this feature will be disabled.
-          '';
+      hijackDirectories = {
+        enable = helpers.defaultNullOpts.mkBool true ''
+          Hijacks new directory buffers when they are opened (`:e dir`).
 
-          autoOpen = helpers.defaultNullOpts.mkBool true ''
-            Opens the tree if the tree was previously closed.
-          '';
-        };
+          Disable this option if you use vim-dirvish or dirbuf.nvim.
+          If `hijackNetrw` and `disableNetrw` are `false`, this feature will be disabled.
+        '';
 
-      updateFocusedFile =
-        helpers.mkCompositeOption
-        ''
+        autoOpen = helpers.defaultNullOpts.mkBool true ''
+          Opens the tree if the tree was previously closed.
+        '';
+      };
+
+      updateFocusedFile = {
+        enable = helpers.defaultNullOpts.mkBool false ''
           Update the focused file on `BufEnter`, un-collapses the folders recursively until it finds
           the file.
-        ''
-        {
-          enable = helpers.defaultNullOpts.mkBool false "Enable this feature.";
+        '';
 
-          updateRoot = helpers.defaultNullOpts.mkBool false ''
-            Update the root directory of the tree if the file is not under current root directory.
-            It prefers vim's cwd and `root_dirs`.
-            Otherwise it falls back to the folder containing the file.
-            Only relevant when `updateFocusedFile.enable` is `true`
-          '';
+        updateRoot = helpers.defaultNullOpts.mkBool false ''
+          Update the root directory of the tree if the file is not under current root directory.
+          It prefers vim's cwd and `root_dirs`.
+          Otherwise it falls back to the folder containing the file.
+          Only relevant when `updateFocusedFile.enable` is `true`
+        '';
 
-          ignoreList = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
-            List of buffer names and filetypes that will not update the root dir of the tree if the
-            file isn't found under the current root directory.
-            Only relevant when `updateFocusedFile.updateRoot` and `updateFocusedFile.enable` are
-            `true`.
-          '';
-        };
+        ignoreList = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+          List of buffer names and filetypes that will not update the root dir of the tree if the
+          file isn't found under the current root directory.
+          Only relevant when `updateFocusedFile.updateRoot` and `updateFocusedFile.enable` are
+          `true`.
+        '';
+      };
 
-      systemOpen =
-        helpers.mkCompositeOption
-        "Open a file or directory in your preferred application."
-        {
-          cmd = helpers.defaultNullOpts.mkStr "" ''
-            The open command itself.
+      systemOpen = {
+        cmd = helpers.defaultNullOpts.mkStr "" ''
+          The open command itself.
 
-            Leave empty for OS specific default:
-              UNIX:    `"xdg-open"`
-              macOS:   `"open"`
-              Windows: "`cmd"`
-          '';
+          Leave empty for OS specific default:
+            UNIX:    `"xdg-open"`
+            macOS:   `"open"`
+            Windows: "`cmd"`
+        '';
 
-          args = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
-            Optional argument list.
+        args = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+          Optional argument list.
 
-            Leave empty for OS specific default:
-              Windows: `{ "/c", "start", '""' }`
-          '';
-        };
+          Leave empty for OS specific default:
+            Windows: `{ "/c", "start", '""' }`
+        '';
+      };
 
-      diagnostics =
-        helpers.mkCompositeOption
-        ''
+      diagnostics = {
+        enable = helpers.defaultNullOpts.mkBool false ''
           Show LSP and COC diagnostics in the signcolumn
           Note that the modified sign will take precedence over the diagnostics signs.
 
@@ -230,46 +221,46 @@ in {
           - `NvimTreeLspDiagnosticsWarning`
           - `NvimTreeLspDiagnosticsInformation`
           - `NvimTreeLspDiagnosticsHint`
-        ''
-        {
-          enable = helpers.defaultNullOpts.mkBool false "Enable/disable the feature.";
+        '';
 
-          debounceDelay = helpers.defaultNullOpts.mkInt 50 ''
-            Idle milliseconds between diagnostic event and update.
-          '';
+        debounceDelay = helpers.defaultNullOpts.mkInt 50 ''
+          Idle milliseconds between diagnostic event and update.
+        '';
 
-          showOnDirs = helpers.defaultNullOpts.mkBool false ''
-            Show diagnostic icons on parent directories.
-          '';
+        showOnDirs = helpers.defaultNullOpts.mkBool false ''
+          Show diagnostic icons on parent directories.
+        '';
 
-          showOnOpenDirs = helpers.defaultNullOpts.mkBool true ''
-            Show diagnostics icons on directories that are open.
-            Only relevant when `diagnostics.showOnDirs` is `true
-          '';
+        showOnOpenDirs = helpers.defaultNullOpts.mkBool true ''
+          Show diagnostics icons on directories that are open.
+          Only relevant when `diagnostics.showOnDirs` is `true
+        '';
 
-          icons = helpers.mkCompositeOption "Icons for diagnostic severity." {
-            hint = helpers.defaultNullOpts.mkStr "" "";
-            info = helpers.defaultNullOpts.mkStr "" "";
-            warning = helpers.defaultNullOpts.mkStr "" "";
-            error = helpers.defaultNullOpts.mkStr "" "";
-          };
-
-          severity = let
-            severityEnum = ["error" "warn" "info" "hint"];
-          in
-            helpers.mkCompositeOption
-            ''
-              Severity for which the diagnostics will be displayed.
-              See |diagnostic-severity|.
-            ''
-            {
-              min = helpers.defaultNullOpts.mkEnum severityEnum "hint" "Minimum severity.";
-              max = helpers.defaultNullOpts.mkEnum severityEnum "error" "Maximum severity.";
-            };
+        icons = {
+          hint = helpers.defaultNullOpts.mkStr "" "";
+          info = helpers.defaultNullOpts.mkStr "" "";
+          warning = helpers.defaultNullOpts.mkStr "" "";
+          error = helpers.defaultNullOpts.mkStr "" "";
         };
 
-      git = helpers.mkCompositeOption "Git integration with icons and colors." {
-        enable = helpers.defaultNullOpts.mkBool true "Enable / disable the feature.";
+        severity = let
+          severityEnum = ["error" "warn" "info" "hint"];
+        in {
+          min = helpers.defaultNullOpts.mkEnum severityEnum "hint" ''
+            Minimum severity for which the diagnostics will be displayed.
+            See `|diagnostic-severity|`.
+          '';
+          max = helpers.defaultNullOpts.mkEnum severityEnum "error" ''
+            Maximum severity for which the diagnostics will be displayed.
+            See `|diagnostic-severity|`.
+          '';
+        };
+      };
+
+      git = {
+        enable = helpers.defaultNullOpts.mkBool true ''
+          Git integration with icons and colors.
+        '';
 
         ignore = helpers.defaultNullOpts.mkBool true ''
           Ignore files based on `.gitignore`. Requires `git.enable` to be `true`.
@@ -290,8 +281,10 @@ in {
         '';
       };
 
-      modified = helpers.mkCompositeOption "Indicate which file have unsaved modification." {
-        enable = helpers.defaultNullOpts.mkBool false "Enable / disable the feature.";
+      modified = {
+        enable = helpers.defaultNullOpts.mkBool false ''
+          Indicate which file have unsaved modification.
+        '';
 
         showOnDirs = helpers.defaultNullOpts.mkBool true ''
           Show modified indication on directory whose children are modified.
@@ -303,29 +296,26 @@ in {
         '';
       };
 
-      filesystemWatchers =
-        helpers.mkCompositeOption
-        ''
+      filesystemWatchers = {
+        enable = helpers.defaultNullOpts.mkBool true ''
           Will use file system watcher (libuv fs_event) to watch the filesystem for changes.
           Using this will disable BufEnter / BufWritePost events in nvim-tree which were used to
           update the whole tree.
           With this feature, the tree will be updated only for the appropriate folder change,
           resulting in better performance.
-        ''
-        {
-          enable = helpers.defaultNullOpts.mkBool true "Enable / disable the feature.";
+        '';
 
-          debounceDelay = helpers.defaultNullOpts.mkInt 50 ''
-            Idle milliseconds between filesystem change and action.
-          '';
+        debounceDelay = helpers.defaultNullOpts.mkInt 50 ''
+          Idle milliseconds between filesystem change and action.
+        '';
 
-          ignoreDirs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
-            List of vim regex for absolute directory paths that will not be watched.
-            Backslashes must be escaped e.g. `"my-project/\\.build$"`.
-            See |string-match|.
-            Useful when path is not in `.gitignore` or git integration is disabled.
-          '';
-        };
+        ignoreDirs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+          List of vim regex for absolute directory paths that will not be watched.
+          Backslashes must be escaped e.g. `"my-project/\\.build$"`.
+          See |string-match|.
+          Useful when path is not in `.gitignore` or git integration is disabled.
+        '';
+      };
 
       onAttach =
         helpers.defaultNullOpts.mkNullable
@@ -425,7 +415,7 @@ in {
           Show diagnostic sign column. Value can be `"yes"`, `"auto"`, `"no"`.
         '';
 
-        float = helpers.mkCompositeOption "Configuration options for floating window." {
+        float = {
           enable = helpers.defaultNullOpts.mkBool false ''
             Tree window will be floating.
           '';
@@ -438,7 +428,7 @@ in {
         };
       };
 
-      renderer = helpers.mkCompositeOption "UI rendering setup" {
+      renderer = {
         addTrailing = helpers.defaultNullOpts.mkBool false ''
           Appends a trailing slash to folder names.
         '';
@@ -505,7 +495,7 @@ in {
           Number of spaces for an each tree nesting level. Minimum 1.
         '';
 
-        indentMarkers = helpers.mkCompositeOption "Configuration options for tree indent markers." {
+        indentMarkers = {
           enable = helpers.defaultNullOpts.mkBool false ''
             Display indent markers when folders are open
           '';
@@ -515,7 +505,7 @@ in {
             |renderer.icons.show.folder_arrow|.
           '';
 
-          icons = helpers.mkCompositeOption "Icons shown before the file/directory. Length 1." {
+          icons = {
             corner = helpers.defaultNullOpts.mkStr "└" "";
             edge = helpers.defaultNullOpts.mkStr "│" "";
             item = helpers.defaultNullOpts.mkStr "│" "";
@@ -524,7 +514,7 @@ in {
           };
         };
 
-        icons = helpers.mkCompositeOption "Configuration options for icons." {
+        icons = {
           webdevColors = helpers.defaultNullOpts.mkBool true ''
             Use the webdev icon colors, otherwise `NvimTreeFileIcon`.
           '';
@@ -559,7 +549,7 @@ in {
             Used as a separator between symlinks' source and target.
           '';
 
-          show = helpers.mkCompositeOption "Configuration options for showing icon types." {
+          show = {
             file = helpers.defaultNullOpts.mkBool true ''
               Show an icon before the file name. `nvim-web-devicons` will be used if available.
             '';
@@ -584,7 +574,7 @@ in {
             '';
           };
 
-          glyphs = helpers.mkCompositeOption "Configuration options for icon glyphs." {
+          glyphs = {
             default = helpers.defaultNullOpts.mkStr "" ''
               Glyph for files. Will be overridden by `nvim-web-devicons` if available.
             '';
@@ -597,7 +587,7 @@ in {
               Icon to display for modified files.
             '';
 
-            folder = helpers.mkCompositeOption "Glyphs for directories." {
+            folder = {
               arrowClosed = helpers.defaultNullOpts.mkStr "" ''
                 Arrow glyphs for closed directories.
               '';
@@ -624,7 +614,7 @@ in {
               '';
             };
 
-            git = helpers.mkCompositeOption "Glyphs for git status." {
+            git = {
               unstaged = helpers.defaultNullOpts.mkStr "✗" ''
                 Glyph for unstaged nodes.
               '';
@@ -661,7 +651,7 @@ in {
         '';
       };
 
-      filters = helpers.mkCompositeOption "Filtering options." {
+      filters = {
         dotfiles = helpers.defaultNullOpts.mkBool false ''
           Do not show dotfiles: files starting with a `.`
           Toggle via the `toggle_dotfiles` action, default mapping `H`.
@@ -692,7 +682,7 @@ in {
         '';
       };
 
-      trash = helpers.mkCompositeOption "Configuration options for trashing." {
+      trash = {
         cmd = helpers.defaultNullOpts.mkStr "gio trash" ''
           The command used to trash items (must be installed on your system).
           The default is shipped with glib2 which is a common linux package.
@@ -700,8 +690,8 @@ in {
         '';
       };
 
-      actions = helpers.mkCompositeOption "Configuration for various actions." {
-        changeDir = helpers.mkCompositeOption "vim |current-directory| behaviour." {
+      actions = {
+        changeDir = {
           enable = helpers.defaultNullOpts.mkBool true ''
             Change the working directory when changing directories in the tree.
           '';
@@ -716,7 +706,7 @@ in {
           '';
         };
 
-        expandAll = helpers.mkCompositeOption "Configuration for expand_all behaviour." {
+        expandAll = {
           maxFolderDiscovery = helpers.defaultNullOpts.mkInt 300 ''
             Limit the number of folders being explored when expanding every folders.
             Avoids hanging neovim when running this action on very large folders.
@@ -728,28 +718,26 @@ in {
           '';
         };
 
-        filePopup = helpers.mkCompositeOption "Configuration for file_popup behaviour." {
+        filePopup = {
           openWinConfig = openWinConfigOption;
         };
 
-        openFile =
-          helpers.mkCompositeOption
-          "Configuration options for opening a file from nvim-tree."
-          {
-            quitOnOpen = helpers.defaultNullOpts.mkBool false ''
-              Closes the explorer when opening a file.
-              It will also disable preventing a buffer overriding the tree.
-            '';
+        openFile = {
+          quitOnOpen = helpers.defaultNullOpts.mkBool false ''
+            Closes the explorer when opening a file.
+            It will also disable preventing a buffer overriding the tree.
+          '';
 
-            resizeWindow = helpers.defaultNullOpts.mkBool true ''
-              Resizes the tree when opening a file.
-            '';
-          };
+          resizeWindow = helpers.defaultNullOpts.mkBool true ''
+            Resizes the tree when opening a file.
+          '';
+        };
 
-        windowPicker = helpers.mkCompositeOption "Window picker configuration." {
+        windowPicker = {
           enable = helpers.defaultNullOpts.mkBool true ''
-            Enable the feature. If the feature is not enabled, files will open in window from
-            which you last opened the tree.
+            Enable the window picker.
+            If the feature is not enabled, files will open in window from which you last opened the
+            tree.
           '';
 
           picker =
@@ -783,7 +771,7 @@ in {
             '';
         };
 
-        removeFile = helpers.mkCompositeOption "" {
+        removeFile = {
           closeWindow = helpers.defaultNullOpts.mkBool true ''
             Close any window displaying a file when removing the file from the tree.
           '';
@@ -797,27 +785,18 @@ in {
         '';
       };
 
-      liveFilter =
-        helpers.mkCompositeOption
-        ''
-          Configurations for the live_filtering feature.
-          The live filter allows you to filter the tree nodes dynamically, based on regex matching
-          (see |vim.regex|).
-          This feature is bound to the `f` key by default.
-          The filter can be cleared with the `F` key by default.
-        ''
-        {
-          prefix = helpers.defaultNullOpts.mkStr "[FILTER]: " ''
-            Prefix of the filter displayed in the buffer.
-          '';
+      liveFilter = {
+        prefix = helpers.defaultNullOpts.mkStr "[FILTER]: " ''
+          Prefix of the filter displayed in the buffer.
+        '';
 
-          alwaysShowFolders = helpers.defaultNullOpts.mkBool true ''
-            Whether to filter folders or not.
-          '';
-        };
+        alwaysShowFolders = helpers.defaultNullOpts.mkBool true ''
+          Whether to filter folders or not.
+        '';
+      };
 
-      tab = helpers.mkCompositeOption "Configuration for tab behaviour." {
-        sync = helpers.mkCompositeOption "Configuration for syncing nvim-tree across tabs." {
+      tab = {
+        sync = {
           open = helpers.defaultNullOpts.mkBool false ''
             Opens the tree automatically when switching tabpage or opening a new tabpage if the tree
             was previously open.
@@ -827,14 +806,14 @@ in {
             Closes the tree across all tabpages when the tree is closed.
           '';
 
-          ignore = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+          ignore = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
             List of filetypes or buffer names on new tab that will prevent
             |nvim-tree.tab.sync.open| and |nvim-tree.tab.sync.close|
           '';
         };
       };
 
-      notify = helpers.mkCompositeOption "Configuration for notification." {
+      notify = {
         threshold = helpers.defaultNullOpts.mkEnum ["error" "warning" "info" "debug"] "info" ''
           Specify minimum notification level, uses the values from |vim.log.levels|
 
@@ -845,8 +824,8 @@ in {
         '';
       };
 
-      ui = helpers.mkCompositeOption "General UI configuration." {
-        confirm = helpers.mkCompositeOption "Confirmation prompts." {
+      ui = {
+        confirm = {
           remove = helpers.defaultNullOpts.mkBool true ''
             Prompt before removing.
           '';
@@ -857,7 +836,7 @@ in {
         };
       };
 
-      log = helpers.mkCompositeOption "Configuration for diagnostic logging." {
+      log = {
         enable = helpers.defaultNullOpts.mkBool false ''
           Enable logging to a file `$XDG_CACHE_HOME/nvim/nvim-tree.log`
         '';
@@ -866,7 +845,7 @@ in {
           Remove existing log file at startup.
         '';
 
-        types = helpers.mkCompositeOption "Specify which information to log." {
+        types = {
           all = helpers.defaultNullOpts.mkBool false "Everything.";
 
           profile = helpers.defaultNullOpts.mkBool false "Timing of some operations.";
@@ -904,54 +883,47 @@ in {
         sync_root_with_cwd = syncRootWithCwd;
         reload_on_bufenter = reloadOnBufenter;
         respect_buf_cwd = respectBufCwd;
-        hijack_directories = with hijackDirectories;
-          ifNonNull' cfg.hijackDirectories {
-            inherit enable;
-            auto_open = autoOpenEnabled;
-          };
-        update_focused_file = with updateFocusedFile;
-          ifNonNull' cfg.updateFocusedFile {
-            inherit enable;
-            update_root = updateRoot;
-            ignore_list = ignoreList;
-          };
+        hijack_directories = with hijackDirectories; {
+          inherit enable;
+          auto_open = autoOpenEnabled;
+        };
+        update_focused_file = with updateFocusedFile; {
+          inherit enable;
+          update_root = updateRoot;
+          ignore_list = ignoreList;
+        };
         system_open = systemOpen;
-        diagnostics = with diagnostics;
-          ifNonNull' cfg.diagnostics {
-            inherit enable;
-            debounce_delay = debounceDelay;
-            show_on_dirs = showOnDirs;
-            show_on_open_dirs = showOnOpenDirs;
-            inherit icons;
-            severity = ifNonNull' cfg.diagnostics.severity (
-              mapAttrs (
-                name: value:
-                  ifNonNull' value
-                  (helpers.mkRaw "vim.diagnostic.severity.${strings.toUpper value}")
-              )
-              severity
-            );
-          };
-        git = with git;
-          ifNonNull' cfg.git {
-            inherit enable;
-            inherit ignore;
-            show_on_dirs = showOnDirs;
-            show_on_open_dirs = showOnOpenDirs;
-            inherit timeout;
-          };
-        modified = with modified;
-          ifNonNull' cfg.modified {
-            inherit enable;
-            show_on_dirs = showOnDirs;
-            show_on_open_dirs = showOnOpenDirs;
-          };
-        filesystem_watchers = with filesystemWatchers;
-          ifNonNull' cfg.filesystemWatchers {
-            inherit enable;
-            debounce_delay = debounceDelay;
-            ignore_dirs = ignoreDirs;
-          };
+        diagnostics = with diagnostics; {
+          inherit enable;
+          debounce_delay = debounceDelay;
+          show_on_dirs = showOnDirs;
+          show_on_open_dirs = showOnOpenDirs;
+          inherit icons;
+          severity =
+            mapAttrs (
+              name: value:
+                ifNonNull' value
+                (helpers.mkRaw "vim.diagnostic.severity.${strings.toUpper value}")
+            )
+            severity;
+        };
+        git = with git; {
+          inherit enable;
+          inherit ignore;
+          show_on_dirs = showOnDirs;
+          show_on_open_dirs = showOnOpenDirs;
+          inherit timeout;
+        };
+        modified = with modified; {
+          inherit enable;
+          show_on_dirs = showOnDirs;
+          show_on_open_dirs = showOnOpenDirs;
+        };
+        filesystem_watchers = with filesystemWatchers; {
+          inherit enable;
+          debounce_delay = debounceDelay;
+          ignore_dirs = ignoreDirs;
+        };
         on_attach = onAttach;
         select_prompts = selectPrompts;
         view = with view; {
@@ -964,114 +936,96 @@ in {
           inherit number;
           inherit relativenumber;
           inherit signcolumn;
-          float = with float;
-            ifNonNull' cfg.view.float {
-              inherit enable;
-              quit_on_focus_loss = quitOnFocusLoss;
-              open_win_config = openWinConfig;
-            };
+          float = with float; {
+            inherit enable;
+            quit_on_focus_loss = quitOnFocusLoss;
+            open_win_config = openWinConfig;
+          };
         };
-        renderer = with renderer;
-          ifNonNull' cfg.renderer {
-            add_trailing = addTrailing;
-            group_empty = groupEmpty;
-            full_name = fullName;
-            highlight_git = highlightGit;
-            highlight_opened_files = highlightOpenedFiles;
-            highlight_modified = highlightModified;
-            root_folder_label = rootFolderLabel;
-            indent_width = indentWidth;
-            indent_markers = with indentMarkers;
-              ifNonNull' cfg.renderer.indentMarkers {
-                inherit enable icons;
-                inline_arrows = inlineArrows;
-              };
-            icons = with icons;
-              ifNonNull' cfg.renderer.icons {
-                webdev_colors = webdevColors;
-                git_placement = gitPlacement;
-                modified_placement = modifiedPlacement;
-                inherit padding;
-                symlink_arrow = symlinkArrow;
-                show = with show;
-                  ifNonNull' cfg.renderer.icons.show {
-                    inherit file folder git modified;
-                    folder_arrow = folderArrow;
-                  };
-                glyphs = with glyphs;
-                  ifNonNull' cfg.renderer.icons.glyphs {
-                    inherit default symlink modified git;
-                    folder = with folder; {
-                      arrow_closed = arrowClosed;
-                      arrow_open = arrowOpen;
-                      inherit default open empty symlink;
-                      empty_open = emptyOpen;
-                      symlink_open = symlinkOpen;
-                    };
-                  };
-              };
-            special_files = specialFiles;
-            symlink_destination = symlinkDestination;
+        renderer = with renderer; {
+          add_trailing = addTrailing;
+          group_empty = groupEmpty;
+          full_name = fullName;
+          highlight_git = highlightGit;
+          highlight_opened_files = highlightOpenedFiles;
+          highlight_modified = highlightModified;
+          root_folder_label = rootFolderLabel;
+          indent_width = indentWidth;
+          indent_markers = with indentMarkers; {
+            inherit enable icons;
+            inline_arrows = inlineArrows;
           };
-        filters = with filters;
-          ifNonNull' cfg.filters {
-            inherit dotfiles custom exclude;
-            git_clean = gitClean;
-            no_buffer = noBuffer;
+          icons = with icons; {
+            webdev_colors = webdevColors;
+            git_placement = gitPlacement;
+            modified_placement = modifiedPlacement;
+            inherit padding;
+            symlink_arrow = symlinkArrow;
+            show = with show; {
+              inherit file folder git modified;
+              folder_arrow = folderArrow;
+            };
+            glyphs = with glyphs; {
+              inherit default symlink modified git;
+              folder = with folder; {
+                arrow_closed = arrowClosed;
+                arrow_open = arrowOpen;
+                inherit default open empty symlink;
+                empty_open = emptyOpen;
+                symlink_open = symlinkOpen;
+              };
+            };
           };
+          special_files = specialFiles;
+          symlink_destination = symlinkDestination;
+        };
+        filters = with filters; {
+          inherit dotfiles custom exclude;
+          git_clean = gitClean;
+          no_buffer = noBuffer;
+        };
         inherit trash;
-        actions = with actions;
-          ifNonNull' cfg.actions {
-            change_dir = with changeDir;
-              ifNonNull' cfg.actions.changeDir {
-                inherit enable global;
-                restrict_above_cwd = restrictAboveCwd;
-              };
-            expand_all = with expandAll;
-              ifNonNull' cfg.actions.expandAll {
-                max_folder_discovery = maxFolderDiscovery;
-                inherit exclude;
-              };
-            file_popup = with filePopup;
-              ifNonNull' cfg.actions.filePopup {
-                open_win_config = filePopup.openWinConfig;
-              };
-            open_file = with openFile;
-              ifNonNull' cfg.actions.openFile {
-                quit_on_open = quitOnOpen;
-                resize_window = resizeWindow;
-                window_picker = windowPicker;
-              };
-            remove_file = with removeFile;
-              ifNonNull' cfg.actions.removeFile {
-                close_window = removeFile.closeWindow;
-              };
-            use_system_clipboard = useSystemClipboard;
+        actions = with actions; {
+          change_dir = with changeDir; {
+            inherit enable global;
+            restrict_above_cwd = restrictAboveCwd;
           };
-        live_filter = with liveFilter;
-          ifNonNull' cfg.liveFilter {
-            inherit prefix;
-            always_show_folders = alwaysShowFolders;
+          expand_all = with expandAll; {
+            max_folder_discovery = maxFolderDiscovery;
+            inherit exclude;
           };
+          file_popup = with filePopup; {
+            open_win_config = openWinConfig;
+          };
+          open_file = with openFile; {
+            quit_on_open = quitOnOpen;
+            resize_window = resizeWindow;
+            window_picker = windowPicker;
+          };
+          remove_file = with removeFile; {
+            close_window = closeWindow;
+          };
+          use_system_clipboard = useSystemClipboard;
+        };
+        live_filter = with liveFilter; {
+          inherit prefix;
+          always_show_folders = alwaysShowFolders;
+        };
         inherit tab;
-        notify = with notify;
-          ifNonNull' cfg.notify {
-            threshold =
-              ifNonNull' cfg.notify.threshold
-              (helpers.mkRaw "vim.log.levels.${strings.toUpper notify.threshold}");
-          };
+        notify = with notify; {
+          threshold =
+            ifNonNull' cfg.notify.threshold
+            (helpers.mkRaw "vim.log.levels.${strings.toUpper notify.threshold}");
+        };
         inherit ui;
-        log = with log;
-          ifNonNull' cfg.log {
-            inherit enable truncate;
-            types = ifNonNull' log.types (
-              with log.types; {
-                inherit all profile dev diagnostics git watcher;
-                inherit (log.types) config;
-                copy_paste = copyPaste;
-              }
-            );
+        log = with log; {
+          inherit enable truncate;
+          types = with log.types; {
+            inherit all profile dev diagnostics git watcher;
+            inherit (log.types) config;
+            copy_paste = copyPaste;
           };
+        };
       }
       // cfg.extraOptions;
 

--- a/plugins/languages/markdown-preview.nix
+++ b/plugins/languages/markdown-preview.nix
@@ -51,7 +51,7 @@ in {
         A custom vim function name to open preview page. This function will receive url as param.
       '';
 
-      previewOptions = helpers.mkCompositeOption "Options for markdown render" {
+      previewOptions = {
         mkit = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" "markdown-it options for render";
         katex = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" "katex options for math";
         uml = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" "markdown-it-plantuml options";
@@ -108,7 +108,7 @@ in {
       mkdp_browser = mkIf (cfg.browser != null) cfg.browser;
       mkdp_echo_preview_url = mkIf (cfg.echoPreviewUrl != null) cfg.echoPreviewUrl;
       mkdp_browserfunc = mkIf (cfg.browserFunc != null) cfg.browserFunc;
-      mkdp_preview_options = mkIf (cfg.previewOptions != null) cfg.previewOptions;
+      mkdp_preview_options = cfg.previewOptions;
       mkdp_markdown_css = mkIf (cfg.markdownCss != null) cfg.markdownCss;
       mkdp_highlight_css = mkIf (cfg.highlightCss != null) cfg.highlightCss;
       mkdp_port = mkIf (cfg.port != null) cfg.port;

--- a/plugins/languages/rust.nix
+++ b/plugins/languages/rust.nix
@@ -35,7 +35,7 @@ in {
         Automatically call RustReloadWorkspace when writing to a Cargo.toml file.
       '';
 
-      inlayHints = helpers.mkCompositeOption "inlay hints" {
+      inlayHints = {
         auto = helpers.defaultNullOpts.mkBool true "automatically set inlay hints (type hints)";
 
         onlyCurrentLine = helpers.defaultNullOpts.mkBool false "Only show for current line";
@@ -71,7 +71,7 @@ in {
         highlight = helpers.defaultNullOpts.mkStr "Comment" "The color of the hints";
       };
 
-      hoverActions = helpers.mkCompositeOption "hover actions" {
+      hoverActions = {
         border =
           helpers.defaultNullOpts.mkBorder ''
             [
@@ -100,7 +100,7 @@ in {
           "whether the hover action window gets automatically focused";
       };
 
-      crateGraph = helpers.mkCompositeOption "create graph" {
+      crateGraph = {
         backend = helpers.defaultNullOpts.mkStr "x11" ''
           Backend used for displaying the graph
           see: https://graphviz.org/docs/outputs/
@@ -146,34 +146,30 @@ in {
             on_initialized = helpers.mkRaw cfg.onInitialized;
 
             reload_workspace_from_cargo_toml = cfg.reloadWorkspaceFromCargoToml;
-            inlay_hints = with cfg.inlayHints;
-              helpers.ifNonNull' cfg.inlayHints {
-                inherit auto;
-                only_current_line = onlyCurrentLine;
-                show_parameter_hints = showParameterHints;
-                parameter_hints_prefix = parameterHintsPrefix;
-                other_hints_prefix = otherHintsPrefix;
-                max_len_align = maxLenAlign;
-                max_len_align_padding = maxLenAlignPadding;
-                right_align = rightAlign;
-                right_align_padding = rightAlignPadding;
-                inherit highlight;
-              };
+            inlay_hints = with cfg.inlayHints; {
+              inherit auto;
+              only_current_line = onlyCurrentLine;
+              show_parameter_hints = showParameterHints;
+              parameter_hints_prefix = parameterHintsPrefix;
+              other_hints_prefix = otherHintsPrefix;
+              max_len_align = maxLenAlign;
+              max_len_align_padding = maxLenAlignPadding;
+              right_align = rightAlign;
+              right_align_padding = rightAlignPadding;
+              inherit highlight;
+            };
 
-            hover_actions = with cfg.hoverActions;
-              helpers.ifNonNull' cfg.hoverActions
-              {
-                inherit border;
-                max_width = maxWidth;
-                max_height = maxHeight;
-                auto_focus = autoFocus;
-              };
+            hover_actions = with cfg.hoverActions; {
+              inherit border;
+              max_width = maxWidth;
+              max_height = maxHeight;
+              auto_focus = autoFocus;
+            };
 
-            crate_graph = with cfg.crateGraph;
-              helpers.ifNonNull' cfg.crateGraph {
-                inherit backend output full;
-                enabled_graphviz_backends = enabledGraphvizBackends;
-              };
+            crate_graph = with cfg.crateGraph; {
+              inherit backend output full;
+              enabled_graphviz_backends = enabledGraphvizBackends;
+            };
           };
           server = {
             inherit (cfg.server) standalone;

--- a/plugins/languages/sniprun.nix
+++ b/plugins/languages/sniprun.nix
@@ -56,7 +56,7 @@ in {
         helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["VirtualTextOk"]''
         "Display modes used in live_mode";
 
-      displayOptions = helpers.mkCompositeOption "Display options" {
+      displayOptions = {
         terminalWidth =
           helpers.defaultNullOpts.mkInt 45
           "Change the terminal display option width.";
@@ -77,42 +77,37 @@ in {
           bg ? "",
           ctermbg ? "",
           ctermfg ? "",
-        }:
-          helpers.mkCompositeOption "" {
-            bg = helpers.defaultNullOpts.mkStr fg "Background color";
-            fg = helpers.defaultNullOpts.mkStr bg "Foreground color";
-            ctermbg = helpers.defaultNullOpts.mkStr ctermbg "Foreground color";
-            ctermfg = helpers.defaultNullOpts.mkStr ctermfg "Foreground color";
-          };
+        }: {
+          bg = helpers.defaultNullOpts.mkStr fg "Background color";
+          fg = helpers.defaultNullOpts.mkStr bg "Foreground color";
+          ctermbg = helpers.defaultNullOpts.mkStr ctermbg "Foreground color";
+          ctermfg = helpers.defaultNullOpts.mkStr ctermfg "Foreground color";
+        };
       in
-        helpers.mkCompositeOption
-        "Customize highlight groups (setting this overrides colorscheme)"
-        (
-          mapAttrs
-          (optionName: colorOption)
-          {
-            SniprunVirtualTextOk = {
-              bg = "#66eeff";
-              fg = "#000000";
-              ctermbg = "Cyan";
-              ctermfg = "Black";
-            };
-            SniprunFloatingWinOk = {
-              fg = "#66eeff";
-              ctermfg = "Cyan";
-            };
-            SniprunVirtualTextErr = {
-              bg = "#881515";
-              fg = "#000000";
-              ctermbg = "DarkRed";
-              ctermfg = "Black";
-            };
-            SniprunFloatingWinErr = {
-              fg = "#881515";
-              ctermfg = "DarkRed";
-            };
-          }
-        );
+        mapAttrs
+        (optionName: colorOption)
+        {
+          SniprunVirtualTextOk = {
+            bg = "#66eeff";
+            fg = "#000000";
+            ctermbg = "Cyan";
+            ctermfg = "Black";
+          };
+          SniprunFloatingWinOk = {
+            fg = "#66eeff";
+            ctermfg = "Cyan";
+          };
+          SniprunVirtualTextErr = {
+            bg = "#881515";
+            fg = "#000000";
+            ctermbg = "DarkRed";
+            ctermfg = "Black";
+          };
+          SniprunFloatingWinErr = {
+            fg = "#881515";
+            ctermfg = "DarkRed";
+          };
+        };
 
       liveModeToggle =
         helpers.defaultNullOpts.mkStr "off"
@@ -144,11 +139,10 @@ in {
           interpreter_options = cfg.interpreterOptions;
           inherit (cfg) display;
           live_display = cfg.liveDisplay;
-          display_options = with cfg.displayOptions;
-            helpers.ifNonNull' cfg.displayOptions {
-              terminal_width = terminalWidth;
-              notification_timeout = notificationTimeout;
-            };
+          display_options = with cfg.displayOptions; {
+            terminal_width = terminalWidth;
+            notification_timeout = notificationTimeout;
+          };
           show_no_output = cfg.showNoOutput;
           inherit (cfg) snipruncolors;
           live_mode_toggle = cfg.liveModeToggle;

--- a/plugins/lsp/fidget.nix
+++ b/plugins/lsp/fidget.nix
@@ -16,7 +16,7 @@ in {
 
         package = helpers.mkPackageOption "fidget" pkgs.vimPlugins.fidget-nvim;
 
-        text = helpers.mkCompositeOption "Fidget text options." {
+        text = {
           spinner =
             helpers.defaultNullOpts.mkNullable
             (types.either
@@ -75,7 +75,7 @@ in {
           '';
         };
 
-        align = helpers.mkCompositeOption "Fidget alignment options." {
+        align = {
           bottom = helpers.defaultNullOpts.mkBool true ''
             Whether to align fidgets along the bottom edge of each buffer.
           '';
@@ -88,7 +88,7 @@ in {
           '';
         };
 
-        timer = helpers.mkCompositeOption "Fidget timing options." {
+        timer = {
           spinnerRate = helpers.defaultNullOpts.mkNum 125 ''
             Duration of each frame of the spinner animation, in ms. Set to
             `0` to only use the first frame of the spinner animation.
@@ -109,7 +109,7 @@ in {
           '';
         };
 
-        window = helpers.mkCompositeOption "Windowing rules options." {
+        window = {
           relative = helpers.defaultNullOpts.mkEnum ["win" "editor"] "win" ''
             Whether to position the window relative to the current window,
             or the editor. Valid values are `"win"` or `"editor"`.
@@ -129,7 +129,7 @@ in {
           '';
         };
 
-        fmt = helpers.mkCompositeOption "Fidget formatting options." {
+        fmt = {
           leftpad = helpers.defaultNullOpts.mkBool true ''
             Whether to right-justify the text in a fidget box by left-padding
             it with spaces. Recommended when `align.right` is `true`.
@@ -194,7 +194,7 @@ in {
             List of options for fidget sources.
           '';
 
-        debug = helpers.mkCompositeOption "Fidget debugging options." {
+        debug = {
           logging = helpers.defaultNullOpts.mkBool false ''
             Whether to enable logging, for debugging. The log is written to
             `~/.local/share/nvim/fidget.nvim.log`.
@@ -216,12 +216,12 @@ in {
     setupOptions =
       {
         inherit (cfg) text align window sources;
-        timer = helpers.ifNonNull' cfg.timer {
+        timer = {
           spinner_rate = cfg.timer.spinnerRate;
           fidget_decay = cfg.timer.fidgetDecay;
           task_decay = cfg.timer.taskDecay;
         };
-        fmt = helpers.ifNonNull' cfg.fmt {
+        fmt = {
           inherit (cfg.fmt) leftpad fidget task;
           stack_upwards = cfg.fmt.stackUpwards;
           max_width = cfg.fmt.maxWidth;

--- a/plugins/lsp/language-servers/pylsp.nix
+++ b/plugins/lsp/language-servers/pylsp.nix
@@ -23,14 +23,14 @@ in {
     };
 
     plugins = {
-      autopep8 = helpers.mkCompositeOption "autopep8 settings" {
+      autopep8 = {
         enabled = helpers.defaultNullOpts.mkBool true ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin (autopep8).
         '';
       };
 
-      flake8 = helpers.mkCompositeOption "flake8 settings" {
+      flake8 = {
         config = helpers.mkNullOrOption types.str ''
           Path to the config file that will be the authoritative config source.
         '';
@@ -84,7 +84,7 @@ in {
         '';
       };
 
-      jedi = helpers.mkCompositeOption "jedi settings" {
+      jedi = {
         auto_import_modules =
           helpers.defaultNullOpts.mkNullable
           (types.listOf types.str)
@@ -100,7 +100,7 @@ in {
         '';
       };
 
-      jedi_completion = helpers.mkCompositeOption "jedi_completion settings" {
+      jedi_completion = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
 
         include_params = helpers.defaultNullOpts.mkBool true ''
@@ -134,7 +134,7 @@ in {
           "Modules for which labels and snippets should be cached.";
       };
 
-      jedi_definition = helpers.mkCompositeOption "jedi_definition settings" {
+      jedi_definition = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
 
         follow_imports = helpers.defaultNullOpts.mkBool true ''
@@ -150,19 +150,19 @@ in {
         '';
       };
 
-      jedi_hover = helpers.mkCompositeOption "jedi_hover settings" {
+      jedi_hover = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
       };
 
-      jedi_references = helpers.mkCompositeOption "jedi_references settings" {
+      jedi_references = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
       };
 
-      jedi_signature_help = helpers.mkCompositeOption "jedi_signature_help settings" {
+      jedi_signature_help = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
       };
 
-      jedi_symbols = helpers.mkCompositeOption "jedi_symbols settings" {
+      jedi_symbols = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
 
         all_scopes = helpers.defaultNullOpts.mkBool true ''
@@ -174,7 +174,7 @@ in {
         '';
       };
 
-      mccabe = helpers.mkCompositeOption "mccabe settings" {
+      mccabe = {
         enabled = helpers.defaultNullOpts.mkBool true ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin (mccabe).
@@ -185,7 +185,7 @@ in {
         '';
       };
 
-      preload = helpers.mkCompositeOption "preload settings" {
+      preload = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
 
         modules = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
@@ -193,7 +193,7 @@ in {
         '';
       };
 
-      pycodestyle = helpers.mkCompositeOption "pycodestyle settings" {
+      pycodestyle = {
         enabled = helpers.defaultNullOpts.mkBool true ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin
@@ -229,7 +229,7 @@ in {
         '';
       };
 
-      pydocstyle = helpers.mkCompositeOption "pydocstyle settings" {
+      pydocstyle = {
         enabled = helpers.defaultNullOpts.mkBool false ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin
@@ -273,14 +273,14 @@ in {
         '';
       };
 
-      pyflakes = helpers.mkCompositeOption "pyflakes settings" {
+      pyflakes = {
         enabled = helpers.defaultNullOpts.mkBool true ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin (pyflakes).
         '';
       };
 
-      pylint = helpers.mkCompositeOption "pylint settings" {
+      pylint = {
         enabled = helpers.defaultNullOpts.mkBool false ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin (pylint).
@@ -297,7 +297,7 @@ in {
         '';
       };
 
-      rope_autoimport = helpers.mkCompositeOption "rope_autoimport settings" {
+      rope_autoimport = {
         enabled = helpers.defaultNullOpts.mkBool false ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin (rope).
@@ -309,7 +309,7 @@ in {
         '';
       };
 
-      rope_completion = helpers.mkCompositeOption "rope_completion settings" {
+      rope_completion = {
         enabled = helpers.defaultNullOpts.mkBool false ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin (rope).
@@ -320,7 +320,7 @@ in {
         '';
       };
 
-      yapf = helpers.mkCompositeOption "yapf settings" {
+      yapf = {
         enabled = helpers.defaultNullOpts.mkBool true ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin (yapf).
@@ -328,7 +328,7 @@ in {
       };
 
       ### THIRD-PARTY PLUGINS
-      pylsp_mypy = helpers.mkCompositeOption "pylsp_mypy settings" {
+      pylsp_mypy = {
         enabled = helpers.defaultNullOpts.mkBool false ''
           Enable or disable the plugin.
           Setting this explicitely to `true` will install the dependency for this plugin
@@ -484,7 +484,7 @@ in {
       ### END OF THIRD-PARTY PLUGINS
     };
 
-    rope = helpers.mkCompositeOption "rope settings" {
+    rope = {
       extensionModules = helpers.mkNullOrOption types.str ''
         Builtin and c-extension modules that are allowed to be imported and inspected by rope.
       '';
@@ -504,7 +504,7 @@ in {
       # plugins to its `propagatedBuildInputs`.
       # See https://github.com/NixOS/nixpkgs/issues/229337
       plugins.lsp.servers.pylsp.package = let
-        isEnabled = x: (x != null) && (x.enabled != null && x.enabled);
+        isEnabled = x: (x.enabled != null && x.enabled);
         inherit (cfg.settings) plugins;
 
         nativePlugins =

--- a/plugins/lsp/trouble.nix
+++ b/plugins/lsp/trouble.nix
@@ -48,90 +48,84 @@ in
         padding = helpers.defaultNullOpts.mkBool true "Add an extra new line on top of the list";
 
         actionKeys =
-          helpers.mkCompositeOption
-          ''
-            Key mappings for actions in the trouble list.
-            Map to `{}` to remove a mapping, for example:
-            `close = {};`
-          ''
-          (mapAttrs
-            (
-              action: config:
-                helpers.defaultNullOpts.mkNullable
-                (with types; either str (listOf str))
-                config.default
-                config.description
-            )
-            {
-              close = {
-                default = "q";
-                description = "Close the list";
-              };
-              cancel = {
-                default = "<esc>";
-                description = "Cancel the preview and get back to your last window / buffer / cursor";
-              };
-              refresh = {
-                default = "r";
-                description = "Manually refresh";
-              };
-              jump = {
-                default = "[ \"<cr>\" \"<tab>\" ]";
-                description = "Jump to the diagnostic or open / close folds";
-              };
-              openSplit = {
-                default = "[ \"<c-x>\" ]";
-                description = "Open buffer in new split";
-              };
-              openVsplit = {
-                default = "[ \"<c-v>\" ]";
-                description = "Open buffer in new vsplit";
-              };
-              openTab = {
-                default = "[ \"<c-t>\" ]";
-                description = "Open buffer in new tab";
-              };
-              jumpClose = {
-                default = "[ \"o\" ]";
-                description = "Jump to the diagnostic and close the list";
-              };
-              toggleMode = {
-                default = "m";
-                description = "toggle between 'workspace' and 'document' diagnostics mode";
-              };
-              togglePreview = {
-                default = "P";
-                description = "Toggle auto_preview";
-              };
-              hover = {
-                default = "K";
-                description = "Opens a small popup with the full multiline message";
-              };
-              preview = {
-                default = "p";
-                description = "Preview the diagnostic location";
-              };
-              closeFolds = {
-                default = "[ \"zM\" \"zm\" ]";
-                description = "Close all folds";
-              };
-              openFolds = {
-                default = "[ \"zR\" \"zr\" ]";
-                description = "Open all folds";
-              };
-              toggleFold = {
-                default = "[ \"zA\" \"za\" ]";
-                description = "Toggle fold of current file";
-              };
-              previous = {
-                default = "k";
-                description = "Previous item";
-              };
-              next = {
-                default = "j";
-                description = "Next item";
-              };
-            });
+          mapAttrs
+          (
+            action: config:
+              helpers.defaultNullOpts.mkNullable
+              (with types; either str (listOf str))
+              config.default
+              config.description
+          )
+          {
+            close = {
+              default = "q";
+              description = "Close the list";
+            };
+            cancel = {
+              default = "<esc>";
+              description = "Cancel the preview and get back to your last window / buffer / cursor";
+            };
+            refresh = {
+              default = "r";
+              description = "Manually refresh";
+            };
+            jump = {
+              default = "[ \"<cr>\" \"<tab>\" ]";
+              description = "Jump to the diagnostic or open / close folds";
+            };
+            openSplit = {
+              default = "[ \"<c-x>\" ]";
+              description = "Open buffer in new split";
+            };
+            openVsplit = {
+              default = "[ \"<c-v>\" ]";
+              description = "Open buffer in new vsplit";
+            };
+            openTab = {
+              default = "[ \"<c-t>\" ]";
+              description = "Open buffer in new tab";
+            };
+            jumpClose = {
+              default = "[ \"o\" ]";
+              description = "Jump to the diagnostic and close the list";
+            };
+            toggleMode = {
+              default = "m";
+              description = "toggle between 'workspace' and 'document' diagnostics mode";
+            };
+            togglePreview = {
+              default = "P";
+              description = "Toggle auto_preview";
+            };
+            hover = {
+              default = "K";
+              description = "Opens a small popup with the full multiline message";
+            };
+            preview = {
+              default = "p";
+              description = "Preview the diagnostic location";
+            };
+            closeFolds = {
+              default = "[ \"zM\" \"zm\" ]";
+              description = "Close all folds";
+            };
+            openFolds = {
+              default = "[ \"zR\" \"zr\" ]";
+              description = "Open all folds";
+            };
+            toggleFold = {
+              default = "[ \"zA\" \"za\" ]";
+              description = "Toggle fold of current file";
+            };
+            previous = {
+              default = "k";
+              description = "Previous item";
+            };
+            next = {
+              default = "j";
+              description = "Next item";
+            };
+          };
 
         indentLines = helpers.defaultNullOpts.mkBool true ''
           Add an indent guide below the fold icons.
@@ -161,21 +155,18 @@ in
           "For the given modes, automatically jump if there is only a single result.";
 
         signs =
-          helpers.mkCompositeOption "Incons/text used for the different diagnostics."
+          mapAttrs
           (
-            mapAttrs
-            (
-              diagnostic: default:
-                helpers.defaultNullOpts.mkStr default "Icon/text for ${diagnostic} diagnostics."
-            )
-            {
-              error = "";
-              warning = "";
-              hint = "";
-              information = "";
-              other = "﫠";
-            }
-          );
+            diagnostic: default:
+              helpers.defaultNullOpts.mkStr default "Icon/text for ${diagnostic} diagnostics."
+          )
+          {
+            error = "";
+            warning = "";
+            hint = "";
+            information = "";
+            other = "﫠";
+          };
 
         useDiagnosticSigns = helpers.defaultNullOpts.mkBool false ''
           Enabling this will use the signs defined in your lsp client
@@ -197,22 +188,6 @@ in
             fold_open = cfg.foldOpen;
             fold_closed = cfg.foldClosed;
             inherit (cfg) group padding;
-            action_keys =
-              helpers.ifNonNull' cfg.actionKeys
-              (with cfg.actionKeys; {
-                inherit close cancel refresh jump;
-                open_split = openSplit;
-                open_vsplit = openVsplit;
-                open_tab = openTab;
-                jump_close = jumpClose;
-                toggle_mode = toggleMode;
-                toggle_preview = togglePreview;
-                inherit hover preview;
-                close_folds = closeFolds;
-                open_folds = openFolds;
-                toggle_fold = toggleFold;
-                inherit next;
-              });
             indent_lines = cfg.indentLines;
             auto_open = cfg.autoOpen;
             auto_close = cfg.autoClose;
@@ -220,6 +195,23 @@ in
             auto_fold = cfg.autoFold;
             auto_jump = cfg.autoJump;
             inherit (cfg) signs;
+            action_keys = with cfg.actionKeys; {
+              inherit close cancel refresh jump;
+              open_split = openSplit;
+              open_vsplit = openVsplit;
+              open_tab = openTab;
+              jump_close = jumpClose;
+              toggle_mode = toggleMode;
+              toggle_preview = togglePreview;
+              inherit
+                hover
+                preview
+                ;
+              close_folds = closeFolds;
+              open_folds = openFolds;
+              toggle_fold = toggleFold;
+              inherit next;
+            };
             use_diagnostic_signs = cfg.useDiagnosticSigns;
           }
           // cfg.extraOptions;

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -11,12 +11,10 @@ with lib; let
   mkSeparatorsOption = {
     leftDefault ? " ",
     rightDefault ? " ",
-    name,
-  }:
-    helpers.mkCompositeOption "${name} separtors." {
-      left = helpers.defaultNullOpts.mkStr leftDefault "Left separator";
-      right = helpers.defaultNullOpts.mkStr rightDefault "Right separator";
-    };
+  }: {
+    left = helpers.defaultNullOpts.mkStr leftDefault "Left separator";
+    right = helpers.defaultNullOpts.mkStr rightDefault "Right separator";
+  };
 
   mkComponentOptions = defaultName:
     helpers.mkNullOrOption
@@ -55,7 +53,7 @@ with lib; let
               )
               "Defines the icon to be displayed in front of the component.";
 
-            separator = mkSeparatorsOption {name = "Component";};
+            separator = mkSeparatorsOption {};
 
             color = helpers.mkNullOrOption (types.attrsOf types.str) ''
               Defines a custom color for the component.
@@ -92,15 +90,14 @@ with lib; let
       ))
     "";
 
-  mkEmptySectionOption = name:
-    helpers.mkCompositeOption name {
-      lualine_a = mkComponentOptions "";
-      lualine_b = mkComponentOptions "";
-      lualine_c = mkComponentOptions "";
-      lualine_x = mkComponentOptions "";
-      lualine_y = mkComponentOptions "";
-      lualine_z = mkComponentOptions "";
-    };
+  mkEmptySectionOption = name: {
+    lualine_a = mkComponentOptions "";
+    lualine_b = mkComponentOptions "";
+    lualine_c = mkComponentOptions "";
+    lualine_x = mkComponentOptions "";
+    lualine_y = mkComponentOptions "";
+    lualine_z = mkComponentOptions "";
+  };
 in {
   options = {
     plugins.lualine = {
@@ -119,16 +116,14 @@ in {
       componentSeparators = mkSeparatorsOption {
         leftDefault = "";
         rightDefault = "";
-        name = "component";
       };
 
       sectionSeparators = mkSeparatorsOption {
         leftDefault = "";
         rightDefault = "";
-        name = "section";
       };
 
-      disabledFiletypes = helpers.mkCompositeOption "Filetypes to disable lualine for." {
+      disabledFiletypes = {
         statusline = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
           Only ignores the ft for statusline.
         '';
@@ -157,23 +152,15 @@ in {
         This feature is only available in neovim 0.7 and higher.
       '';
 
-      refresh =
-        helpers.mkCompositeOption
-        ''
-          Sets how often lualine should refresh it's contents (in ms).
-          The refresh option sets minimum time that lualine tries to maintain between refresh.
-          It's not guarantied if situation arises that lualine needs to refresh itself before this
-          time it'll do it.
-        ''
-        {
-          statusline = helpers.defaultNullOpts.mkInt 1000 "Refresh time for the status line (ms)";
+      refresh = {
+        statusline = helpers.defaultNullOpts.mkInt 1000 "Refresh time for the status line (ms)";
 
-          tabline = helpers.defaultNullOpts.mkInt 1000 "Refresh time for the tabline (ms)";
+        tabline = helpers.defaultNullOpts.mkInt 1000 "Refresh time for the tabline (ms)";
 
-          winbar = helpers.defaultNullOpts.mkInt 1000 "Refresh time for the winbar (ms)";
-        };
+        winbar = helpers.defaultNullOpts.mkInt 1000 "Refresh time for the winbar (ms)";
+      };
 
-      sections = helpers.mkCompositeOption "Sections configuration" {
+      sections = {
         lualine_a = mkComponentOptions "mode";
         lualine_b = mkComponentOptions "branch";
         lualine_c = mkComponentOptions "filename";
@@ -183,7 +170,7 @@ in {
         lualine_z = mkComponentOptions "location";
       };
 
-      inactiveSections = helpers.mkCompositeOption "Inactive Sections configuration" {
+      inactiveSections = {
         lualine_a = mkComponentOptions "";
         lualine_b = mkComponentOptions "";
         lualine_c = mkComponentOptions "filename";
@@ -245,11 +232,11 @@ in {
         always_divide_middle = cfg.alwaysDivideMiddle;
       };
 
-      sections = mapNullable processSections cfg.sections;
-      inactive_sections = mapNullable processSections cfg.inactiveSections;
-      tabline = mapNullable processSections cfg.tabline;
-      winbar = mapNullable processSections cfg.winbar;
-      inactive_winbar = mapNullable processSections cfg.inactiveWinbar;
+      sections = processSections cfg.sections;
+      inactive_sections = processSections cfg.inactiveSections;
+      tabline = processSections cfg.tabline;
+      winbar = processSections cfg.winbar;
+      inactive_winbar = processSections cfg.inactiveWinbar;
     };
   in
     mkIf cfg.enable {

--- a/plugins/ui/noice.nix
+++ b/plugins/ui/noice.nix
@@ -20,7 +20,7 @@ with lib; {
 
       package = helpers.mkPackageOption "noice" pkgs.vimPlugins.noice-nvim;
 
-      cmdline = helpers.mkCompositeOption "" {
+      cmdline = {
         enabled = helpers.defaultNullOpts.mkBool true "enables Noice cmdline UI";
         view = helpers.defaultNullOpts.mkStr "cmdline_popup" "";
         opts = helpers.defaultNullOpts.mkNullable types.anything "{}" "";
@@ -45,18 +45,19 @@ with lib; {
           '';
       };
 
-      messages =
-        helpers.mkCompositeOption
-        "NOTE: If you enable messages, then the cmdline is enabled automatically" {
-          enabled = helpers.defaultNullOpts.mkBool true "enables the messages UI";
-          view = helpers.defaultNullOpts.mkStr "notify" "default view for messages";
-          viewError = helpers.defaultNullOpts.mkStr "notify" "default view for errors";
-          viewWarn = helpers.defaultNullOpts.mkStr "notify" "default view for warnings";
-          viewHistory = helpers.defaultNullOpts.mkStr "messages" "view for :messages";
-          viewSearch = helpers.defaultNullOpts.mkStr "virtualtext" "view for search count messages";
-        };
+      messages = {
+        enabled = helpers.defaultNullOpts.mkBool true ''
+          Enables the messages UI.
+          NOTE: If you enable messages, then the cmdline is enabled automatically.
+        '';
+        view = helpers.defaultNullOpts.mkStr "notify" "default view for messages";
+        viewError = helpers.defaultNullOpts.mkStr "notify" "default view for errors";
+        viewWarn = helpers.defaultNullOpts.mkStr "notify" "default view for warnings";
+        viewHistory = helpers.defaultNullOpts.mkStr "messages" "view for :messages";
+        viewSearch = helpers.defaultNullOpts.mkStr "virtualtext" "view for search count messages";
+      };
 
-      popupmenu = helpers.mkCompositeOption "" {
+      popupmenu = {
         enabled = helpers.defaultNullOpts.mkBool true "enables the Noice popupmenu UI";
         backend = helpers.defaultNullOpts.mkEnumFirstDefault ["nui" "cmp"] "";
         kindIcons =
@@ -110,20 +111,21 @@ with lib; {
         }
       '' "You can add any custom commands that will be available with `:Noice command`";
 
-      notify =
-        helpers.mkCompositeOption ''
-          Noice can be used as `vim.notify` so you can route any notification like other messages
-          Notification messages have their level and other properties set.
-          event is always "notify" and kind can be any log level as a string
-          The default routes will forward notifications to nvim-notify
-          Benefit of using Noice for this is the routing and consistent history view
-        '' {
-          enabled = helpers.defaultNullOpts.mkBool true "enable notification handling";
-          view = helpers.defaultNullOpts.mkStr "notify" "";
-        };
+      notify = {
+        enabled = helpers.defaultNullOpts.mkBool true ''
+          Enable notification handling.
 
-      lsp = helpers.mkCompositeOption "" {
-        progress = helpers.mkCompositeOption "" {
+          Noice can be used as `vim.notify` so you can route any notification like other messages.
+          Notification messages have their level and other properties set.
+          event is always "notify" and kind can be any log level as a string.
+          The default routes will forward notifications to nvim-notify.
+          Benefit of using Noice for this is the routing and consistent history view.
+        '';
+        view = helpers.defaultNullOpts.mkStr "notify" "";
+      };
+
+      lsp = {
+        progress = {
           enabled = helpers.defaultNullOpts.mkBool true "enable LSP progress";
 
           format =
@@ -150,7 +152,7 @@ with lib; {
           }
         '' "";
 
-        hover = helpers.mkCompositeOption "" {
+        hover = {
           enabled = helpers.defaultNullOpts.mkBool true "enable hover UI";
           view =
             helpers.defaultNullOpts.mkNullable types.str "null"
@@ -160,10 +162,10 @@ with lib; {
             "merged with defaults from documentation";
         };
 
-        signature = helpers.mkCompositeOption "" {
+        signature = {
           enabled = helpers.defaultNullOpts.mkBool true "enable signature UI";
 
-          autoOpen = helpers.mkCompositeOption "" {
+          autoOpen = {
             enabled = helpers.defaultNullOpts.mkBool true "";
             trigger =
               helpers.defaultNullOpts.mkBool true
@@ -184,14 +186,14 @@ with lib; {
             "merged with defaults from documentation";
         };
 
-        message = helpers.mkCompositeOption "Messages shown by lsp servers" {
+        message = {
           enabled = helpers.defaultNullOpts.mkBool true "enable display of messages";
 
           view = helpers.defaultNullOpts.mkStr "notify" "";
           opts = helpers.defaultNullOpts.mkNullable types.anything "{}" "";
         };
 
-        documentation = helpers.mkCompositeOption "defaults for hover and signature help" {
+        documentation = {
           view = helpers.defaultNullOpts.mkStr "hover" "";
 
           opts = helpers.defaultNullOpts.mkNullable types.anything ''
@@ -206,7 +208,7 @@ with lib; {
         };
       };
 
-      markdown = helpers.mkCompositeOption "" {
+      markdown = {
         hover = helpers.defaultNullOpts.mkNullable (types.attrsOf types.str) ''
           {
             "|(%S-)|" = helpers.mkRaw "vim.cmd.help"; // vim help links
@@ -226,22 +228,23 @@ with lib; {
         '' "set highlight groups";
       };
 
-      health = helpers.mkCompositeOption "" {
+      health = {
         checker =
           helpers.defaultNullOpts.mkBool true
           "Disable if you don't want health checks to run";
       };
 
-      smartMove =
-        helpers.mkCompositeOption
-        "noice tries to move out of the way of existing floating windows." {
-          enabled = helpers.defaultNullOpts.mkBool true "you can disable this behaviour here";
-          excludedFiletypes =
-            helpers.defaultNullOpts.mkNullable (types.listOf types.str)
-            ''[ "cmp_menu" "cmp_docs" "notify"]'' ''
-              add any filetypes here, that shouldn't trigger smart move
-            '';
-        };
+      smartMove = {
+        enabled = helpers.defaultNullOpts.mkBool true ''
+          Noice tries to move out of the way of existing floating windows.
+          You can disable this behaviour here
+        '';
+        excludedFiletypes =
+          helpers.defaultNullOpts.mkNullable (types.listOf types.str)
+          ''[ "cmp_menu" "cmp_docs" "notify"]'' ''
+            add any filetypes here, that shouldn't trigger smart move
+          '';
+      };
 
       presets =
         helpers.defaultNullOpts.mkNullable (types.either types.bool types.anything) ''
@@ -272,74 +275,68 @@ with lib; {
     cfg = config.plugins.noice;
     setupOptions = {
       inherit (cfg) presets views routes status format;
-      cmdline = helpers.ifNonNull' cfg.cmdline {
+      cmdline = {
         inherit (cfg.cmdline) enabled view opts format;
       };
       messages = let
         cfgM = cfg.messages;
-      in
-        helpers.ifNonNull' cfgM {
-          inherit (cfgM) enabled view;
-          view_error = cfgM.viewError;
-          view_warn = cfgM.viewWarn;
-          view_history = cfgM.viewHistory;
-          view_search = cfgM.viewSearch;
-        };
+      in {
+        inherit (cfgM) enabled view;
+        view_error = cfgM.viewError;
+        view_warn = cfgM.viewWarn;
+        view_history = cfgM.viewHistory;
+        view_search = cfgM.viewSearch;
+      };
       popupmenu = let
         cfgP = cfg.popupmenu;
-      in
-        helpers.ifNonNull' cfgP {
-          inherit (cfgP) enabled backend;
-          kind_icons = cfgP.kindIcons;
-        };
+      in {
+        inherit (cfgP) enabled backend;
+        kind_icons = cfgP.kindIcons;
+      };
       inherit (cfg) redirect commands;
-      notify = helpers.ifNonNull' cfg.notify {
+      notify = {
         inherit (cfg.notify) enabled view;
       };
       lsp = let
         cfgL = cfg.lsp;
-      in
-        helpers.ifNonNull' cfgL {
-          progress = let
-            cfgLP = cfgL.progress;
-          in
-            helpers.ifNonNull' cfgLP {
-              inherit (cfgLP) enabled format throttle view;
-              format_done = cfgLP.formatDone;
-            };
-          inherit (cfgL) override;
-          hover = helpers.ifNonNull' cfgL.hover {
-            inherit (cfgL.hover) enabled view opts;
-          };
-          signature = let
-            cfgLS = cfgL.signature;
-          in
-            helpers.ifNonNull' cfgLS {
-              inherit (cfgLS) enabled view opts;
-              auto_open = helpers.ifNonNull' cfgLS.autoOpen {
-                inherit (cfgLS.autoOpen) enabled trigger luasnip throttle;
-              };
-            };
-          message = helpers.ifNonNull' cfgL.message {
-            inherit (cfgL.message) enabled view opts;
-          };
-          documentation = helpers.ifNonNull' cfgL.documentation {
-            inherit (cfgL.documentation) view opts;
+      in {
+        progress = let
+          cfgLP = cfgL.progress;
+        in {
+          inherit (cfgLP) enabled format throttle view;
+          format_done = cfgLP.formatDone;
+        };
+        inherit (cfgL) override;
+        hover = {
+          inherit (cfgL.hover) enabled view opts;
+        };
+        signature = let
+          cfgLS = cfgL.signature;
+        in {
+          inherit (cfgLS) enabled view opts;
+          auto_open = {
+            inherit (cfgLS.autoOpen) enabled trigger luasnip throttle;
           };
         };
-      markdown = helpers.ifNonNull' cfg.markdown {
+        message = {
+          inherit (cfgL.message) enabled view opts;
+        };
+        documentation = {
+          inherit (cfgL.documentation) view opts;
+        };
+      };
+      markdown = {
         inherit (cfg.markdown) hover highlights;
       };
-      health = helpers.ifNonNull' cfg.health {
+      health = {
         inherit (cfg.health) checker;
       };
       smart_move = let
         cfgS = cfg.smartMove;
-      in
-        helpers.ifNonNull' cfgS {
-          inherit (cfgS) enabled;
-          excluded_filetypes = cfgS.excludedFiletypes;
-        };
+      in {
+        inherit (cfgS) enabled;
+        excluded_filetypes = cfgS.excludedFiletypes;
+      };
     };
   in
     mkIf cfg.enable {

--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -79,7 +79,7 @@ in {
             ```
           '';
 
-        guiStyle = helpers.mkCompositeOption "The gui style for highlight groups." {
+        guiStyle = {
           fg = helpers.defaultNullOpts.mkStr "NONE" ''
             The gui style to use for the fg highlight group.
           '';
@@ -93,7 +93,7 @@ in {
           When true, custom keywords will be merged with the default
         '';
 
-        highlight = helpers.mkCompositeOption "Highlight options." {
+        highlight = {
           multiline = helpers.defaultNullOpts.mkBool true ''
             Enable multiline todo comments.
           '';
@@ -163,7 +163,7 @@ in {
             ```
           '';
 
-        search = helpers.mkCompositeOption "Search options." {
+        search = {
           command = helpers.defaultNullOpts.mkStr "rg" "Command to use for searching for keywords.";
 
           args = helpers.mkNullOrOption (types.listOf types.str) ''
@@ -231,7 +231,7 @@ in {
         inherit (cfg) keywords;
         gui_style = cfg.guiStyle;
         merge_keywords = cfg.mergeKeywords;
-        highlight = helpers.ifNonNull' cfg.highlight {
+        highlight = {
           inherit
             (cfg.highlight)
             multiline
@@ -249,7 +249,7 @@ in {
           max_line_len = cfg.highlight.maxLineLen;
         };
         inherit (cfg) colors;
-        search = helpers.ifNonNull' cfg.search {
+        search = {
           inherit (cfg.search) command args;
           pattern =
             helpers.ifNonNull' cfg.search.pattern


### PR DESCRIPTION
Some overall cleaning of the code base.
Mostly removing useless uses of `mkCompositeOptions`.
Otherwise, changes are only "esthetic".