### PR TITLE
fix(dashboard-nvim): update to new setup schema

### DIFF
--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -123,7 +123,7 @@ in {
         shortcut = if cfg.theme == "doom" then cfg.center else null;
 
         center = if cfg.theme == "hyper" then cfg.center else null;
-        foooter = if cfg.theme == "hyper" then cfg.foooter else null;
+        footer = if cfg.theme == "hyper" then cfg.footer else null;
       };
 
       hide = {

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -7,12 +7,19 @@
 }:
 with lib; let
   cfg = config.plugins.dashboard;
+  themes = [ "hyper" "doom" ];
 in {
   options = {
     plugins.dashboard = {
       enable = mkEnableOption "dashboard";
 
       package = helpers.mkPackageOption "dashboard" pkgs.vimPlugins.dashboard-nvim;
+
+      theme = mkOption {
+        description = "Dashboard theme";
+        type = types.oneOf themes;
+        default = "hyper";
+      };
 
       header = mkOption {
         description = "Header text";
@@ -41,7 +48,7 @@ in {
               type = types.str;
             };
 
-            shortcut = mkOption {
+            key = mkOption {
               description = "Item shortcut";
               type = types.nullOr types.str;
               default = null;
@@ -54,12 +61,6 @@ in {
             };
           };
         }));
-        default = null;
-      };
-
-      sessionDirectory = mkOption {
-        description = "Path to session file";
-        type = types.nullOr types.str;
         default = null;
       };
 
@@ -106,24 +107,38 @@ in {
         type = types.nullOr types.bool;
         default = null;
       };
+
+      hideWinbar = mkOption {
+        description = "Whether to hide winbar in Dashboard buffer";
+        type = types.nullOr types.bool;
+        default = null;
+      };
     };
   };
 
   config = let
     options = {
-      custom_header = cfg.header;
-      custom_footer = cfg.footer;
-      custom_center = cfg.center;
+      theme = cfg.theme;
 
-      preview_file_path = cfg.preview.file;
-      preview_file_height = cfg.preview.height;
-      preview_file_width = cfg.preview.width;
-      preview_command = cfg.preview.command;
+      config = {
+        shortcut = if cfg.theme == "doom" then cfg.center else null;
 
-      hide_statusline = cfg.hideStatusline;
-      hide_tabline = cfg.hideTabline;
+        center = if cfg.theme == "hyper" then cfg.center else null;
+        foooter = if cfg.theme == "hyper" then cfg.foooter else null;
+      };
 
-      session_directory = cfg.sessionDirectory;
+      hide = {
+        statusline = cfg.hideStatusline;
+        tabline = cfg.hideTabline;
+        winbar = cfg.hideWinbar;
+      };
+
+      preview = {
+        command = cfg.preview.command;
+        file_height = cfg.preview.height;
+        file_path = cfg.preview.file;
+        file_width = cfg.preview.width;
+      };
     };
 
     filteredOptions = filterAttrs (_: v: v != null) options;

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -124,6 +124,12 @@ in {
         type = types.bool;
         default = false;
       };
+
+      disableMove = mkOption {
+        description = "Whether to disable the move keys";
+        type = types.bool;
+        default = true;
+      };
     };
   };
 
