### PR TITLE
plugins/none-ls: add bean_format

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -101,6 +101,9 @@ with lib; let
       alejandra = {
         package = pkgs.alejandra;
       };
+      bean_format = {
+        package = pkgs.beancount;
+      };
       beautysh = {
         package = pkgs.beautysh;
       };

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -83,6 +83,7 @@
         };
         formatting = {
           alejandra.enable = true;
+          bean_format.enable = true;
           black.enable = true;
           # As of 2024-01-04, cbfmt is broken on darwin
           # TODO: re-enable this test when fixed


### PR DESCRIPTION
# Description

Add an option to enable the [bean_format][bean_format] none-ls source.

# CONTRIBUTING.md Checks

- [X] Formatting: The code is formatted with `nix fmt`.
- [X] Testing: The added language server is added to
  `tests/test-sources/plugins/none-ls.nix/` as `bean_format.enable = true;` on
  `default.formatting`.
- [X] Backwards Compatibility: The change does not break existing configurations.
- [X] `nix flake check --all-systems` succeeds.

[bean_format]: <https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-format>

