### PR TITLE
plugins/crates-nvim: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -118,6 +118,7 @@
     ./utils/commentary.nix
     ./utils/conjure.nix
     ./utils/coverage.nix
+    ./utils/crates-nvim.nix
     ./utils/cursorline.nix
     ./utils/dashboard.nix
     ./utils/easyescape.nix

--- a/plugins/utils/crates-nvim.nix
+++ b/plugins/utils/crates-nvim.nix
@@ -1,0 +1,13 @@
+{
+  helpers,
+  pkgs,
+  config,
+  ...
+}:
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "crates";
+  defaultPackage = pkgs.vimPlugins.crates-nvim;
+  maintainers = [helpers.maintainers.alisonjenkins];
+  settingsOptions = {};
+  settingsExample = {};
+}

--- a/tests/test-sources/plugins/utils/crates-nvim.nix
+++ b/tests/test-sources/plugins/utils/crates-nvim.nix
@@ -1,0 +1,1 @@
+{empty = {plugins.crates-nvim.enable = true;};}


### PR DESCRIPTION
Adds crates-nvim as a plugin instead of just a completion source for cmp.

Resolves: https://github.com/nix-community/nixvim/issues/1149