### PR TITLE
plugins/haskell-scope-highlighting: switch to mkVimPlugin

### DIFF
--- a/plugins/languages/haskell-scope-highlighting.nix
+++ b/plugins/languages/haskell-scope-highlighting.nix
@@ -5,20 +5,18 @@
   config,
   ...
 }:
-with lib; let
-  cfg = config.plugins.haskell-scope-highlighting;
-in {
-  options.plugins.haskell-scope-highlighting = {
-    enable = mkEnableOption "haskell-scope-highlighting";
+with lib;
+  helpers.vim-plugin.mkVimPlugin config {
+    name = "haskell-scope-highlighting";
+    originalName = "haskell-scope-highlighting.nvim";
+    defaultPackage = pkgs.vimPlugins.haskell-scope-highlighting-nvim;
 
-    package = helpers.mkPackageOption "haskell-scope-highlighting" pkgs.vimPlugins.haskell-scope-highlighting-nvim;
-  };
+    maintainers = [lib.maintainers.GaetanLepage];
 
-  config = mkIf cfg.enable {
-    warnings = optional (!config.plugins.treesitter.enable) ''
-      Nixvim (plugins.haskell-scope-highlighting): haskell-scope-highlighting needs treesitter to function as intended. Please, enable it by setting `plugins.treesitter.enable` to `true`.
-    '';
-
-    extraPlugins = [cfg.package];
-  };
-}
+    extraConfig = _: {
+      warnings = optional (!config.plugins.treesitter.enable) ''
+        Nixvim (plugins.haskell-scope-highlighting): haskell-scope-highlighting needs treesitter to function as intended.
+        Please, enable it by setting `plugins.treesitter.enable` to `true`.
+      '';
+    };
+  }


### PR DESCRIPTION
No incidence on user-facing options. Just internal change to see if `mkVimPlugin` can handle most relevant cases.