### PR TITLE
fix: neocord logo and logo_tooltip

### DIFF
--- a/plugins/utils/neocord.nix
+++ b/plugins/utils/neocord.nix
@@ -20,11 +20,11 @@ with lib;
         `:lua package.loaded.neocord:update()`
       '';
 
-      logo = helpers.defaultNullOpts.mkEnum ["auto" "url"] "auto" ''
+      logo = helpers.defaultNullOpts.mkStr "auto" ''
         Update the Logo to the specified option ("auto" or url).
       '';
 
-      logo_tooltip = helpers.defaultNullOpts.mkEnum ["null" "string"] "null" ''
+      logo_tooltip = helpers.mkNullOrStr ''
         Sets the logo tooltip
       '';
 

--- a/tests/test-sources/plugins/utils/neocord.nix
+++ b/tests/test-sources/plugins/utils/neocord.nix
@@ -47,7 +47,7 @@
         #General options
         auto_update = true;
         logo = "auto";
-        logo_tooltip = null;
+        logo_tooltip = "Nixvim";
         main_image = "language";
         client_id = "1157438221865717891";
         log_level = null;


### PR DESCRIPTION
I misclosed #1108.

User couldn't set the logo url, also logo_tooltip didn't allow custom string because of the enum.