### PR TITLE
plugins/none-ls: add google-java-format

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -152,6 +152,9 @@ with lib; let
       golines = {
         package = pkgs.golines;
       };
+      google-java-format = {
+        package = pkgs.google-java-format;
+      };
       isort = {
         package = pkgs.isort;
       };

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -101,6 +101,7 @@
           goimports.enable = true;
           goimports_reviser.enable = true;
           golines.enable = true;
+          google-java-format.enable = true;
           ktlint.enable = true;
           nixfmt.enable = true;
           nixpkgs_fmt.enable = true;


### PR DESCRIPTION
Add an option to enable google-java-format none-ls source.