### PR TITLE
plugins/debugprint-nvim: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -43,6 +43,7 @@
     ./git/neogit.nix
 
     ./languages/clangd-extensions.nix
+    ./languages/debugprint.nix
     ./languages/julia/julia-cell.nix
     ./languages/lean.nix
     ./languages/ledger.nix

--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -1,0 +1,93 @@
+{
+  config,
+  helpers,
+  lib,
+  pkgs,
+  ...
+}: {
+  options.plugins.debugprint = let
+    # https://github.com/NixOS/nixpkgs/blob/055ba65fed8eac15b13ed68f70a7d506f9b2d291/lib/options.nix#L91-L105
+    mkEnableOptionInverted = name:
+      lib.mkOption {
+        default = true;
+
+        description =
+          if name ? _type && name._type == "mdDoc"
+          then lib.mdDoc "Whether to enable ${name.text}."
+          else "Whether to enable ${name}.";
+
+        example = false;
+        type = lib.types.bool;
+      };
+
+    packageName = "debugprint.nvim";
+  in {
+    createKeymaps = mkEnableOptionInverted "keymaps";
+    displayCounter = mkEnableOptionInverted "display counter";
+    displaySnippet = mkEnableOptionInverted "display snippet";
+
+    filetypes = lib.mkOption {
+      default = {};
+
+      example = {
+        left = ''print "'';
+        mid_var = ''''${'';
+        right = ''"'';
+        right_var = ''}"'';
+      };
+
+      description = "Custom filetypes";
+      type = lib.types.attrs;
+    };
+
+    ignoreTreesitter = lib.mkEnableOption "treesitter";
+    moveToDebugline = lib.mkEnableOption "move to debugline";
+
+    printTag = lib.mkOption {
+      default = "DEBUGPRINT";
+      description = "The string inserted into each print statement, which can be used to uniquely identify statements inserted by `debugprint`.";
+      example = "DEBUG";
+      type = lib.types.str;
+    };
+
+    enable = lib.mkEnableOption packageName;
+
+    package = let
+      package = pkgs.vimUtils.buildVimPlugin {
+        meta.homepage = "https://github.com/andrewferrier/debugprint.nvim/";
+        pname = "debugprint-nvim";
+
+        src = pkgs.fetchFromGitHub {
+          owner = "andrewferrier";
+          repo = "debugprint.nvim";
+          rev = "8a6d66bd6162e9c49804e9286a7d4ceba60355d5";
+          sha256 = "sha256-dctYG+ECPuYYNupwycwaE3sdJFi1UK8E+i5057RsfXo=";
+        };
+
+        version = "2022-11-29";
+      };
+    in
+      helpers.mkPackageOption packageName package;
+  };
+
+  config = let
+    cfg = config.plugins.debugprint;
+  in
+    lib.mkIf cfg.enable {
+      extraConfigLua = let
+        options = {
+          inherit (cfg) filetypes;
+          create_keymaps = cfg.createKeymaps;
+          display_counter = cfg.displayCounter;
+          display_snippet = cfg.displaySnippet;
+          ignore_treesitter = cfg.ignoreTreesitter;
+          move_to_debugline = cfg.moveToDebugline;
+          print_tag = cfg.printTag;
+        };
+      in ''
+        require("debugprint").setup(${helpers.toLuaObject options})
+      '';
+
+      extraPlugins = [cfg.package];
+    };
+}

--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -22,6 +22,7 @@
 
     packageName = "debugprint.nvim";
   in {
+    createCommands = mkEnableOptionInverted "commands";
     createKeymaps = mkEnableOptionInverted "keymaps";
     displayCounter = mkEnableOptionInverted "display counter";
     displaySnippet = mkEnableOptionInverted "display snippet";
@@ -77,6 +78,7 @@
       extraConfigLua = let
         options = {
           inherit (cfg) filetypes;
+          create_commands = cfg.createCommands;
           create_keymaps = cfg.createKeymaps;
           display_counter = cfg.displayCounter;
           display_snippet = cfg.displaySnippet;

--- a/tests/test-sources/plugins/languages/debugprint.nix
+++ b/tests/test-sources/plugins/languages/debugprint.nix
@@ -1,0 +1,29 @@
+{
+  default = {
+    plugins.debugprint = {
+      create_keymaps = true;
+      display_counter = true;
+      display_snippet = true;
+      enable = false;
+      filetypes = {};
+      ignore_treesitter = false;
+      move_to_debugline = false;
+      print_tag = "DEBUGPRINT";
+    };
+  };
+
+  empty.plugins.debugprint.enable = true;
+
+  example = {
+    plugins.debugprint = {
+      create_keymaps = false;
+      display_counter = false;
+      display_snippet = false;
+      enable = true;
+      filetypes = {};
+      ignore_treesitter = true;
+      move_to_debugline = true;
+      print_tag = "DEBUG";
+    };
+  };
+}

--- a/tests/test-sources/plugins/languages/debugprint.nix
+++ b/tests/test-sources/plugins/languages/debugprint.nix
@@ -1,14 +1,14 @@
 {
   default = {
     plugins.debugprint = {
-      create_keymaps = true;
-      display_counter = true;
-      display_snippet = true;
+      createKeymaps = true;
+      displayCounter = true;
+      displaySnippet = true;
       enable = false;
       filetypes = {};
-      ignore_treesitter = false;
-      move_to_debugline = false;
-      print_tag = "DEBUGPRINT";
+      ignoreTreesitter = false;
+      moveToDebugline = false;
+      printTag = "DEBUGPRINT";
     };
   };
 
@@ -16,14 +16,14 @@
 
   example = {
     plugins.debugprint = {
-      create_keymaps = false;
-      display_counter = false;
-      display_snippet = false;
+      createKeymaps = false;
+      displayCounter = false;
+      displaySnippet = false;
       enable = true;
       filetypes = {};
-      ignore_treesitter = true;
-      move_to_debugline = true;
-      print_tag = "DEBUG";
+      ignoreTreesitter = true;
+      moveToDebugline = true;
+      printTag = "DEBUG";
     };
   };
 }


### PR DESCRIPTION
Add support for the https://github.com/andrewferrier/debugprint.nvim plugin.

Notes:

- Although, this plugin works in my Nixvim configuration, I am currently unable to run the added tests due to my system setup. Could someone try them for me?
- Once https://github.com/NixOS/nixpkgs/pull/270968 lands, the hard-coded `pkgs.vimUtils.buildVimPlugin` statement can be replaced by the Nixpkgs package.

Closes: https://github.com/nix-community/nixvim/issues/763

Requires:

- https://github.com/NixOS/nixpkgs/pull/270968
- https://github.com/NixOS/nixpkgs/pull/271007
