### PR TITLE
plugins/lightline: Add option for inactive components

### DIFF
--- a/plugins/statuslines/lightline.nix
+++ b/plugins/statuslines/lightline.nix
@@ -76,15 +76,15 @@ in {
         default = null;
         type = types.nullOr (types.submodule {
           options = let
-            listType = with types; nullOr (listOf (listOf str));
+            listType = with helpers.nixvimTypes; maybeRaw (listOf (listOf str));
           in {
-            left = mkOption {
+            left = helpers.mkNullOrOption {
               type = listType;
               description = "List of components that will show up on the left side of the bar";
               default = null;
             };
 
-            right = mkOption {
+            right = helpers.mkNullOrOption {
               type = listType;
               description = "List of components that will show up on the right side of the bar";
               default = null;

--- a/plugins/statuslines/lightline.nix
+++ b/plugins/statuslines/lightline.nix
@@ -78,17 +78,9 @@ in {
           options = let
             listType = with helpers.nixvimTypes; maybeRaw (listOf (listOf str));
           in {
-            left = helpers.mkNullOrOption {
-              type = listType;
-              description = "List of components that will show up on the left side of the bar";
-              default = null;
-            };
+            left = helpers.mkNullOrOption listType "List of components that will show up on the left side of the bar";
 
-            right = helpers.mkNullOrOption {
-              type = listType;
-              description = "List of components that will show up on the right side of the bar";
-              default = null;
-            };
+            right = helpers.mkNullOrOption listType "List of components that will show up on the right side of the bar";
           };
         });
       };

--- a/plugins/statuslines/lightline.nix
+++ b/plugins/statuslines/lightline.nix
@@ -72,6 +72,27 @@ in {
         });
       };
 
+      inactive = mkOption {
+        default = null;
+        type = types.nullOr (types.submodule {
+          options = let
+            listType = with types; nullOr (listOf (listOf str));
+          in {
+            left = mkOption {
+              type = listType;
+              description = "List of components that will show up on the left side of the bar";
+              default = null;
+            };
+
+            right = mkOption {
+              type = listType;
+              description = "List of components that will show up on the right side of the bar";
+              default = null;
+            };
+          };
+        });
+      };
+
       modeMap = mkOption {
         type = with types; nullOr (attrsOf str);
         description = "Mode name mappings";
@@ -82,7 +103,7 @@ in {
 
   config = let
     configAttrs = filterAttrs (_: v: v != null) {
-      inherit (cfg) colorscheme active component componentFunction modeMap;
+      inherit (cfg) colorscheme active inactive component componentFunction modeMap;
     };
   in
     mkIf cfg.enable {


### PR DESCRIPTION
The lightline plugin has an option for which components to display in active panes, which is currently supported by nixvim, but it also has an equivalent option for inactive panes. This PR just adds that option.