### PR TITLE
plugins/yanky: fix wrong definition of setupOptions

### DIFF
--- a/plugins/utils/yanky.nix
+++ b/plugins/utils/yanky.nix
@@ -227,20 +227,20 @@ in {
                     picker.telescope.mappings
                   );
               };
-              system_clipboard = {
-                sync_with_ring = systemClipboard.syncWithRing;
-              };
-              highlight = {
-                on_put = highlight.onPut;
-                on_yank = highlight.onYank;
-                inherit (highlight) timer;
-              };
-              preserve_cursor_position = {
-                inherit (preserveCursorPosition) enabled;
-              };
-              textobj = {
-                inherit (textobj) enabled;
-              };
+            };
+            system_clipboard = {
+              sync_with_ring = systemClipboard.syncWithRing;
+            };
+            highlight = {
+              on_put = highlight.onPut;
+              on_yank = highlight.onYank;
+              inherit (highlight) timer;
+            };
+            preserve_cursor_position = {
+              inherit (preserveCursorPosition) enabled;
+            };
+            textobj = {
+              inherit (textobj) enabled;
             };
           }
           // cfg.extraOptions;


### PR DESCRIPTION
The layout of the `setupOptions` table was invalid.

Fixes #967 