### PR TITLE
plguins/lsp: add perlpls language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -439,6 +439,11 @@ with lib; let
       };
     }
     {
+      name = "perlpls";
+      description = "Enable PLS, for Perl";
+      package = pkgs.perlPackages.PLS;
+    }
+    {
       name = "pest_ls";
       description = "Enable pest_ls, for pest";
       package = pkgs.pest-ide-tools;

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -115,6 +115,7 @@
         nil_ls.enable = true;
         nixd.enable = true;
         omnisharp.enable = true;
+        perlpls.enable = true;
         pest_ls.enable = true;
         prismals.enable = true;
         pylsp.enable = true;


### PR DESCRIPTION
I haven't been able to successfully run the test suite, but I suspect it's not related to my changes ([logs](https://paste.frogeye.fr/?9f9a594a55a661b8#DJpsNgV3ofMbe5yi6qicyA3bDvGcHdDkAtmW6TGuxvz9), seems like `cache.nixos.org` went down at some point?). It's currently trying to run again but since it takes a while and I might forget I wanted to at least post the MR.


If you want to test manually without learning Perl (wouldn't recommend 🙈), create a `.pl` file with the following content:

```perl
use strict;
printf "$var\n";
```

It should complain about `$var` not being declared.