### PR TITLE
plugins/lsp: add beancount-language-server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -27,6 +27,11 @@ with lib; let
       package = pkgs.nodePackages.bash-language-server;
     }
     {
+      name = "beancount";
+      description = "Enable beancount-language-server";
+      package = pkgs.beancount-language-server;
+    }
+    {
       name = "biome";
       description = "Enable Biome, Toolchain of the Web";
     }

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -83,6 +83,7 @@
           ansiblels.enable = true;
           astro.enable = true;
           bashls.enable = true;
+          beancount.enable = true;
           biome.enable = true;
           ccls.enable = true;
           clangd.enable = true;


### PR DESCRIPTION
# Description

Add an option to enable the [bencount-language-server][beanlsp].

# CONTRIBUTING.md Checks

- [X] Formatting: The code is formatted with `nix fmt`.
- [X] Testing: The added language server is added to
  `tests/test-sources/plugins/lsp/_lsp.nix` as `beancount.enable = true;` on
  `all-servers.plugins.lsp.servers`.
- [X] Backwards Compatibility: The change does not break existing configurations.
- [X] `nix flake check --all-systems` succeeds.

[beanlsp]: <https://github.com/polarmutex/beancount-language-server>
