### PR TITLE
plugins/nvim-cmp: fix nvim-cmp lsp completion capabilities

### DIFF
--- a/plugins/completion/nvim-cmp/default.nix
+++ b/plugins/completion/nvim-cmp/default.nix
@@ -570,7 +570,7 @@ in {
         (mkIf (elem "nvim_lsp" foundSources)
           {
             lsp.capabilities = ''
-              capabilities = require('cmp_nvim_lsp').default_capabilities()
+              capabilities = vim.tbl_deep_extend("force", capabilities, require('cmp_nvim_lsp').default_capabilities())
             '';
           })
       ];


### PR DESCRIPTION
fixes a bug where the default client capabilities are overwritten by nvim-cmp's default capabilities