### PR TITLE
Add ruff source to none-ls

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -93,6 +93,9 @@ with lib; let
       staticcheck = {
         pacakge = pkgs.go-tools;
       };
+      ruff = {
+        package = pkgs.ruff;
+      };
       statix = {
         package = pkgs.statix;
       };
@@ -200,6 +203,12 @@ with lib; let
       };
       protolint = {
         package = pkgs.protolint;
+      };
+      ruff = {
+        package = pkgs.ruff;
+      };
+      ruff_format = {
+        package = pkgs.ruff;
       };
       rustfmt = {
         package = pkgs.rustfmt;

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -87,14 +87,14 @@ with lib; let
       revive = {
         pacakge = pkgs.revive;
       };
+      ruff = {
+        package = pkgs.ruff;
+      };
       shellcheck = {
         package = pkgs.shellcheck;
       };
       staticcheck = {
         pacakge = pkgs.go-tools;
-      };
-      ruff = {
-        package = pkgs.ruff;
       };
       statix = {
         package = pkgs.statix;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -70,8 +70,8 @@
           ktlint.enable = true;
           ltrs.enable = true;
           markdownlint.enable = true;
-          shellcheck.enable = true;
           ruff.enable = true;
+          shellcheck.enable = true;
           statix.enable = true;
           staticcheck.enable = true;
           typos.enable = true;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -71,6 +71,7 @@
           ltrs.enable = true;
           markdownlint.enable = true;
           shellcheck.enable = true;
+          ruff.enable = true;
           statix.enable = true;
           staticcheck.enable = true;
           typos.enable = true;
@@ -122,6 +123,8 @@
           markdownlint.enable = true;
           pint.enable = true;
           protolint.enable = true;
+          ruff.enable = true;
+          ruff_format.enable = true;
           rustfmt.enable = true;
           sqlfluff.enable = true;
           trim_newlines.enable = true;


### PR DESCRIPTION
Thank you for the amazing project :)

This adds the ruff linter and formatter as a source for none-ls.
I basically copied similar previous PRs and tested locally, so please let me know if you see any issue.