### PR TITLE
Update wrapper imports (fixes #898)

### DIFF
--- a/flake-modules/wrappers.nix
+++ b/flake-modules/wrappers.nix
@@ -28,8 +28,8 @@ in {
   };
 
   flake = {
-    nixosModules.nixvim = import ./nixos.nix wrapperArgs;
-    homeManagerModules.nixvim = import ./wrappers/hm.nix wrapperArgs;
-    nixDarwinModules.nixvim = import ./wrappers/darwin.nix wrapperArgs;
+    nixosModules.nixvim = import ../wrappers/nixos.nix wrapperArgs;
+    homeManagerModules.nixvim = import ../wrappers/hm.nix wrapperArgs;
+    nixDarwinModules.nixvim = import ../wrappers/darwin.nix wrapperArgs;
   };
 }


### PR DESCRIPTION
As described in #898, it is currently not possible to use the wrappers. It seems to be cause by a relative import from the current directory, while the wrappers are actually stored in a top-level folder. This should hopefully fix these imports.

Fixes #898 