### PR TITLE
keymaps: use 'action.__raw' instead of 'lua = true' internally

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -22,8 +22,7 @@ with lib; {
             # Mode can be a string or a list of strings
             mode = "n";
             key = "<leader>p";
-            action = "require('my-plugin').do_stuff";
-            lua = true;
+            action.__raw = "require('my-plugin').do_stuff";
             # Note that all of the mapping options are now under the `options` attrs
             options = {
               silent = true;

--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -128,8 +128,7 @@ in {
             in {
               mode = "n";
               inherit key;
-              action = prefix + actionStr;
-              lua = true;
+              action.__raw = prefix + actionStr;
 
               options =
                 {

--- a/plugins/lsp/wtf.nix
+++ b/plugins/lsp/wtf.nix
@@ -12,15 +12,13 @@ with lib; let
     ai = {
       key = "gw";
       mode = ["n" "x"];
-      action = "require('wtf').ai";
-      lua = true;
+      action.__raw = "require('wtf').ai";
     };
 
     search = {
       key = "gW";
       mode = "n";
-      action = "require('wtf').search";
-      lua = true;
+      action.__raw = "require('wtf').search";
     };
   };
 in {

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -104,8 +104,7 @@ in {
         in {
           mode = "n";
           inherit key;
-          action = "require('telescope.builtin').${actionStr}";
-          lua = true;
+          action.__raw = "require('telescope.builtin').${actionStr}";
 
           options =
             {

--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -233,7 +233,7 @@ in {
               (key != null)
               {
                 inherit key;
-                action = luaFunc;
+                action.__raw = luaFunc;
               }
           )
           {
@@ -256,7 +256,7 @@ in {
               mapAttrsToList
               (id: key: {
                 inherit key;
-                action = genLuaFunc id;
+                action.__raw = genLuaFunc id;
               })
               mappingsAttrs
             )
@@ -283,7 +283,6 @@ in {
         helpers.keymaps.mkKeymaps
         {
           mode = "n";
-          lua = true;
           options.silent = cfg.keymapsSilent;
         }
         allMappings;

--- a/plugins/utils/intellitab.nix
+++ b/plugins/utils/intellitab.nix
@@ -23,8 +23,7 @@ in {
       {
         mode = "i";
         key = "<Tab>";
-        action = "require('intellitab').indent";
-        lua = true;
+        action.__raw = "require('intellitab').indent";
       }
     ];
     plugins.treesitter = {

--- a/plugins/utils/nvim-osc52.nix
+++ b/plugins/utils/nvim-osc52.nix
@@ -61,8 +61,7 @@ with lib; {
           {
             mode = "n";
             key = copy;
-            action = "require('osc52').copy_operator";
-            lua = true;
+            action.__raw = "require('osc52').copy_operator";
             options = {
               expr = true;
               inherit silent;
@@ -80,8 +79,7 @@ with lib; {
           {
             mode = "v";
             key = copyVisual;
-            action = "require('osc52').copy_visual";
-            lua = true;
+            action.__raw = "require('osc52').copy_visual";
             options.silent = silent;
           }
         ];

--- a/plugins/utils/spider.nix
+++ b/plugins/utils/spider.nix
@@ -57,8 +57,7 @@ in {
         motion: key: {
           mode = ["n" "o" "x"];
           inherit key;
-          action = "function() require('spider').motion('${motion}') end";
-          lua = true;
+          action.__raw = "function() require('spider').motion('${motion}') end";
           options = {
             inherit (cfg.keymaps) silent;
             desc = "Spider-${motion}";


### PR DESCRIPTION
Let's use `action.__raw` instead of `lua = true`.
This has no effect on users (only internal changes).