### PR TITLE
fix: add ripgrep for todo-comments functionality

### DIFF
--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -33,6 +33,15 @@ in {
           "todo-comments"
           pkgs.vimPlugins.todo-comments-nvim;
 
+        ripgrep = {
+          enable = mkOption {
+            type = types.bool;
+            description = "Enable ripgrep for searching files for todo comments.";
+            default = true;
+          };
+          package = helpers.mkPackageOption "ripgrep" pkgs.ripgrep;
+        };
+
         signs = helpers.defaultNullOpts.mkBool true "Show icons in the signs column.";
 
         signPriority = helpers.defaultNullOpts.mkInt 8 "Sign priority.";
@@ -264,6 +273,7 @@ in {
   in
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
+      extraPackages = optional cfg.ripgrep.enable cfg.ripgrep.package;
       extraConfigLua = ''
         require("todo-comments").setup${helpers.toLuaObject setupOptions}
       '';

--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -33,13 +33,11 @@ in {
           "todo-comments"
           pkgs.vimPlugins.todo-comments-nvim;
 
-        ripgrep = {
-          enable = mkOption {
-            type = types.bool;
-            description = "Enable ripgrep for searching files for todo comments.";
-            default = true;
-          };
-          package = helpers.mkPackageOption "ripgrep" pkgs.ripgrep;
+        ripgrepPackage = mkOption {
+          type = with types; nullOr package;
+          default = pkgs.ripgrep;
+          example = null;
+          description = "Which package (if any) to be added for file search support in todo-comments.";
         };
 
         signs = helpers.defaultNullOpts.mkBool true "Show icons in the signs column.";
@@ -273,7 +271,7 @@ in {
   in
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
-      extraPackages = optional cfg.ripgrep.enable cfg.ripgrep.package;
+      extraPackages = optional (cfg.ripgrepPackage != null) cfg.ripgrepPackage;
       extraConfigLua = ''
         require("todo-comments").setup${helpers.toLuaObject setupOptions}
       '';

--- a/tests/test-sources/plugins/utils/todo-comments.nix
+++ b/tests/test-sources/plugins/utils/todo-comments.nix
@@ -125,4 +125,12 @@
       };
     };
   };
+
+  withoutRipgrep = {
+    plugins.todo-comments = {
+      enable = true;
+
+      ripgrepPackage = null;
+    };
+  };
 }


### PR DESCRIPTION
Attempting to use todo-comments without `ripgrep` isn't very useful since the plugin won't be able to find comments in your files based on keywords. This commit adds a new option, defaulting enabled, to add `ripgrep` to the resulting neovim build.