### PR TITLE
standalone: Fix extraSpecialArgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,10 @@
               lib-tests = import ./tests/lib-tests.nix {
                 inherit (pkgs) pkgs lib;
               };
+              extra-args-tests = import ./tests/extra-args.nix {
+                inherit pkgs;
+                inherit (self.legacyPackages.${system}) makeNixvimWithModule;
+              };
               pre-commit-check = pre-commit-hooks.lib.${system}.run {
                 src = ./.;
                 hooks = {

--- a/tests/extra-args.nix
+++ b/tests/extra-args.nix
@@ -1,0 +1,26 @@
+{
+  makeNixvimWithModule,
+  pkgs,
+}: let
+  generated = makeNixvimWithModule {
+    module = {importedArgument, ...}: {
+      extraConfigLua = ''
+        -- importedArgument=${importedArgument}
+      '';
+    };
+    extraSpecialArgs = {
+      importedArgument = "foobar";
+    };
+  };
+in
+  pkgs.runCommand "special-arg-test" {
+    printConfig = "${generated}/bin/nixvim-print-init";
+  } ''
+    config=$($printConfig)
+    if ! "$printConfig" | grep -- '-- importedArgument=foobar'; then
+      echo "Missing importedArgument in config"
+      exit 1
+    fi
+
+    touch $out
+  ''

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -12,13 +12,11 @@ default_pkgs: {
 
   shared = import ./_shared.nix modules {
     inherit pkgs lib;
-    config = {
-      _module.args = extraSpecialArgs;
-    };
+    config = {};
   };
 
   eval = lib.evalModules {
-    modules = [module wrap] ++ shared.topLevelModules;
+    modules = [module wrap {_module.args = extraSpecialArgs;}] ++ shared.topLevelModules;
   };
 
   handleAssertions = config: let


### PR DESCRIPTION
This commit fixes the usage of `extraSpecialArgs` for standalone nixvim installations and adds a test to ensure this.

Fixes #779