### PR TITLE
feat: add option for customizing lsp capabilities

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -62,6 +62,9 @@ in {
                   type = types.nullOr (types.attrsOf types.bool);
                   description = "Control resolved capabilities for the language server.";
                   default = null;
+                  example = {
+                    documentFormattingProvider = false;
+                  };
                 };
 
                 extraOptions = mkOption {


### PR DESCRIPTION
Some servers like `tsserver` conflict with additional LSPs when they are active on the same buffer. Other servers may misreport their capabilities or need tweaking to match user preferences. Previously this needed to be done in a much more ad-hoc way in the user's configuration or bespoke lua config would need to be written to handle these cases. This commit provides a central, nix-based solution for toggling lsp capabilities declaratively.