### PR TITLE
wrappers: add nixvim-print-init package

### DIFF
--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -28,7 +28,10 @@ in {
   config = mkIf cfg.enable (mkMerge [
     {
       environment.systemPackages =
-        [cfg.finalPackage]
+        [
+          cfg.finalPackage
+          cfg.printInitPackage
+        ]
         ++ (lib.optional cfg.enableMan self.packages.${pkgs.system}.man-docs);
     }
     {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -37,7 +37,10 @@ in {
     (mkMerge [
       {
         home.packages =
-          [cfg.finalPackage]
+          [
+            cfg.finalPackage
+            cfg.printInitPackage
+          ]
           ++ (lib.optional cfg.enableMan self.packages.${pkgs.system}.man-docs);
       }
       (mkIf (!cfg.wrapRc) {

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -38,7 +38,10 @@ in {
     (mkMerge [
       {
         environment.systemPackages =
-          [cfg.finalPackage]
+          [
+            cfg.finalPackage
+            cfg.printInitPackage
+          ]
           ++ (lib.optional cfg.enableMan self.packages.${pkgs.system}.man-docs);
       }
       (mkIf (!cfg.wrapRc) {

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -33,7 +33,10 @@ in
   pkgs.symlinkJoin {
     name = "nixvim";
     paths =
-      [config.finalPackage]
+      [
+        config.finalPackage
+        config.printInitPackage
+      ]
       ++ pkgs.lib.optional config.enableMan self.packages.${pkgs.system}.man-docs;
     meta.mainProgram = "nvim";
   }


### PR DESCRIPTION
This patch creates a `nixvim-print-init` binary which shows the content of the generated `init.lua` configuration file.