### PR TITLE
helpers/options: allow raw values for border options

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -143,7 +143,7 @@ with nixvimUtils; rec {
     mkEnumFirstDefault = enumValues: mkEnum enumValues (head enumValues);
     mkBorder = default: name: desc:
       mkNullable
-      nixvimTypes.border
+      (with nixvimTypes; maybeRaw border)
       default
       (let
         defaultDesc = ''

--- a/tests/test-sources/plugins/completion/nvim-cmp.nix
+++ b/tests/test-sources/plugins/completion/nvim-cmp.nix
@@ -126,7 +126,7 @@
         documentation = {
           maxHeight = "math.floor(40 * (40 / vim.o.lines))";
           maxWidth = "math.floor((40 * 2) * (vim.o.columns / (40 * 2 * 16 / 9)))";
-          border = ["" "" "" " " "" "" "" " "];
+          border.__raw = "cmp.config.window.bordered()";
           winhighlight = "FloatBorder:NormalFloat";
         };
       };


### PR DESCRIPTION
Allows you to do (for instance):
```nix
plugins.nvim-cmp.documentation.border.__raw = "cmp.config.window.bordered()";
```