### PR TITLE
Revert "plugins/lsp: Add statix"

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -83,7 +83,6 @@ in {
         "rust-analyzer"
         "solargraph"
         "sourcekit"
-        "statix"
         "svelte"
         "tailwindcss"
         "taplo"

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -564,10 +564,6 @@ with lib; let
       package = pkgs.sourcekit-lsp;
     }
     {
-      name = "statix";
-      description = "statix for Nix";
-    }
-    {
       name = "svelte";
       description = "svelte language server for Svelte";
       package = pkgs.nodePackages.svelte-language-server;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -151,7 +151,6 @@
           # As of 2023-12-13, sourcekit-lsp is broken
           # TODO: re-enable this test when fixed
           sourcekit.enable = false;
-          statix.enable = true;
           svelte.enable = true;
           tailwindcss.enable = true;
           taplo.enable = true;


### PR DESCRIPTION
Reverts nix-community/nixvim#1105

After a bit of digging, it looks like [statix](https://github.com/nerdypepper/statix) [does not](https://github.com/neovim/nvim-lspconfig/issues/2887) actually implement the lsp.

I suggest we pull this out, or possibly mark it as "broken" to avoid any further confusion.

