### PR TITLE
plugins/lsp: set correct name for the elixirls package

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -207,7 +207,7 @@ with lib; let
     }
     {
       name = "elixirls";
-      package = pkgs.elixir_ls;
+      package = pkgs.elixir-ls;
       cmd = cfg: ["${cfg.package}/bin/elixir-ls"];
     }
     {


### PR DESCRIPTION
plugins/lsp: set correct name for the elixirls package.