### PR TITLE
helpers/vim-plugin/mkVimPlugin: add optionsRenamedToSettings option

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -14,7 +14,7 @@ in
     keymaps = import ./keymap-helpers.nix {inherit lib nixvimOptions nixvimTypes;};
     autocmd = import ./autocmd-helpers.nix {inherit lib nixvimOptions nixvimTypes;};
     neovim-plugin = import ./neovim-plugin.nix {inherit lib nixvimOptions nixvimUtils toLuaObject;};
-    vim-plugin = import ./vim-plugin.nix {inherit lib nixvimOptions;};
+    vim-plugin = import ./vim-plugin.nix {inherit lib nixvimOptions nixvimUtils;};
     inherit nixvimTypes;
     inherit toLuaObject;
   }

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -8,6 +8,8 @@ with lib; {
     namespace ? "plugins",
     maintainers ? [],
     imports ? [],
+    # deprecations
+    deprecateExtraConfig ? false,
     # options
     originalName ? name,
     defaultPackage ? null,
@@ -15,7 +17,6 @@ with lib; {
     settingsOptions ? {},
     settingsExample ? null,
     globalPrefix ? "",
-    addExtraConfigRenameWarning ? false,
     extraOptions ? {},
     # config
     extraConfig ? cfg: {},
@@ -89,7 +90,7 @@ with lib; {
 
     imports =
       imports
-      ++ optional (addExtraConfigRenameWarning && createSettingsOption) (
+      ++ optional (deprecateExtraConfig && createSettingsOption) (
         mkRenamedOptionModule
         ["plugins" name "extraConfig"]
         ["plugins" name "settings"]

--- a/plugins/completion/copilot-vim.nix
+++ b/plugins/completion/copilot-vim.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "copilot.vim";
     defaultPackage = pkgs.vimPlugins.copilot-vim;
     globalPrefix = "copilot_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       nodeCommand = mkDefaultOpt {

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "vim-ledger";
     defaultPackage = pkgs.vimPlugins.vim-ledger;
     globalPrefix = "ledger_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       maxWidth = mkDefaultOpt {

--- a/plugins/languages/markdown-preview.nix
+++ b/plugins/languages/markdown-preview.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "markdown-preview.nvim";
     defaultPackage = pkgs.vimPlugins.markdown-preview-nvim;
     globalPrefix = "mkdp_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       autoStart = mkDefaultOpt {

--- a/plugins/languages/tagbar.nix
+++ b/plugins/languages/tagbar.nix
@@ -8,6 +8,6 @@ helpers.vim-plugin.mkVimPlugin config {
   name = "tagbar";
   defaultPackage = pkgs.vimPlugins.tagbar;
   globalPrefix = "tagbar_";
-  addExtraConfigRenameWarning = true;
+  deprecateExtraConfig = true;
   extraPackages = [pkgs.ctags];
 }

--- a/plugins/languages/vim-slime.nix
+++ b/plugins/languages/vim-slime.nix
@@ -11,7 +11,7 @@ with helpers.vim-plugin;
     name = "vim-slime";
     defaultPackage = pkgs.vimPlugins.vim-slime;
     globalPrefix = "slime_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       target = mkDefaultOpt {

--- a/plugins/languages/zig.nix
+++ b/plugins/languages/zig.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "zig.vim";
     defaultPackage = pkgs.vimPlugins.zig-vim;
     globalPrefix = "zig_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     # Possibly add option to disable Treesitter highlighting if this is installed
     options = {

--- a/plugins/statuslines/airline.nix
+++ b/plugins/statuslines/airline.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "vim-airline";
     defaultPackage = pkgs.vimPlugins.vim-airline;
     globalPrefix = "airline_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options =
       (

--- a/plugins/utils/emmet.nix
+++ b/plugins/utils/emmet.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "emmet-vim";
     defaultPackage = pkgs.vimPlugins.emmet-vim;
     globalPrefix = "user_emmet_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       mode = mkDefaultOpt {

--- a/plugins/utils/goyo.nix
+++ b/plugins/utils/goyo.nix
@@ -12,7 +12,7 @@ with lib;
     originalName = "goyo.vim";
     defaultPackage = pkgs.vimPlugins.goyo-vim;
     globalPrefix = "goyo_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       width = mkDefaultOpt {

--- a/plugins/utils/instant.nix
+++ b/plugins/utils/instant.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "instant.nvim";
     defaultPackage = pkgs.vimPlugins.instant-nvim;
     globalPrefix = "instant_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = let
       mkStr = global: default: desc:

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "magma-nvim";
     defaultPackage = pkgs.vimPlugins.magma-nvim-goose;
     globalPrefix = "magma_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       imageProvider = mkDefaultOpt {

--- a/plugins/utils/molten.nix
+++ b/plugins/utils/molten.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "molten-nvim";
     defaultPackage = pkgs.vimPlugins.molten-nvim;
     globalPrefix = "molten_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       autoOpenOutput = mkDefaultOpt {

--- a/plugins/utils/startify.nix
+++ b/plugins/utils/startify.nix
@@ -12,7 +12,7 @@ with helpers.vim-plugin;
     originalName = "vim-startify";
     defaultPackage = pkgs.vimPlugins.vim-startify;
     globalPrefix = "startify_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       sessionDir = mkDefaultOpt {

--- a/plugins/utils/undotree.nix
+++ b/plugins/utils/undotree.nix
@@ -11,7 +11,7 @@ with helpers.vim-plugin;
     name = "undotree";
     defaultPackage = pkgs.vimPlugins.undotree;
     globalPrefix = "undotree_";
-    addExtraConfigRenameWarning = true;
+    deprecateExtraConfig = true;
 
     options = {
       windowLayout = mkDefaultOpt {


### PR DESCRIPTION
This allows to easily create the necessary renamed warnings.