### PR TITLE
Renamed nvim-base16 to base16-nvim

### DIFF
--- a/plugins/colorschemes/base16.nix
+++ b/plugins/colorschemes/base16.nix
@@ -13,7 +13,7 @@ in {
     colorschemes.base16 = {
       enable = mkEnableOption "base16";
 
-      package = helpers.mkPackageOption "base16" pkgs.vimPlugins.nvim-base16;
+      package = helpers.mkPackageOption "base16" pkgs.vimPlugins.base16-nvim;
 
       useTruecolor = mkOption {
         type = types.bool;


### PR DESCRIPTION
Small patch to fix nvim-base16 being renamed to base16-nvim 