### PR TITLE
plugins/none-ls: add gofumpt and goimports_reviser

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -131,8 +131,14 @@ with lib; let
       gofmt = {
         package = pkgs.go;
       };
+      gofumpt = {
+        package = pkgs.gofumpt;
+      };
       goimports = {
         package = pkgs.gotools;
+      };
+      goimports_reviser = {
+        package = pkgs.goimports-reviser;
       };
       golines = {
         package = pkgs.golines;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -94,7 +94,9 @@
           fnlfmt.enable = true;
           fourmolu.enable = true;
           gofmt.enable = true;
+          gofumpt.enable = true;
           goimports.enable = true;
+          goimports_reviser.enable = true;
           golines.enable = true;
           ktlint.enable = true;
           nixfmt.enable = true;


### PR DESCRIPTION
Adds [gofumpt](https://github.com/mvdan/gofumpt) and [goimports_reviser](https://github.com/incu6us/goimports-reviser) formatter sources for none-ls. 