### PR TITLE
plugins/lint: uncomment autoCmd config line

### DIFF
--- a/plugins/languages/lint.nix
+++ b/plugins/languages/lint.nix
@@ -297,6 +297,6 @@ in {
         )
       );
 
-    # autoCmd = optional (cfg.autoCmd != null) cfg.autoCmd;
+    autoCmd = optional (cfg.autoCmd != null) cfg.autoCmd;
   };
 }


### PR DESCRIPTION
I think that this line stayed commented by mistake...