### PR TITLE
plugins/none-ls: fix withArgs type, syntax

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -383,7 +383,7 @@ in {
             withArgs =
               if source.withArgs == null
               then sourceItem
-              else "${sourceItem}.with(${source.withArgs}})";
+              else "${sourceItem}.with(${source.withArgs})";
           in
             helpers.mkRaw ''
               require("null-ls").builtins.${withArgs}

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -331,9 +331,7 @@ in {
         (source: _:
           {
             enable = mkEnableOption "the ${source} ${sourceType} source for none-ls";
-            withArgs = helpers.mkNullOrStr ''
-              Raw Lua code passed as an argument to the source's `with` method.
-            '';
+            withArgs = helpers.mkNullOrOption helpers.nivimTypes.strLua;
           }
           // lib.optionalAttrs (hasBuiltinPackage source) {
             package = let

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -331,7 +331,7 @@ in {
         (source: _:
           {
             enable = mkEnableOption "the ${source} ${sourceType} source for none-ls";
-            withArgs = helpers.mkNullOrLua ''
+            withArgs = helpers.mkNullOrStr ''
               Raw Lua code passed as an argument to the source's `with` method.
             '';
           }

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -331,7 +331,9 @@ in {
         (source: _:
           {
             enable = mkEnableOption "the ${source} ${sourceType} source for none-ls";
-            withArgs = helpers.mkNullOrOption helpers.nivimTypes.strLua;
+            withArgs = helpers.mkNullOrOption helpers.nivimTypes.strLua ''
+              Raw Lua code passed as an argument to the source's `with` method.
+            '';
           }
           // lib.optionalAttrs (hasBuiltinPackage source) {
             package = let

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -331,7 +331,7 @@ in {
         (source: _:
           {
             enable = mkEnableOption "the ${source} ${sourceType} source for none-ls";
-            withArgs = helpers.mkNullOrOption helpers.nivimTypes.strLua ''
+            withArgs = helpers.mkNullOrOption helpers.nixvimTypes.strLua ''
               Raw Lua code passed as an argument to the source's `with` method.
             '';
           }


### PR DESCRIPTION
This was previously null or string, but was changed to null or Lua in nix-community/nixvim#1169. Internally, `withArgs` is expected to be a string, but `mkNullOrLua` applies `mkRaw`, leading to a type error when generating the output, as it is attempting to interpolate a set rather than a string.

Additionally, there was an errant extra } when interpolating the args, which led to a broken init.lua.

Tested locally, and verified that it fixes my setup.