### PR TITLE
plugins/lsp: add helm-ls

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -240,6 +240,11 @@ with lib; let
       package = pkgs.nodePackages.graphql-language-service-cli;
     }
     {
+      name = "helm-ls";
+      description = "helm_ls for Helm";
+      serverName = "helm_ls";
+    }
+    {
       name = "hls";
       description = "haskell language server";
       package = pkgs.haskell-language-server;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -108,6 +108,7 @@
           gleam.enable = true;
           gopls.enable = true;
           graphql.enable = true;
+          helm-ls.enable = true;
           hls.enable = true;
           html.enable = true;
           htmx.enable = true;


### PR DESCRIPTION
Add support for the [helm-ls](https://github.com/mrjosh/helm-ls) language server for Helm.

Partially fixes #989 