### PR TITLE
helpers: simplification accross the codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,43 +29,7 @@ Most of nixvim is dedicated to wrapping neovim plugin such that we can configure
 To add a new plugin you need to do the following.
 
 1.  Add a file in the correct sub-directory of [plugins](plugins). This depends on your exact plugin.
-    You will most certainly need the `helpers`, they can be added by doing something like:
-
-    ```nix
-    {
-      lib,
-      pkgs,
-      ...
-    } @ args:
-
-    let
-      helpers = import ../helpers.nix args;
-    in {
-    }
-    ```
-
-2.  Create the minimal options for a new plugin (in `options.plugins.<plug-name>`:
-
-    - `enable = mkEnableOption ...` to toggle the plugin.
-    - `package = helpers.mkPackageOption ...` to change the package options.
-
-3.  Add the plugin package to the installed plugins if it is enabled. This can be done with the following:
-
-    ```nix
-    {
-      config =
-        let
-          cfg = config.plugins."<plug-name>";
-
-        in lib.mkIf cfg.enable {
-          extraPlugins = [cfg.package];
-
-          extraConfigLua = ''
-            <plugin configuration if needed>
-          '';
-        };
-    }
-    ```
+2. Write the code for the corresponding nixvim module. You can start from the [template](plugins/TEMPLATE.nix).
 
 You will then need to add Nix options for all (or most) of the upstream plugin options.
 These options should be in `camelCase` (whereas most plugins define their options in `snake_case`), and their names should match exactly (except the case) to the upstream names.

--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -3,13 +3,14 @@
     pkgs,
     config,
     system,
+    helpers,
     makeNixvimWithModuleUnfree,
     makeNixvimWithModule,
     ...
   }: {
     checks = {
       tests = import ../tests {
-        inherit pkgs;
+        inherit pkgs helpers;
         inherit (pkgs) lib;
         makeNixvim = configuration:
           makeNixvimWithModuleUnfree {
@@ -25,7 +26,7 @@
       };
 
       lib-tests = import ../tests/lib-tests.nix {
-        inherit pkgs;
+        inherit pkgs helpers;
         inherit (pkgs) lib;
       };
     };

--- a/lib/autocmd-helpers.nix
+++ b/lib/autocmd-helpers.nix
@@ -1,7 +1,9 @@
-{lib, ...}:
-with lib; let
-  helpers = import ../lib/helpers.nix {inherit lib;};
-in rec {
+{
+  lib,
+  nixvimOptions,
+  nixvimTypes,
+}:
+with lib; rec {
   autoGroupOption = types.submodule {
     options = {
       clear = mkOption {
@@ -13,34 +15,34 @@ in rec {
   };
 
   autoCmdOptions = {
-    event = helpers.mkNullOrOption (with types; either str (listOf str)) ''
+    event = nixvimOptions.mkNullOrOption (with types; either str (listOf str)) ''
       The event or events to register this autocommand.
     '';
 
-    group = helpers.mkNullOrOption (with types; either str int) ''
+    group = nixvimOptions.mkNullOrOption (with types; either str int) ''
       The autocommand group name or id to match against.
     '';
 
-    pattern = helpers.mkNullOrOption (with types; either str (listOf str)) ''
+    pattern = nixvimOptions.mkNullOrOption (with types; either str (listOf str)) ''
       Pattern or patterns to match literally against.
     '';
 
-    buffer = helpers.mkNullOrOption types.int ''
+    buffer = nixvimOptions.mkNullOrOption types.int ''
       Buffer number for buffer local autocommands |autocmd-buflocal|.
       Cannot be used with `pattern`.
     '';
 
     # Introduced early October 2023.
     # TODO remove in early December 2023.
-    description = helpers.mkNullOrOption types.str ''
+    description = nixvimOptions.mkNullOrOption types.str ''
       DEPRECATED, please use `desc`.
     '';
 
-    desc = helpers.mkNullOrOption types.str ''
+    desc = nixvimOptions.mkNullOrOption types.str ''
       A textual description of this autocommand.
     '';
 
-    callback = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
+    callback = nixvimOptions.mkNullOrOption (with types; either str nixvimTypes.rawLua) ''
       A function or a string.
       - if a string, the name of a Vimscript function to call when this autocommand is triggered.
       - Otherwise, a Lua function which is called when this autocommand is triggered.
@@ -64,13 +66,13 @@ in rec {
         }
     '';
 
-    command = helpers.defaultNullOpts.mkStr "" ''
+    command = nixvimOptions.defaultNullOpts.mkStr "" ''
       Vim command to execute on event. Cannot be used with `callback`.
     '';
 
-    once = helpers.defaultNullOpts.mkBool false "Run the autocommand only once.";
+    once = nixvimOptions.defaultNullOpts.mkBool false "Run the autocommand only once.";
 
-    nested = helpers.defaultNullOpts.mkBool false "Run nested autocommands.";
+    nested = nixvimOptions.defaultNullOpts.mkBool false "Run nested autocommands.";
   };
 
   autoCmdOption = types.submodule {

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -5,7 +5,7 @@
 in
   {
     maintainers = import ./maintainers.nix;
-    keymaps = import ./keymap-helpers.nix {inherit lib;};
+    keymaps = import ./keymap-helpers.nix {inherit lib nixvimOptions nixvimTypes;};
     autocmd = import ./autocmd-helpers.nix {inherit lib;};
     neovim-plugin = import ./neovim-plugin.nix {inherit lib nixvimOptions;};
     vim-plugin = import ./vim-plugin.nix {inherit lib nixvimOptions;};

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -6,7 +6,7 @@ in
   {
     maintainers = import ./maintainers.nix;
     keymaps = import ./keymap-helpers.nix {inherit lib nixvimOptions nixvimTypes;};
-    autocmd = import ./autocmd-helpers.nix {inherit lib;};
+    autocmd = import ./autocmd-helpers.nix {inherit lib nixvimOptions nixvimTypes;};
     neovim-plugin = import ./neovim-plugin.nix {inherit lib nixvimOptions;};
     vim-plugin = import ./vim-plugin.nix {inherit lib nixvimOptions;};
     inherit (import ./to-lua.nix {inherit lib;}) toLuaObject;

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -1,39 +1,41 @@
-{lib, ...}:
-with lib; let
-  helpers = import ../lib/helpers.nix {inherit lib;};
-in rec {
+{
+  lib,
+  nixvimOptions,
+  nixvimTypes,
+}:
+with lib; rec {
   # These are the configuration options that change the behavior of each mapping.
   mapConfigOptions = {
     silent =
-      helpers.defaultNullOpts.mkBool false
+      nixvimOptions.defaultNullOpts.mkBool false
       "Whether this mapping should be silent. Equivalent to adding <silent> to a map.";
 
     nowait =
-      helpers.defaultNullOpts.mkBool false
+      nixvimOptions.defaultNullOpts.mkBool false
       "Whether to wait for extra input on ambiguous mappings. Equivalent to adding <nowait> to a map.";
 
     script =
-      helpers.defaultNullOpts.mkBool false
+      nixvimOptions.defaultNullOpts.mkBool false
       "Equivalent to adding <script> to a map.";
 
     expr =
-      helpers.defaultNullOpts.mkBool false
+      nixvimOptions.defaultNullOpts.mkBool false
       "Means that the action is actually an expression. Equivalent to adding <expr> to a map.";
 
     unique =
-      helpers.defaultNullOpts.mkBool false
+      nixvimOptions.defaultNullOpts.mkBool false
       "Whether to fail if the map is already defined. Equivalent to adding <unique> to a map.";
 
     noremap =
-      helpers.defaultNullOpts.mkBool true
+      nixvimOptions.defaultNullOpts.mkBool true
       "Whether to use the 'noremap' variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
 
     remap =
-      helpers.defaultNullOpts.mkBool false
+      nixvimOptions.defaultNullOpts.mkBool false
       "Make the mapping recursive. Inverses \"noremap\"";
 
     desc =
-      helpers.mkNullOrOption types.str
+      nixvimOptions.mkNullOrOption types.str
       "A textual description of this keybind, to be shown in which-key, if you have it.";
   };
 
@@ -105,7 +107,7 @@ in rec {
         };
 
         action = mkOption ({
-            type = helpers.nixvimTypes.maybeRaw str;
+            type = nixvimTypes.maybeRaw str;
             description = "The action to execute.";
           }
           // (

--- a/plugins/completion/nvim-cmp/cmp-helpers.nix
+++ b/plugins/completion/nvim-cmp/cmp-helpers.nix
@@ -1,66 +1,65 @@
 {
   lib,
+  helpers,
   config,
   pkgs,
   ...
-}: let
-  helpers = import ../../helpers.nix {inherit lib;};
-in
-  with helpers.vim-plugin;
-  with lib; {
-    mkCmpSourcePlugin = {
-      name,
-      extraPlugins ? [],
-      useDefaultPackage ? true,
-      ...
-    }:
-      mkVimPlugin config {
-        inherit name;
-        extraPlugins = extraPlugins ++ (lists.optional useDefaultPackage pkgs.vimPlugins.${name});
-      };
-
-    pluginAndSourceNames = {
-      "buffer" = "cmp-buffer";
-      "calc" = "cmp-calc";
-      "dap" = "cmp-dap";
-      "cmdline" = "cmp-cmdline";
-      "cmp-clippy" = "cmp-clippy";
-      "cmp-cmdline-history" = "cmp-cmdline-history";
-      "cmp_pandoc" = "cmp-pandoc-nvim";
-      "cmp_tabby" = "cmp-tabby";
-      "cmp_tabnine" = "cmp-tabnine";
-      "codeium" = "codeium-nvim";
-      "conventionalcommits" = "cmp-conventionalcommits";
-      "copilot" = "copilot-cmp";
-      "crates" = "crates-nvim";
-      "dictionary" = "cmp-dictionary";
-      "digraphs" = "cmp-digraphs";
-      "emoji" = "cmp-emoji";
-      "fish" = "cmp-fish";
-      "fuzzy_buffer" = "cmp-fuzzy-buffer";
-      "fuzzy_path" = "cmp-fuzzy-path";
-      "git" = "cmp-git";
-      "greek" = "cmp-greek";
-      "latex_symbols" = "cmp-latex-symbols";
-      "look" = "cmp-look";
-      "luasnip" = "cmp_luasnip";
-      "nvim_lsp" = "cmp-nvim-lsp";
-      "nvim_lsp_document_symbol" = "cmp-nvim-lsp-document-symbol";
-      "nvim_lsp_signature_help" = "cmp-nvim-lsp-signature-help";
-      "nvim_lua" = "cmp-nvim-lua";
-      "npm" = "cmp-npm";
-      "omni" = "cmp-omni";
-      "pandoc_references" = "cmp-pandoc-references";
-      "path" = "cmp-path";
-      "rg" = "cmp-rg";
-      "snippy" = "cmp-snippy";
-      "spell" = "cmp-spell";
-      "tmux" = "cmp-tmux";
-      "treesitter" = "cmp-treesitter";
-      "ultisnips" = "cmp-nvim-ultisnips";
-      "vim_lsp" = "cmp-vim-lsp";
-      "vimwiki-tags" = "cmp-vimwiki-tags";
-      "vsnip" = "cmp-vsnip";
-      "zsh" = "cmp-zsh";
+}:
+with helpers.vim-plugin;
+with lib; {
+  mkCmpSourcePlugin = {
+    name,
+    extraPlugins ? [],
+    useDefaultPackage ? true,
+    ...
+  }:
+    mkVimPlugin config {
+      inherit name;
+      extraPlugins = extraPlugins ++ (lists.optional useDefaultPackage pkgs.vimPlugins.${name});
     };
-  }
+
+  pluginAndSourceNames = {
+    "buffer" = "cmp-buffer";
+    "calc" = "cmp-calc";
+    "dap" = "cmp-dap";
+    "cmdline" = "cmp-cmdline";
+    "cmp-clippy" = "cmp-clippy";
+    "cmp-cmdline-history" = "cmp-cmdline-history";
+    "cmp_pandoc" = "cmp-pandoc-nvim";
+    "cmp_tabby" = "cmp-tabby";
+    "cmp_tabnine" = "cmp-tabnine";
+    "codeium" = "codeium-nvim";
+    "conventionalcommits" = "cmp-conventionalcommits";
+    "copilot" = "copilot-cmp";
+    "crates" = "crates-nvim";
+    "dictionary" = "cmp-dictionary";
+    "digraphs" = "cmp-digraphs";
+    "emoji" = "cmp-emoji";
+    "fish" = "cmp-fish";
+    "fuzzy_buffer" = "cmp-fuzzy-buffer";
+    "fuzzy_path" = "cmp-fuzzy-path";
+    "git" = "cmp-git";
+    "greek" = "cmp-greek";
+    "latex_symbols" = "cmp-latex-symbols";
+    "look" = "cmp-look";
+    "luasnip" = "cmp_luasnip";
+    "nvim_lsp" = "cmp-nvim-lsp";
+    "nvim_lsp_document_symbol" = "cmp-nvim-lsp-document-symbol";
+    "nvim_lsp_signature_help" = "cmp-nvim-lsp-signature-help";
+    "nvim_lua" = "cmp-nvim-lua";
+    "npm" = "cmp-npm";
+    "omni" = "cmp-omni";
+    "pandoc_references" = "cmp-pandoc-references";
+    "path" = "cmp-path";
+    "rg" = "cmp-rg";
+    "snippy" = "cmp-snippy";
+    "spell" = "cmp-spell";
+    "tmux" = "cmp-tmux";
+    "treesitter" = "cmp-treesitter";
+    "ultisnips" = "cmp-nvim-ultisnips";
+    "vim_lsp" = "cmp-vim-lsp";
+    "vimwiki-tags" = "cmp-vimwiki-tags";
+    "vsnip" = "cmp-vsnip";
+    "zsh" = "cmp-zsh";
+  };
+}

--- a/plugins/completion/nvim-cmp/sources/default.nix
+++ b/plugins/completion/nvim-cmp/sources/default.nix
@@ -1,11 +1,12 @@
 {
   lib,
   config,
+  helpers,
   pkgs,
   ...
 }:
 with lib; let
-  cmpLib = import ../cmp-helpers.nix {inherit lib config pkgs;};
+  cmpLib = import ../cmp-helpers.nix {inherit lib config helpers pkgs;};
   cmpSourcesPluginNames = attrValues cmpLib.pluginAndSourceNames;
   pluginModules = lists.map (name: cmpLib.mkCmpSourcePlugin {inherit name;}) cmpSourcesPluginNames;
 in {

--- a/plugins/dap/dap-go.nix
+++ b/plugins/dap/dap-go.nix
@@ -7,7 +7,7 @@
 }:
 with lib; let
   cfg = config.plugins.dap.extensions.dap-go;
-  dapHelpers = import ./dapHelpers.nix {inherit lib;};
+  dapHelpers = import ./dapHelpers.nix {inherit lib helpers;};
 in {
   options.plugins.dap.extensions.dap-go = {
     enable = mkEnableOption "dap-go";

--- a/plugins/dap/dap-python.nix
+++ b/plugins/dap/dap-python.nix
@@ -7,7 +7,7 @@
 }:
 with lib; let
   cfg = config.plugins.dap.extensions.dap-python;
-  dapHelpers = import ./dapHelpers.nix {inherit lib;};
+  dapHelpers = import ./dapHelpers.nix {inherit lib helpers;};
 in {
   options.plugins.dap.extensions.dap-python = {
     enable = mkEnableOption "dap-python";

--- a/plugins/dap/dapHelpers.nix
+++ b/plugins/dap/dapHelpers.nix
@@ -1,7 +1,8 @@
-{lib, ...}:
-with lib; let
-  helpers = import ../helpers.nix {inherit lib;};
-in rec {
+{
+  lib,
+  helpers,
+}:
+with lib; rec {
   mkAdapterType = attrs:
     types.submodule {
       options =

--- a/plugins/dap/default.nix
+++ b/plugins/dap/default.nix
@@ -7,7 +7,7 @@
 }:
 with lib; let
   cfg = config.plugins.dap;
-  dapHelpers = import ./dapHelpers.nix {inherit lib;};
+  dapHelpers = import ./dapHelpers.nix {inherit lib helpers;};
 in
   with dapHelpers; {
     imports = [

--- a/plugins/helpers.nix
+++ b/plugins/helpers.nix
@@ -1,1 +1,0 @@
-import ../lib/helpers.nix

--- a/plugins/languages/treesitter/ts-autotag.nix
+++ b/plugins/languages/treesitter/ts-autotag.nix
@@ -1,12 +1,11 @@
 {
   pkgs,
   lib,
+  helpers,
   config,
   ...
 }:
-with lib; let
-  helpers = import ../../helpers.nix {inherit lib;};
-in {
+with lib; {
   options.plugins.ts-autotag =
     helpers.neovim-plugin.extraOptionsOptions
     // {

--- a/plugins/lsp/helpers.nix
+++ b/plugins/lsp/helpers.nix
@@ -13,13 +13,12 @@
   {
     pkgs,
     config,
+    helpers,
     lib,
-    options,
     ...
   }:
     with lib; let
       cfg = config.plugins.lsp.servers.${name};
-      helpers = import ../helpers.nix {inherit lib;};
 
       packageOption =
         if package != null

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -303,7 +303,7 @@ with lib; let
       name = "ltex";
       description = "ltex-ls for LanguageTool";
       package = pkgs.ltex-ls;
-      settingsOptions = import ./ltex-settings.nix {inherit lib;};
+      settingsOptions = import ./ltex-settings.nix {inherit lib helpers;};
       settings = cfg: {ltex = cfg;};
     }
     {

--- a/plugins/lsp/language-servers/ltex-settings.nix
+++ b/plugins/lsp/language-servers/ltex-settings.nix
@@ -1,7 +1,8 @@
-{lib}:
-with lib; let
-  helpers = import ../../helpers.nix {inherit lib;};
-in {
+{
+  lib,
+  helpers,
+}:
+with lib; {
   enabled =
     helpers.defaultNullOpts.mkNullable
     (with types; either bool (listOf str))

--- a/plugins/none-ls/helpers.nix
+++ b/plugins/none-ls/helpers.nix
@@ -12,10 +12,10 @@
     pkgs,
     config,
     lib,
+    helpers,
     ...
-  } @ args:
+  }:
     with lib; let
-      helpers = import ../helpers.nix args;
       cfg = config.plugins.none-ls.sources.${sourceType}.${name};
       # does this evaluate package?
       packageOption =

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib; let
-  helpers = import ./helpers.nix;
+  cmpHelpers = import ./helpers.nix;
   serverData = {
     code_actions = {
       eslint = {
@@ -225,7 +225,7 @@ with lib; let
   dataFlattened = flatten serverDataFormatted;
 in {
   imports =
-    (map helpers.mkServer dataFlattened)
+    (map cmpHelpers.mkServer dataFlattened)
     ++ [
       ./prettier.nix
       # Introduced January 22 2024.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,6 +1,7 @@
 {
   makeNixvim,
   lib,
+  helpers,
   pkgs,
 }: let
   fetchTests = import ./fetch-tests.nix;
@@ -9,7 +10,7 @@
 
   # List of files containing configurations
   testFiles = fetchTests {
-    inherit lib pkgs;
+    inherit lib pkgs helpers;
     root = ./test-sources;
   };
 

--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -2,6 +2,7 @@
   root,
   lib,
   pkgs,
+  helpers,
 }: let
   # Handle an entry from readDir and either extract the configuration if its a regular file,
   # or continue to recurse if it's a directory. While recursing maintain a list of the traversed
@@ -35,7 +36,6 @@
   # Remove the nesting
   testsList = lib.lists.flatten (parseDirectories root []);
 
-  helpers = import ../lib/helpers.nix {inherit lib;};
   testsListEvaluated = builtins.map ({
       cases,
       namespace,

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -3,8 +3,8 @@
 {
   lib,
   pkgs,
+  helpers,
 }: let
-  helpers = import ../lib/helpers.nix {inherit lib pkgs;};
   results = pkgs.lib.runTests {
     testToLuaObject = {
       expr = helpers.toLuaObject {


### PR DESCRIPTION
Get rid of all `helpers = import ../../helpers.nix args;`.