### PR TITLE
plugins/clipboard-image: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -105,6 +105,7 @@
     ./utils/auto-save.nix
     ./utils/auto-session.nix
     ./utils/better-escape.nix
+    ./utils/clipboard-image.nix
     ./utils/comment-nvim.nix
     ./utils/commentary.nix
     ./utils/conjure.nix

--- a/plugins/utils/clipboard-image.nix
+++ b/plugins/utils/clipboard-image.nix
@@ -1,0 +1,153 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.clipboard-image;
+
+  pluginOptions = {
+    imgDir =
+      helpers.defaultNullOpts.mkNullable
+      (with helpers.nixvimTypes;
+        oneOf [
+          str
+          (listOf str)
+          rawLua
+        ])
+      "img"
+      ''
+        Dir name where the image will be pasted to.
+
+        Note: If you want to create nested dir, it is better to use table since windows and unix
+        have different path separator.
+      '';
+
+    imgDirTxt =
+      helpers.defaultNullOpts.mkNullable
+      (with helpers.nixvimTypes;
+        oneOf [
+          str
+          (listOf str)
+          rawLua
+        ])
+      "img"
+      "Dir that will be inserted into text/buffer.";
+
+    imgName =
+      helpers.defaultNullOpts.mkStr
+      ''{__raw = "function() return os.date('%Y-%m-%d-%H-%M-%S') end";}''
+      "Image's name.";
+
+    imgHandler = helpers.defaultNullOpts.mkLuaFn "function(img) end" ''
+      Function that will handle image after pasted.
+
+      Note: `img` is a table that contain pasted image's `{name}` and `{path}`.
+    '';
+
+    affix = helpers.mkNullOrStr ''
+      String that sandwiched the image's path.
+
+      Default:
+        - `default`: `"{img_path}"`
+        - `markdown`: `"![]({img_path})"`
+
+      Note:
+        Affix can be multi lines, like this:
+
+        ```nix
+        # You can use line break escape sequence
+        affix = "<\n  %s\n>";
+        ```
+
+        ```nix
+        # Or lua's double square brackets
+        affix.__raw = \'\'
+          [[<
+            %s
+          >]]
+        \'\'
+        ```
+    '';
+  };
+
+  processPluginOptions = opts:
+    with opts; {
+      img_dir = imgDir;
+      img_dir_txt = imgDirTxt;
+      img_name = imgName;
+      img_handler = imgHandler;
+      inherit affix;
+    };
+in {
+  meta.maintainers = [maintainers.GaetanLepage];
+
+  options.plugins.clipboard-image =
+    helpers.extraOptionsOptions
+    // {
+      enable = mkEnableOption "clipboard-image.nvim";
+
+      package = helpers.mkPackageOption "clipboard-image.nvim" pkgs.vimPlugins.clipboard-image-nvim;
+
+      clipboardPackage = mkOption {
+        type = with types; nullOr package;
+        description = ''
+          Which clipboard provider to use.
+
+          Recommended:
+            - X11: `pkgs.xclip`
+            - Wayland: `pkgs.wl-clipboard`
+            - MacOS: `pkgs.pngpaste`
+        '';
+        example = pkgs.wl-clipboard;
+      };
+
+      default = pluginOptions;
+
+      filetypes = mkOption {
+        type = with types;
+          attrsOf (
+            submodule {
+              options = pluginOptions;
+            }
+          );
+        apply = mapAttrs (_: processPluginOptions);
+        default = {};
+        description = "Override certain options for specific filetypes.";
+        example = {
+          markdown = {
+            imgDir = ["src" "assets" "img"];
+            imgDirTxt = "/assets/img";
+            imgHandler = ''
+              function(img)
+                local script = string.format('./image_compressor.sh "%s"', img.path)
+                os.execute(script)
+              end
+            '';
+          };
+        };
+      };
+    };
+
+  config = mkIf cfg.enable {
+    extraPlugins = [cfg.package];
+
+    extraPackages =
+      optional
+      (cfg.clipboardPackage != null)
+      cfg.clipboardPackage;
+
+    extraConfigLua = let
+      setupOptions =
+        {
+          default = processPluginOptions cfg.default;
+        }
+        // cfg.filetypes
+        // cfg.extraOptions;
+    in ''
+      require('clipboard-image').setup(${helpers.toLuaObject setupOptions})
+    '';
+  };
+}

--- a/tests/test-sources/plugins/utils/clipboard-image.nix
+++ b/tests/test-sources/plugins/utils/clipboard-image.nix
@@ -1,0 +1,35 @@
+{pkgs, ...}: {
+  empty = {
+    plugins.clipboard-image = {
+      enable = true;
+      clipboardPackage = null;
+    };
+  };
+
+  example = {
+    plugins.clipboard-image = {
+      enable = true;
+
+      clipboardPackage = pkgs.wl-clipboard;
+      default = {
+        imgDir = "img";
+        imgDirTxt = "img";
+        imgName.__raw = "function() return os.date('%Y-%m-%d-%H-%M-%S') end";
+        imgHandler = "function(img) end";
+        affix = "{img_path}";
+      };
+      filetypes = {
+        markdown = {
+          imgDir = ["src" "assets" "img"];
+          imgDirTxt = "/assets/img";
+          imgHandler = ''
+            function(img) -- New feature from PR #22
+              local script = string.format('./image_compressor.sh "%s"', img.path)
+              os.execute(script)
+            end
+          '';
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [clipboard-image.nvim](https://github.com/ekickx/clipboard-image.nvim).

Fixes #965 