### PR TITLE
helpers/neovim-plugin: add mkNeovimPlugin

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -1,16 +1,21 @@
-{lib, ...}: let
+{
+  lib,
+  pkgs,
+  ...
+}: let
   nixvimTypes = import ./types.nix {inherit lib nixvimOptions;};
   nixvimUtils = import ./utils.nix {inherit lib;};
   nixvimOptions = import ./options.nix {inherit lib nixvimTypes nixvimUtils;};
+  inherit (import ./to-lua.nix {inherit lib;}) toLuaObject;
 in
   {
     maintainers = import ./maintainers.nix;
     keymaps = import ./keymap-helpers.nix {inherit lib nixvimOptions nixvimTypes;};
     autocmd = import ./autocmd-helpers.nix {inherit lib nixvimOptions nixvimTypes;};
-    neovim-plugin = import ./neovim-plugin.nix {inherit lib nixvimOptions;};
+    neovim-plugin = import ./neovim-plugin.nix {inherit lib nixvimOptions toLuaObject;};
     vim-plugin = import ./vim-plugin.nix {inherit lib nixvimOptions;};
-    inherit (import ./to-lua.nix {inherit lib;}) toLuaObject;
     inherit nixvimTypes;
+    inherit toLuaObject;
   }
   // nixvimUtils
   // nixvimOptions

--- a/plugins/TEMPLATE.nix
+++ b/plugins/TEMPLATE.nix
@@ -5,30 +5,16 @@
   pkgs,
   ...
 }:
-with lib; let
-  cfg = config.plugins.my-plugin; # TODO replace
-in {
-  meta.maintainers = [maintainers.MyName]; # TODO replace with your name
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "my-plugin";
+  originalName = "my-plugin.nvim";
+  defaultPackage = pkgs.vimPlugins.my-plugin-nvim; # TODO replace
 
-  # TODO replace
-  options.plugins.my-plugin =
-    helpers.neovim-plugin.extraOptionsOptions
-    // {
-      enable = mkEnableOption "my-plugin.nvim"; # TODO replace
-
-      package = helpers.mkPackageOption "my-plugin.nvim" pkgs.vimPlugins.my-plugin-nvim; # TODO replace
-    };
-
-  config = mkIf cfg.enable {
-    extraPlugins = [cfg.package];
-
-    extraConfigLua = let
-      setupOptions = with cfg;
-        {
-        }
-        // cfg.extraOptions;
-    in ''
-      require('my-plugin').setup(${helpers.toLuaObject setupOptions})
-    '';
+  # Optionnally provide an example for the `settings` option.
+  settingsExample = {
+    foo = 42;
+    bar.__raw = "function() print('hello') end";
   };
+
+  maintainers = [lib.maintainers.MyName]; # TODO replace with your name
 }

--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -4,78 +4,63 @@
   config,
   pkgs,
   ...
-}:
-with lib; let
-  cfg = config.colorschemes.gruvbox;
-in {
-  meta.maintainers = [maintainers.GaetanLepage];
-
-  # Introduced January 31 2024
-  # TODO remove in early March 2024.
+}: {
   imports =
-    map
-    (
-      optionName:
-        mkRemovedOptionModule
-        ["colorschemes" "gruvbox" optionName]
-        "Please use `colorschemes.gruvbox.settings.${helpers.toSnakeCase optionName}` instead."
-    )
     [
-      "italics"
-      "bold"
-      "underline"
-      "undercurl"
-      "contrastDark"
-      "contrastLight"
-      "highlightSearchCursor"
-      "numberColumn"
-      "signColumn"
-      "colorColumn"
-      "vertSplitColor"
-      "italicizeComments"
-      "italicizeStrings"
-      "invertSelection"
-      "invertSigns"
-      "invertIndentGuides"
-      "invertTabline"
-      "improvedStrings"
-      "improvedWarnings"
-      "transparentBg"
-      "trueColor"
-    ];
+      (
+        helpers.neovim-plugin.mkNeovimPlugin config {
+          name = "gruvbox";
+          namespace = "colorschemes";
+          originalName = "gruvbox.nvim";
+          defaultPackage = pkgs.vimPlugins.gruvbox-nvim;
 
-  options.colorschemes.gruvbox = {
-    enable = mkEnableOption "gruvbox.nvim";
+          settingsExample = {
+            terminal_colors = true;
+            palette_overrides = {
+              dark1 = "#323232";
+              dark2 = "#383330";
+              dark3 = "#323232";
+              bright_blue = "#5476b2";
+              bright_purple = "#fb4934";
+            };
+          };
 
-    package = helpers.mkPackageOption "gruvbox.nvim" pkgs.vimPlugins.gruvbox-nvim;
-
-    settings = mkOption {
-      type = with types;
-        submodule {
-          freeformType = attrs;
-          options = {};
-        };
-      description = "The configuration options for gruvbox.";
-      default = {};
-      example = {
-        terminal_colors = true;
-        palette_overrides = {
-          dark1 = "#323232";
-          dark2 = "#383330";
-          dark3 = "#323232";
-          bright_blue = "#5476b2";
-          bright_purple = "#fb4934";
-        };
-      };
-    };
-  };
-
-  config = mkIf cfg.enable {
-    colorscheme = "gruvbox";
-    extraPlugins = [cfg.package];
-
-    extraConfigLua = ''
-      require('gruvbox').setup(${helpers.toLuaObject cfg.settings})
-    '';
-  };
+          maintainers = [lib.maintainers.GaetanLepage];
+        }
+      )
+    ]
+    # Introduced January 31 2024
+    # TODO remove in early March 2024.
+    ++ (
+      map
+      (
+        optionName:
+          lib.mkRemovedOptionModule
+          ["colorschemes" "gruvbox" optionName]
+          "Please use `colorschemes.gruvbox.settings.${helpers.toSnakeCase optionName}` instead."
+      )
+      [
+        "italics"
+        "bold"
+        "underline"
+        "undercurl"
+        "contrastDark"
+        "contrastLight"
+        "highlightSearchCursor"
+        "numberColumn"
+        "signColumn"
+        "colorColumn"
+        "vertSplitColor"
+        "italicizeComments"
+        "italicizeStrings"
+        "invertSelection"
+        "invertSigns"
+        "invertIndentGuides"
+        "invertTabline"
+        "improvedStrings"
+        "improvedWarnings"
+        "transparentBg"
+        "trueColor"
+      ]
+    );
 }


### PR DESCRIPTION
This PR introduces a new helper: `helpers.neovim-plugin.mkNeovimPlugin`.
It allows to very quickly create the module for a "conventional" plugin.
By "conventional", I mean a lua plugin which is configured through a `require('plugin-name').setup` function.