### PR TITLE
plugins/lsp: add dagger language server (for cuelang)

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -63,6 +63,11 @@ with lib; let
       cmd = cfg: ["${cfg.package}/bin/vscode-css-language-server" "--stdio"];
     }
     {
+      name = "dagger";
+      description = "Enable dagger, for Cuelang";
+      package = pkgs.cuelsp;
+    }
+    {
       name = "dartls";
       description = "Enable dart language-server, for dart";
       package = pkgs.dart;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -91,6 +91,7 @@
           # pkgs.csharp-ls only supports linux platforms
           csharp-ls.enable = pkgs.stdenv.isLinux;
           cssls.enable = true;
+          dagger.enable = true;
           dartls.enable = true;
           denols.enable = true;
           dhall-lsp-server.enable = true;


### PR DESCRIPTION
This adds an option for enabling Dagger's Cue LSP.