### PR TITLE
helpers/vim-plugin/mkVimPlugin: don't accept random parameters

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -246,7 +246,7 @@ with nixvimUtils; rec {
     mkOption {
       type = with types;
         submodule {
-          freeformType = with types; attrsOf anything;
+          freeformType = attrsOf anything;
           inherit options;
         };
       default = {};

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -16,7 +16,6 @@ with lib; {
     # config
     extraPlugins ? [],
     extraPackages ? [],
-    ...
   }: let
     cfg = config.plugins.${name};
 


### PR DESCRIPTION
This could lead to very tricky bugs.
This function is not meant to accept undefined parameters.