### PR TITLE
plugin/illuminate: Avoid using mkAttrsOf with submodules

### DIFF
--- a/plugins/utils/illuminate.nix
+++ b/plugins/utils/illuminate.nix
@@ -73,10 +73,12 @@ in {
 
       package = mkPackageOption "vim-illuminate" pkgs.vimPlugins.vim-illuminate;
 
-      filetypeOverrides = helpers.defaultNullOpts.mkAttrsOf (types.submodule {options = commonOptions;}) "{}" ''
-        Filetype specific overrides.
-        The keys are strings to represent the filetype.
-      '';
+      filetypeOverrides =
+        helpers.defaultNullOpts.mkNullable
+        (with types; attrsOf (submodule {options = commonOptions;})) "{}" ''
+          Filetype specific overrides.
+          The keys are strings to represent the filetype.
+        '';
 
       largeFileOverrides = mkOption {
         type = types.submodule {

--- a/plugins/utils/illuminate.nix
+++ b/plugins/utils/illuminate.nix
@@ -75,7 +75,9 @@ in {
 
       filetypeOverrides =
         helpers.defaultNullOpts.mkNullable
-        (with types; attrsOf (submodule {options = commonOptions;})) "{}" ''
+        (with types; attrsOf (submodule {options = commonOptions;}))
+        "{}"
+        ''
           Filetype specific overrides.
           The keys are strings to represent the filetype.
         '';


### PR DESCRIPTION
This confuses the documentation, as mentioned in the function definition.