### PR TITLE
modules/highlights: add highlightOverride

### DIFF
--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -9,7 +9,18 @@ with lib; {
     highlight = mkOption {
       type = types.attrsOf helpers.nixvimTypes.highlight;
       default = {};
-      description = "Define highlight groups.";
+      description = "Define new highlight groups";
+      example = ''
+        highlight = {
+          MacchiatoRed.fg = "#ed8796";
+        };
+      '';
+    };
+
+    highlightOverride = mkOption {
+      type = types.attrsOf helpers.nixvimTypes.highlight;
+      default = {};
+      description = "Define highlight groups to override existing highlight";
       example = ''
         highlight = {
           Comment.fg = "#ff0000";
@@ -31,19 +42,27 @@ with lib; {
 
   config = {
     extraConfigLuaPre =
-      (optionalString (config.highlight != {}) ''
-        -- Highlight groups {{
-        do
-          local highlights = ${helpers.toLuaObject config.highlight}
+      (optionalString (config.highlight != {})
+        /*
+        lua
+        */
+        ''
+          -- Highlight groups {{
+          do
+            local highlights = ${helpers.toLuaObject config.highlight}
 
-          for k,v in pairs(highlights) do
-            vim.api.nvim_set_hl(0, k, v)
+            for k,v in pairs(highlights) do
+              vim.api.nvim_set_hl(0, k, v)
+            end
           end
-        end
-        -- }}
-      '')
-      + (optionalString (config.match != {}) ''
-        -- Match groups {{
+          -- }}
+        '')
+      + (optionalString (config.match != {})
+        /*
+        lua
+        */
+        ''
+          -- Match groups {{
           do
             local match = ${helpers.toLuaObject config.match}
 
@@ -51,7 +70,24 @@ with lib; {
               vim.fn.matchadd(k, v)
             end
           end
-          -- }}
-      '');
+            -- }}
+        '');
+
+    extraConfigLuaPost =
+      optionalString (config.highlightOverride != {})
+      /*
+      lua
+      */
+      ''
+        -- Highlight groups {{
+        do
+          local highlights = ${helpers.toLuaObject config.highlightOverride}
+
+          for k,v in pairs(highlights) do
+            vim.api.nvim_set_hl(0, k, v)
+          end
+        end
+        -- }}
+      '';
   };
 }

--- a/tests/test-sources/modules/highlight.nix
+++ b/tests/test-sources/modules/highlight.nix
@@ -1,7 +1,12 @@
 {
   example = {
     options.termguicolors = true;
+
     highlight = {
+      MacchiatoRed.fg = "#ed8796";
+    };
+
+    highlightOverride = {
       Normal.fg = "#ff0000";
 
       # With raw


### PR DESCRIPTION
Follow up to https://github.com/nix-community/nixvim/pull/1016. Support a new highlight override option that is called in post to allow overriding existing highlight groups. 