### PR TITLE
change type of pylsp_mypy.overrides

### DIFF
--- a/plugins/lsp/language-servers/pylsp.nix
+++ b/plugins/lsp/language-servers/pylsp.nix
@@ -356,7 +356,8 @@ in {
 
         overrides =
           helpers.defaultNullOpts.mkNullable
-          (with types; listOf (either bool str))
+          (types.listOf
+            (types.oneOf [types.bool types.str helpers.rawType]))
           "[true]"
           ''
             Specifies a list of alternate or supplemental command-line options.


### PR DESCRIPTION
I have this specified in my config: 
```nix
pylsp_mypy = {
  enabled = true;
  overrides = ["--python-executable" (helpers.mkRaw "py_path") true];
};
extraConfigLuaPre = ''
  local venv_path = os.getenv('VIRTUAL_ENV') or os.getenv("CONDA_PREFIX")
  local py_path = nil
  if venv_path ~= nil then
    py_path = venv_path .. "/bin/python3"
  else
    py_path = vim.g.python3_host_prog
  end
'';
```
since most people wouldn't have globally installed python packages(and that won't even work in nix), mypy will never find the required packages and not work. so I have some lua code to look if currently in a python virtual environment. if yes then use python executable from that environment else just use vim's python. This would have all the dependencies inside the project available to it. Then I can simply provide this executable to mypy.

Currently, the only available types are listOf str or bool. I added a rawType as well.