### PR TITLE
helpers/vim-plugin/mkVimPlugin: add extraOptions and extraConfig options

### DIFF
--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -18,6 +18,7 @@ with lib; {
     addExtraConfigRenameWarning ? false,
     extraOptions ? {},
     # config
+    extraConfig ? cfg: {},
     extraPlugins ? [],
     extraPackages ? [],
   }: let
@@ -98,12 +99,19 @@ with lib; {
         ["plugins" name "settings"]
       );
 
-    config = mkIf cfg.enable {
-      inherit extraPackages;
-      globals = mapAttrs' (n: nameValuePair (globalPrefix + n)) globals;
-      # does this evaluate package? it would not be desired to evaluate pacakge if we use another package.
-      extraPlugins = extraPlugins ++ optional (package != null) cfg.package;
-    };
+    config =
+      mkIf cfg.enable
+      (
+        mkMerge [
+          {
+            inherit extraPackages;
+            globals = mapAttrs' (n: nameValuePair (globalPrefix + n)) globals;
+            # does this evaluate package? it would not be desired to evaluate pacakge if we use another package.
+            extraPlugins = extraPlugins ++ optional (package != null) cfg.package;
+          }
+          (extraConfig cfg)
+        ]
+      );
   };
 
   mkDefaultOpt = {

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -16,6 +16,7 @@ with lib; {
     settingsExample ? null,
     globalPrefix ? "",
     addExtraConfigRenameWarning ? false,
+    extraOptions ? {},
     # config
     extraPlugins ? [],
     extraPackages ? [],
@@ -86,7 +87,8 @@ with lib; {
       }
       // settingsOption
       // packageOption
-      // pluginOptions;
+      // pluginOptions
+      // extraOptions;
 
     imports =
       imports


### PR DESCRIPTION
Add two options to the `vim-plugin.mkVimPlugin` helpers:
- `extraOptions` allows to add arbitrary options to the plugin module
- `extraConfig` allows to do extra fancy configuration