### PR TITLE
modules/commands: fix lua cmd.options value when no options are set

### DIFF
--- a/modules/commands.nix
+++ b/modules/commands.nix
@@ -54,7 +54,7 @@ in {
       extraConfigLua = helpers.wrapDo ''
         local cmds = ${helpers.toLuaObject (mapAttrs cleanupCommand config.userCommands)};
         for name,cmd in pairs(cmds) do
-          vim.api.nvim_create_user_command(name, cmd.command, cmd.options)
+          vim.api.nvim_create_user_command(name, cmd.command, cmd.options or {})
         end
       '';
     };

--- a/tests/test-sources/modules/commands.nix
+++ b/tests/test-sources/modules/commands.nix
@@ -5,6 +5,9 @@
         command = ":w<CR>";
         desc = "Write file";
       };
+      "Z" = {
+        command = ":echo fooo<CR>";
+      };
     };
   };
 }


### PR DESCRIPTION
Currently, `cmd.options` can be `nil` if no option is set. This is invalid as `nvim_create_user_command` expects a table.
This patch fixes this behavior.

Fixes #954 