### PR TITLE
modules/colorscheme: Set colorscheme after everything else

### DIFF
--- a/modules/colorscheme.nix
+++ b/modules/colorscheme.nix
@@ -13,8 +13,8 @@ with lib; {
   };
 
   config = mkIf (config.colorscheme != "" && config.colorscheme != null) {
-    extraConfigVim = ''
-      colorscheme ${config.colorscheme}
+    extraConfigLuaPost = ''
+      vim.cmd.colorscheme("${config.colorscheme}")
     '';
   };
 }


### PR DESCRIPTION
Without that, e.g. require('gruvbox').setup() was run *after* setting the colorsheme. Thus all settings were ignored.