### PR TITLE
modules/highlights: post -> pre loading

### DIFF
--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -30,7 +30,7 @@ with lib; {
   };
 
   config = mkIf (config.highlight != {} || config.match != {}) {
-    extraConfigLuaPost =
+    extraConfigLuaPre =
       (optionalString (config.highlight != {}) ''
         -- Highlight groups {{
         do


### PR DESCRIPTION
Highlights currently get configured in extraConfigLuaPost. Any plugin configs that reference them before they get injected will throw errors. This moves the global highlights to be injected at the beginning of the config with extraConfigLuaPre. 