### PR TITLE
helpers/options: add mkSettingsOption

### DIFF
--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -3,28 +3,20 @@
   nixvimOptions,
 }:
 with lib; {
-  mkSettingsOption = pluginName: options:
-    mkOption {
-      type = with types;
-        submodule {
-          freeformType = with types; attrsOf anything;
-          inherit options;
-        };
-      description = ''
-        Options provided to the `require('${pluginName}').setup` function.
-      '';
-      default = {};
-      example = {
-        foo_bar = 42;
-        hostname = "localhost:8080";
-        callback.__raw = ''
-          function()
-            print('nixvim')
-          end
-        '';
-      };
+  mkSettingsOption = {
+    pluginName ? null,
+    options ? {},
+    description ?
+      if pluginName != null
+      then "Options provided to the `require('${pluginName}').setup` function."
+      else throw "mkSettingsOption: Please provide either a `pluginName` or `description`.",
+    example ? null,
+  }:
+    nixvimOptions.mkSettingsOption {
+      inherit options description example;
     };
 
+  # TODO: DEPRECATED: use the `settings` option instead
   extraOptionsOptions = {
     extraOptions = mkOption {
       default = {};

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -237,4 +237,31 @@ with nixvimUtils; rec {
       inherit default;
       description = "Plugin to use for ${name}";
     };
+
+  mkSettingsOption = {
+    options ? {},
+    description,
+    example ? null,
+  }:
+    mkOption {
+      type = with types;
+        submodule {
+          freeformType = with types; attrsOf anything;
+          inherit options;
+        };
+      default = {};
+      inherit description;
+      example =
+        if example == null
+        then {
+          foo_bar = 42;
+          hostname = "localhost:8080";
+          callback.__raw = ''
+            function()
+              print('nixvim')
+            end
+          '';
+        }
+        else example;
+    };
 }


### PR DESCRIPTION
- Add `helpers.mkSettingsOption` to quickly create a RFC-42 style `settings` option
- Have `helpers.vim-plugin.mkVimPlugin` to call `helpers.mkSettingsOption`
- Have `helpers.neovim-plugin.mkSettingsOption` to call `helpers.mkSettingsOption`
  Also have `helpers.neovim-plugin.mkNeovimPlugin` to call `helpers.neovim-plugin.mkSettingsOption`