### PR TITLE
plugins/oil.nvim: Update add a few missing options

### DIFF
--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -265,14 +265,18 @@ in {
         "Selecting a new/moved/renamed file or directory will prompt you to save changes first.";
 
       cleanupDelayMs =
-        helpers.defaultNullOpts.mkInt 2000 ''
+        helpers.defaultNullOpts.mkNullable
+        (types.either types.int (types.enum [false]))
+        "2000" ''
           Oil will automatically delete hidden buffers after this delay.
           You can set the delay to false to disable cleanup entirely.
           Note that the cleanup process only starts when none of the oil buffers are currently displayed
         '';
 
       lspRenameAutosave =
-        helpers.defaultNullOpts.mkBool false
+        helpers.defaultNullOpts.mkNullable
+        (types.either types.bool (types.enum ["unmodified"]))
+        "false"
         "Set to true to autosave buffers that are updated with LSP willRenameFiles. Set to \"unmodified\" to only save unmodified buffers";
 
       keymaps =
@@ -388,6 +392,8 @@ in {
         delete_to_trash = cfg.deleteToTrash;
         trash_command = cfg.trashCommand;
         prompt_save_on_select_new_entry = cfg.promptSaveOnSelectNewEntry;
+        lsp_rename_autosave = cfg.lspRenameAutosave;
+        cleanup_delay_ms = cfg.cleanupDelayMs;
         inherit (cfg) keymaps;
         use_default_keymaps = cfg.useDefaultKeymaps;
         view_options = with cfg.viewOptions; {

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -264,6 +264,17 @@ in {
         helpers.defaultNullOpts.mkBool true
         "Selecting a new/moved/renamed file or directory will prompt you to save changes first.";
 
+      cleanupDelayMs =
+        helpers.defaultNullOpts.mkInt 2000 ''
+          Oil will automatically delete hidden buffers after this delay.
+          You can set the delay to false to disable cleanup entirely.
+          Note that the cleanup process only starts when none of the oil buffers are currently displayed
+        '';
+
+      lspRenameAutosave =
+        helpers.defaultNullOpts.mkBool false
+        "Set to true to autosave buffers that are updated with LSP willRenameFiles. Set to \"unmodified\" to only save unmodified buffers";
+
       keymaps =
         helpers.defaultNullOpts.mkNullable
         types.attrs

--- a/tests/test-sources/plugins/utils/oil.nix
+++ b/tests/test-sources/plugins/utils/oil.nix
@@ -68,6 +68,8 @@
       deleteToTrash = false;
       trashCommand = "trash-put";
       promptSaveOnSelectNewEntry = true;
+      lspRenameAutosave = true;
+      cleanupDelayMs = 500;
       keymaps = {
         "g?" = "actions.show_help";
         "<CR>" = "actions.select";


### PR DESCRIPTION
I added few options that probably were added recently and not updated here, the version on unstable: https://github.com/stevearc/oil.nvim/tree/bf753c3e3f8736939ad5597f92329dfe7b1df4f5?tab=readme-ov-file#options 