### PR TITLE
Add _nixvimTests = false to flake.lib output

### DIFF
--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -14,7 +14,6 @@
         import ../lib {
           inherit pkgs lib;
           inherit (config.legacyPackages) makeNixvim makeNixvimWithModule;
-          _nixvimTests = false;
         }
     )
   );

--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -14,6 +14,7 @@
         import ../lib {
           inherit pkgs lib;
           inherit (config.legacyPackages) makeNixvim makeNixvimWithModule;
+          _nixvimTests = false;
         }
     )
   );

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,11 +3,12 @@
   makeNixvim,
   makeNixvimWithModule,
   pkgs,
+  _nixvimTests ? false,
   ...
 } @ args: {
   # Add all exported modules here
   check = import ../tests/test-derivation.nix {
     inherit makeNixvim makeNixvimWithModule pkgs;
   };
-  helpers = import ./helpers.nix args;
+  helpers = import ./helpers.nix (args // {inherit _nixvimTests;});
 }


### PR DESCRIPTION
In my personal configuration, I rely on `nixvim.lib.${system}.helpers` to get access to things like `mkRaw` and `toLuaObject` for use in my extended `lib`.

With the changes made in 6d7e429537ae8143d8405c44a61479248776758c, `nixvim.lib.${system}.helpers` can no longer be accessed directly from the `nixvim` input as `_nixvimTests` is not provided as an input attribute, so loading `helpers.nix` fails.

This small change restores what I *think* is the intended behavior of this module.