### PR TITLE
plugins/smart-splits: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -159,6 +159,7 @@
     ./utils/quickmath.nix
     ./utils/refactoring.nix
     ./utils/rest.nix
+    ./utils/smart-splits.nix
     ./utils/specs.nix
     ./utils/spider.nix
     ./utils/startify.nix

--- a/plugins/utils/smart-splits.nix
+++ b/plugins/utils/smart-splits.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  helpers,
+  ...
+}:
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "smart-splits";
+  originalName = "smart-splits.nvim";
+  defaultPackage = pkgs.vimPlugins.smart-splits-nvim;
+
+  maintainers = [lib.maintainers.foo-dogsquared];
+
+  settingsExample = {
+    resize_mode = {
+      quit_key = "<ESC>";
+      resize_keys = ["h" "j" "k" "l"];
+      silent = true;
+    };
+    ignored_events = ["BufEnter" "WinEnter"];
+  };
+}

--- a/tests/test-sources/plugins/utils/smart-splits.nix
+++ b/tests/test-sources/plugins/utils/smart-splits.nix
@@ -1,0 +1,24 @@
+{
+  empty = {
+    plugins.smart-splits.enable = true;
+  };
+
+  example = {
+    plugins.smart-splits = {
+      enable = true;
+
+      settings = {
+        ignored_filetypes = ["nofile" "quickfix" "prompt"];
+        ignored_buftypes = ["NvimTree"];
+        default_amount = 3;
+        move_cursor_same_row = true;
+        cursor_follows_swapped_bufs = true;
+        resize_mode = {
+          quit_key = "<ESC>";
+          resize_keys = ["h" "j" "k" "l"];
+          silent = true;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
First stab at making a (formal) NixVim plugin unlike what I'm doing at my own NixVim config. I'm guessing there is a migration at Nix RFC42-style settings so I did that.

Resolves #1050. (Probably a follow-up PR for [legendary.nvim](https://github.com/mrjones2014/legendary.nvim) as it has integration for it. Also, it looks interesting.)

Also, I cannot test this in my local setup as it always crashes so I hope you don't mind if I fully rely on the CI for the testing.