### PR TITLE
plugins/alpha: fix example (for buttons)

### DIFF
--- a/plugins/utils/alpha.nix
+++ b/plugins/utils/alpha.nix
@@ -104,12 +104,16 @@ in {
             type = "group";
             val = [
               {
+                type = "button";
                 val = "  New file";
                 on_press.__raw = "function() vim.cmd[[ene]] end";
+                opts.shortcut = "n";
               }
               {
+                type = "button";
                 val = " Quit Neovim";
                 on_press.__raw = "function() vim.cmd[[qa]] end";
+                opts.shortcut = "q";
               }
             ];
           }

--- a/tests/test-sources/plugins/utils/alpha.nix
+++ b/tests/test-sources/plugins/utils/alpha.nix
@@ -46,12 +46,16 @@
           type = "group";
           val = [
             {
+              type = "button";
               val = "  New file";
               on_press.__raw = "function() vim.cmd[[ene]] end";
+              opts.shortcut = "n";
             }
             {
+              type = "button";
               val = " Quit Neovim";
               on_press.__raw = "function() vim.cmd[[qa]] end";
+              opts.shortcut = "q";
             }
           ];
         }


### PR DESCRIPTION
The alpha doc is misleading: all of the `opts` options should be optional.
However, for buttons, not specifying `opts.shortcut` is causing an error.
This patch fixes the affected examples.