### PR TITLE
Revert "gitignore: add templates/_wrapper/simple/flake.lock"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,5 +20,5 @@ jobs:
           name: nix-community
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix flake check --all-systems
-      - run: nix flake check --all-systems ./templates/_wrapper/simple --no-write-lock-file
+      - run: nix flake check --all-systems ./templates/_wrapper/simple
       - run: nix build .#docs --show-trace

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 result
 .pre-commit-config.yaml
 .direnv
-
-templates/_wrapper/simple/flake.lock


### PR DESCRIPTION
This reverts commit 7f9cfe1db3dbbf4d3c700ec056377cd4715e83f0 introduced in  #795.
It might lead to Ci failures. The `flake.lock` should not be added to the repo, but we still shouldn't add it to `.gitignore`.
This is explained in [the relevant README](https://github.com/nix-community/nixvim/blob/c9149122a8930b370678bf59b7b3226a2a6ee76a/templates/_wrapper/README.md?plain=1#L9). 