### PR TITLE
ci/check: prevent CI from using remote builders

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           name: nix-community
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix flake check --all-systems
-      - run: nix flake check --all-systems ./templates/_wrapper/simple --no-write-lock-file
+      - run: nix flake check --all-systems --builders ""
+      - run: nix flake check --all-systems --builders "" ./templates/_wrapper/simple --no-write-lock-file
       - run: nix build .#docs --show-trace


### PR DESCRIPTION
As right now, the CI runs on my self-hosted runner, it is using the remote builders configured on this system.
This only slows down the build.