### PR TITLE
plugins/none-ls,efmls-configs: Use php-codesniffer package for phpcbf

### DIFF
--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -92,7 +92,6 @@ with lib; let
       ;
     inherit
       (phpPackages)
-      phpcbf
       phan
       phpcs
       phpstan
@@ -126,6 +125,7 @@ with lib; let
     mcs = mono;
     php_cs_fixer = phpPackages.php-cs-fixer;
     prettier_d = prettierd;
+    phpcbf = phpPackages.php-codesniffer;
     slither = slither-analyzer;
     staticcheck = go-tools;
     terraform_fmt = terraform;

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -193,7 +193,7 @@ with lib; let
       };
       pint = {};
       phpcbf = {
-        package = pkgs.phpPackages.phpcbf;
+        package = pkgs.phpPackages.php-codesniffer;
       };
       prettier = {
         package = pkgs.nodePackages.prettier;


### PR DESCRIPTION
error: `phpcbf` is now deprecated, use `php-codesniffer` instead which contains both `phpcs` and `phpcbf`.

Closes #1160