### PR TITLE
plugins/none-ls: add bandit source

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -30,6 +30,9 @@ with lib; let
       ansiblelint = {
         package = pkgs.ansible-lint;
       };
+      bandit = {
+        package = pkgs.python3Packages.bandit;
+      };
       cppcheck = {
         package = pkgs.cppcheck;
       };

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -57,6 +57,7 @@
         };
         diagnostics = {
           ansiblelint.enable = true;
+          bandit.enable = true;
           cppcheck.enable = true;
           deadnix.enable = true;
           eslint.enable = true;


### PR DESCRIPTION
Adds none-ls' source for [bandit](https://github.com/PyCQA/bandit)