### PR TITLE
colorschemes/nord: properly set the vim colorscheme to "nord"

### DIFF
--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -61,4 +61,8 @@ helpers.vim-plugin.mkVimPlugin config {
     disable_background = true;
     italic = false;
   };
+
+  extraConfig = cfg: {
+    colorscheme = "nord";
+  };
 }


### PR DESCRIPTION
This was wrongly removed in https://github.com/nix-community/nixvim/commit/be87309e0c1da19d99d969625300aaed36ff1b91.

Fixes #1189 