### PR TITLE
flake/dev: add a convenient devshell

### DIFF
--- a/flake-modules/default.nix
+++ b/flake-modules/default.nix
@@ -1,6 +1,6 @@
 {inputs, ...}: {
   imports = [
-    ./dev.nix
+    ./dev
     ./helpers.nix
     ./lib.nix
     ./legacy-packages.nix

--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -1,17 +1,10 @@
 {inputs, ...}: {
   imports = [
     inputs.pre-commit-hooks.flakeModule
+    ./devshell.nix
   ];
 
-  perSystem = {
-    pkgs,
-    config,
-    ...
-  }: {
-    devShells.default = pkgs.mkShellNoCC {
-      shellHook = config.pre-commit.installationScript;
-    };
-
+  perSystem = {pkgs, ...}: {
     formatter = pkgs.alejandra;
 
     pre-commit = {

--- a/flake-modules/dev/devshell.nix
+++ b/flake-modules/dev/devshell.nix
@@ -1,0 +1,66 @@
+{inputs, ...}: {
+  imports = [
+    inputs.devshell.flakeModule
+  ];
+
+  perSystem = {
+    pkgs,
+    config,
+    system,
+    ...
+  }: {
+    devshells.default = {
+      devshell.startup.pre-commit.text = config.pre-commit.installationScript;
+
+      commands = let
+        # Thanks to this, the user can choose to use `nix-output-monitor` (`nom`) instead of plain `nix`
+        nix = "$([ '$\{NIXVIM_NOM:-0}' = '1' ] && echo ${pkgs.lib.getExe pkgs.nom} || echo nix)";
+      in [
+        {
+          name = "checks";
+          help = "Run all nixvim checks";
+          command = "nix flake check";
+        }
+        {
+          name = "tests";
+          help = "Run nixvim tests";
+          command = ''
+            echo "=> Running nixvim tests for the '${system}' architecture..."
+
+            ${nix} build .#checks.${system}.tests
+          '';
+        }
+        {
+          name = "format";
+          help = "Format the entire codebase";
+          command = "nix fmt";
+        }
+        {
+          name = "docs";
+          help = "Build nixvim documentation";
+          command = ''
+            echo "=> Building nixvim documentation..."
+
+            ${nix} build .#docs
+          '';
+        }
+        {
+          name = "serve-docs";
+          help = "Build and serve documentation locally";
+          command = ''
+            echo -e "=> Building nixvim documentation...\n"
+
+            doc_derivation=$(${nix} build .#docs --no-link --print-out-paths)
+
+            echo -e "\n=> Documentation succesfully built ('$doc_derivation')"
+
+            port=8000
+            echo -e "\n=> Now open your browser and navigate to 'localhost:$port'\n"
+
+            ${pkgs.lib.getExe pkgs.python3} -m http.server -d "$doc_derivation"/share/doc
+          '';
+        }
+      ];
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708939976,
+        "narHash": "sha256-O5+nFozxz2Vubpdl1YZtPrilcIXPcRAjqNdNE8oCRoA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "5ddecd67edbd568ebe0a55905273e56cc82aabe3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "locked": {
         "lastModified": 1696426674,
@@ -53,6 +74,24 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -148,7 +187,7 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -173,6 +212,7 @@
     },
     "root": {
       "inputs": {
+        "devshell": "devshell",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
@@ -182,6 +222,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
 


### PR DESCRIPTION
Create a convenient devshell that provides the following commands:
- checks: Run all nixvim checks
- docs: Build nixvim documentation
- format: Format the entire codebase
- menu: prints this menu
- serve-docs: Build and serve documentation locally
- tests: Run nixvim tests