### PR TITLE
plugins/parinfer-rust: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -57,6 +57,7 @@
     ./languages/nix.nix
     ./languages/nvim-jdtls.nix
     ./languages/openscad.nix
+    ./languages/parinfer-rust.nix
     ./languages/plantuml-syntax.nix
     ./languages/rust-tools.nix
     ./languages/rustaceanvim.nix

--- a/plugins/languages/parinfer-rust.nix
+++ b/plugins/languages/parinfer-rust.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+helpers.vim-plugin.mkVimPlugin config {
+  name = "parinfer-rust";
+  defaultPackage = pkgs.vimPlugins.parinfer-rust;
+  globalPrefix = "parinfer_";
+
+  maintainers = [lib.maintainers.GaetanLepage];
+
+  settingsOptions = {
+    mode = helpers.defaultNullOpts.mkEnumFirstDefault ["smart" "indent" "paren"] ''
+      The mode used to process buffer changes.
+    '';
+
+    force_balance = helpers.defaultNullOpts.mkBool false ''
+      In smart mode and indent mode, parinfer will sometimes leave unbalanced brackets around the
+      cursor and fix them when the cursor moves away.
+      When this option is set to `true`, the brackets will be fixed immediately (and fixed again
+      when text is inserted).
+    '';
+  };
+}

--- a/tests/test-sources/plugins/languages/parinfer-rust.nix
+++ b/tests/test-sources/plugins/languages/parinfer-rust.nix
@@ -1,0 +1,24 @@
+{
+  empty = {
+    plugins.parinfer-rust.enable = true;
+  };
+
+  defaults = {
+    plugins.parinfer-rust = {
+      enable = true;
+
+      settings = {
+        mode = "smart";
+        enabled = true;
+        force_balance = false;
+        comment_char = ";";
+        string_delimiters = [''"''];
+        lisp_vline_symbols = false;
+        lisp_block_comments = false;
+        guile_block_comments = false;
+        scheme_sexp_comments = false;
+        janet_long_strings = false;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [parinfer-rust](https://github.com/eraserhd/parinfer-rust). It infers parentheses for Clojure, Lisp and Scheme.

Fixes #1059