### PR TITLE
tests: Introduce a way to disable options when running in tests

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -37,3 +37,6 @@ A certain number of helpers are defined that can be useful:
   ```lua
     {"a", "b", [foo] = "bar"}
   ```
+
+- `helpers.enableExceptInTests`: Evaluates to `true`, except in `mkTestDerivationFromNixvimModule`
+  where it evaluates to `false`. This allows to skip instantiating plugins that can't be run in tests.

--- a/flake-modules/helpers.nix
+++ b/flake-modules/helpers.nix
@@ -1,7 +1,7 @@
 {getHelpers, ...}: {
-  _module.args.getHelpers = pkgs:
+  _module.args.getHelpers = pkgs: _nixvimTests:
     import ../lib/helpers.nix {
-      inherit pkgs;
+      inherit pkgs _nixvimTests;
       inherit (pkgs) lib;
     };
 
@@ -10,6 +10,6 @@
     config,
     ...
   }: {
-    _module.args.helpers = getHelpers pkgs;
+    _module.args.helpers = getHelpers pkgs false;
   };
 }

--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -13,7 +13,7 @@
       }:
         import ../lib {
           inherit pkgs lib;
-          inherit (config.legacyPackages) makeNixvim;
+          inherit (config.legacyPackages) makeNixvim makeNixvimWithModule;
         }
     )
   );

