### PR TITLE
plugins/ltex-extra: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -53,6 +53,7 @@
     ./languages/lean.nix
     ./languages/ledger.nix
     ./languages/lint.nix
+    ./languages/ltex-extra.nix
     ./languages/markdown-preview.nix
     ./languages/nix.nix
     ./languages/nvim-jdtls.nix

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.ltex-extra;
+in {
+  meta.maintainers = [maintainers.loicreynier];
+
+  options.plugins.ltex-extra =
+    helpers.neovim-plugin.extraOptionsOptions
+    // {
+      enable = mkEnableOption "ltex-extra";
+
+      package = helpers.mkPackageOption "ltex-extra" pkgs.vimPlugins.ltex_extra-nvim;
+
+      path = helpers.defaultNullOpts.mkStr "" ''
+        Path (relative to project root) to load external files from.
+
+        Commonly used values are:
+        - `.ltex`
+        - `.vscode` for compatibility with projects using the associated VS Code extension.
+      '';
+
+      initCheck = helpers.defaultNullOpts.mkBool true ''
+        Whether to load dicionnaries on startup.
+      '';
+
+      loadLangs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["en-US"]'' ''
+        Languages for witch dicionnaries will be loaded.
+        See `plugins.lsp.servers.ltex.languages` for possible values.
+      '';
+
+      logLevel = helpers.defaultNullOpts.mkStr "none" ''
+        Log level. Possible values:
+        - "none"
+        - "trace"
+        - "debug"
+        - "info"
+        - "warn"
+        - "error"
+        - "fatal"
+      '';
+    };
+
+  config = let
+    setupOptions = with cfg; {
+      inherit path;
+      init_check = initCheck;
+      load_langs = loadLangs;
+      log_level = logLevel;
+    };
+  in
+    mkIf cfg.enable {
+      warnings = optional (!config.plugins.lsp.enable) ''
+        You have enabled `ltex-extra` but not the lsp (`plugins.lsp`).
+        You should set `plugins.lsp.enable = true` to make use of the LTeX_extra plugin's features.
+      '';
+
+      extraPlugins = [cfg.package];
+
+      plugins.lsp = {
+        # Enable the ltex language server
+        servers.ltex.enable = true;
+
+        postConfig = ''
+          require("ltex_extra").setup(${helpers.toLuaObject setupOptions})
+        '';
+      };
+    };
+}

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -59,7 +59,7 @@ with lib;
           enable = true;
 
           onAttach.function = ''
-            require("ltex_extra").setup(${helpers.toLuaObject setupOptions})
+            require("ltex_extra").setup(${helpers.toLuaObject cfg.settings})
           '';
         };
       };

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -67,7 +67,7 @@ in {
           # Enable the ltex language server
           enable = true;
 
-          onAttach = ''
+          onAttach.function = ''
             require("ltex_extra").setup(${helpers.toLuaObject setupOptions})
           '';
         };

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -5,18 +5,17 @@
   pkgs,
   ...
 }:
