### PR TITLE
plugins/emmet: remove to strict typing on option 'mode'

### DIFF
--- a/plugins/utils/emmet.nix
+++ b/plugins/utils/emmet.nix
@@ -14,8 +14,7 @@ with helpers.vim-plugin;
 
     options = {
       mode = mkDefaultOpt {
-        type = types.enum ["i" "n" "v" "a"];
-        global = "mode";
+        type = types.str;
         description = "Mode where emmet will enable";
       };
 

--- a/plugins/utils/emmet.nix
+++ b/plugins/utils/emmet.nix
@@ -27,7 +27,6 @@ with helpers.vim-plugin;
 
       settings = mkDefaultOpt {
         type = with types; attrsOf anything;
-        global = "settings";
         description = "Emmet settings";
       };
     };


### PR DESCRIPTION
Values such as `"inv"` should be allowed.