### PR TITLE
misc/wrapRc: switch to XDG compliant path resolution

### DIFF
--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -155,8 +155,8 @@ in {
 
     extraConfigLuaPre = lib.optionalString config.wrapRc ''
       -- Ignore the user lua configuration
-      vim.opt.runtimepath:remove(vim.fn.expand('~/.config/nvim'))
-      vim.opt.packpath:remove(vim.fn.expand('~/.local/share/nvim/site'))
+      vim.opt.runtimepath:remove(vim.fn.stdpath('config'))  -- ~/.config/nvim
+      vim.opt.runtimepath:remove(vim.fn.stdpath('data') .. "/site")  -- ~/.local/share/nvim/site
     '';
 
     extraPlugins =


### PR DESCRIPTION
This is a more generic solution to resolve paths to ignore:
- `~/.config/nvim` -> `vim.fn.stdpath('config')`
- `~/.local/share/nvim/site` -> `vim.fn.stdpath('data') .. '/site'`