### PR TITLE
plugins/lsp: add nushell language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -414,6 +414,11 @@ with lib; let
       settings = cfg: {nixd = cfg;};
     }
     {
+      name = "nushell";
+      description = "Enable nushell language server";
+      cmd = cfg: ["${cfg.package}/bin/nu" "--lsp"];
+    }
+    {
       name = "ols";
       description = "Enable ols, for the odin programming language";
       package = pkgs.ols;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -122,6 +122,7 @@
           metals.enable = true;
           nil_ls.enable = true;
           nixd.enable = true;
+          nushell.enable = true;
           ols.enable =
             # ols is not supported on aarch64-linux
             (pkgs.stdenv.hostPlatform.system != "aarch64-linux")


### PR DESCRIPTION
Support for nushells built-in [language server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#nushell).