### PR TITLE
standalone: Allow to extend a standalone derivation with a new module

### DIFF
--- a/docs/man/default.nix
+++ b/docs/man/default.nix
@@ -34,6 +34,7 @@
       cat \
         ${./nixvim-header-start.5} \
         ${mkMDSection ../user-guide/helpers.md} \
+        ${mkMDSection ../user-guide/extending-config.md} \
         ${mkMDSection ../user-guide/faq.md} \
         ${./nixvim-header-end.5} \
         >$out/nixvim-header.5

--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -4,6 +4,7 @@
 
 - [Installation](./user-guide/install.md)
 - [Helpers](./user-guide/helpers.md)
+- [Extending a standalone configuration](./user-guide/extending-config.md)
 - [FAQ](./user-guide/faq.md)
 
 # Options

--- a/docs/user-guide/extending-config.md
+++ b/docs/user-guide/extending-config.md
@@ -1,0 +1,26 @@
+# Extending a standalone configuration
+
+Given a `nvim` derivation obtained from `makeNixvim` or `makeNivxmiWithModule` it is possible to create a new derivation with additional options.
+
+This is done through the `nvim.nixvimExtend` function. This function takes a NixOS module that is going to be merged with the currently set options.
+
+This attribute is recursive, meaning that it can be applied an arbitrary number of times.
+
+## Example
+
+```nix
+{makeNixvimWithModule}: let
+    first = makeNixvimWithModule {
+        module = {
+            extraConfigLua = "-- first stage";
+        };
+    };
+
+    second = first.nixvimExtend {extraConfigLua = "-- second stage";};
+    
+    third = second.nixvimExtend {extraConfigLua = "-- third stage";};
+in
+    third
+```
+
+This will generate a `init.lua` that will contain the three comments from each stages.

--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -25,6 +25,10 @@
         inherit makeNixvimWithModule;
       };
 
+      extend = import ../tests/extend.nix {
+        inherit pkgs makeNixvimWithModule;
+      };
+
       enable-except-in-tests = import ../tests/enable-except-in-tests.nix {
         inherit pkgs makeNixvimWithModule;
         inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;

--- a/tests/extend.nix
+++ b/tests/extend.nix
@@ -1,0 +1,28 @@
+{
+  makeNixvimWithModule,
+  pkgs,
+}: let
+  firstStage = makeNixvimWithModule {
+    module = {
+      extraConfigLua = "-- first stage";
+    };
+  };
+
+  secondStage = firstStage.nixvimExtend {extraConfigLua = "-- second stage";};
+
+  generated = secondStage.nixvimExtend {extraConfigLua = "-- third stage";};
+in
+  pkgs.runCommand "extend-test" {
+    printConfig = "${generated}/bin/nixvim-print-init";
+  } ''
+    config=$($printConfig)
+    for stage in "first" "second" "third"; do
+      if ! "$printConfig" | grep -q -- "-- $stage stage"; then
+        echo "Missing $stage stage in config"
+        echo "$config"
+        exit 1
+      fi
+    done
+
+    touch $out
+  ''


### PR DESCRIPTION
This adds the `nixvimExtend` attribute to the generated standalone derivation, this attribute takes a module as an argument and returns a new standalone derivation with the initial module & the extended module merged together.