### PR TITLE
expose withNodeJs option to pass to neovim wrapper

### DIFF
--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -22,6 +22,12 @@ with lib; {
       '';
     };
 
+    withNodeJs = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable Node provider.";
+    };
+
     package = mkOption {
       type = types.package;
       default = pkgs.neovim-unwrapped;
@@ -84,6 +90,7 @@ with lib; {
           extraPython3Packages
           viAlias
           vimAlias
+          withNodeJs
           ;
         # inherit customRC;
         plugins = normalizedPlugins;


### PR DESCRIPTION
This allows the neovim wrapper to be built with node plugin support by specifying it in the nixvim config. I confirmed that it is present with `:checkhealth` and that I could load something via a runtimepath `rplugin/node` folder.

`:checkhealth` output:

```
Node.js provider (optional) ~
- Node.js: v18.18.2
- Nvim node.js host: /nix/store/5g13wzq09yx4kp3r6z3w3p913r7y1ik4-neovim-4.11.0/bin/neovim-node-host
- WARNING Package "neovim" is out-of-date. Installed: 4.11.0, latest: 5.0.1
  - ADVICE:
    - Run in shell: npm install -g neovim
    - Run in shell (if you use yarn): yarn global add neovim
    - Run in shell (if you use pnpm): pnpm install -g neovim
```

Setting this new option changes the command-line lua argument passed by the neovim wrapper such that `vim.g.loaded_node_provider=0` is not passed meaning provider will loaded, and also now the `vim.g.node_host_prog` gets set. The difference looks like this if you look at ps outout:

`withNodeJs` option set to true:

```
 /nix/store/8dz8z8ypimcy52lf81kj5lc3b17h39wn-nixvim/bin/nvim --cmd lua vim.g.node_host_prog='/nix/store/l3nlpj3mr5bizrai1f0ijdxxg78qpd94-neovim-0.9.5/bin/nvim-node';vim
.g.loaded_perl_provider=0;vim.g.loaded_python_provider=0;vim.g.python3_host_prog='/nix/store/l3nlpj3mr5bizrai1f0ijdxxg78qpd94-neovim-0.9.5/bin/nvim-python3';vim.g.ruby_host_prog='/nix/store/l3nl
pj3mr5bizrai1f0ijdxxg78qpd94-neovim-0.9.5/bin/nvim-ruby' --cmd set packpath^=/nix/store/fv3169bd1qdv5qbs3bq3j26k7f9f0y5p-vim-pack-dir --cmd set rtp^=/nix/store/fv3169bd1qdv5qbs3bq3j26k7f9f0y5p-v
im-pack-dir -u /nix/store/53ds455c4j8k5flw7hna8x3lrazcifk8-init.lua 
```

Without the option set:
```
/nix/store/0pmpp842897a107s5yab46cyr7sxdqm4-nixvim/bin/nvim --cmd lua vim.g.loaded_node_provider=0;vim.g.loaded_perl_provider=0;vim.g.loaded_python_provider=0;vim.g.python3_
host_prog='/nix/store/6fldmqmgv3xj72sw8azqgd27aalirjv3-neovim-0.9.5/bin/nvim-python3';vim.g.ruby_host_prog='/nix/store/6fldmqmgv3xj72sw8azqgd27aalirjv3-neovim-0.9.5/bin/nvim-ruby' --cmd set pack
path^=/nix/store/r1ik79k79kv2v5gi0fh0hpcdfmxpp8r0-vim-pack-dir --cmd set rtp^=/nix/store/r1ik79k79kv2v5gi0fh0hpcdfmxpp8r0-vim-pack-dir -u /nix/store/gjd9hdnvwy3h9l8sg0jdfzgyw8kkj6r0-init.lua
```

Note that the `nix flake check` tests fail for me with the following error:

```
ERROR: [null-ls] You required a deprecated builtin (code_actions/eslint.lua), which will be removed in March.
```

But I think this has nothing to do with my change. I'm happy to run tests again, if there is something I'm missing here.

If this PR is accepted then probably the other neovim provider option should be exposed (perl, python, ruby, etc) but I don't have the means to test those atm so didn't include them.