### PR TITLE
Support more options for icon in lualine

### DIFF
--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -36,7 +36,23 @@ with lib; let
               Enables the display of icons alongside the component.
             '';
 
-            icon = helpers.mkNullOrOption (with types; either str (attrsOf anything)) ''
+            icon = helpers.mkNullOrOption
+              (
+                with types;
+                  either
+                  str
+                  (submodule {
+                    freeformType = attrsOf anything;
+                    
+                    options = {
+                      icon = mkOption {
+                        type = str;
+                        description = "Icon character.";
+                      };
+                    };
+                  })
+              )
+              "Defines the icon to be displayed in front of the component.";
               Defines the icon to be displayed in front of the component.
             '';
 

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -36,7 +36,7 @@ with lib; let
               Enables the display of icons alongside the component.
             '';
 
-            icon = helpers.mkNullOrOption types.str ''
+            icon = helpers.mkNullOrOption (types.either types.str helpers.rawType) ''
               Defines the icon to be displayed in front of the component.
             '';
 

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -36,7 +36,7 @@ with lib; let
               Enables the display of icons alongside the component.
             '';
 
-            icon = helpers.mkNullOrOption (types.either types.str helpers.rawType) ''
+            icon = helpers.mkNullOrOption (with types; either str (attrsOf anything)) ''
               Defines the icon to be displayed in front of the component.
             '';
 
@@ -211,7 +211,11 @@ in {
       mergeAttrs
       {
         "__unkeyed" = name;
-        inherit icons_enabled icon separator color padding;
+        icon =
+          if isAttrs icon
+          then removeAttrs (icon // {"__unkeyed" = icon.icon;}) ["icon"]
+          else icon;
+        inherit icons_enabled separator color padding;
       }
       extraConfig;
     processSections = mapAttrs (_: mapNullable (map processComponent));

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -36,14 +36,15 @@ with lib; let
               Enables the display of icons alongside the component.
             '';
 
-            icon = helpers.mkNullOrOption
+            icon =
+              helpers.mkNullOrOption
               (
                 with types;
                   either
                   str
                   (submodule {
                     freeformType = attrsOf anything;
-                    
+
                     options = {
                       icon = mkOption {
                         type = str;
@@ -53,8 +54,6 @@ with lib; let
                   })
               )
               "Defines the icon to be displayed in front of the component.";
-              Defines the icon to be displayed in front of the component.
-            '';
 
             separator = mkSeparatorsOption {name = "Component";};
 


### PR DESCRIPTION
From lualine documentation the icons can be configure more than just an string 

https://github.com/nvim-lualine/lualine.nvim#general-component-options

example 
```lua
{'branch', icon = {'', align='right', color={fg='green'}}}
```
Currently is defined as string which cover for most of the cases but if you want to set a color or more is not possible. I think that adding support for raw type makes more extensible.

I think also setting an object is possible but I lack the knowledge to do so, with this I was able to extend my configuration as I needed.

Let me know what do you think.

Kind regards, thanks for maintaining the project.