### PR TITLE
helpers: Add option helpers for types that are either a lua str or a value

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -95,6 +95,28 @@ with lib; rec {
       apply = mkRaw;
     };
 
+  mkNullOrStrLuaOr = ty: desc:
+    lib.mkOption {
+      type = lib.types.nullOr (types.either nixvimTypes.strLua ty);
+      default = null;
+      description = desc;
+      apply = v:
+        if builtins.isString v
+        then mkRaw v
+        else v;
+    };
+
+  mkNullOrStrLuaFnOr = ty: desc:
+    lib.mkOption {
+      type = lib.types.nullOr (types.either nixvimTypes.strLuaFn ty);
+      default = null;
+      description = desc;
+      apply = v:
+        if builtins.isString v
+        then mkRaw v
+        else v;
+    };
+
   defaultNullOpts = let
     maybeRaw = t: lib.types.either t nixvimTypes.rawLua;
   in rec {
@@ -115,6 +137,30 @@ with lib; rec {
     # Note that this function is _not_ to be used with submodule elements, as it may obstruct the
     # documentation
     mkNullableWithRaw = type: mkNullable (maybeRaw type);
+
+    mkStrLuaOr = type: default: desc:
+      mkNullOrStrLuaOr type (let
+        defaultDesc = "default: `${default}`";
+      in
+        if desc == ""
+        then defaultDesc
+        else ''
+          ${desc}
+
+          ${defaultDesc}
+        '');
+
+    mkStrLuaFnOr = type: default: desc:
+      mkNullOrStrLuaFnOr type (let
+        defaultDesc = "default: `${default}`";
+      in
+        if desc == ""
+        then defaultDesc
+        else ''
+          ${desc}
+
+          ${defaultDesc}
+        '');
 
     mkLua = default: desc:
       mkNullOrLua

--- a/plugins/colorschemes/ayu.nix
+++ b/plugins/colorschemes/ayu.nix
@@ -21,13 +21,8 @@ in {
         '';
 
         overrides =
-          helpers.defaultNullOpts.mkNullable
-          (
-            with types;
-              either
-              (attrsOf helpers.nixvimTypes.highlight)
-              str
-          )
+          helpers.defaultNullOpts.mkStrLuaOr
+          (with helpers.nixvimTypes; attrsOf highlight)
           "{}"
           ''
             A dictionary of group names, each associated with a dictionary of parameters
@@ -44,10 +39,7 @@ in {
   config = let
     setupOptions = with cfg;
       {
-        overrides =
-          if isString overrides
-          then helpers.mkRaw overrides
-          else overrides;
+        inherit overrides;
       }
       // cfg.extraOptions;
   in

--- a/plugins/dap/dap-python.nix
+++ b/plugins/dap/dap-python.nix
@@ -37,7 +37,7 @@ in {
       If neither is found "unittest" is used.
     '';
 
-    testRunners = helpers.mkNullOrOption (types.attrsOf types.str) ''
+    testRunners = helpers.mkNullOrOption (with helpers.nixvimTypes; attrsOf strLuaFn) ''
       Set to register test runners.
       Built-in are test runners for unittest, pytest and django.
       The key is the test runner name, the value a function to generate the

--- a/plugins/dap/dapHelpers.nix
+++ b/plugins/dap/dapHelpers.nix
@@ -12,7 +12,7 @@ in rec {
             For most debug adapters setting this is not necessary.
           '';
 
-          enrichConfig = helpers.mkNullOrOption types.str ''
+          enrichConfig = helpers.mkNullOrLuaFn ''
             A lua function (`func(config, on_config)`) which allows an adapter to enrich a
             configuration with additional information. It receives a configuration as first
             argument, and a callback that must be called with the final configuration as second argument.
@@ -129,7 +129,7 @@ in rec {
             adapter
             // {
               inherit type;
-              enrich_config = helpers.mkRaw adapter.enrichConfig;
+              enrich_config = adapter.enrichConfig;
             }
           ))
       adapters;

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -769,8 +769,8 @@ in {
           "This is determined automatically, you probably don't need to set it";
 
         findArgs =
-          helpers.mkNullOrOption
-          (types.either types.str (types.submodule {
+          helpers.mkNullOrStrLuaFnOr
+          (types.submodule {
             options = {
               fd =
                 helpers.defaultNullOpts.mkNullable (types.listOf types.str)
@@ -784,7 +784,7 @@ in {
                 ''
                 "You can specify extra args to pass to the find command.";
             };
-          }))
+          })
           ''
             Find arguments
 
@@ -1154,10 +1154,7 @@ in {
           };
           find_by_full_path_words = findByFullPathWords;
           find_command = findCommand;
-          find_args =
-            if isString findArgs
-            then mkRaw findArgs
-            else findArgs;
+          find_args = findArgs;
           group_empty_dirs = groupEmptyDirs;
           search_limit = searchLimit;
           follow_current_file = followCurrentFile;

--- a/plugins/languages/lint.nix
+++ b/plugins/languages/lint.nix
@@ -81,7 +81,7 @@ with lib; let
     };
 
     parser = {
-      type = str;
+      type = helpers.nixvimTypes.strLuaFn;
       description = "The code for your parser function.";
       example = ''
         require('lint.parser').from_pattern(pattern, groups, severity_map, defaults, opts)

--- a/plugins/languages/treesitter/treesitter-textobjects.nix
+++ b/plugins/languages/treesitter/treesitter-textobjects.nix
@@ -84,21 +84,17 @@ with lib; {
             selection mode per capture, default is `v`(charwise).
           '';
 
-        includeSurroundingWhitespace =
-          helpers.defaultNullOpts.mkNullable
-          (with types; either bool str)
-          "`false`"
-          ''
-            `true` or `false`, when `true` textobjects are extended to include preceding or
-            succeeding whitespace.
+        includeSurroundingWhitespace = helpers.defaultNullOpts.mkStrLuaFnOr types.bool "`false`" ''
+          `true` or `false`, when `true` textobjects are extended to include preceding or
+          succeeding whitespace.
 
-            Can also be a function which gets passed a table with the keys `query_string`
-            (`@function.inner`) and `selection_mode` (`v`) and returns `true` of `false`.
+          Can also be a function which gets passed a table with the keys `query_string`
+          (`@function.inner`) and `selection_mode` (`v`) and returns `true` of `false`.
 
-            If you set this to `true` (default is `false`) then any textobject is extended to
-            include preceding or succeeding whitespace.
-            Succeeding whitespace has priority in order to act similarly to eg the built-in `ap`.
-          '';
+          If you set this to `true` (default is `false`) then any textobject is extended to
+          include preceding or succeeding whitespace.
+          Succeeding whitespace has priority in order to act similarly to eg the built-in `ap`.
+        '';
       };
 
       swap = {
@@ -227,10 +223,7 @@ with lib; {
               ;
             keymaps = processKeymapsOpt keymaps;
             selection_modes = selectionModes;
-            include_surrounding_whitespace =
-              if isString includeSurroundingWhitespace
-              then helpers.mkRaw includeSurroundingWhitespace
-              else includeSurroundingWhitespace;
+            include_surrounding_whitespace = includeSurroundingWhitespace;
           };
           swap = with swap; {
             inherit

--- a/plugins/lsp/fidget.nix
+++ b/plugins/lsp/fidget.nix
@@ -218,8 +218,7 @@ in {
             '';
 
           clearOnDetach =
-            helpers.defaultNullOpts.mkNullable
-            (with types; either str (enum [false]))
+            helpers.defaultNullOpts.mkStrLuaFnOr (types.enum [false])
             ''
               function(client_id)
                 local client = vim.lsp.get_client_by_id(client_id)
@@ -264,18 +263,14 @@ in {
                 per-server limit.
               '';
 
-            doneTtl =
-              helpers.defaultNullOpts.mkNullable
-              (with types; either str ints.unsigned)
-              "3"
-              ''
-                How long a message should persist after completion.
+            doneTtl = helpers.defaultNullOpts.mkStrLuaOr types.ints.unsigned "3" ''
+              How long a message should persist after completion.
 
-                Set to `0` to use notification group config default, and `math.huge` to show
-                notification indefinitely (until overwritten).
+              Set to `0` to use notification group config default, and `math.huge` to show
+              notification indefinitely (until overwritten).
 
-                Measured in seconds.
-              '';
+              Measured in seconds.
+            '';
 
             doneIcon = mkIconOption "✔" "Icon shown when all LSP progress tasks are complete.";
 
@@ -283,13 +278,9 @@ in {
               Highlight group for completed LSP tasks.
             '';
 
-            progressTtl =
-              helpers.defaultNullOpts.mkNullable
-              (with types; either str ints.unsigned)
-              "math.huge"
-              ''
-                How long a message should persist when in progress.
-              '';
+            progressTtl = helpers.defaultNullOpts.mkStrLuaFnOr types.ints.unsigned "math.huge" ''
+              How long a message should persist when in progress.
+            '';
 
             progressIcon =
               mkIconOption
@@ -441,8 +432,7 @@ in {
             '';
 
           redirect =
-            helpers.defaultNullOpts.mkNullable
-            (with types; either str (enum [false]))
+            helpers.defaultNullOpts.mkStrLuaFnOr (types.enum [false])
             ''
               function(msg, level, opts)
                 if opts and opts.on_open then
@@ -654,23 +644,14 @@ in {
             ignore_done_already = ignoreDoneAlready;
             ignore_empty_message = ignoreEmptyMessage;
             notification_group = notificationGroup;
-            clear_on_detach =
-              if isString clearOnDetach
-              then helpers.mkRaw clearOnDetach
-              else clearOnDetach;
+            clear_on_detach = clearOnDetach;
             inherit ignore;
             display = with display; {
               render_limit = renderLimit;
-              done_ttl =
-                if isString doneTtl
-                then helpers.mkRaw doneTtl
-                else doneTtl;
+              done_ttl = doneTtl;
               done_icon = doneIcon;
               done_style = doneStyle;
-              progress_ttl =
-                if isString progressTtl
-                then helpers.mkRaw progressTtl
-                else progressTtl;
+              progress_ttl = progressTtl;
               progress_icon = progressIcon;
               progress_style = progressStyle;
               group_style = groupStyle;
@@ -711,10 +692,7 @@ in {
                 )
                 configs
               );
-            redirect =
-              if isString redirect
-              then helpers.mkRaw redirect
-              else redirect;
+            inherit redirect;
             view = with view; {
               stack_upwards = stackUpwards;
               icon_separator = iconSeparator;

--- a/plugins/telescope/undo.nix
+++ b/plugins/telescope/undo.nix
@@ -29,7 +29,7 @@ in {
       the side-by-side view even if this is set to false.
     '';
 
-    diffContextLines = helpers.defaultNullOpts.mkNullable (with types; either ints.unsigned str) "vim.o.scrolloff" ''
+    diffContextLines = helpers.defaultNullOpts.mkStrLuaOr types.ints.unsigned "vim.o.scrolloff" ''
       Defaults to the scrolloff.
     '';
 
@@ -78,10 +78,7 @@ in {
       use_delta = useDelta;
       use_custom_command = useCustomCommand;
       side_by_side = sideBySide;
-      diff_context_lines =
-        if isString diffContextLines
-        then helpers.mkRaw diffContextLines
-        else diffContextLines;
+      diff_context_lines = diffContextLines;
       entry_format = entryFormat;
       time_format = timeFormat;
       mappings = with mappings; {

--- a/plugins/utils/better-escape.nix
+++ b/plugins/utils/better-escape.nix
@@ -20,11 +20,7 @@ in {
       '';
 
       timeout =
-        helpers.defaultNullOpts.mkNullable
-        (
-          with types;
-            either ints.unsigned str
-        )
+        helpers.defaultNullOpts.mkStrLuaOr types.ints.unsigned
         "vim.o.timeoutlen"
         ''
           The time in which the keys must be hit in ms.
@@ -58,11 +54,7 @@ in {
   config = let
     setupOptions = with cfg;
       {
-        inherit mapping;
-        timeout =
-          if isString timeout
-          then helpers.mkRaw timeout
-          else timeout;
+        inherit mapping timeout;
         clear_empty_lines = clearEmptyLines;
         inherit keys;
       }

--- a/plugins/utils/mkdnflow.nix
+++ b/plugins/utils/mkdnflow.nix
@@ -219,8 +219,7 @@ in {
         '';
 
         transformExplicit =
-          helpers.defaultNullOpts.mkNullable
-          (with types; either str (enum [false]))
+          helpers.defaultNullOpts.mkStrLuaFnOr (types.enum [false])
           "false"
           ''
             A function that transforms the text to be inserted as the source/path of a link when a
@@ -241,8 +240,7 @@ in {
           '';
 
         transformImplicit =
-          helpers.defaultNullOpts.mkNullable
-          (with types; either str (enum [false]))
+          helpers.defaultNullOpts.mkStrLuaFnOr (types.enum [false])
           ''
             function(text)
                 text = text:gsub(" ", "-")
@@ -578,14 +576,8 @@ in {
             context
             ;
           implicit_extension = implicitExtension;
-          transform_implicit =
-            if isString transformImplicit
-            then helpers.mkRaw transformImplicit
-            else transformImplicit;
-          transform_explicit =
-            if isString transformExplicit
-            then helpers.mkRaw transformExplicit
-            else transformExplicit;
+          transform_implicit = transformImplicit;
+          transform_explicit = transformExplicit;
         };
         to_do = with toDo; {
           inherit symbols;

--- a/plugins/utils/toggleterm.nix
+++ b/plugins/utils/toggleterm.nix
@@ -13,26 +13,24 @@ in {
 
     package = helpers.mkPackageOption "toggleterm" pkgs.vimPlugins.toggleterm-nvim;
 
-    size =
-      helpers.defaultNullOpts.mkNullable
-      (with types; either number str) "12" ''
-        Size of the terminal.
-        `size` can be a number or function
-        Example:
-        ```nix
-        size = 20
-        ```
-        OR
-        ```
-        size = function(term)
-          if term.direction == "horizontal" then
-            return 15
-          elseif term.direction == "vertical" then
-            return vim.o.columns * 0.4
-          end
+    size = helpers.defaultNullOpts.mkStrLuaFnOr types.number "12" ''
+      Size of the terminal.
+      `size` can be a number or function
+      Example:
+      ```nix
+      size = 20
+      ```
+      OR
+      ```
+      size = function(term)
+        if term.direction == "horizontal" then
+          return 15
+        elseif term.direction == "vertical" then
+          return vim.o.columns * 0.4
         end
-        ```
-      '';
+      end
+      ```
+    '';
 
     openMapping = helpers.mkNullOrOption types.str ''
       Setting the open_mapping key to use for toggling the terminal(s) will set up mappings for
@@ -170,12 +168,7 @@ in {
   };
   config = let
     setupOptions = with cfg; {
-      inherit autochdir highlights direction shell;
-      size = helpers.ifNonNull' size (
-        if isInt size
-        then size
-        else helpers.mkRaw size
-      );
+      inherit autochdir highlights direction shell size;
       open_mapping = helpers.ifNonNull' openMapping (helpers.mkRaw "[[${openMapping}]]");
       on_create = onCreate;
       on_open = onOpen;

--- a/plugins/utils/wilder.nix
+++ b/plugins/utils/wilder.nix
@@ -151,7 +151,7 @@ in {
         Setting the option after the first run has no effect.
       '';
 
-      pipeline = helpers.mkNullOrOption (with types; listOf str) ''
+      pipeline = helpers.mkNullOrOption (with helpers.nixvimTypes; listOf strLua) ''
         Sets the pipeline to use to get completions.
         See `|wilder-pipeline|`.
 


### PR DESCRIPTION
Those types needed the following code in apply:

if builtins.isString value
then mkRaw value
else value

This commit avoids this boilerplate, and clarifies that the `str` is lua code in the documentation.