### PR TITLE
plugins/telescope: add ui-select extension

### DIFF
--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -15,6 +15,7 @@ in {
     ./fzy-native.nix
     ./media-files.nix
     ./project-nvim.nix
+    ./ui-select.nix
     ./undo.nix
   ];
 

--- a/plugins/telescope/ui-select.nix
+++ b/plugins/telescope/ui-select.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.telescope.extensions.ui-select;
+in {
+  options.plugins.telescope.extensions.ui-select = {
+    enable = mkEnableOption "ui-select extension for telescope";
+
+    package = helpers.mkPackageOption "telescope extension ui-select" pkgs.vimPlugins.telescope-ui-select-nvim;
+
+    settings = mkOption {
+      type = with types; attrsOf anything;
+      default = {};
+      example = {
+        specific_opts.codeactions = false;
+      };
+      description = "Settings for this extension.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    plugins.telescope = {
+      enabledExtensions = ["ui-select"];
+      extensionConfig."ui-select" = cfg.settings;
+    };
+
+    extraPlugins = [cfg.package];
+  };
+}

--- a/tests/test-sources/plugins/telescope/ui-select.nix
+++ b/tests/test-sources/plugins/telescope/ui-select.nix
@@ -1,0 +1,22 @@
+{
+  empty = {
+    plugins.telescope = {
+      enable = true;
+      extensions.ui-select.enable = true;
+    };
+  };
+
+  example = {
+    plugins.telescope = {
+      enable = true;
+
+      extensions.ui-select = {
+        enable = true;
+
+        settings = {
+          specific_opts.codeactions = false;
+        };
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/telescope/undo.nix
+++ b/tests/test-sources/plugins/telescope/undo.nix
@@ -1,6 +1,9 @@
 {
   empty = {
-    plugins.telescope.enable = true;
+    plugins.telescope = {
+      enable = true;
+      extensions.undo.enable = true;
+    };
   };
 
   example = {


### PR DESCRIPTION
Add support for the [telescope-ui-select.nvim](https://github.com/nvim-telescope/telescope-ui-select.nvim/) telescope extension.

Fixes #972 