-with lib; let
-  cfg = config.plugins.ltex-extra;
-in {
-  meta.maintainers = [maintainers.loicreynier];
+with lib;
+  helpers.neovim-plugin.mkNeovimPlugin config {
+    name = "ltex-extra";
+    originalName = "ltex_extra.nvim";
+    defaultPackage = pkgs.vimPlugins.ltex_extra-nvim;
 
-  options.plugins.ltex-extra =
-    helpers.neovim-plugin.extraOptionsOptions
-    // {
-      enable = mkEnableOption "ltex-extra";
+    maintainers = [maintainers.loicreynier];
 
-      package = helpers.mkPackageOption "ltex-extra" pkgs.vimPlugins.ltex_extra-nvim;
+    callSetup = false;
 
+    settingsOptions = {
       path = helpers.defaultNullOpts.mkStr "" ''
         Path (relative to project root) to load external files from.
 
@@ -26,7 +25,7 @@ in {
       '';
 
       initCheck = helpers.defaultNullOpts.mkBool true ''
-        Whether to load dicionnaries on startup.
+        Whether to load dictionaries on startup.
       '';
 
       loadLangs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["en-US"]'' ''
@@ -46,15 +45,7 @@ in {
       '';
     };
 
-  config = let
-    setupOptions = with cfg; {
-      inherit path;
-      init_check = initCheck;
-      load_langs = loadLangs;
-      log_level = logLevel;
-    };
-  in
-    mkIf cfg.enable {
+    extraConfig = cfg: {
       warnings = optional (!config.plugins.lsp.enable) ''
         You have enabled `ltex-extra` but not the lsp (`plugins.lsp`).
         You should set `plugins.lsp.enable = true` to make use of the LTeX_extra plugin's features.
@@ -73,4 +64,11 @@ in {
         };
       };
     };
-}
+
+    settingsExample = {
+      path = ".ltex";
+      initCheck = true;
+      loadLangs = ["en-US" "fr-FR"];
+      logLevel = "non";
+    };
+  }

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -63,12 +63,14 @@ in {
       extraPlugins = [cfg.package];
 
       plugins.lsp = {
-        # Enable the ltex language server
-        servers.ltex.enable = true;
+        servers.ltex = {
+          # Enable the ltex language server
+          enable = true;
 
-        postConfig = ''
-          require("ltex_extra").setup(${helpers.toLuaObject setupOptions})
-        '';
+          onAttach = ''
+            require("ltex_extra").setup(${helpers.toLuaObject setupOptions})
+          '';
+        };
       };
     };
 }

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -24,16 +24,16 @@ with lib;
         - `.vscode` for compatibility with projects using the associated VS Code extension.
       '';
 
-      initCheck = helpers.defaultNullOpts.mkBool true ''
+      init_check = helpers.defaultNullOpts.mkBool true ''
         Whether to load dictionaries on startup.
       '';
 
-      loadLangs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["en-US"]'' ''
+      load_langs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["en-US"]'' ''
         Languages for witch dicionnaries will be loaded.
         See `plugins.lsp.servers.ltex.languages` for possible values.
       '';
 
-      logLevel = helpers.defaultNullOpts.mkStr "none" ''
+      log_level = helpers.defaultNullOpts.mkStr "none" ''
         Log level. Possible values:
         - "none"
         - "trace"

--- a/plugins/lsp/language-servers/ltex-settings.nix
+++ b/plugins/lsp/language-servers/ltex-settings.nix
@@ -636,32 +636,4 @@ with lib; {
           server.
       '';
   };
-
-  ltex_extra = {
-    enable = helpers.defaultNullOpts.mkBool true ''
-      Enable LTeX_extra plugin which provides external LTeX file handling
-      and other extra features.
-    '';
-    path = helpers.defaultNullOpts.mkStr "" ''
-      Path (relative to project root) to load external files from.
-
-      Commonly used values are:
-      - `.ltex`
-      - `.vscode` for compatibility with projects using the associated VS Code extension.
-    '';
-  };
-
-  config = let
-    cfg = config.lsp.servers.ltex.ltex_extra;
-  in
-    mkIf ltex_extra.enabled {
-      plugins.lsp.servers.ltex.onAttach.function = ''
-        require("ltex_extra").setup{
-          path = "${cfg.path}",
-        }
-      '';
-      extraPlugins = with pkgs.vimPlugins; [
-        ltex_extra-nvim
-      ];
-    };
 }

--- a/plugins/lsp/language-servers/ltex-settings.nix
+++ b/plugins/lsp/language-servers/ltex-settings.nix
@@ -636,4 +636,32 @@ with lib; {
           server.
       '';
   };
+
+  ltex_extra = {
+    enable = helpers.defaultNullOpts.mkBool true ''
+      Enable LTeX_extra plugin which provides external LTeX file handling
+      and other extra features.
+    '';
+    path = helpers.defaultNullOpts.mkStr "" ''
+      Path (relative to project root) to load external files from.
+
+      Commonly used values are:
+      - `.ltex`
+      - `.vscode` for compatibility with projects using the associated VS Code extension.
+    '';
+  };
+
+  config = let
+    cfg = config.lsp.servers.ltex.ltex_extra;
+  in
+    mkIf ltex_extra.enabled {
+      plugins.lsp.servers.ltex.onAttach.function = ''
+        require("ltex_extra").setup{
+          path = "${cfg.path}",
+        }
+      '';
+      extraPlugins = with pkgs.vimPlugins; [
+        ltex_extra-nvim
+      ];
+    };
 }


### PR DESCRIPTION
Add an option to `plugins.lsp.servers.ltex` to enable the [LTeX_extra](https://github.com/barreiroleo/ltex_extra.nvim) plugins which enable LTeX LSP code action, external file handling and more features. 

I let this PR as a draft as I have not properly tested it yet and I am not sure if adding this plugin as an option to `plugins.lsp.servers.ltex` is the preferred way.