### PR TITLE
feat(plugins/languages/debugprint): add missing `createCommands` option

### DIFF
--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -100,7 +100,7 @@ in {
     extraConfigLua = let
       setupOptions = with cfg;
         {
-          create_command = createCommands;
+          create_commands = createCommands;
           create_keymaps = createKeymaps;
           move_to_debugline = moveToDebugline;
           display_counter = displayCounter;

--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -15,6 +15,10 @@ in {
 
       package = helpers.mkPackageOption "debugprint.nvim" pkgs.vimPlugins.debugprint-nvim;
 
+      createCommands = helpers.defaultNullOpts.mkBool true ''
+        Creates default commands.
+      '';
+
       createKeymaps = helpers.defaultNullOpts.mkBool true ''
         Creates default keymappings.
       '';
@@ -96,6 +100,7 @@ in {
     extraConfigLua = let
       setupOptions = with cfg;
         {
+          create_command = createCommands;
           create_keymaps = createKeymaps;
           move_to_debugline = moveToDebugline;
           display_counter = displayCounter;

--- a/tests/test-sources/plugins/languages/debugprint.nix
+++ b/tests/test-sources/plugins/languages/debugprint.nix
@@ -8,6 +8,7 @@
       enable = true;
 
       createKeymaps = true;
+      createCommands = true;
       moveToDebugline = false;
       displayCounter = true;
       displaySnippet = true;


### PR DESCRIPTION
Add missing `createCommands` option.

Follows: https://github.com/nix-community/nixvim/pull/821