### PR TITLE
plugins/conform: add str type for formatAfterSave

### DIFF
--- a/tests/test-sources/plugins/lsp/conform-nvim.nix
+++ b/tests/test-sources/plugins/lsp/conform-nvim.nix
@@ -94,4 +94,30 @@
       '';
     };
   };
+
+  custom_format_after_save_function = {
+    plugins.conform-nvim = {
+      enable = true;
+
+      formattersByFt = {
+        lua = ["stylua"];
+        python = ["isort" "black"];
+        javascript = [["prettierd" "prettier"]];
+        "*" = ["codespell"];
+        "_" = ["trimWhitespace"];
+      };
+
+      formatAfterSave = ''
+        function(bufnr)
+          if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then
+            return
+          end
+          if not _conform_slow_format_filetypes[vim.bo[bufnr].filetype] then
+            return
+          end
+          return { lsp_fallback = true }
+        end
+      '';
+    };
+  };
 }


### PR DESCRIPTION
this is the same change that was performed previously on formatOnSave in https://github.com/nix-community/nixvim/pull/804

With this change it is possible to define a function to be run in formatAfterSave. It makes possible implementing the recipe to run slow formatters asynchronously: https://github.com/stevearc/conform.nvim/blob/master/doc/recipes.md#automatically-run-slow-formatters-async

pd: I found the devshell to be very nice, easing formatting and testing, thanks! I think I'll integrate that as well in some of my projects :D