### PR TITLE
fantomas: enable darwin test

### DIFF
--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -98,7 +98,7 @@
           cbfmt.enable = !pkgs.stdenv.isDarwin;
           eslint.enable = true;
           eslint_d.enable = true;
-          fantomas.enable = pkgs.stdenv.isLinux;
+          fantomas.enable = true;
           fnlfmt.enable = true;
           fourmolu.enable = true;
           gofmt.enable = true;


### PR DESCRIPTION
### Changes 

 * Enables the tests for Darwin platforms based on this newly closed issue
https://github.com/NixOS/nixpkgs/pull/289791

### Status

 * [https://nixpk.gs/pr-tracker.html?pr=289791](https://nixpk.gs/pr-tracker.html?pr=289791)
 * The flake lock needs to be updated when the above pr has been merged