### PR TITLE
plugins/committia: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -5,4 +5,11 @@
 # expected to follow the same format as that list.
 #
 # Nixpkgs maintainers: https://github.com/NixOS/nixpkgs/blob/0212bde005b3335b2665c1476c36b3936e113b15/maintainers/maintainer-list.nix
-{}
+{
+  alisonjenkins = {
+    email = "alison.juliet.jenkins@gmail.com";
+    github = "alisonjenkins";
+    githubId = 1176328;
+    name = "Alison Jenkins";
+  };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -34,6 +34,7 @@
     ./filetrees/neo-tree.nix
     ./filetrees/nvim-tree.nix
 
+    ./git/committia.nix
     ./git/diffview.nix
     ./git/fugitive.nix
     ./git/git-worktree.nix

--- a/plugins/git/committia.nix
+++ b/plugins/git/committia.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  config,
+  helpers,
+  pkgs,
+  ...
+}:
+helpers.vim-plugin.mkVimPlugin config {
+  name = "committia";
+  description = "committia.vim";
+  package = pkgs.vimPlugins.committia-vim;
+  globalPrefix = "committia_";
+  extraPackages = [pkgs.git];
+
+  maintainers = [lib.maintainers.alisonjenkins];
+
+  settingsOptions = {
+    open_only_vim_starting = helpers.defaultNullOpts.mkBool true ''
+      If `false`, committia.vim always attempts to open committia's buffer when `COMMIT_EDITMSG` buffer is opened.
+      If you use `vim-fugitive`, I recommend to set this value to `true`.
+    '';
+
+    use_singlecolumn = helpers.defaultNullOpts.mkStr "always" ''
+      If the value is 'always', `committia.vim` always employs single column mode.
+    '';
+
+    min_window_width = helpers.defaultNullOpts.mkUnsignedInt 160 ''
+      If the width of window is narrower than the value, `committia.vim` employs single column mode.
+    '';
+
+    status_window_opencmd = helpers.defaultNullOpts.mkStr "belowright split" ''
+      Vim command which opens a status window in multi-columns mode.
+    '';
+
+    diff_window_opencmd = helpers.defaultNullOpts.mkStr "botright vsplit" ''
+      Vim command which opens a diff window in multi-columns mode.
+    '';
+
+    singlecolumn_diff_window_opencmd = helpers.defaultNullOpts.mkStr "belowright split" ''
+      Vim command which opens a diff window in single-column mode.
+    '';
+
+    edit_window_width = helpers.defaultNullOpts.mkUnsignedInt 80 ''
+      If `committia.vim` is in multi-columns mode, specifies the width of the edit window.
+    '';
+
+    status_window_min_height = helpers.defaultNullOpts.mkUnsignedInt 0 ''
+      Minimum height of a status window.
+    '';
+  };
+}

--- a/tests/test-sources/plugins/git/committia.nix
+++ b/tests/test-sources/plugins/git/committia.nix
@@ -1,0 +1,22 @@
+{
+  empty = {
+    plugins.committia.enable = true;
+  };
+
+  default = {
+    plugins.committia = {
+      enable = true;
+
+      settings = {
+        open_only_vim_starting = true;
+        use_singlecolumn = "always";
+        min_window_width = 160;
+        status_window_opencmd = "belowright split";
+        diff_window_opencmd = "botright vsplit";
+        singlecolumn_diff_window_opencmd = "belowright split";
+        edit_window_width = 80;
+        status_window_min_height = 0;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Will resolve: https://github.com/nix-community/nixvim/issues/1022

# Questions:

## Testing
* I migrated over to NixOS from Arch Linux in the hope that I would be able to run all the tests however the suggested ```nix flake check --all-systems``` is throwing the error: 
```
❯ nix flake check --all-systems
error:
       … while checking flake output 'checks'

         at «none»:0: (source not available)

       … while evaluating the attribute 'optionalValue.value'

         at /nix/store/mcm21fbi7i6m3f189pkm7zcdn4c9xl40-source/lib/modules.nix:856:5:

          855|
          856|     optionalValue =
             |     ^
          857|       if isDefined then { value = mergedValue; }

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: a 'aarch64-linux' with features {} is required to build '/nix/store/rzffqiqwi50nyinpmnaai43qy4a3qqhb-nixpkgs-nixvim-doc.drv', but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test}
```
Is there some way to make NixOS on x86_64-linux do CPU virtualisation to be able to run the tests or something? Or do you need to have NixOS builders of the other architectures to be able to run the tests?

I was however able to successfully run ```nix flake check```

* I could not find any examples of Vimscript plugins being tested. Do we not test these? If so I will remove the fairly redundant test and example.

## Maintainers
* I have added a commit to add myself as a maintainer in this repo (I do not yet contribute to Nixpkgs but it is just a matter of time until I do). Was I correct to do this as part of this PR or shall I split it out into another?
* I have set myself as the maintainer of this package. Was I right to do so or should this be the maintainer of the package in Nixpkgs?