### PR TITLE
plugins/lsp: add gleam language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -214,6 +214,10 @@ with lib; let
       package = null;
     }
     {
+      name = "gleam";
+      description = "Enable gleam, for gleam.";
+    }
+    {
       name = "gopls";
       description = "Enable gopls, for Go.";
     }

--- a/tests/test-sources/plugins/lsp/nvim-lsp.nix
+++ b/tests/test-sources/plugins/lsp/nvim-lsp.nix
@@ -101,6 +101,7 @@
         # See https://github.com/NixOS/nixpkgs/issues/271704
         fsautocomplete.enable = false;
         futhark-lsp.enable = true;
+        gleam.enable = true;
         gopls.enable = true;
         hls.enable = true;
         html.enable = true;


### PR DESCRIPTION
Add support for the [gleam language server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#gleam).

Fixes #807 