### PR TITLE
Fix renderer in wildmenu

### DIFF
--- a/plugins/utils/wilder.nix
+++ b/plugins/utils/wilder.nix
@@ -175,7 +175,7 @@ in {
         ```
       '';
 
-      render = helpers.mkNullOrOption types.str ''
+      renderer = helpers.mkNullOrOption types.str ''
         Sets the renderer to used to display the completions.
         See `|wilder-renderer|`.
 
@@ -237,7 +237,7 @@ in {
         pipeline =
           helpers.ifNonNull' pipeline
           (map helpers.mkRaw pipeline);
-        render = helpers.mkRaw render;
+        renderer = helpers.mkRaw renderer;
         preHook = helpers.mkRaw preHook;
         postHook = helpers.mkRaw postHook;
       }

--- a/tests/test-sources/plugins/utils/wilder.nix
+++ b/tests/test-sources/plugins/utils/wilder.nix
@@ -36,7 +36,7 @@
           )
         ''
       ];
-      render = ''
+      renderer = ''
         wilder.wildmenu_renderer({
           -- highlighter applies highlighting to the candidates
           highlighter = wilder.basic_highlighter(),


### PR DESCRIPTION
The field in the nixvim config is called `render`, although in wilder it's called `renderer`. This PR fixes that issue