### PR TITLE
fix-kanagawa-colorscheme

### DIFF
--- a/plugins/colorschemes/kanagawa.nix
+++ b/plugins/colorschemes/kanagawa.nix
@@ -188,7 +188,10 @@ in {
       // cfg.extraOptions;
   in
     mkIf cfg.enable {
-      colorscheme = "kanagawa";
+      colorscheme =
+        if cfg.theme == null
+        then "kanagawa"
+        else "kanagawa-${cfg.theme}";
 
       extraPlugins = [cfg.package];
 


### PR DESCRIPTION
The theme is not applied to the colorscheme. for example setting the theme `dragon` has no effect since always the colorscheme was set to `kanagawa`.

I went to the approach of just checking to not be null and use the selected theme.