### PR TITLE
misc: refactor helpers propagation

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,5 +1,6 @@
 {
   rawModules,
+  helpers,
   pkgs,
 }: let
   pkgsDoc =
@@ -73,7 +74,13 @@ in
     options-json =
       (pkgsDoc.nixosOptionsDoc
         {
-          inherit (lib.evalModules {modules = topLevelModules;}) options;
+          inherit
+            (lib.evalModules {
+              modules = topLevelModules;
+              specialArgs.helpers = helpers;
+            })
+            options
+            ;
           inherit transformOptions;
           warningsAreErrors = false;
         })
@@ -86,5 +93,6 @@ in
     docs = pkgsDoc.callPackage ./mdbook {
       inherit transformOptions;
       modules = topLevelModules;
+      inherit helpers;
     };
   }

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -2,13 +2,14 @@
   pkgs,
   lib,
   modules,
+  helpers,
   nixosOptionsDoc,
   transformOptions,
 }:
 with lib; let
   options = lib.evalModules {
     inherit modules;
-    specialArgs = {inherit pkgs lib;};
+    specialArgs = {inherit pkgs lib helpers;};
   };
 
   mkMDDoc = options:

--- a/flake-modules/default.nix
+++ b/flake-modules/default.nix
@@ -1,6 +1,7 @@
 {inputs, ...}: {
   imports = [
     ./dev.nix
+    ./helpers.nix
     ./lib.nix
     ./legacy-packages.nix
     ./modules.nix

--- a/flake-modules/helpers.nix
+++ b/flake-modules/helpers.nix
@@ -1,0 +1,15 @@
+{getHelpers, ...}: {
+  _module.args.getHelpers = pkgs:
+    import ../lib/helpers.nix {
+      inherit pkgs;
+      inherit (pkgs) lib;
+    };
+
+  perSystem = {
+    pkgs,
+    config,
+    ...
+  }: {
+    _module.args.helpers = getHelpers pkgs;
+  };
+}

--- a/flake-modules/modules.nix
+++ b/flake-modules/modules.nix
@@ -10,7 +10,6 @@
           _module.args = {
             pkgs = pkgs.lib.mkForce pkgs;
             inherit (pkgs) lib;
-            helpers = import ../lib/helpers.nix {inherit (pkgs) lib;};
           };
         };
       };

--- a/flake-modules/packages.nix
+++ b/flake-modules/packages.nix
@@ -3,10 +3,11 @@
     pkgs,
     config,
     rawModules,
+    helpers,
     ...
   }: {
     packages = import ../docs {
-      inherit rawModules pkgs;
+      inherit rawModules pkgs helpers;
     };
 
     # Test that all packages build fine when running `nix flake check`.

--- a/flake-modules/wrappers.nix
+++ b/flake-modules/wrappers.nix
@@ -1,12 +1,14 @@
 {
   inputs,
   modules,
+  getHelpers,
   self,
   ...
 }: let
   wrapperArgs = {
     inherit modules;
     inherit self;
+    inherit getHelpers;
   };
 in {
   perSystem = {

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,4 +1,7 @@
-modules: {
+{
+  modules,
+  helpers,
+}: {
   lib,
   pkgs,
   config,
@@ -20,7 +23,7 @@ in {
       check = builtins.isAttrs;
     };
     description = "Use this option to access the helpers";
-    default = import ../plugins/helpers.nix {inherit (pkgs) lib;};
+    default = helpers;
   };
 
   configFiles = let

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -1,6 +1,7 @@
 {
   modules,
   self,
+  getHelpers,
 }: {
   pkgs,
   config,
@@ -8,19 +9,25 @@
   ...
 } @ args: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkForce mkMerge mkIf types;
-  shared = import ./_shared.nix modules args;
+  helpers = getHelpers pkgs;
+  shared = import ./_shared.nix {inherit modules helpers;} args;
   cfg = config.programs.nixvim;
 in {
   options = {
     programs.nixvim = mkOption {
       default = {};
-      type = types.submodule ([
-          {
-            options.enable = mkEnableOption "nixvim";
-            config.wrapRc = mkForce true;
-          }
-        ]
-        ++ shared.topLevelModules);
+      type = types.submoduleWith {
+        shorthandOnlyDefinesConfig = true;
+        specialArgs.helpers = helpers;
+        modules =
+          [
+            {
+              options.enable = mkEnableOption "nixvim";
+              config.wrapRc = mkForce true;
+            }
+          ]
+          ++ shared.topLevelModules;
+      };
     };
     nixvim.helpers = shared.helpers;
   };

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -1,6 +1,7 @@
 {
   modules,
   self,
+  getHelpers,
 }: {
   pkgs,
   config,
@@ -8,7 +9,8 @@
   ...
 } @ args: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkForce mkMerge mkIf types;
-  shared = import ./_shared.nix modules args;
+  helpers = getHelpers pkgs;
+  shared = import ./_shared.nix {inherit modules helpers;} args;
   cfg = config.programs.nixvim;
   files =
     shared.configFiles
@@ -19,16 +21,21 @@ in {
   options = {
     programs.nixvim = mkOption {
       default = {};
-      type = types.submodule ([
-          {
-            options = {
-              enable = mkEnableOption "nixvim";
-              defaultEditor = mkEnableOption "nixvim as the default editor";
-            };
-            config.wrapRc = mkForce true;
-          }
-        ]
-        ++ shared.topLevelModules);
+      type = types.submoduleWith {
+        shorthandOnlyDefinesConfig = true;
+        specialArgs.helpers = helpers;
+        modules =
+          [
+            {
+              options = {
+                enable = mkEnableOption "nixvim";
+                defaultEditor = mkEnableOption "nixvim as the default editor";
+              };
+              config.wrapRc = mkForce true;
+            }
+          ]
+          ++ shared.topLevelModules;
+      };
     };
     nixvim.helpers = shared.helpers;
   };

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -1,6 +1,7 @@
 default_pkgs: {
   modules,
   self,
+  getHelpers,
 }: {
   pkgs ? default_pkgs,
   extraSpecialArgs ? {},
@@ -8,16 +9,24 @@ default_pkgs: {
 }: let
   inherit (pkgs) lib;
 
-  wrap = {wrapRc = true;};
-
-  shared = import ./_shared.nix modules {
+  helpers = getHelpers pkgs;
+  shared = import ./_shared.nix {inherit modules helpers;} {
     inherit pkgs lib;
     config = {};
   };
 
   eval = lib.evalModules {
-    modules = [module wrap] ++ shared.topLevelModules;
-    specialArgs = extraSpecialArgs;
+    modules =
+      [
+        module
+        {wrapRc = true;}
+      ]
+      ++ shared.topLevelModules;
+    specialArgs =
+      {
+        inherit helpers;
+      }
+      // extraSpecialArgs;
   };
 
   handleAssertions = config: let


### PR DESCRIPTION
This PR moves the `helpers` from `_module.args` to `specialArgs`.
This is well more adapted and will allow us to not have to import `helpers.nix` from anywhere in the code base.