### PR TITLE
plugins/colorschemes/base16: switch to new package name

### DIFF
--- a/plugins/colorschemes/base16.nix
+++ b/plugins/colorschemes/base16.nix
@@ -13,7 +13,7 @@ in {
     colorschemes.base16 = {
       enable = mkEnableOption "base16";
 
-      package = helpers.mkPackageOption "base16" pkgs.vimPlugins.nvim-base16;
+      package = helpers.mkPackageOption "base16" pkgs.vimPlugins.base16-nvim;
 
       useTruecolor = mkOption {
         type = types.bool;


### PR DESCRIPTION
Fixes #1112 with regards to the base16 package name being changed.