### PR TITLE
Fix issue with non flake import

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,14 @@
-(import (
-    fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/c75e76f80c57784a6734356315b306140646ee84.tar.gz";
-      sha256 = "071aal00zp2m9knnhddgr2wqzlx6i6qa1263lv1y7bdn2w20h10h";
-    }
-  ) {
-    src = ./.;
-  })
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;}
+)
 .defaultNix

--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -30,6 +30,12 @@
         inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
       };
 
+      no-flake = import ../tests/no-flake.nix {
+        inherit system;
+        inherit (self.lib.${system}.check) mkTestDerivationFromNvim;
+        nixvim = "${self}";
+      };
+
       lib-tests = import ../tests/lib-tests.nix {
         inherit pkgs helpers;
         inherit (pkgs) lib;

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,20 @@
 {
   "nodes": {
     "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -133,7 +147,7 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
@@ -159,6 +173,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
 
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/tests/no-flake.nix
+++ b/tests/no-flake.nix
@@ -1,0 +1,32 @@
+{
+  system,
+  nixvim,
+  mkTestDerivationFromNvim,
+}: let
+  # This simulates the `default.nix`, but in a pure way so because we are currently in a flake.
+  nixvim' =
+    (
+      import
+      (
+        let
+          lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+        in
+          fetchTarball {
+            url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+            sha256 = lock.nodes.flake-compat.locked.narHash;
+          }
+      )
+      {src = nixvim;}
+    )
+    .defaultNix;
+
+  config = {
+    colorschemes.gruvbox.enable = true;
+  };
+
+  nvim = nixvim'.legacyPackages."${system}".makeNixvim config;
+in
+  mkTestDerivationFromNvim {
+    name = "no-flakes";
+    inherit nvim;
+  }


### PR DESCRIPTION
There were issues with handling of store vs non store paths that got ~recently fixed in flake-compat. We now use the flake distribution of flake compat so that it is maintained up-to-date.

Resolves #938.