### PR TITLE
feat: improve dashboard options

### DIFF
--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -7,22 +7,66 @@
 }:
 with lib; let
   cfg = config.plugins.dashboard;
+
+  helpers = import ../helpers.nix {inherit lib;};
+
+  shortcutType = types.submodule {
+    options.icon = mkOption {
+      description = "The icon to display";
+      type = types.nullOr types.str;
+      default = null;
+    };
+    options.desc = mkOption {
+      description = "The text to display";
+      type = types.nullOr types.str;
+      default = null;
+    };
+    options.key = mkOption {
+      description = "The shortcut key to assign";
+      type = types.nullOr types.str;
+      default = null;
+    };
+    options.group = mkOption {
+      description = "The highlight group to set";
+      type = types.nullOr types.str;
+      default = null;
+    };
+    options.action = mkOption {
+      description = "The command to run when chosen";
+      type = types.nullOr types.str;
+      default = null;
+    };
+  };
 in {
+  imports = [
+    (lib.mkRenamedOptionModule ["plugins" "dashboard" "hideStatusline"] ["plugins" "dashboard" "hide" "statusline"])
+    (lib.mkRenamedOptionModule ["plugins" "dashboard" "hideTabline"] ["plugins" "dashboard" "hide" "tabline"])
+    (lib.mkRemovedOptionModule ["plugins" "dashboard" "sessionDirectory"] ''
+      dashboard-nvim no longer provides session support.
+    '')
+  ];
+
   options = {
     plugins.dashboard = {
       enable = mkEnableOption "dashboard";
 
       package = helpers.mkPackageOption "dashboard" pkgs.vimPlugins.dashboard-nvim;
 
+      theme = mkOption {
+        description = "The theme to use";
+        type = types.nullOr (types.enum ["hyper" "doom"]);
+        default = null;
+      };
+
       header = mkOption {
         description = "Header text";
-        type = types.nullOr (types.listOf types.str);
+        type = types.nullOr (types.either (types.listOf types.str) helpers.nixvimTypes.rawLua);
         default = null;
       };
 
       footer = mkOption {
         description = "Footer text";
-        type = types.nullOr (types.listOf types.str);
+        type = types.nullOr (types.either (types.listOf types.str) helpers.nixvimTypes.rawLua);
         default = null;
       };
 
@@ -54,12 +98,6 @@ in {
             };
           };
         }));
-        default = null;
-      };
-
-      sessionDirectory = mkOption {
-        description = "Path to session file";
-        type = types.nullOr types.str;
         default = null;
       };
 
@@ -95,15 +133,105 @@ in {
         default = {};
       };
 
