### PR TITLE
plugins/lsp: add templ language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -546,6 +546,11 @@ with lib; let
       package = pkgs.taplo;
     }
     {
+      name = "templ";
+      description = "Enable the templ language server for the templ HTML templating language";
+      package = pkgs.templ;
+    }
+    {
       name = "terraformls";
       description = "Enable terraform-ls, for terraform";
       package = pkgs.terraform-ls;

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -548,7 +548,6 @@ with lib; let
     {
       name = "templ";
       description = "Enable the templ language server for the templ HTML templating language";
-      package = pkgs.templ;
     }
     {
       name = "terraformls";

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -148,6 +148,7 @@
           svelte.enable = true;
           tailwindcss.enable = true;
           taplo.enable = true;
+          templ.enable = true;
           terraformls.enable = true;
           texlab.enable = true;
           tsserver.enable = true;


### PR DESCRIPTION
Adds lsp support for [templ](https://templ.guide), the HTML templating language for Go.