### PR TITLE
helpers: Add mkLua,mkLuaFn (defaultNullOpts or not)

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -166,10 +166,14 @@ with lib; rec {
     in
       mkNullOrLua
       (
-        if desc == ""
-        then defaultDesc
-        else ''
+        (optionalString (desc != "") ''
           ${desc}
+          
+        '')
+        + ''
+          default: `${default}`
+        ''
+      );
 
           ${defaultDesc}
         ''

--- a/plugins/languages/clangd-extensions.nix
+++ b/plugins/languages/clangd-extensions.nix
@@ -69,7 +69,7 @@ in {
       '';
 
       inlayHints = {
-        inline = helpers.defaultNullOpts.mkStr ''vim.fn.has("nvim-0.10") == 1'' ''
+        inline = helpers.defaultNullOpts.mkLua ''vim.fn.has("nvim-0.10") == 1'' ''
           Show hints inline.
         '';
 
@@ -159,7 +159,7 @@ in {
     setupOptions = with cfg;
       {
         inlay_hints = with inlayHints; {
-          inline = helpers.mkRaw inline;
+          inherit inline;
           only_current_line = onlyCurrentLine;
           only_current_line_autocmd = onlyCurrentLineAutocmd;
           show_parameter_hints = showParameterHints;

--- a/plugins/lsp/fidget.nix
+++ b/plugins/lsp/fidget.nix
@@ -200,7 +200,7 @@ in {
           '';
 
           notificationGroup =
-            helpers.defaultNullOpts.mkStr
+            helpers.defaultNullOpts.mkLuaFn
             "function(msg) return msg.lsp_name end"
             ''
               How to get a progress message's notification group key
@@ -321,7 +321,7 @@ in {
             '';
 
             formatMessage =
-              helpers.defaultNullOpts.mkStr
+              helpers.defaultNullOpts.mkLua
               "require('fidget.progress.display').default_format_message"
               ''
                 How to format a progress message.
@@ -341,12 +341,12 @@ in {
               '';
 
             formatAnnote =
-              helpers.defaultNullOpts.mkStr
+              helpers.defaultNullOpts.mkLuaFn
               "function(msg) return msg.title end"
               "How to format a progress annotation.";
 
             formatGroupName =
-              helpers.defaultNullOpts.mkStr
+              helpers.defaultNullOpts.mkLuaFn
               "function(group) return tostring(group) end"
               "How to format a progress notification group's name.";
 
@@ -653,7 +653,7 @@ in {
             suppress_on_insert = suppressOnInsert;
             ignore_done_already = ignoreDoneAlready;
             ignore_empty_message = ignoreEmptyMessage;
-            notification_group = helpers.mkRaw notificationGroup;
+            notification_group = notificationGroup;
             clear_on_detach =
               if isString clearOnDetach
               then helpers.mkRaw clearOnDetach
@@ -677,9 +677,9 @@ in {
               icon_style = iconStyle;
               inherit priority;
               skip_history = skipHistory;
-              format_message = helpers.mkRaw formatMessage;
-              format_annote = helpers.mkRaw formatAnnote;
-              format_group_name = helpers.mkRaw formatGroupName;
+              format_message = formatMessage;
+              format_annote = formatAnnote;
+              format_group_name = formatGroupName;
               overrides =
                 helpers.ifNonNull' overrides
                 (

--- a/plugins/utils/auto-save.nix
+++ b/plugins/utils/auto-save.nix
@@ -100,7 +100,7 @@ in {
         mapAttrs
         (
           name: desc:
-            helpers.mkNullOrOption types.str "The code of the function that runs ${desc}."
+            helpers.mkNullOrLuaFn "The code of the function that runs ${desc}."
         )
         {
           enabling = "when enabling auto-save";
@@ -123,13 +123,12 @@ in {
         inherit (cfg) condition;
         write_all_buffers = cfg.writeAllBuffers;
         debounce_delay = cfg.debounceDelay;
-        callbacks = with cfg.callbacks;
-          mapAttrs (_: helpers.mkRaw) {
-            inherit enabling disabling;
-            before_asserting_save = beforeAssertingSave;
-            before_saving = beforeSaving;
-            after_saving = afterSaving;
-          };
+        callbacks = with cfg.callbacks; {
+          inherit enabling disabling;
+          before_asserting_save = beforeAssertingSave;
+          before_saving = beforeSaving;
+          after_saving = afterSaving;
+        };
       }
       // cfg.extraOptions;
   in

--- a/plugins/utils/nvim-autopairs.nix
+++ b/plugins/utils/nvim-autopairs.nix
@@ -33,7 +33,7 @@ in {
 
       disableInReplaceMode = helpers.defaultNullOpts.mkBool true "Disable in replace mode.";
 
-      ignoredNextChar = helpers.defaultNullOpts.mkStr "[=[[%w%%%'%[%\"%.%`%$]]=]" ''
+      ignoredNextChar = helpers.defaultNullOpts.mkLua "[=[[%w%%%'%[%\"%.%`%$]]=]" ''
         Regexp to ignore if it matches the next character.
       '';
 
@@ -81,7 +81,7 @@ in {
         disable_in_macro = cfg.disableInMacro;
         disable_in_visualblock = cfg.disableInVisualblock;
         disable_in_replace_mode = cfg.disableInReplaceMode;
-        ignored_next_char = helpers.mkRaw cfg.ignoredNextChar;
+        ignored_next_char = cfg.ignoredNextChar;
         enable_moveright = cfg.enableMoveright;
         enable_afterquote = cfg.enableAfterQuote;
         enable_check_bracket_line = cfg.enableCheckBracketLine;


### PR DESCRIPTION
This makes it such that defaultNullOpts.mkStr never represents a lua string, easing documenting where a string is a lua string vs lua code.