### PR TITLE
plugins/which-key: add key group support for registrations 

### DIFF
--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -14,7 +14,7 @@ with lib; {
     package = helpers.mkPackageOption "whick-key-nvim" pkgs.vimPlugins.which-key-nvim;
 
     registrations = mkOption {
-      type = with types; attrsOf str;
+      type = with types; attrsOf (oneOf [str (listOf str) (attrsOf str)]);
       default = {};
       description = "Manually register the description of mappings.";
       example = {

--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -14,7 +14,7 @@ with lib; {
     package = helpers.mkPackageOption "whick-key-nvim" pkgs.vimPlugins.which-key-nvim;
 
     registrations = mkOption {
-      type = with types; attrsOf (oneOf [str (listOf str) (attrsOf str)]);
+      type = with types; attrsOf anything;
       default = {};
       description = "Manually register the description of mappings.";
       example = {

--- a/tests/test-sources/plugins/utils/which-key.nix
+++ b/tests/test-sources/plugins/utils/which-key.nix
@@ -24,6 +24,20 @@
           "Raw Lua Code and List KeyMapping Test"
         ];
         "oo" = "Label Test 2";
+        "<tab>" = {
+          name = "Group in Group Test";
+          f = [
+            {
+              __raw = ''
+                function()
+                  vim.cmd("echo 'Raw Lua Code and List KeyMapping Test 2'")
+                end
+              '';
+            }
+
+            "Raw Lua Code and List KeyMapping Test 2"
+          ];
+        };
       };
 
       plugins = {

--- a/tests/test-sources/plugins/utils/which-key.nix
+++ b/tests/test-sources/plugins/utils/which-key.nix
@@ -7,11 +7,23 @@
     plugins.which-key = {
       enable = true;
 
-      # Simple mapping with only Description
-      registrations."ff" = "Test";
-
+      # Testing for registrations
       registrations."f" = {
+        prefix = "<leader>";
+        mode = ["n" "v" "i" "t" "c" "x" "s" "o"];
         name = "Group Test";
+        f = "Label Test";
+        "1" = [
+          {
+            __raw = ''
+              function()
+                print("Raw Lua Code and List KeyMapping Test")
+              end
+            '';
+          }
+          "Raw Lua Code and List KeyMapping Test"
+        ];
+        "oo" = "Label Test 2";
       };
 
       plugins = {

--- a/tests/test-sources/plugins/utils/which-key.nix
+++ b/tests/test-sources/plugins/utils/which-key.nix
@@ -10,6 +10,10 @@
       # Simple mapping with only Description
       registrations."ff" = "Test";
 
+      registrations."f" = {
+        name = "Group Test";
+      };
+
       plugins = {
         marks = true;
         registers = true;


### PR DESCRIPTION
I've only just recently started trying to migrate my NeoVim configuration to NixVim. What I'm doing is basically copying LazyVim's configuration since that's what I was using before. however, I've found that the `registrations` option for which-key in NixVim only supports the str type, but the str type can only bind labels for a shortcut key, not a group name for a shortcut key prefix. After looking at the source code I found that it is implemented like this

https://github.com/nix-community/nixvim/blob/c1cbb0012685b69fc6391f93d279975032b37dcf/plugins/utils/which-key.nix#L205-L213

So I think it probably just needs a change in the type restriction for the `registrations`.

I don't know much about writing Nix modules at the moment, so I'm not sure if a type definition like this is in line with the specification.