### PR TITLE
plugins/none-ls: add go linters and formatters

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -128,6 +128,9 @@ with lib; let
       gofmt = {
         package = pkgs.go;
       };
+      goimports = {
+        package = pkgs.gotools;
+      };
       isort = {
         package = pkgs.isort;
       };

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -72,6 +72,9 @@ with lib; let
       pylint = {
         package = pkgs.pylint;
       };
+      revive = {
+        pacakge = pkgs.revive;
+      };
       shellcheck = {
         package = pkgs.shellcheck;
       };

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -78,6 +78,9 @@ with lib; let
       shellcheck = {
         package = pkgs.shellcheck;
       };
+      staticcheck = {
+        pacakge = pkgs.go-tools;
+      };
       statix = {
         package = pkgs.statix;
       };

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -131,6 +131,9 @@ with lib; let
       goimports = {
         package = pkgs.gotools;
       };
+      golines = {
+        package = pkgs.golines;
+      };
       isort = {
         package = pkgs.isort;
       };

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -91,6 +91,7 @@
           fnlfmt.enable = true;
           fourmolu.enable = true;
           gofmt.enable = true;
+          goimports.enable = true;
           ktlint.enable = true;
           nixfmt.enable = true;
           nixpkgs_fmt.enable = true;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -72,6 +72,7 @@
           vulture.enable = true;
           alex.enable = true;
           protolint.enable = true;
+          revive.enable = true;
           hadolint.enable = true;
           luacheck.enable = true;
           mypy.enable = true;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -92,6 +92,7 @@
           fourmolu.enable = true;
           gofmt.enable = true;
           goimports.enable = true;
+          golines.enable = true;
           ktlint.enable = true;
           nixfmt.enable = true;
           nixpkgs_fmt.enable = true;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -68,6 +68,7 @@
           markdownlint.enable = true;
           shellcheck.enable = true;
           statix.enable = true;
+          staticcheck.enable = true;
           vale.enable = true;
           vulture.enable = true;
           alex.enable = true;


### PR DESCRIPTION
Add more options for linters and formatters when using go.

### Changes
 * Add revive
 * Add staticcheck
 * Add goimports
 * Add golines

Have added corresponding tests for all the packages.