### PR TITLE
plugins/none-ls: Add google_java_format as a source for none-ls

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -164,6 +164,9 @@ with lib; let
       golines = {
         package = pkgs.golines;
       };
+      google_java_format = {
+        package = pkgs.google-java-format;
+      };
       isort = {
         package = pkgs.isort;
       };

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -105,6 +105,7 @@
           goimports.enable = true;
           goimports_reviser.enable = true;
           golines.enable = true;
+          google_java_format.enable = true;
           ktlint.enable = true;
           nixfmt.enable = true;
           nixpkgs_fmt.enable = true;


### PR DESCRIPTION
Add google_java_format for none-ls sources.