### PR TITLE
plugins/none-ls: add asmfmt

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -113,6 +113,9 @@ with lib; let
       alejandra = {
         package = pkgs.alejandra;
       };
+      asmfmt = {
+        package = pkgs.asmfmt;
+      };
       astyle = {
         package = pkgs.astyle;
       };

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -87,6 +87,7 @@
         };
         formatting = {
           alejandra.enable = true;
+          asmfmt.enable = true;
           astyle.enable = true;
           bean_format.enable = true;
           black.enable = true;


### PR DESCRIPTION
Add an option to enable asmfmt in none-ls sources.