### PR TITLE
plugins/none-ls: add typos

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -99,6 +99,9 @@ with lib; let
       stylelint = {
         package = pkgs.stylelint;
       };
+      typos = {
+        package = pkgs.typos;
+      };
       vale = {
         package = pkgs.vale;
       };

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -73,6 +73,7 @@
           shellcheck.enable = true;
           statix.enable = true;
           staticcheck.enable = true;
+          typos.enable = true;
           vale.enable = true;
           vulture.enable = true;
           alex.enable = true;


### PR DESCRIPTION
Adds [`typos`](https://github.com/crate-ci/typos) to none-ls