### PR TITLE
standalone: pass `extraSpecialArgs` to lib.evalModules directly

### DIFF
--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -16,7 +16,8 @@ default_pkgs: {
   };
 
   eval = lib.evalModules {
-    modules = [module wrap {_module.args = extraSpecialArgs;}] ++ shared.topLevelModules;
+    modules = [module wrap] ++ shared.topLevelModules;
+    specialArgs = extraSpecialArgs;
   };
 
   handleAssertions = config: let


### PR DESCRIPTION
Currently, `extraSpecialArgs` are assigned to `_module.args` in the standalone wrapper. I would like to pass some arguments that shall be used for imports, so `_module.args` sadly does not work. This PR proposes to change the behavior and align it with what Home Manager for example does: Pass the property `extraSpecialArgs` as `specialArgs` to `lib.evalModules`. This would enable my use case.

Strictly speaking this is a breaking change, but since Nix/NixOS openly advocates the use of `_modules.args` for regular parameters anyway, I assume users are familiar with it and people wanting to retain the current behavior (i.e., overriding values in `extraSpecialArgs`) should hopefully be using `_modules.args` already.

In any case, this change should **not** be backported to the `23.11` branch.