@@ -131,9 +137,10 @@ in {
     options = {
       theme = cfg.theme;
 
-      header = cfg.header;
-
       config = {
+        header = cfg.header;
+        disable_move = cfg.disableMove;
+
         # Only available in "hyper" theme.
         shortcut = cfg.center;
         packages.enable = cfg.showPackages;

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -7,7 +7,6 @@
 }:
 with lib; let
   cfg = config.plugins.dashboard;
-  themes = [ "hyper" "doom" ];
 in {
   options = {
     plugins.dashboard = {
@@ -17,7 +16,7 @@ in {
 
       theme = mkOption {
         description = "Dashboard theme";
-        type = types.oneOf themes;
+        type = with types; oneOf [(enum ["hyper"]) (enum ["doom"])];
         default = "hyper";
       };
 

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -146,7 +146,7 @@ in {
       extraPlugins = [cfg.package];
       extraConfigLua = ''
         require("dashboard").setup {
-          ${toString (mapAttrsToList (n: v: "${n} = ${helpers.toLuaObject v}\n")
+          ${toString (mapAttrsToList (n: v: "${n} = ${helpers.toLuaObject v},\n")
               filteredOptions)}
         }
       '';

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -56,12 +56,12 @@ in {
 
             concat = mkOption {
               description = "Text to be added after the time string line";
-              type = types.nullOr (types.listOf types.str);
+              type = types.nullOr types.str;
               default = null;
             };
 
             append = mkOption {
-              description = "Text to be 'table' appended after the time string line";
+              description = "Text to be table appended after the time string line";
               type = types.nullOr (types.listOf types.str);
               default = null;
             };

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -145,7 +145,7 @@ in {
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
       extraConfigLua = ''
-        dashboard = require("dashboard").setup {
+        require("dashboard").setup {
           ${toString (mapAttrsToList (n: v: "${n} = ${helpers.toLuaObject v}\n")
               filteredOptions)}
         }

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -94,28 +94,29 @@ in {
 
       shortcut = mkOption {
         description = "Shortcut section, only available for the `hyper` theme";
-        type = types.listOf (types.submodule {
-          options = {
-            desc =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The shortcut's description";
+        type = with types;
+          nullOr (listOf (submodule {
+            options = {
+              desc =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The shortcut's description";
 
-            group =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The highlight group of the action";
+              group =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The highlight group of the action";
 
-            action =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The action to be taken";
-          };
-        });
-        default = [];
+              action =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The action to be taken";
+            };
+          }));
+        default = null;
         example = [
           {
             desc = "Find files";
@@ -132,38 +133,41 @@ in {
 
       project = mkOption {
         description = "Project showcase options. Only available in the 'hyper' theme";
-        type = types.submodule {
-          options = {
-            enable =
-              helpers.defaultNullOpts.mkBool
-              true
-              "Whether to enable the showcase of the project list";
+        type = with types;
+          nullOr (submodule {
+            options = {
+              enable =
+                helpers.defaultNullOpts.mkNullable
+                types.bool
+                "null"
+                "Whether to enable the showcase of the project list";
 
-            limit =
-              helpers.defaultNullOpts.mkInt
-              8
-              "The limit of projects to be showcased";
+              limit =
+                helpers.defaultNullOpts.mkNullable
+                types.int
+                "null"
+                "The limit of projects to be showcased";
 
-            icon =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The icon of the project section";
+              icon =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The icon of the project section";
 
-            label =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The label of the project section";
+              label =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The label of the project section";
 
-            action =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The action to be ran when selecting a project, this can be a function";
-          };
-        };
-        default = {};
+              action =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The action to be ran when selecting a project, this can be a function";
+            };
+          });
+        default = null;
         example = {
           enable = true;
           limit = 10;
@@ -175,32 +179,36 @@ in {
 
       mru = mkOption {
         description = "Configuration for the 'Most Recently Files' module.";
-        type = types.submodule {
-          options = {
-            limit =
-              helpers.defaultNullOpts.mkInt
-              10
-              "The limit of recently opened files to be shown";
+        type = with types;
+          nullOr (submodule {
+            options = {
+              limit =
+                helpers.defaultNullOpts.mkNullable
+                types.int
+                "null"
+                "The limit of recently opened files to be shown";
 
-            icon =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The icon of the module's section";
+              icon =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The icon of the module's section";
 
-            label =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "The label of the module's section";
+              label =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "The label of the module's section";
 
-            cwd_only =
-              helpers.defaultNullOpts.mkBool
-              false
-              "Whether to only change the directory when selecting a file";
-          };
-        };
-        default = {
+              cwd_only =
+                helpers.defaultNullOpts.mkNullable
+                types.bool
+                "null"
+                "Whether to only change the directory when selecting a file";
+            };
+          });
+        default = null;
+        example = {
           limit = 10;
           icon = "»";
           label = "Most recently opened files";
@@ -210,58 +218,59 @@ in {
 
       center = mkOption {
         description = "Center section";
-        type = types.listOf (types.submodule {
-          options = {
-            icon =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Item's icon";
+        type = with types;
+          nullOr (listOf (submodule {
+            options = {
+              icon =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Item's icon";
 
-            icon_hl =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Icon's highlight group";
+              icon_hl =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Icon's highlight group";
 
-            desc =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Item's description";
+              desc =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Item's description";
 
-            desc_hl =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Description's highlight group";
+              desc_hl =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Description's highlight group";
 
-            key =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Item's shortcut";
+              key =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Item's shortcut";
 
-            key_hl =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Shortcut's highlight group";
+              key_hl =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Shortcut's highlight group";
 
-            key_format =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Shortcut's text format, %s will be replaced with the value of `key`";
+              key_format =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Shortcut's text format, %s will be replaced with the value of `key`";
 
-            action =
-              helpers.defaultNullOpts.mkNullable
-              types.str
-              "null"
-              "Item's action";
-          };
-        });
-        default = [];
+              action =
+                helpers.defaultNullOpts.mkNullable
+                types.str
+                "null"
+                "Item's action";
+            };
+          }));
+        default = null;
         example = [
           {
             icon = "Ω";

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -112,6 +112,18 @@ in {
         type = types.nullOr types.bool;
         default = null;
       };
+
+      showProjects = mkOption {
+        description = "Whether to hide the project list. Only available in the 'hyper' theme";
+        type = types.bool;
+        default = false;
+      };
+
+      showPackages = mkOption {
+        description = "Whether to hide what packages have looaded. Only available in the 'hyper' theme";
+        type = types.bool;
+        default = false;
+      };
     };
   };
 
@@ -119,11 +131,17 @@ in {
     options = {
       theme = cfg.theme;
 
-      config = {
-        shortcut = if cfg.theme == "doom" then cfg.center else null;
+      header = cfg.header;
 
-        center = if cfg.theme == "hyper" then cfg.center else null;
-        footer = if cfg.theme == "hyper" then cfg.footer else null;
+      config = {
+        # Only available in "hyper" theme.
+        shortcut = cfg.center;
+        packages.enable = cfg.showPackages;
+        project.enable = cfg.showProjects;
+
+        # Only available in "doom" theme.
+        center = cfg.center;
+        footer = cfg.footer;
       };
 
       hide = {

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -145,10 +145,10 @@ in {
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
       extraConfigLua = ''
-        local dashboard = require("dashboard")
-
-        ${toString (mapAttrsToList (n: v: "dashboard.${n} = ${helpers.toLuaObject v}\n")
-            filteredOptions)}
+        dashboard = require("dashboard").setup {
+          ${toString (mapAttrsToList (n: v: "${n} = ${helpers.toLuaObject v}\n")
+              filteredOptions)}
+        }
       '';
     };
 }

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -16,13 +16,13 @@ in {
 
       theme = mkOption {
         description = "Dashboard theme";
-        type = with types; oneOf [(enum ["hyper"]) (enum ["doom"])];
+        type = with types; nullOr (oneOf [(enum ["hyper"]) (enum ["doom"])]);
         default = "hyper";
       };
 
       disableMove = mkOption {
         description = "Whether to disable the move keys";
-        type = types.bool;
+        type = types.nullOr types.bool;
         default = true;
       };
 
@@ -196,7 +196,7 @@ in {
 
             desc = mkOption {
               description = "Item description";
-              type = types.str;
+              type = types.nullOr types.str;
             };
 
             desc_hl = mkOption {

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -56,13 +56,13 @@ in {
 
             concat = mkOption {
               description = "Text to be added after the time string line";
-              type = types.nullOr types.str;
+              type = types.nullOr (types.listOf types.str);
               default = null;
             };
 
             append = mkOption {
               description = "Text to be 'table' appended after the time string line";
-              type = types.nullOr types.str;
+              type = types.nullOr (types.listOf types.str);
               default = null;
             };
           };

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -14,273 +14,311 @@ in {
 
       package = helpers.mkPackageOption "dashboard" pkgs.vimPlugins.dashboard-nvim;
 
-      theme = mkOption {
-        description = "Dashboard theme";
-        type = with types; nullOr (oneOf [(enum ["hyper"]) (enum ["doom"])]);
-        default = "hyper";
-      };
+      theme =
+        helpers.defaultNullOpts.mkNullable
+        (with types; either (enum ["hyper"]) (enum ["doom"]))
+        "hyper"
+        "The dashboard's theme.";
 
-      disableMove = mkOption {
-        description = "Whether to disable the move keys";
-        type = types.nullOr types.bool;
-        default = true;
-      };
+      disableMove =
+        helpers.defaultNullOpts.mkBool
+        true
+        "Whether to disable the move keys";
 
-      shortcutType = mkOption {
-        description = "Shortcut type";
-        type = with types; nullOr (oneOf [(enum ["letter"]) (enum ["number"])]);
-        default = null;
-      };
+      shortcutType =
+        helpers.defaultNullOpts.mkNullable
+        (with types; either (enum ["letter"]) (enum ["number"]))
+        "letter"
+        "The shortcut type.";
 
-      changeVCSRoot = mkOption {
-        description = "Change to the root of VCS for hyper mru";
-        type = types.nullOr types.bool;
-        default = false;
-      };
+      changeVCSRoot =
+        helpers.defaultNullOpts.mkBool
+        false
+        "Change the root of VCS for the `hyper` theme's MRU module.";
 
-      header = mkOption {
-        description = "Header text";
-        type = types.nullOr (types.listOf types.str);
-        default = null;
-      };
+      header =
+        helpers.defaultNullOpts.mkListOf
+        types.str
+        "null"
+        "The header's text.";
 
       weekHeader = mkOption {
         description = "Week header options";
-        type = types.nullOr (types.submodule {
+        type = types.submodule {
           options = {
-            enable = mkOption {
-              description = "Whether to enable the week header";
-              type = types.nullOr types.bool;
-              default = null;
-            };
+            enable =
+              helpers.defaultNullOpts.mkBool
+              false
+              "Whether to enable the week header.";
 
-            concat = mkOption {
-              description = "Text to be added after the time string line";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            concat =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Text to be added after the time string line.";
 
-            append = mkOption {
-              description = "Text to be table appended after the time string line";
-              type = types.nullOr (types.listOf types.str);
-              default = null;
-            };
+            append =
+              helpers.defaultNullOpts.mkListOf
+              types.str
+              "null"
+              "List of text to be appended after the time string line, since the `header` is filled by `weekHeader` this allows you to create ASCII art right below it.";
           };
-        });
-        default = null;
+        };
+        default = {};
+        example = {
+          enable = true;
+          concat = "Some text to be going after the clock.";
+          append = [
+            "⠤⠤⠤⠤⠤⠤⢤⣄⣀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀"
+            "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠙⠒⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠤⠤⠶⠶⠶⠦⠤⠤⠤⠤⠤⢤⣤⣀⣀⣀⣀⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀"
+            "⠀⠀⠀⠀⢀⠄⢂⣠⣭⣭⣕⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠤⠀⠀⠀⠤⠀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠉⠉⠉⠉⠉⠉⠉"
+            "⠀⠀⢀⠜⣳⣾⡿⠛⣿⣿⣿⣦⡠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠠⣤⣤⣤⣤⣤⣤⣤⣤⣤⣍⣀⣦⠦⠄⣀⠀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀"
+            "⠀⠠⣄⣽⣿⠋⠀⡰⢿⣿⣿⣿⣿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣼⣿⡿⠛⠛⡿⠿⣿⣿⣿⣿⣿⣿⣷⣶⣿⣁⣂⣤⡄⠀⠀⠀⠀⠀⠀"
+            "⢳⣶⣼⣿⠃⠀⢀⠧⠤⢜⣿⣿⣿⣿⣷⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣾⠟⠁⠀⠀⠀⡇⠀⣀⡈⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⡀⠁⠐⠀⣀⠀⠀"
+            "⠀⠙⠻⣿⠀⠀⠀⠀⠀⠀⢹⣿⣿⡝⢿⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢰⡿⠋⠀⠀⠀⠀⠠⠃⠁⠀⠀⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣶⣿⡿⠋⠀⠀"
+            "⠀⠀⠀⠙⡄⠀⠀⠀⠀⠀⢸⣿⣿⡃⢼⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⣿⣿⣿⣿⡏⠉⠉⠻⣿⡿⠋⠀⠀⠀⠀"
+            "⠀⠀⠀⠀⢰⠀⠀⠰⡒⠊⠻⠿⠋⠐⡼⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣿⣿⣿⣿⠀⠀⠀⠀⣿⠇⠀⠀⠀⠀⠀"
+            "⠀⠀⠀⠀⠸⣇⡀⠀⠑⢄⠀⠀⠀⡠⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢖⠠⠤⠤⠔⠙⠻⠿⠋⠱⡑⢄⠀⢠⠟⠀⠀⠀⠀⠀⠀"
+            "⠀⠀⠀⠀⠀⠀⠈⠉⠒⠒⠻⠶⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⡄⠀⠀⠀⠀⠀⠀⠀⠀⠡⢀⡵⠃⠀⠀⠀⠀⠀⠀⠀"
+            "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⠦⣀⠀⠀⠀⠀⠀⢀⣤⡟⠉⠀⠀⠀⠀⠀⠀⠀⠀"
+            "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠉⠉⠉⠙⠛⠓⠒⠲⠿⢍⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀"
+          ];
+        };
       };
 
-      footer = mkOption {
-        description = "Footer text";
-        type = types.nullOr (types.listOf types.str);
-        default = null;
-      };
+      footer =
+        helpers.defaultNullOpts.mkListOf
+        types.str
+        "null"
+        "Dashboard's footer text";
 
       shortcut = mkOption {
         description = "Shortcut section, only available for the `hyper` theme";
-        type = types.nullOr (types.listOf (types.submodule {
+        type = types.listOf (types.submodule {
           options = {
-            desc = mkOption {
-              description = "The description of the action";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            desc =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The shortcut's description";
 
-            group = mkOption {
-              description = "The highlight group of the action";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            group =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The highlight group of the action";
 
-            action = mkOption {
-              description = "The action to be taken";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            action =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The action to be taken";
           };
-        }));
-        default = null;
+        });
+        default = [];
+        example = [
+          {
+            desc = "Find files";
+            group = "EndOfBuffer";
+            action = "Telescope find_files";
+          }
+        ];
       };
 
-      showPackages = mkOption {
-        description = "Whether to hide what packages have looaded. Only available in the 'hyper' theme";
-        type = types.bool;
-        default = false;
-      };
+      showPackages =
+        helpers.defaultNullOpts.mkBool
+        false
+        "Whether to hide what packages have looaded. Only available in the 'hyper' theme";
 
       project = mkOption {
         description = "Project showcase options. Only available in the 'hyper' theme";
-        type = types.nullOr (types.submodule {
+        type = types.submodule {
           options = {
-            enable = mkOption {
-              description = "Whether to enable the showcase of the project list";
-              type = types.nullOr types.bool;
-              default = null;
-            };
+            enable =
+              helpers.defaultNullOpts.mkBool
+              true
+              "Whether to enable the showcase of the project list";
 
-            limit = mkOption {
-              description = "The limit of projects to be showcased";
-              type = types.nullOr types.int;
-              default = null;
-            };
+            limit =
+              helpers.defaultNullOpts.mkInt
+              8
+              "The limit of projects to be showcased";
 
-            icon = mkOption {
-              description = "The icon of the project section";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            icon =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The icon of the project section";
 
-            label = mkOption {
-              description = "The label of the project section";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            label =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The label of the project section";
 
-            action = mkOption {
-              description = "The action to be ran when selecting a project, this can be a function";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            action =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The action to be ran when selecting a project, this can be a function";
           };
-        });
-        default = null;
+        };
+        default = {};
+        example = {
+          enable = true;
+          limit = 10;
+          icon = "»";
+          label = "Find projects' files";
+          action = "Telescope find_files cwd=";
+        };
       };
 
       mru = mkOption {
-        description = "MRU section";
-        type = types.nullOr (types.submodule {
+        description = "Configuration for the 'Most Recently Files' module.";
+        type = types.submodule {
           options = {
-            limit = mkOption {
-              description = "The limit of recently opened projects to be shown";
-              type = types.nullOr types.int;
-              default = null;
-            };
+            limit =
+              helpers.defaultNullOpts.mkInt
+              10
+              "The limit of recently opened files to be shown";
 
-            icon = mkOption {
-              description = "The icon of the MRU section";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            icon =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The icon of the module's section";
 
-            label = mkOption {
-              description = "The label of the MRU section";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            label =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "The label of the module's section";
 
-            cwd_only = mkOption {
-              description = "Whether to cwd only";
-              type = types.nullOr types.bool;
-              default = null;
-            };
+            cwd_only =
+              helpers.defaultNullOpts.mkBool
+              false
+              "Whether to only change the directory when selecting a file";
           };
-        });
-        default = null;
+        };
+        default = {
+          limit = 10;
+          icon = "»";
+          label = "Most recently opened files";
+          cwd_only = true;
+        };
       };
 
       center = mkOption {
         description = "Center section";
-        type = types.nullOr (types.listOf (types.submodule {
+        type = types.listOf (types.submodule {
           options = {
-            icon = mkOption {
-              description = "Item icon";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            icon =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Item's icon";
 
-            icon_hl = mkOption {
-              description = "Icon's highlight group";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            icon_hl =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Icon's highlight group";
 
-            desc = mkOption {
-              description = "Item description";
-              type = types.nullOr types.str;
-            };
+            desc =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Item's description";
 
-            desc_hl = mkOption {
-              description = "Description's highlight group";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            desc_hl =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Description's highlight group";
 
-            key = mkOption {
-              description = "Item shortcut";
-              type = types.nullOr types.str;
-              default = null;
-            };
-            key_hl = mkOption {
-              description = "Shortcut's highlight group";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            key =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Item's shortcut";
 
-            key_format = mkOption {
-              description = "Shortcut's text format, %s will be replaced with the value of `key`";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            key_hl =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Shortcut's highlight group";
 
-            action = mkOption {
-              description = "Item action";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            key_format =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Shortcut's text format, %s will be replaced with the value of `key`";
+
+            action =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Item's action";
           };
-        }));
-        default = null;
+        });
+        default = [];
+        example = [
+          {
+            icon = "Ω";
+            icon_hl = "Directory";
+            desc = "Find files";
+            desc_hl = "ModeMsg";
+            key = "<leader>f";
+            key_hl = "CurSearch";
+            key_format = "{ %s }";
+            action = "Telescope find_files";
+          }
+        ];
       };
 
       preview = mkOption {
         description = "Preview options";
         type = types.submodule {
           options = {
-            command = mkOption {
-              description = "Command to print file contents";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            command =
+              helpers.defaultNullOpts.mkStr
+              ""
+              "Command to print file contents";
 
-            file = mkOption {
-              description = "Path to preview file";
-              type = types.nullOr types.str;
-              default = null;
-            };
+            file =
+              helpers.defaultNullOpts.mkNullable
+              types.str
+              "null"
+              "Path to preview file";
 
-            height = mkOption {
-              description = "The height of the preview file";
-              type = types.nullOr types.int;
-              default = null;
-            };
+            height =
+              helpers.defaultNullOpts.mkInt
+              0
+              "The height of the preview file";
 
-            width = mkOption {
-              description = "The width of the preview file";
-              type = types.nullOr types.int;
-              default = null;
-            };
+            width =
+              helpers.defaultNullOpts.mkInt
+              0
+              "The width of the preview file";
           };
         };
         default = {};
       };
 
-      hideStatusline = mkOption {
-        description = "Whether to hide statusline in Dashboard buffer";
-        type = types.nullOr types.bool;
-        default = null;
-      };
+      hideStatusline =
+        helpers.defaultNullOpts.mkBool
+        true
+        "Whether to hide statusline in Dashboard buffer";
 
-      hideTabline = mkOption {
-        description = "Whether to hide tabline in Dashboard buffer";
-        type = types.nullOr types.bool;
-        default = null;
-      };
+      hideTabline =
+        helpers.defaultNullOpts.mkBool
+        true
+        "Whether to hide tabline in Dashboard buffer";
 
-      hideWinbar = mkOption {
-        description = "Whether to hide winbar in Dashboard buffer";
-        type = types.nullOr types.bool;
-        default = null;
-      };
+      hideWinbar =
+        helpers.defaultNullOpts.mkBool
+        false
+        "Whether to hide winbar in Dashboard buffer";
     };
   };
 

--- a/tests/test-sources/plugins/utils/dashboard.nix
+++ b/tests/test-sources/plugins/utils/dashboard.nix
@@ -1,0 +1,58 @@
+{helpers, ...}: {
+  empty = {
+    plugins.dashboard.enable = true;
+  };
+
+  defaults = {
+    plugins.dashboard = {
+      enable = true;
+
+      changeVCSRoot = null;
+      disableMove = null;
+      footer = null;
+      header = null;
+      hideStatusline = null;
+      hideTabline = null;
+      hideWinbar = null;
+      mru = null;
+      project = null;
+      shortcutType = null;
+      showPackages = false;
+      theme = null;
+
+      center = [
+        {
+          icon = null;
+          icon_hl = null;
+          desc = null;
+          desc_hl = null;
+          key = null;
+          key_hl = null;
+          key_format = null;
+          action = null;
+        }
+      ];
+
+      preview = {
+        command = null;
+        file = null;
+        height = null;
+        width = null;
+      };
+
+      shortcut = [
+        {
+          desc = null;
+          group = null;
+          action = null;
+        }
+      ];
+
+      weekHeader = {
+        enable = null;
+        concat = null;
+        append = null;
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/utils/dashboard.nix
+++ b/tests/test-sources/plugins/utils/dashboard.nix
@@ -14,11 +14,24 @@
       hideStatusline = null;
       hideTabline = null;
       hideWinbar = null;
-      mru = null;
-      project = null;
       shortcutType = null;
       showPackages = false;
       theme = null;
+
+      mru = {
+        limit = null;
+        icon = null;
+        label = null;
+        cwd_only = null;
+      };
+
+      project = {
+        enable = null;
+        limit = null;
+        icon = null;
+        label = null;
+        action = null;
+      };
 
       center = [
         {


### PR DESCRIPTION
Hello, first time contributing to a nix project! I hope this is helpful for users of this distribution of _neovim_.

When doing my configuration using `nixvim` I couldn't get [`dashboard-nvim`](https://github.com/nvimdev/dashboard-nvim) to work, and when digging deeper I realized that the plugin's configuration hasn't been updated in a bit and it underwent some breaking changes. So this pull request adapts to such breaking changes and gets it back to a working state!

I've tested it both with the default theme `hyper`:

<img src="https://github.com/nix-community/nixvim/assets/26727907/d98a8ffe-79c6-43f8-b5a0-146c4024b6a5" width="500px" />

as well as `doom`:

<img src="https://github.com/nix-community/nixvim/assets/26727907/2a7da5ff-4c17-4d4c-9629-9720a4f02461" width="500px" />

Here's with an actual configuration of `doom`:

<img src="https://github.com/nix-community/nixvim/assets/26727907/2a9eda7f-1ea2-456c-a475-b29cee90d44d" height="500px" />


I've tried to follow the [contribution guidelines](https://github.com/nix-community/nixvim/blob/0379ab34cc7bc1b846bfdbb3d6707f5c8b03ce2c/CONTRIBUTING.md) and I _think_ I followed it correctly but please do correct me where I may be wrong! Specially code-wise, I am fairly new to the language's specifications!