--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -1,4 +1,4 @@
-{
+{self, ...}: {
   perSystem = {
     pkgs,
     config,
@@ -10,7 +10,7 @@
   }: {
     checks = {
       tests = import ../tests {
-        inherit pkgs helpers;
+        inherit pkgs helpers makeNixvimWithModule;
         inherit (pkgs) lib;
         makeNixvim = configuration:
           makeNixvimWithModuleUnfree {
@@ -23,6 +23,11 @@
       extra-args-tests = import ../tests/extra-args.nix {
         inherit pkgs;
         inherit makeNixvimWithModule;
+      };
+
+      enable-except-in-tests = import ../tests/enable-except-in-tests.nix {
+        inherit pkgs makeNixvimWithModule;
+        inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
       };
 
       lib-tests = import ../tests/lib-tests.nix {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,12 +1,13 @@
 # Args probably only needs pkgs and lib
 {
   makeNixvim,
+  makeNixvimWithModule,
   pkgs,
   ...
 } @ args: {
   # Add all exported modules here
   check = import ../tests/test-derivation.nix {
-    inherit makeNixvim pkgs;
+    inherit makeNixvim makeNixvimWithModule pkgs;
   };
   helpers = import ./helpers.nix args;
 }

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -1,10 +1,11 @@
 {
   lib,
   pkgs,
+  _nixvimTests,
   ...
 }: let
   nixvimTypes = import ./types.nix {inherit lib nixvimOptions;};
-  nixvimUtils = import ./utils.nix {inherit lib;};
+  nixvimUtils = import ./utils.nix {inherit lib _nixvimTests;};
   nixvimOptions = import ./options.nix {inherit lib nixvimTypes nixvimUtils;};
   inherit (import ./to-lua.nix {inherit lib;}) toLuaObject;
 in

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -1,8 +1,13 @@
-{lib}:
+{
+  lib,
+  _nixvimTests,
+}:
 with lib; {
   listToUnkeyedAttrs = list:
     builtins.listToAttrs
     (lib.lists.imap0 (idx: lib.nameValuePair "__unkeyed-${toString idx}") list);
+
+  enableExceptInTests = !_nixvimTests;
 
   emptyTable = {"__empty" = null;};
 

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -29,7 +29,7 @@
       }: let
         nixvimLib = nixvim.lib.${system};
         nixvim' = nixvim.legacyPackages.${system};
-        nvim = nixvim'.makeNixvimWithModule {
+        nixvimModule = {
           inherit pkgs;
           module = config;
           # You can use `extraSpecialArgs` to pass additional arguments to your module files
@@ -37,13 +37,11 @@
             # inherit (inputs) foo;
           };
         };
+        nvim = nixvim'.makeNixvimWithModule nixvimModule;
       in {
         checks = {
           # Run `nix flake check .` to verify that your config is not broken
-          default = nixvimLib.check.mkTestDerivationFromNvim {
-            inherit nvim;
-            name = "A nixvim configuration";
-          };
+          default = nixvimLib.check.mkTestDerivationFromNixvimModule nixvimModule;
         };
 
         packages = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,11 +1,12 @@
 {
   makeNixvim,
+  makeNixvimWithModule,
   lib,
   helpers,
   pkgs,
 }: let
   fetchTests = import ./fetch-tests.nix;
-  test-derivation = import ./test-derivation.nix {inherit pkgs makeNixvim;};
+  test-derivation = import ./test-derivation.nix {inherit pkgs makeNixvim makeNixvimWithModule;};
   inherit (test-derivation) mkTestDerivation;
 
   # List of files containing configurations

--- a/tests/enable-except-in-tests.nix
+++ b/tests/enable-except-in-tests.nix
@@ -1,0 +1,41 @@
+{
+  pkgs,
+  mkTestDerivationFromNixvimModule,
+  makeNixvimWithModule,
+}: let
+  module = {helpers, ...}: {
+    plugins.image.enable = helpers.enableExceptInTests;
+  };
+
+  inTest = mkTestDerivationFromNixvimModule {
+    name = "enable-except-in-tests-test";
+    inherit pkgs module;
+  };
+
+  notInTest = let
+    nvim = makeNixvimWithModule {
+      inherit pkgs module;
+    };
+  in
+    pkgs.runCommand "enable-except-in-tests-not-in-test" {
+      printConfig = "${nvim}/bin/nixvim-print-init";
+    } ''
+      if ! "$printConfig" | grep 'require("image").setup'; then
+        echo "image.nvim is not present in the configuration"
+        echo -e "configuration:\n$($printConfig)"
+        exit 1
+      fi
+
+      touch $out
+    '';
+in
+  pkgs.linkFarm "enable-except-in-tests" [
+    {
+      name = "in-test";
+      path = inTest;
+    }
+    {
+      name = "not-in-test";
+      path = notInTest;
+    }
+  ]

--- a/tests/test-derivation.nix
+++ b/tests/test-derivation.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeNixvim,
+  makeNixvimWithModule,
 }: let
   # Create a nix derivation from a nixvim executable.
   # The build phase simply consists in running the provided nvim binary.
@@ -40,6 +41,21 @@
       '';
     };
 
+  mkTestDerivationFromNixvimModule = {
+    name ? "nixvim-check",
+    pkgs,
+    module,
+    extraSpecialArgs ? {},
+  }: let
+    nvim = makeNixvimWithModule {
+      inherit pkgs module extraSpecialArgs;
+      _nixvimTests = true;
+    };
+  in
+    mkTestDerivationFromNvim {
+      inherit name nvim;
+    };
+
   # Create a nix derivation from a nixvim configuration.
   # The build phase simply consists in running neovim with the given configuration.
   mkTestDerivation = name: config: let
@@ -56,5 +72,5 @@
       inherit (testAttributes) dontRun;
     };
 in {
-  inherit mkTestDerivation mkTestDerivationFromNvim;
+  inherit mkTestDerivation mkTestDerivationFromNvim mkTestDerivationFromNixvimModule;
 }

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -9,7 +9,7 @@
   ...
 } @ args: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkForce mkMerge mkIf types;
-  helpers = getHelpers pkgs;
+  helpers = getHelpers pkgs false;
   shared = import ./_shared.nix {inherit modules helpers;} args;
   cfg = config.programs.nixvim;
 in {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -9,7 +9,7 @@
   ...
 } @ args: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkMerge mkIf types;
-  helpers = getHelpers pkgs;
+  helpers = getHelpers pkgs false;
   shared = import ./_shared.nix {inherit modules helpers;} args;
   cfg = config.programs.nixvim;
   files =

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -9,7 +9,7 @@
   ...
 } @ args: let
   inherit (lib) mkEnableOption mkOption mkOptionType mkForce mkMerge mkIf types;
-  helpers = getHelpers pkgs;
+  helpers = getHelpers pkgs false;
   shared = import ./_shared.nix {inherit modules helpers;} args;
   cfg = config.programs.nixvim;
   files =

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -5,11 +5,12 @@ default_pkgs: {
 }: {
   pkgs ? default_pkgs,
   extraSpecialArgs ? {},
+  _nixvimTests ? false,
   module,
 }: let
   inherit (pkgs) lib;
 
-  helpers = getHelpers pkgs;
+  helpers = getHelpers pkgs _nixvimTests;
   shared = import ./_shared.nix {inherit modules helpers;} {
     inherit pkgs lib;
     config = {};


### PR DESCRIPTION
In our basic template we used to provide a check based on `mkTestDerivationFromNvim`. The issue with this check (that is handled correctly internally) is that some plugins _can't_ be used in the test environment, for example image.nvim like in #1085.

This commit introduces a new function to generate such checks, `mkTestDerivationFromNixvimModule`, that wraps a nixvim configuration instead of a built nvim instance.

Then a configuration can rely on the newly added
`helpers.enableExceptInTests` attribute to disable parts of the configuration depending if it is evaluated in tests or in a real final configuration.

Resolves #1085