### PR TITLE
fix: typo in mini module example

### DIFF
--- a/plugins/utils/mini.nix
+++ b/plugins/utils/mini.nix
@@ -27,7 +27,7 @@ in {
           n_lines = 50;
           search_method = "cover_or_next";
         };
-        surrounds = {};
+        surround = {};
       };
     };
   };


### PR DESCRIPTION
If you use the example, nvim will throw an error that surrounds does not exist. `surround` is also used in the test.