-      hideStatusline = mkOption {
-        description = "Whether to hide statusline in Dashboard buffer";
+      changeToVcsRoot = mkOption {
+        type = types.nullOr types.bool;
+        description = "For open file in hyper mru. It will change to the root of vcs";
+        default = null;
+      };
+
+      disableMove = mkOption {
+        type = types.nullOr types.bool;
+        description = "Disable the move keymap for hyper";
+        default = null;
+      };
+
+      hide = {
+        statusline = mkOption {
+          description = "Whether to hide statusline in Dashboard buffer";
+          type = types.nullOr types.bool;
+          default = null;
+        };
+
+        tabline = mkOption {
+          description = "Whether to hide tabline in Dashboard buffer";
+          type = types.nullOr types.bool;
+          default = null;
+        };
+
+        winbar = mkOption {
+          description = "Whether to hide winbar in Dashboard buffer";
+          type = types.nullOr types.bool;
+          default = null;
+        };
+      };
+
+      packages.enable = mkOption {
+        description = "Whether to display installed Vim packages";
         type = types.nullOr types.bool;
         default = null;
       };
 
-      hideTabline = mkOption {
-        description = "Whether to hide tabline in Dashboard buffer";
+      week_header.enable = mkOption {
+        description = "Whether to display the week day header";
         type = types.nullOr types.bool;
+        default = null;
+      };
+
+      project = {
+        enable = mkOption {
+          description = "Whether to display projects in hyper";
+          type = types.nullOr types.bool;
+          default = null;
+        };
+
+        icon = mkOption {
+          description = "The icon to display";
+          type = types.nullOr types.str;
+          default = null;
+        };
+
+        label = mkOption {
+          description = "The text to display";
+          type = types.nullOr types.str;
+          default = null;
+        };
+
+        limit = mkOption {
+          description = "The max amount of projects to show";
+          type = types.nullOr types.int;
+          default = null;
+        };
+
+        action = mkOption {
+          description = "The command to run when selecting a project";
+          type = types.nullOr types.str;
+          default = null;
+        };
+      };
+
+      mru = {
+        icon = mkOption {
+          description = "The icon to display";
+          type = types.nullOr types.str;
+          default = null;
+        };
+
+        label = mkOption {
+          description = "The text to display";
+          type = types.nullOr types.str;
+          default = null;
+        };
+
+        limit = mkOption {
+          description = "The max amount of projects to show";
+          type = types.nullOr types.int;
+          default = null;
+        };
+      };
+
+      shortcut = mkOption {
+        description = "Shortcuts to display";
+        type = types.nullOr (types.listOf shortcutType);
         default = null;
       };
     };
@@ -111,30 +239,39 @@ in {
 
   config = let
     options = {
-      custom_header = cfg.header;
-      custom_footer = cfg.footer;
-      custom_center = cfg.center;
+      inherit (cfg) theme hide;
 
-      preview_file_path = cfg.preview.file;
-      preview_file_height = cfg.preview.height;
-      preview_file_width = cfg.preview.width;
-      preview_command = cfg.preview.command;
+      disable_move = cfg.disableMove;
+      change_to_vcs_root = cfg.changeToVcsRoot;
 
-      hide_statusline = cfg.hideStatusline;
-      hide_tabline = cfg.hideTabline;
+      config = {
+        inherit (cfg) header footer center project mru shortcut packages week_header;
+        disable_move = cfg.disableMove;
+      };
 
-      session_directory = cfg.sessionDirectory;
+      preview = {
+        inherit (cfg.preview) command file height width;
+      };
     };
 
-    filteredOptions = filterAttrs (_: v: v != null) options;
+    filterNullOrEmptyAttrs = attrs:
+      filterAttrs
+      (
+        _: v:
+          v
+          == null
+          || v == {}
+          || (builtins.isAttrs v && (filterNullOrEmptyAttrs v != {}))
+      )
+      attrs;
+
+    # filteredOptions = filterAttrs (_: v: v != null) options;
+    filteredOptions = filterNullOrEmptyAttrs options;
   in
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
       extraConfigLua = ''
-        local dashboard = require("dashboard")
-
-        ${toString (mapAttrsToList (n: v: "dashboard.${n} = ${helpers.toLuaObject v}\n")
-            filteredOptions)}
+        require("dashboard").setup(${helpers.toLuaObject filteredOptions})
       '';
     };
 }

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -8,8 +8,6 @@
 with lib; let
   cfg = config.plugins.dashboard;
 
-  helpers = import ../helpers.nix {inherit lib;};
-
   shortcutType = types.submodule {
     options.icon = mkOption {
       description = "The icon to display";

--- a/tests/test-sources/plugins/utils/dashboard.nix
+++ b/tests/test-sources/plugins/utils/dashboard.nix
@@ -1,0 +1,60 @@
+{
+  empty = {
+    plugins.dashboard.enable = true;
+  };
+
+  example = {
+    plugins.dashboard = {
+      enable = true;
+
+      theme = "hyper";
+      disableMove = true;
+      changeToVcsRoot = true;
+
+      packages.enable = false;
+      week_header.enable = false;
+
+      hide = {
+        statusline = true;
+        tabline = true;
+        winbar = true;
+      };
+
+      project = {
+        enable = true;
+        icon = "P";
+        label = "Projects";
+        limit = 8;
+        action = "e ";
+      };
+
+      mru = {
+        icon = "R";
+        label = "Recent Files";
+        limit = 10;
+      };
+
+      shortcut = [
+        {
+          icon = "O";
+          desc = "Open Example File";
+          key = "f";
+          action = "e example.txt";
+        }
+      ];
+
+      header = [
+        "███╗   ██╗██╗██╗  ██╗██╗   ██╗██╗███╗   ███╗"
+        "████╗  ██║██║╚██╗██╔╝██║   ██║██║████╗ ████║"
+        "██╔██╗ ██║██║ ╚███╔╝ ██║   ██║██║██╔████╔██║"
+        "██║╚██╗██║██║ ██╔██╗ ╚██╗ ██╔╝██║██║╚██╔╝██║"
+        "██║ ╚████║██║██╔╝ ██╗ ╚████╔╝ ██║██║ ╚═╝ ██║"
+        "╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝  ╚═══╝  ╚═╝╚═╝     ╚═╝"
+      ];
+
+      footer = [
+        "Made with ❤️ "
+      ];
+    };
+  };
+}


### PR DESCRIPTION
There were a handful of options missing from the Dashboard module. I've gone ahead and added more along with a new test for the module. Some functionality like session management was also removed from the neovim plugin, so this is now caught in case users are trying to activate it.