### PR TITLE
helpers/options: add defaultNullOpts.mkLogLevel and defaultNullOpts.mkSeverity

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -196,6 +196,37 @@ with lib; rec {
             ${defaultDesc}
           '';
       };
+    mkLogLevel = default: desc:
+      mkOption {
+        type = with types;
+          nullOr
+          (
+            either ints.unsigned
+            (
+              enum
+              ["off" "error" "warn" "info" "debug" "trace"]
+            )
+          );
+        default = null;
+        apply =
+          mapNullable
+          (
+            value:
+              if isInt value
+              then value
+              else mkRaw "vim.log.levels.${strings.toUpper value}"
+          );
+        description = let
+          defaultDesc = "default: `${toString default}`";
+        in
+          if desc == ""
+          then defaultDesc
+          else ''
+            ${desc}
+
+            ${defaultDesc}
+          '';
+      };
 
     mkHighlight = default: name: desc:
       mkNullable

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -165,6 +165,37 @@ with lib; rec {
           ${desc}
           ${defaultDesc}
         '');
+    mkSeverity = default: desc:
+      mkOption {
+        type = with types;
+          nullOr
+          (
+            either ints.unsigned
+            (
+              enum
+              ["error" "warn" "info" "hint"]
+            )
+          );
+        default = null;
+        apply =
+          mapNullable
+          (
+            value:
+              if isInt value
+              then value
+              else mkRaw "vim.diagnostic.severity.${strings.toUpper value}"
+          );
+        description = let
+          defaultDesc = "default: `${toString default}`";
+        in
+          if desc == ""
+          then defaultDesc
+          else ''
+            ${desc}
+
+            ${defaultDesc}
+          '';
+      };
 
     mkHighlight = default: name: desc:
       mkNullable

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -812,7 +812,7 @@ in {
       };
 
       notify = {
-        threshold = helpers.defaultNullOpts.mkEnum ["error" "warning" "info" "debug"] "info" ''
+        threshold = helpers.defaultNullOpts.mkLogLevel "info" ''
           Specify minimum notification level, uses the values from |vim.log.levels|
 
           - `error`:   hard errors e.g. failure to read from the file system.
@@ -1010,9 +1010,7 @@ in {
         };
         inherit tab;
         notify = with notify; {
-          threshold =
-            ifNonNull' cfg.notify.threshold
-            (helpers.mkRaw "vim.log.levels.${strings.toUpper notify.threshold}");
+          inherit threshold;
         };
         inherit ui;
         log = with log; {

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -243,14 +243,12 @@ in {
           error = helpers.defaultNullOpts.mkStr "" "";
         };
 
-        severity = let
-          severityEnum = ["error" "warn" "info" "hint"];
-        in {
-          min = helpers.defaultNullOpts.mkEnum severityEnum "hint" ''
+        severity = {
+          min = helpers.defaultNullOpts.mkSeverity "hint" ''
             Minimum severity for which the diagnostics will be displayed.
             See `|diagnostic-severity|`.
           '';
-          max = helpers.defaultNullOpts.mkEnum severityEnum "error" ''
+          max = helpers.defaultNullOpts.mkSeverity "error" ''
             Maximum severity for which the diagnostics will be displayed.
             See `|diagnostic-severity|`.
           '';
@@ -899,13 +897,12 @@ in {
           show_on_dirs = showOnDirs;
           show_on_open_dirs = showOnOpenDirs;
           inherit icons;
-          severity =
-            mapAttrs (
-              name: value:
-                ifNonNull' value
-                (helpers.mkRaw "vim.diagnostic.severity.${strings.toUpper value}")
-            )
-            severity;
+          severity = with severity; {
+            inherit
+              min
+              max
+              ;
+          };
         };
         git = with git; {
           inherit enable;

--- a/plugins/languages/treesitter/rainbow-delimiters.nix
+++ b/plugins/languages/treesitter/rainbow-delimiters.nix
@@ -136,15 +136,11 @@ with lib; {
             (see `|standard-path|`).
           '';
 
-        level =
-          helpers.defaultNullOpts.mkEnum
-          ["debug" "error" "info" "trace" "warn" "off"]
-          "warn"
-          ''
-            Only messages equal to or above this value will be logged.
-            The default is to log warnings or above.
-            See `|log_levels|` for possible values.
-          '';
+        level = helpers.defaultNullOpts.mkLogLevel "warn" ''
+          Only messages equal to or above this value will be logged.
+          The default is to log warnings or above.
+          See `|log_levels|` for possible values.
+        '';
       };
     };
 
@@ -210,10 +206,10 @@ with lib; {
             blacklist
             ;
           log = with log; {
-            inherit file;
-            level =
-              helpers.ifNonNull' level
-              (helpers.mkRaw "vim.log.levels.${strings.toUpper level}");
+            inherit
+              file
+              level
+              ;
           };
         }
         // cfg.extraOptions;

--- a/plugins/languages/treesitter/rainbow-delimiters.nix
+++ b/plugins/languages/treesitter/rainbow-delimiters.nix
@@ -6,25 +6,6 @@
   ...
 }:
 with lib; {
-  # TODO those warnings have been added XX/XX/2023
-  # -> Remove them in ~ 1 month (oct. 2023)
-  imports =
-    mapAttrsToList
-    (
-      old: new:
-        mkRenamedOptionModule
-        ["plugins" "treesitter-rainbow" old]
-        ["plugins" "rainbow-delimiters" new]
-    )
-    {
-      enable = "enable";
-      package = "package";
-      strategy = "strategy";
-      query = "query";
-      disable = "blacklist";
-      hlgroups = "highlight";
-    };
-
   options.plugins.rainbow-delimiters =
     helpers.extraOptionsOptions
     // {

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -165,7 +165,7 @@ in {
         + ''
           require('nvim-treesitter.configs').setup(${helpers.toLuaObject tsOptions})
         ''
-        + (optionalString (cfg.languageRegister != null) ''
+        + (optionalString (cfg.languageRegister != {}) ''
           __parserFiltypeMappings = ${helpers.toLuaObject cfg.languageRegister}
 
           for parser_name, ft in pairs(__parserFiltypeMappings) do

--- a/plugins/lsp/conform-nvim.nix
+++ b/plugins/lsp/conform-nvim.nix
@@ -85,10 +85,9 @@ in {
           This can also be a function that returns the table.
         '';
 
-      logLevel =
-        helpers.defaultNullOpts.mkEnumFirstDefault
-        ["ERROR" "DEBUG" "INFO" "TRACE" "WARN" "OFF"]
-        "Set the log level. Use `:ConformInfo` to see the location of the log file.";
+      logLevel = helpers.defaultNullOpts.mkLogLevel "error" ''
+        Set the log level. Use `:ConformInfo` to see the location of the log file.
+      '';
 
       notifyOnError =
         helpers.defaultNullOpts.mkBool true
@@ -114,7 +113,7 @@ in {
         format_after_save = helpers.ifNonNull' formatAfterSave {
           lsp_fallback = formatAfterSave.lspFallback;
         };
-        log_level = helpers.ifNonNull' logLevel (helpers.mkRaw "vim.log.levels.${logLevel}");
+        log_level = logLevel;
         notify_on_error = notifyOnError;
         inherit formatters;
       }

--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -109,14 +109,10 @@ in {
         method, described in [BUILTIN_CONFIG](BUILTIN_CONFIG.md).
       '';
 
-      fallbackSeverity =
-        helpers.defaultNullOpts.mkNullable
-        (with types; either int (enum ["error" "warn" "info" "hint"]))
-        "error"
-        ''
-          Defines the severity used when a diagnostic source does not explicitly define a severity.
-          See `:help diagnostic-severity` for available values.
-        '';
+      fallbackSeverity = helpers.defaultNullOpts.mkSeverity "error" ''
+        Defines the severity used when a diagnostic source does not explicitly define a severity.
+        See `:help diagnostic-severity` for available values.
+      '';
 
       logLevel =
         helpers.defaultNullOpts.mkEnum ["off" "error" "warn" "info" "debug" "trace"] "warn"
@@ -257,10 +253,7 @@ in {
           default_timeout = defaultTimeout;
           diagnostic_config = diagnosticConfig;
           diagnostics_format = diagnosticsFormat;
-          fallback_severity =
-            if isString fallbackSeverity
-            then helpers.mkRaw "vim.diagnostic.severity.${strings.toUpper fallbackSeverity}"
-            else fallbackSeverity;
+          fallback_severity = fallbackSeverity;
           log_level = logLevel;
           notify_format = notifyFormat;
           on_attach = helpers.mkRaw onAttach';

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -15,18 +15,9 @@ in {
 
       package = helpers.mkPackageOption "nvim-notify" pkgs.vimPlugins.nvim-notify;
 
-      level =
-        helpers.defaultNullOpts.mkNullable
-        (
-          with types;
-            oneOf [
-              ints.unsigned
-              helpers.rawType
-              str
-            ]
-        )
-        ''{__raw = "vim.log.levels.INFO";}''
-        "Minimum log level to display. See `vim.log.levels`.";
+      level = helpers.defaultNullOpts.mkLogLevel "info" ''
+        Minimum log level to display. See `vim.log.levels`.
+      '';
 
       timeout = helpers.defaultNullOpts.mkUnsignedInt 5000 "Default timeout for notification.";
 

--- a/tests/test-sources/plugins/lsp/conform-nvim.nix
+++ b/tests/test-sources/plugins/lsp/conform-nvim.nix
@@ -21,7 +21,7 @@
       formatAfterSave = {
         lspFallback = true;
       };
-      logLevel = "ERROR";
+      logLevel = "error";
       notifyOnError = true;
       formatters = {
         myFormatter = {

--- a/tests/test-sources/plugins/utils/notify.nix
+++ b/tests/test-sources/plugins/utils/notify.nix
@@ -7,7 +7,7 @@
     plugins.notify = {
       enable = true;
 
-      level.__raw = "vim.log.levels.INFO";
+      level = "info";
       timeout = 5000;
       maxWidth = null;
       maxHeight = null;


### PR DESCRIPTION
Add those two new options which properly wrap the values from `vim.log.levels` and `vim.diagnostic.severity`.