### PR TITLE
plugins/lsp: add graphql language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -222,6 +222,11 @@ with lib; let
       description = "Enable gopls, for Go.";
     }
     {
+      name = "graphql";
+      description = "Enable graphql, for GraphQL.";
+      package = pkgs.nodePackages.graphql-language-service-cli;
+    }
+    {
       name = "hls";
       description = "Enable haskell language server";
       package = pkgs.haskell-language-server;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -102,6 +102,7 @@
         futhark-lsp.enable = true;
         gleam.enable = true;
         gopls.enable = true;
+        graphql.enable = true;
         hls.enable = true;
         html.enable = true;
         java-language-server.enable = true;


### PR DESCRIPTION
Add the [graphql](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-server) language server.

Fixes #813 