### PR TITLE
modules/keymaps: deprecate maps option

### DIFF
--- a/tests/test-sources/modules/keymaps.nix
+++ b/tests/test-sources/modules/keymaps.nix
@@ -1,38 +1,4 @@
 {helpers, ...}: {
-  legacy = {
-    maps.normal."," = "<cmd>echo \"test\"<cr>";
-  };
-
-  legacy-mkMaps = {
-    maps = helpers.keymaps.mkMaps {silent = true;} {
-      normal."," = "<cmd>echo \"test\"<cr>";
-      visual = {
-        "<C-a>" = {
-          action = "function() print('toto') end";
-          lua = true;
-          silent = false;
-        };
-        "<C-z>" = {
-          action = "bar";
-        };
-      };
-    };
-  };
-
-  legacy-mkModeMaps = {
-    maps.normal = helpers.keymaps.mkModeMaps {silent = true;} {
-      "," = "<cmd>echo \"test\"<cr>";
-      "<C-a>" = {
-        action = "function() print('toto') end";
-        lua = true;
-        silent = false;
-      };
-      "<leader>b" = {
-        action = "bar";
-      };
-    };
-  };
-
   example = {
     keymaps = [
       {
@@ -47,7 +13,7 @@
     ];
   };
 
-  mkMaps = {
+  mkKeymaps = {
     keymaps =
       helpers.keymaps.mkKeymaps
       {


### PR DESCRIPTION
The `maps` option has been marked as deprecated in favor of `keymaps` in #605 (Sept. 26).
It is now time to finally get rid of it.