### PR TITLE
plugins/lsp: add marksman language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -353,6 +353,11 @@ with lib; let
       settings = cfg: {Lua = cfg;};
     }
     {
+      name = "marksman";
+      description = "Enable marksman, for Markdown";
+      package = pkgs.marksman;
+    }
+    {
       name = "metals";
       description = "Enable metals, for Scala";
     }

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -111,6 +111,7 @@
         leanls.enable = true;
         ltex.enable = true;
         lua-ls.enable = true;
+        marksman.enable = true;
         metals.enable = true;
         nil_ls.enable = true;
         nixd.enable = true;


### PR DESCRIPTION
Hi there,
I propose to add the [marksman language server for Markdown](https://github.com/artempyanykh/marksman).
Best,
Markus