### PR TITLE
Fix typos in `plugins.treesitter-refactor.navigation.keymaps`

### DIFF
--- a/plugins/languages/treesitter/treesitter-refactor.nix
+++ b/plugins/languages/treesitter/treesitter-refactor.nix
@@ -72,12 +72,12 @@ with lib; {
             mapping fo `lua require'nvim-treesitter.refactor.navigation(nil, fallback_function)<cr>`.
           '';
         };
-        listDefinitons = mkOption {
+        listDefinitions = mkOption {
           type = types.nullOr types.str;
           default = "gnD";
           description = "list all definitions from the current file";
         };
-        listDefinitonsToc = mkOption {
+        listDefinitionsToc = mkOption {
           type = types.nullOr types.str;
           default = "gO";
           description = ''
@@ -98,6 +98,15 @@ with lib; {
       };
     };
   };
+
+  imports = [
+    (mkRenamedOptionModule
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitons"]
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitions"])
+    (mkRenamedOptionModule
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitonsToc"]
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitionsToc"])
+  ];
 
   config = let
     cfg = config.plugins.treesitter-refactor;
@@ -126,8 +135,8 @@ with lib; {
           in {
             goto_definition = cfgK.gotoDefinition;
             goto_definition_lsp_fallback = cfgK.gotoDefinitionLspFallback;
-            list_definitions = cfgK.listDefinitons;
-            list_definitions_toc = cfgK.listDefinitonsToc;
+            list_definitions = cfgK.listDefinitions;
+            list_definitions_toc = cfgK.listDefinitionsToc;
             goto_next_usage = cfgK.gotoNextUsage;
             goto_previous_usage = cfgK.gotoPreviousUsage;
           };

--- a/plugins/languages/treesitter/treesitter-refactor.nix
+++ b/plugins/languages/treesitter/treesitter-refactor.nix
@@ -1,126 +1,124 @@
-{ lib
-, helpers
-, config
-, pkgs
-, ...
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
 }:
 with lib; {
-  options.plugins.treesitter-refactor =
-    let
-      disable = mkOption {
-        type = types.listOf types.str;
-        default = [ ];
-        description = "List of languages to disable the module on";
-      };
-    in
-    {
+  options.plugins.treesitter-refactor = let
+    disable = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = "List of languages to disable the module on";
+    };
+  in {
+    enable =
+      mkEnableOption
+      "treesitter-refactor (requires plugins.treesitter.enable to be true)";
+
+    package = helpers.mkPackageOption "treesitter-refactor" pkgs.vimPlugins.nvim-treesitter-refactor;
+
+    highlightDefinitions = {
+      inherit disable;
       enable =
         mkEnableOption
-          "treesitter-refactor (requires plugins.treesitter.enable to be true)";
-
-      package = helpers.mkPackageOption "treesitter-refactor" pkgs.vimPlugins.nvim-treesitter-refactor;
-
-      highlightDefinitions = {
-        inherit disable;
-        enable =
-          mkEnableOption
-            "Highlights definition and usages of the current symbol under the cursor.";
-        clearOnCursorMove = mkOption {
-          type = types.bool;
-          default = true;
-          description = ''
-            Controls if highlights should be cleared when the cursor is moved. If your 'updatetime'
-            is around `100` you can set this to false to have a less laggy experience.
-          '';
-        };
-      };
-      highlightCurrentScope = {
-        inherit disable;
-        enable = mkEnableOption "highlighting the block from the current scope where the cursor is";
-      };
-      smartRename = {
-        inherit disable;
-        enable =
-          mkEnableOption
-            "Renames the symbol under the cursor within the current scope (and current file).";
-        keymaps = {
-          smartRename = mkOption {
-            type = types.nullOr types.str;
-            default = "grr";
-            description = "rename symbol under the cursor";
-          };
-        };
-      };
-      navigation = {
-        inherit disable;
-        enable = mkEnableOption ''
-          Provides "go to definition" for the symbol under the cursor,
-          and lists the definitions from the current file.
+        "Highlights definition and usages of the current symbol under the cursor.";
+      clearOnCursorMove = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Controls if highlights should be cleared when the cursor is moved. If your 'updatetime'
+          is around `100` you can set this to false to have a less laggy experience.
         '';
-
-        keymaps = {
-          gotoDefinition = mkOption {
-            type = types.nullOr types.str;
-            default = "gnd";
-            description = "go to the definition of the symbol under the cursor";
-          };
-          gotoDefinitionLspFallback = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            description = ''
-              go to the definition of the symbol under the cursor or use vim.lsp.buf.definition if
-              the symbol can not be resolved. You can use your own fallback function if create a
-              mapping fo `lua require'nvim-treesitter.refactor.navigation(nil, fallback_function)<cr>`.
-            '';
-          };
-          listDefinitions = mkOption {
-            type = types.nullOr types.str;
-            default = "gnD";
-            description = "list all definitions from the current file";
-          };
-          listDefinitionsToc = mkOption {
-            type = types.nullOr types.str;
-            default = "gO";
-            description = ''
-              list all definitions from the current file like a table of contents (similar to the one
-              you see when pressing |gO| in help files).
-            '';
-          };
-          gotoNextUsage = mkOption {
-            type = types.nullOr types.str;
-            default = "<a-*>";
-            description = "go to next usage of identifier under the cursor";
-          };
-          gotoPreviousUsage = mkOption {
-            type = types.nullOr types.str;
-            default = "<a-#>";
-            description = "go to previous usage of identifier";
-          };
+      };
+    };
+    highlightCurrentScope = {
+      inherit disable;
+      enable = mkEnableOption "highlighting the block from the current scope where the cursor is";
+    };
+    smartRename = {
+      inherit disable;
+      enable =
+        mkEnableOption
+        "Renames the symbol under the cursor within the current scope (and current file).";
+      keymaps = {
+        smartRename = mkOption {
+          type = types.nullOr types.str;
+          default = "grr";
+          description = "rename symbol under the cursor";
         };
       };
     };
+    navigation = {
+      inherit disable;
+      enable = mkEnableOption ''
+        Provides "go to definition" for the symbol under the cursor,
+        and lists the definitions from the current file.
+      '';
+
+      keymaps = {
+        gotoDefinition = mkOption {
+          type = types.nullOr types.str;
+          default = "gnd";
+          description = "go to the definition of the symbol under the cursor";
+        };
+        gotoDefinitionLspFallback = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = ''
+            go to the definition of the symbol under the cursor or use vim.lsp.buf.definition if
+            the symbol can not be resolved. You can use your own fallback function if create a
+            mapping fo `lua require'nvim-treesitter.refactor.navigation(nil, fallback_function)<cr>`.
+          '';
+        };
+        listDefinitions = mkOption {
+          type = types.nullOr types.str;
+          default = "gnD";
+          description = "list all definitions from the current file";
+        };
+        listDefinitionsToc = mkOption {
+          type = types.nullOr types.str;
+          default = "gO";
+          description = ''
+            list all definitions from the current file like a table of contents (similar to the one
+            you see when pressing |gO| in help files).
+          '';
+        };
+        gotoNextUsage = mkOption {
+          type = types.nullOr types.str;
+          default = "<a-*>";
+          description = "go to next usage of identifier under the cursor";
+        };
+        gotoPreviousUsage = mkOption {
+          type = types.nullOr types.str;
+          default = "<a-#>";
+          description = "go to previous usage of identifier";
+        };
+      };
+    };
+  };
 
   imports = [
     # Added 2024-02-07
     (mkRenamedOptionModule
-      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitons" ]
-      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitions" ])
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitons"]
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitions"])
     # Added 2024-02-07
     (mkRenamedOptionModule
-      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitonsToc" ]
-      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitionsToc" ])
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitonsToc"]
+      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitionsToc"])
   ];
 
-  config =
-    let
-      cfg = config.plugins.treesitter-refactor;
-    in
+  config = let
+    cfg = config.plugins.treesitter-refactor;
+  in
     mkIf cfg.enable {
       warnings = mkIf (!config.plugins.treesitter.enable) [
         "Nixvim: treesitter-refactor needs treesitter to function as intended"
       ];
 
-      extraPlugins = [ cfg.package ];
+      extraPlugins = [cfg.package];
 
       plugins.treesitter.moduleConfig.refactor = {
         highlight_definitions = {
@@ -130,22 +128,20 @@ with lib; {
         highlight_current_scope = cfg.highlightCurrentScope;
         smart_rename = {
           inherit (cfg.smartRename) enable disable;
-          keymaps = { smart_rename = cfg.smartRename.keymaps.smartRename; };
+          keymaps = {smart_rename = cfg.smartRename.keymaps.smartRename;};
         };
         navigation = {
           inherit (cfg.navigation) enable disable;
-          keymaps =
-            let
-              cfgK = cfg.navigation.keymaps;
-            in
-            {
-              goto_definition = cfgK.gotoDefinition;
-              goto_definition_lsp_fallback = cfgK.gotoDefinitionLspFallback;
-              list_definitions = cfgK.listDefinitions;
-              list_definitions_toc = cfgK.listDefinitionsToc;
-              goto_next_usage = cfgK.gotoNextUsage;
-              goto_previous_usage = cfgK.gotoPreviousUsage;
-            };
+          keymaps = let
+            cfgK = cfg.navigation.keymaps;
+          in {
+            goto_definition = cfgK.gotoDefinition;
+            goto_definition_lsp_fallback = cfgK.gotoDefinitionLspFallback;
+            list_definitions = cfgK.listDefinitions;
+            list_definitions_toc = cfgK.listDefinitionsToc;
+            goto_next_usage = cfgK.gotoNextUsage;
+            goto_previous_usage = cfgK.gotoPreviousUsage;
+          };
         };
       };
     };

--- a/plugins/languages/treesitter/treesitter-refactor.nix
+++ b/plugins/languages/treesitter/treesitter-refactor.nix
@@ -1,122 +1,126 @@
-{
-  lib,
-  helpers,
-  config,
-  pkgs,
-  ...
+{ lib
+, helpers
+, config
+, pkgs
+, ...
 }:
 with lib; {
-  options.plugins.treesitter-refactor = let
-    disable = mkOption {
-      type = types.listOf types.str;
-      default = [];
-      description = "List of languages to disable the module on";
-    };
-  in {
-    enable =
-      mkEnableOption
-      "treesitter-refactor (requires plugins.treesitter.enable to be true)";
-
-    package = helpers.mkPackageOption "treesitter-refactor" pkgs.vimPlugins.nvim-treesitter-refactor;
-
-    highlightDefinitions = {
-      inherit disable;
+  options.plugins.treesitter-refactor =
+    let
+      disable = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "List of languages to disable the module on";
+      };
+    in
+    {
       enable =
         mkEnableOption
-        "Highlights definition and usages of the current symbol under the cursor.";
-      clearOnCursorMove = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Controls if highlights should be cleared when the cursor is moved. If your 'updatetime'
-          is around `100` you can set this to false to have a less laggy experience.
+          "treesitter-refactor (requires plugins.treesitter.enable to be true)";
+
+      package = helpers.mkPackageOption "treesitter-refactor" pkgs.vimPlugins.nvim-treesitter-refactor;
+
+      highlightDefinitions = {
+        inherit disable;
+        enable =
+          mkEnableOption
+            "Highlights definition and usages of the current symbol under the cursor.";
+        clearOnCursorMove = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Controls if highlights should be cleared when the cursor is moved. If your 'updatetime'
+            is around `100` you can set this to false to have a less laggy experience.
+          '';
+        };
+      };
+      highlightCurrentScope = {
+        inherit disable;
+        enable = mkEnableOption "highlighting the block from the current scope where the cursor is";
+      };
+      smartRename = {
+        inherit disable;
+        enable =
+          mkEnableOption
+            "Renames the symbol under the cursor within the current scope (and current file).";
+        keymaps = {
+          smartRename = mkOption {
+            type = types.nullOr types.str;
+            default = "grr";
+            description = "rename symbol under the cursor";
+          };
+        };
+      };
+      navigation = {
+        inherit disable;
+        enable = mkEnableOption ''
+          Provides "go to definition" for the symbol under the cursor,
+          and lists the definitions from the current file.
         '';
-      };
-    };
-    highlightCurrentScope = {
-      inherit disable;
-      enable = mkEnableOption "highlighting the block from the current scope where the cursor is";
-    };
-    smartRename = {
-      inherit disable;
-      enable =
-        mkEnableOption
-        "Renames the symbol under the cursor within the current scope (and current file).";
-      keymaps = {
-        smartRename = mkOption {
-          type = types.nullOr types.str;
-          default = "grr";
-          description = "rename symbol under the cursor";
-        };
-      };
-    };
-    navigation = {
-      inherit disable;
-      enable = mkEnableOption ''
-        Provides "go to definition" for the symbol under the cursor,
-        and lists the definitions from the current file.
-      '';
 
-      keymaps = {
-        gotoDefinition = mkOption {
-          type = types.nullOr types.str;
-          default = "gnd";
-          description = "go to the definition of the symbol under the cursor";
-        };
-        gotoDefinitionLspFallback = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = ''
-            go to the definition of the symbol under the cursor or use vim.lsp.buf.definition if
-            the symbol can not be resolved. You can use your own fallback function if create a
-            mapping fo `lua require'nvim-treesitter.refactor.navigation(nil, fallback_function)<cr>`.
-          '';
-        };
-        listDefinitions = mkOption {
-          type = types.nullOr types.str;
-          default = "gnD";
-          description = "list all definitions from the current file";
-        };
-        listDefinitionsToc = mkOption {
-          type = types.nullOr types.str;
-          default = "gO";
-          description = ''
-            list all definitions from the current file like a table of contents (similar to the one
-            you see when pressing |gO| in help files).
-          '';
-        };
-        gotoNextUsage = mkOption {
-          type = types.nullOr types.str;
-          default = "<a-*>";
-          description = "go to next usage of identifier under the cursor";
-        };
-        gotoPreviousUsage = mkOption {
-          type = types.nullOr types.str;
-          default = "<a-#>";
-          description = "go to previous usage of identifier";
+        keymaps = {
+          gotoDefinition = mkOption {
+            type = types.nullOr types.str;
+            default = "gnd";
+            description = "go to the definition of the symbol under the cursor";
+          };
+          gotoDefinitionLspFallback = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = ''
+              go to the definition of the symbol under the cursor or use vim.lsp.buf.definition if
+              the symbol can not be resolved. You can use your own fallback function if create a
+              mapping fo `lua require'nvim-treesitter.refactor.navigation(nil, fallback_function)<cr>`.
+            '';
+          };
+          listDefinitions = mkOption {
+            type = types.nullOr types.str;
+            default = "gnD";
+            description = "list all definitions from the current file";
+          };
+          listDefinitionsToc = mkOption {
+            type = types.nullOr types.str;
+            default = "gO";
+            description = ''
+              list all definitions from the current file like a table of contents (similar to the one
+              you see when pressing |gO| in help files).
+            '';
+          };
+          gotoNextUsage = mkOption {
+            type = types.nullOr types.str;
+            default = "<a-*>";
+            description = "go to next usage of identifier under the cursor";
+          };
+          gotoPreviousUsage = mkOption {
+            type = types.nullOr types.str;
+            default = "<a-#>";
+            description = "go to previous usage of identifier";
+          };
         };
       };
     };
-  };
 
   imports = [
+    # Added 2024-02-07
     (mkRenamedOptionModule
-      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitons"]
-      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitions"])
+      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitons" ]
+      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitions" ])
+    # Added 2024-02-07
     (mkRenamedOptionModule
-      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitonsToc"]
-      ["plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitionsToc"])
+      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitonsToc" ]
+      [ "plugins" "treesitter-refactor" "navigation" "keymaps" "listDefinitionsToc" ])
   ];
 
-  config = let
-    cfg = config.plugins.treesitter-refactor;
-  in
+  config =
+    let
+      cfg = config.plugins.treesitter-refactor;
+    in
     mkIf cfg.enable {
       warnings = mkIf (!config.plugins.treesitter.enable) [
         "Nixvim: treesitter-refactor needs treesitter to function as intended"
       ];
 
-      extraPlugins = [cfg.package];
+      extraPlugins = [ cfg.package ];
 
       plugins.treesitter.moduleConfig.refactor = {
         highlight_definitions = {
@@ -126,20 +130,22 @@ with lib; {
         highlight_current_scope = cfg.highlightCurrentScope;
         smart_rename = {
           inherit (cfg.smartRename) enable disable;
-          keymaps = {smart_rename = cfg.smartRename.keymaps.smartRename;};
+          keymaps = { smart_rename = cfg.smartRename.keymaps.smartRename; };
         };
         navigation = {
           inherit (cfg.navigation) enable disable;
-          keymaps = let
-            cfgK = cfg.navigation.keymaps;
-          in {
-            goto_definition = cfgK.gotoDefinition;
-            goto_definition_lsp_fallback = cfgK.gotoDefinitionLspFallback;
-            list_definitions = cfgK.listDefinitions;
-            list_definitions_toc = cfgK.listDefinitionsToc;
-            goto_next_usage = cfgK.gotoNextUsage;
-            goto_previous_usage = cfgK.gotoPreviousUsage;
-          };
+          keymaps =
+            let
+              cfgK = cfg.navigation.keymaps;
+            in
+            {
+              goto_definition = cfgK.gotoDefinition;
+              goto_definition_lsp_fallback = cfgK.gotoDefinitionLspFallback;
+              list_definitions = cfgK.listDefinitions;
+              list_definitions_toc = cfgK.listDefinitionsToc;
+              goto_next_usage = cfgK.gotoNextUsage;
+              goto_previous_usage = cfgK.gotoPreviousUsage;
+            };
         };
       };
     };


### PR DESCRIPTION
The keymap options `listDefinitions` and `listDefinitionsToc` were misspelled.
This also adds a renamed option warning for backward compatibility.
