### PR TITLE
plugins/lsp: add prolog-ls

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -498,6 +498,12 @@ with lib; let
       package = pkgs.nodePackages."@prisma/language-server";
     }
     {
+      name = "prolog-ls";
+      description = "enable prolog_ls, for SWI-Prolog";
+      serverName = "prolog_ls";
+      package = pkgs.swiProlog;
+    }
+    {
       name = "pylsp";
       description = "Enable pylsp, for Python.";
       package = pkgs.python3Packages.python-lsp-server;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -133,6 +133,7 @@
           perlpls.enable = true;
           pest_ls.enable = true;
           prismals.enable = true;
+          prolog-ls.enable = true;
           pylsp.enable = true;
           pylyzer.enable = true;
           pyright.enable = true;


### PR DESCRIPTION
Add support for the [prolog_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.txt#prolog_ls) language server.