### PR TITLE
helpers: move rawType to helpers.nixvimTypes

### DIFF
--- a/lib/autocmd-helpers.nix
+++ b/lib/autocmd-helpers.nix
@@ -40,7 +40,7 @@ in rec {
       A textual description of this autocommand.
     '';
 
-    callback = helpers.mkNullOrOption (with types; either str helpers.rawType) ''
+    callback = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
       A function or a string.
       - if a string, the name of a Vimscript function to call when this autocommand is triggered.
       - Otherwise, a Lua function which is called when this autocommand is triggered.

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -141,7 +141,7 @@ with lib; rec {
     );
 
   defaultNullOpts = let
-    maybeRaw = t: lib.types.either t rawType;
+    maybeRaw = t: lib.types.either t nixvimTypes.rawLua;
   in rec {
     mkNullable = type: default: desc:
       mkNullOrOption type (
@@ -404,13 +404,18 @@ with lib; rec {
     end
   '';
 
-  rawType = mkOptionType {
-    name = "rawType";
-    description = "raw lua code";
-    descriptionClass = "noun";
-    merge = mergeEqualOption;
-    check = isRawType;
-  };
+  nixvimTypes =
+    {
+      rawLua = mkOptionType {
+        name = "rawType";
+        description = "raw lua code";
+        descriptionClass = "noun";
+        merge = mergeEqualOption;
+        check = isRawType;
+      };
+    }
+    # Allow to do `with nixvimTypes;` instead of `with types;`
+    // types;
 
   isRawType = v: lib.isAttrs v && lib.hasAttr "__raw" v && lib.isString v.__raw;
 }

--- a/modules/commands.nix
+++ b/modules/commands.nix
@@ -15,7 +15,7 @@ with lib; let
       nargs = helpers.mkNullOrOption (types.enum ["0" "1" "*" "?" "+"]) ''
         The number of arguments to expect, see :h command-nargs.
       '';
-      complete = helpers.mkNullOrOption (with types; either str helpers.rawType) ''
+      complete = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
         Tab-completion behaviour, see :h command-complete.
       '';
       range = helpers.mkNullOrOption (with types; oneOf [bool int (enum ["%"])]) ''

--- a/modules/filetype.nix
+++ b/modules/filetype.nix
@@ -13,7 +13,7 @@ with lib; let
           # Raw filetype
           str
           # Function to set the filetype
-          helpers.rawType
+          helpers.nixvimTypes.rawLua
           # ["filetype" {priority = xx;}]
           (listOf (either str (submodule {
             options = {

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -121,7 +121,7 @@ in {
             with types;
               either
               (enum ["none" "ordinal" "buffer_id" "both"])
-              helpers.rawType
+              helpers.nixvimTypes.rawLua
           )
           "none"
           ''

--- a/plugins/completion/copilot-lua.nix
+++ b/plugins/completion/copilot-lua.nix
@@ -70,7 +70,7 @@ in {
 
         filetypes =
           helpers.defaultNullOpts.mkNullable
-          (with types; attrsOf (either bool helpers.rawType))
+          (with types; attrsOf (either bool helpers.nixvimTypes.rawLua))
           ''
             {
               yaml = false;

--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -123,7 +123,7 @@ in {
           (
             with types;
               either
-              helpers.rawType
+              helpers.nixvimTypes.rawLua
               (enum (attrNames snippetEngines))
           )
           ''

--- a/plugins/dap/dap-python.nix
+++ b/plugins/dap/dap-python.nix
@@ -31,7 +31,7 @@ in {
       By default the `VIRTUAL_ENV` and `CONDA_PREFIX` environment variables are used if present.
     '';
 
-    testRunner = helpers.mkNullOrOption (types.either types.str helpers.rawType) ''
+    testRunner = helpers.mkNullOrOption (types.either types.str helpers.nixvimTypes.rawLua) ''
       The name of test runner to use by default.
       The default value is dynamic and depends on `pytest.ini` or `manage.py` markers.
       If neither is found "unittest" is used.

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -99,7 +99,7 @@ in {
         (
           types.either
           (types.enum ["name" "case_sensitive" "modification_time" "extension"])
-          helpers.rawType
+          helpers.nixvimTypes.rawLua
         )
         "name"
         ''
@@ -317,7 +317,7 @@ in {
 
       onAttach =
         helpers.defaultNullOpts.mkNullable
-        (with types; either (enum ["default"]) helpers.rawType)
+        (with types; either (enum ["default"]) helpers.nixvimTypes.rawLua)
         "default"
         ''
           Function ran when creating the nvim-tree buffer.
@@ -378,7 +378,7 @@ in {
 
                   padding =
                     helpers.defaultNullOpts.mkNullable
-                    (either ints.unsigned helpers.rawType)
+                    (either ints.unsigned helpers.nixvimTypes.rawLua)
                     "1"
                     "Extra padding to the right.";
                 };
@@ -466,7 +466,7 @@ in {
         rootFolderLabel =
           helpers.defaultNullOpts.mkNullable
           # Type
-          (with types; oneOf [str bool helpers.rawType])
+          (with types; oneOf [str bool helpers.nixvimTypes.rawLua])
           # Default
           ":~:s?$?/..?"
           # Description
@@ -740,7 +740,7 @@ in {
 
           picker =
             helpers.defaultNullOpts.mkNullable
-            (types.either types.str helpers.rawType)
+            (types.either types.str helpers.nixvimTypes.rawLua)
             "default"
             ''
               Change the default window picker, can be a string `"default"` or a function.

--- a/plugins/git/gitlinker.nix
+++ b/plugins/git/gitlinker.nix
@@ -20,7 +20,7 @@ with lib; {
       '';
 
       actionCallback =
-        helpers.defaultNullOpts.mkNullable (with types; either str helpers.rawType)
+        helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
         "copy_to_clipboard"
         ''
           Callback for what to do with the url.
@@ -47,7 +47,7 @@ with lib; {
             (
               either
               str
-              helpers.rawType
+              helpers.nixvimTypes.rawLua
             )
         )
         ''

--- a/plugins/languages/lint.nix
+++ b/plugins/languages/lint.nix
@@ -40,7 +40,7 @@ with lib; let
     };
 
     args = {
-      type = listOf (either str helpers.rawType);
+      type = listOf (either str helpers.nixvimTypes.rawLua);
       description = ''
         List of arguments.
         Can contain functions with zero arguments that will be evaluated once the linter is used.
@@ -229,7 +229,7 @@ in {
 
                   callback = mkOption {
                     type = with types;
-                      nullOr (either str helpers.rawType);
+                      nullOr (either str helpers.nixvimTypes.rawLua);
                     default = defaultCallback;
                     description = "What action to perform for linting";
                   };

--- a/plugins/languages/nvim-jdtls.nix
+++ b/plugins/languages/nvim-jdtls.nix
@@ -63,7 +63,7 @@ in {
 
       rootDir =
         helpers.defaultNullOpts.mkNullable
-        (types.either types.str helpers.rawType)
+        (types.either types.str helpers.nixvimTypes.rawLua)
         ''{ __raw = "require('jdtls.setup').find_root({'.git', 'mvnw', 'gradlew'})"; }''
         ''
           This is the default if not provided, you can remove it. Or adjust as needed.

--- a/plugins/languages/treesitter/rainbow-delimiters.nix
+++ b/plugins/languages/treesitter/rainbow-delimiters.nix
@@ -22,7 +22,7 @@ with lib; {
           with types;
             attrsOf (
               either
-              helpers.rawType
+              helpers.nixvimTypes.rawLua
               (enum ["global" "local" "noop"])
             )
         )
@@ -106,7 +106,7 @@ with lib; {
       log = {
         file =
           helpers.defaultNullOpts.mkNullable
-          (with types; either str helpers.rawType)
+          (with types; either str helpers.nixvimTypes.rawLua)
           ''
             {
               __raw = "vim.fn.stdpath('log') .. '/rainbow-delimiters.log'";

--- a/plugins/languages/vim-slime.nix
+++ b/plugins/languages/vim-slime.nix
@@ -46,7 +46,7 @@ in
 
       defaultConfig =
         helpers.defaultNullOpts.mkNullable
-        (with types; attrsOf (either str helpers.rawType))
+        (with types; attrsOf (either str helpers.nixvimTypes.rawLua))
         "null"
         ''
           Pre-filled prompt answer.

--- a/plugins/lsp/fidget.nix
+++ b/plugins/lsp/fidget.nix
@@ -14,7 +14,7 @@ with lib; let
       with types;
         oneOf [
           str
-          helpers.rawType
+          helpers.nixvimTypes.rawLua
           (listOf str)
           (attrsOf (either str ints.unsigned))
         ]
@@ -593,7 +593,7 @@ in {
 
           path =
             helpers.defaultNullOpts.mkNullable
-            (with types; either str helpers.rawType)
+            (with types; either str helpers.nixvimTypes.rawLua)
             ''{__raw = "string.format('%s/fidget.nvim.log', vim.fn.stdpath('cache'))";}''
             ''
               Where Fidget writes its logs to.

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -323,7 +323,7 @@ with lib; let
               nullOr
               (
                 listOf
-                (either str helpers.rawType)
+                (either str helpers.nixvimTypes.rawLua)
               );
             description = ''
               An array of abosolute or workspace-relative paths that will be added to the workspace

--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -190,7 +190,7 @@ in {
       miscFormatters = languageTools "misc" "formatters";
 
       mkChooseOption = lang: kind: possible: let
-        toolType = with types; either (enum possible) helpers.rawType;
+        toolType = with types; either (enum possible) helpers.nixvimTypes.rawLua;
       in
         mkOption {
           type = with types; either toolType (listOf toolType);

--- a/plugins/lsp/language-servers/pylsp.nix
+++ b/plugins/lsp/language-servers/pylsp.nix
@@ -357,7 +357,7 @@ in {
         overrides =
           helpers.defaultNullOpts.mkNullable
           (types.listOf
-            (types.oneOf [types.bool types.str helpers.rawType]))
+            (types.oneOf [types.bool types.str helpers.nixvimTypes.rawLua]))
           "[true]"
           ''
             Specifies a list of alternate or supplemental command-line options.

--- a/plugins/lsp/wtf.nix
+++ b/plugins/lsp/wtf.nix
@@ -51,7 +51,7 @@ in {
           Default AI popup type.
         '';
 
-        openaiApiKey = helpers.mkNullOrOption (with types; either str helpers.rawType) ''
+        openaiApiKey = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
           An alternative way to set your API key.
         '';
 

--- a/plugins/pluginmanagers/packer.nix
+++ b/plugins/pluginmanagers/packer.nix
@@ -55,8 +55,8 @@ in {
                 helpers.mkNullOrOption
                 (oneOf [
                   str
-                  helpers.rawType
-                  (listOf (either str helpers.rawType))
+                  helpers.nixvimTypes.rawLua
+                  (listOf (either str helpers.nixvimTypes.rawLua))
                 ])
                 "Post-install hook";
 
@@ -67,11 +67,11 @@ in {
                 "Luarocks dependencies";
 
               config =
-                helpers.mkNullOrOption (either str helpers.rawType)
+                helpers.mkNullOrOption (either str helpers.nixvimTypes.rawLua)
                 "Code to run after this plugin is loaded";
 
               setup =
-                helpers.mkNullOrOption (either str helpers.rawType)
+                helpers.mkNullOrOption (either str helpers.nixvimTypes.rawLua)
                 "Code to be run before this plugin is loaded";
 
               cmd =
@@ -98,8 +98,8 @@ in {
                 helpers.mkNullOrOption
                 (oneOf [
                   str
-                  helpers.rawType
-                  (listOf (either str helpers.rawType))
+                  helpers.nixvimTypes.rawLua
+                  (listOf (either str helpers.nixvimTypes.rawLua))
                 ])
                 "Conditional test to load this plugin";
 

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -60,12 +60,12 @@ in {
                 [
                   str
                   path
-                  helpers.rawType
+                  helpers.nixvimTypes.rawLua
                   (listOf (oneOf
                     [
                       str
                       path
-                      helpers.rawType
+                      helpers.nixvimTypes.rawLua
                     ]))
                 ]);
           };
@@ -122,12 +122,12 @@ in {
                   [
                     str
                     path
-                    helpers.rawType
+                    helpers.nixvimTypes.rawLua
                     (listOf (oneOf
                       [
                         str
                         path
-                        helpers.rawType
+                        helpers.nixvimTypes.rawLua
                       ]))
                   ]
                 )

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -25,7 +25,7 @@ with lib; let
         (submodule {
           options = {
             name = mkOption {
-              type = types.either types.str helpers.rawType;
+              type = types.either types.str helpers.nixvimTypes.rawLua;
               description = "Component name or function";
               default = defaultName;
             };

--- a/plugins/telescope/file-browser.nix
+++ b/plugins/telescope/file-browser.nix
@@ -31,12 +31,12 @@ in {
 
     theme = helpers.mkNullOrOption types.str "Custom theme, will use your global theme by default.";
 
-    path = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "vim.loop.cwd()" ''
+    path = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "vim.loop.cwd()" ''
       Directory to browse files from.
       `vim.fn.expanded` automatically.
     '';
 
-    cwd = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "vim.loop.cwd()" ''
+    cwd = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "vim.loop.cwd()" ''
       Directory to browse folders from.
       `vim.fn.expanded` automatically.
     '';
@@ -131,7 +131,7 @@ in {
     mappings =
       helpers.mkNullOrOption (
         with types;
-          attrsOf (attrsOf (either str helpers.rawType))
+          attrsOf (attrsOf (either str helpers.nixvimTypes.rawLua))
       ) ''
         `fb_actions` mappings.
         Mappings can also be a lua function.

--- a/plugins/utils/auto-save.nix
+++ b/plugins/utils/auto-save.nix
@@ -32,7 +32,7 @@ in {
       executionMessage = {
         message =
           helpers.defaultNullOpts.mkNullable
-          (with types; either str helpers.rawType)
+          (with types; either str helpers.nixvimTypes.rawLua)
           ''
             {
               __raw = \'\'

--- a/plugins/utils/auto-session.nix
+++ b/plugins/utils/auto-session.nix
@@ -32,7 +32,7 @@ in {
 
         rootDir =
           helpers.defaultNullOpts.mkNullable
-          (with types; either str helpers.rawType)
+          (with types; either str helpers.nixvimTypes.rawLua)
           "{__raw = \"vim.fn.stdpath 'data' .. '/sessions/'\";}"
           ''
             Root directory for session files.
@@ -128,7 +128,7 @@ in {
         sessionControl = {
           controlDir =
             helpers.defaultNullOpts.mkNullable
-            (with types; either str helpers.rawType)
+            (with types; either str helpers.nixvimTypes.rawLua)
             "\"vim.fn.stdpath 'data' .. '/auto_session/'\""
             ''
               Auto session control dir, for control files, like alternating between two sessions

--- a/plugins/utils/better-escape.nix
+++ b/plugins/utils/better-escape.nix
@@ -39,7 +39,7 @@ in {
         helpers.defaultNullOpts.mkNullable
         (
           with types;
-            either str helpers.rawType
+            either str helpers.nixvimTypes.rawLua
         )
         "<ESC>"
         ''

--- a/plugins/utils/flash.nix
+++ b/plugins/utils/flash.nix
@@ -34,7 +34,7 @@ in {
 
         mode =
           helpers.defaultNullOpts.mkNullable
-          (with types; either (enum ["exact" "search" "fuzzy"]) helpers.rawType) ''"exact"'' ''
+          (with types; either (enum ["exact" "search" "fuzzy"]) helpers.nixvimTypes.rawLua) ''"exact"'' ''
             - exact: exact match
             - search: regular search
             - fuzzy: fuzzy search
@@ -48,7 +48,7 @@ in {
         incremental = helpers.defaultNullOpts.mkBool false "behave like `incsearch`";
 
         exclude =
-          helpers.defaultNullOpts.mkNullable (with types; listOf (either str helpers.rawType)) ''
+          helpers.defaultNullOpts.mkNullable (with types; listOf (either str helpers.nixvimTypes.rawLua)) ''
             [
               "notify"
               "cmp_menu"

--- a/plugins/utils/hardtime.nix
+++ b/plugins/utils/hardtime.nix
@@ -126,7 +126,7 @@ in {
             options = {
               message = lib.mkOption {
                 description = "Hint message to be displayed.";
-                type = helpers.rawType;
+                type = helpers.nixvimTypes.rawLua;
               };
 
               length = lib.mkOption {

--- a/plugins/utils/molten.nix
+++ b/plugins/utils/molten.nix
@@ -157,7 +157,7 @@ with import ../helpers.nix {inherit lib;};
 
           Default: `{__raw = "vim.fn.stdpath('data')..'/molten'";}`
         '';
-        type = with types; either str rawType;
+        type = with nixvimTypes; either str rawLua;
       };
 
       useBorderHighlights = mkDefaultOpt {

--- a/plugins/utils/navbuddy.nix
+++ b/plugins/utils/navbuddy.nix
@@ -166,7 +166,7 @@ in {
             (
               either
               str
-              helpers.rawType
+              helpers.nixvimTypes.rawLua
             )
         )
         ''

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -21,11 +21,11 @@ in {
 
       timeout = helpers.defaultNullOpts.mkUnsignedInt 5000 "Default timeout for notification.";
 
-      maxWidth = helpers.mkNullOrOption (with types; either ints.unsigned helpers.rawType) ''
+      maxWidth = helpers.mkNullOrOption (with types; either ints.unsigned helpers.nixvimTypes.rawLua) ''
         Max number of columns for messages.
       '';
 
-      maxHeight = helpers.mkNullOrOption (with types; either ints.unsigned helpers.rawType) ''
+      maxHeight = helpers.mkNullOrOption (with types; either ints.unsigned helpers.nixvimTypes.rawLua) ''
         Max number of lines for a message.
       '';
 
@@ -85,7 +85,7 @@ in {
           with types;
             either
             (enum ["default" "minimal"])
-            helpers.rawType
+            helpers.nixvimTypes.rawLua
         )
         "default"
         "Function to render a notification buffer or a built-in renderer name.";

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -67,7 +67,7 @@ in {
       package = helpers.mkPackageOption "oil" pkgs.vimPlugins.oil-nvim;
 
       columns = let
-        highlightsOption = helpers.mkNullOrOption (with types; either str helpers.rawType) ''
+        highlightsOption = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
           A string or a lua function (`fun(value: string): string`).
           Highlight group, or function that returns a highlight group.
         '';

--- a/plugins/utils/persistence.nix
+++ b/plugins/utils/persistence.nix
@@ -14,7 +14,7 @@ with lib; {
       package = helpers.mkPackageOption "persistence.nvim" pkgs.vimPlugins.persistence-nvim;
 
       dir =
-        helpers.defaultNullOpts.mkNullable (with types; either str helpers.rawType)
+        helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
         ''vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/")''
         "directory where session files are saved";
 

--- a/plugins/utils/presence-nvim.nix
+++ b/plugins/utils/presence-nvim.nix
@@ -54,7 +54,7 @@ in {
 
         buttons =
           helpers.defaultNullOpts.mkNullable
-          (types.either helpers.rawType
+          (types.either helpers.nixvimTypes.rawLua
             (types.listOf (types.submodule {
               options = {
                 label = helpers.mkNullOrOption types.str "";
@@ -99,49 +99,49 @@ in {
         showTime = helpers.defaultNullOpts.mkBool true "Show the timer.";
 
         # Rich presence text options.
-        editingText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "Editing %s" ''
+        editingText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Editing %s" ''
           String rendered when an editable file is loaded in the buffer.
 
           Can also be a lua function:
           `function(filename: string): string`
         '';
 
-        fileExplorerText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "Browsing %s" ''
+        fileExplorerText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Browsing %s" ''
           String rendered when browsing a file explorer.
 
           Can also be a lua function:
           `function(file_explorer_name: string): string`
         '';
 
-        gitCommitText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "Committing changes" ''
+        gitCommitText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Committing changes" ''
           String rendered when committing changes in git.
 
           Can also be a lua function:
           `function(filename: string): string`
         '';
 
-        pluginManagerText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "Managing plugins" ''
+        pluginManagerText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Managing plugins" ''
           String rendered when managing plugins.
 
           Can also be a lua function:
           `function(plugin_manager_name: string): string`
         '';
 
-        readingText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "Reading %s" ''
+        readingText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Reading %s" ''
           String rendered when a read-only/unmodifiable file is loaded into the buffer.
 
           Can also be a lua function:
           `function(filename: string): string`
         '';
 
-        workspaceText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "Working on %s" ''
+        workspaceText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Working on %s" ''
           String rendered when in a git repository.
 
           Can also be a lua function:
           `function(project_name: string|nil, filename: string): string`
         '';
 
-        lineNumberText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.rawType) "Line %s out of %s" ''
+        lineNumberText = helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Line %s out of %s" ''
           String rendered when `enableLineNumber` is set to `true` to display the current line number.
 
           Can also be a lua function:

--- a/plugins/utils/project-nvim.nix
+++ b/plugins/utils/project-nvim.nix
@@ -64,7 +64,7 @@ in {
 
       dataPath =
         helpers.defaultNullOpts.mkNullable
-        (with types; either str helpers.rawType)
+        (with types; either str helpers.nixvimTypes.rawLua)
         ''{__raw = "vim.fn.stdpath('data')";}''
         "Path where project.nvim will store the project history for use in telescope.";
     };

--- a/plugins/utils/startup.nix
+++ b/plugins/utils/startup.nix
@@ -77,7 +77,7 @@ in {
                           (listOf str)
                         )
                       )
-                      helpers.rawType
+                      helpers.nixvimTypes.rawLua
                       # for "oldfiles" sections
                       (enum [""])
                     ]

--- a/plugins/utils/yanky.nix
+++ b/plugins/utils/yanky.nix
@@ -40,7 +40,7 @@ in {
 
         storagePath =
           helpers.defaultNullOpts.mkNullable
-          (with types; either str helpers.rawType)
+          (with types; either str helpers.nixvimTypes.rawLua)
           ''{__raw = "vim.fn.stdpath('data') .. '/databases/yanky.db'";}''
           "Only for sqlite storage.";
 
@@ -70,7 +70,7 @@ in {
 
       picker = {
         select = {
-          action = helpers.mkNullOrOption (with types; either helpers.rawType str) ''
+          action = helpers.mkNullOrOption (with types; either helpers.nixvimTypes.rawLua str) ''
             This define the action that should be done when selecting an item in the
             `vim.ui.select` prompt.
             If you let this option to `null`, this will use the default action: put selected item

--- a/tests/test-sources/plugins/lsp/efmls-configs.nix
+++ b/tests/test-sources/plugins/lsp/efmls-configs.nix
@@ -62,7 +62,7 @@
         # tool options are a `either toolType (listOf toolType)`
         # Look into `nestedTypes.left` to get a `toolType` option.
         toolType = opt.type.nestedTypes.left;
-        # toolType is a `either (enum possible) helpers.rawType
+        # toolType is a `either (enum possible) helpers.nixvimTypes.rawLua
         # Look into `nestedTypes.left` for the enum
         possible = toolType.nestedTypes.left;
         # possible is an enum, look into functor.payload for the variants


### PR DESCRIPTION
This is done in preparation of adding new (lua) types to help the documentation.