### PR TITLE
plugins/none-ls: automatic check for tools packages declaration

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -21,9 +21,6 @@ with lib; let
       alejandra
       asmfmt
       astyle
-      autoflake
-      beancount
-      beautysh
       bibclean
       biome
       buf
@@ -34,13 +31,11 @@ with lib; let
       codespell
       commitlint
       cppcheck
-      cpplint
       csharpier
       deadnix
       dfmt
       djhtml
       djlint
-      dprint
       erlfmt
       fantomas
       fish
@@ -53,7 +48,6 @@ with lib; let
       hclfmt
       isort
       joker
-      jq
       just
       ktlint
       leptosfmt
@@ -61,7 +55,6 @@ with lib; let
       mdl
       mypy
       nixfmt
-      php
       pmd
       prettierd
       proselint
@@ -71,14 +64,11 @@ with lib; let
       rstcheck
       rubocop
       rubyfmt
-      ruff
       rufo
-      rustfmt
       rustywind
       scalafmt
       selene
       semgrep
-      shellcheck
       shellharden
       shfmt
       smlfmt
@@ -86,66 +76,35 @@ with lib; let
       statix
       stylelint
       stylua
-      taplo
-      templ
       tfsec
       topiary
       treefmt
       trivy
-      typos
       typstfmt
       uncrustify
       usort
       vale
       verilator
-      xmlformat
-      xq
       yamlfix
       yamlfmt
       yamllint
       yapf
-      yq
       zprint
       zsh
       ;
     inherit
       (pkgs.nodePackages)
       alex
-      eslint
-      eslint_d
-      fixjson
-      jsonlint
       prettier
       ;
     inherit
       (pkgs.python3.pkgs)
-      autopep8
-      bandit
       black
-      docformatter
-      flake8
-      pycodestyle
-      pydocstyle
-      pylama
-      vulture
-      ;
-    inherit
-      (pkgs.luaPackages)
-      luacheck
-      ;
-    inherit
-      (pkgs.haskellPackages)
-      fourmolu
       ;
     inherit
       (pkgs.phpPackages)
       phpmd
       phpstan
-      psalm
-      ;
-    inherit
-      (pkgs.rubyPackages)
-      htmlbeautifier
       ;
     inherit
       (pkgs.ocamlPackages)
@@ -155,10 +114,7 @@ with lib; let
     bean_format = pkgs.beancount;
     blackd = pkgs.black;
     buildifier = pkgs.bazel-buildtools;
-    cabal_fmt = pkgs.haskellPackages.cabal-fmt;
     cfn_lint = pkgs.python3.pkgs.cfn-lint;
-    chktex = pkgs.texliveMedium;
-    clang_check = pkgs.clang-tools;
     clang_format = pkgs.clang-tools;
     clj_kondo = pkgs.clj-kondo;
     cmake_format = pkgs.cmake-format;
@@ -168,8 +124,6 @@ with lib; let
     cue_fmt = pkgs.cue;
     d2_fmt = pkgs.d2;
     dart_format = pkgs.dart;
-    deno_fmt = pkgs.deno;
-    deno_lint = pkgs.deno;
     dictionary = pkgs.curl;
     dotenv_linter = pkgs.dotenv-linter;
     editorconfig_checker = pkgs.editorconfig-checker;
@@ -192,72 +146,48 @@ with lib; let
     haml_lint = pkgs.mastodon;
     haxe_formatter = pkgs.haxe;
     isortd = pkgs.isort;
-    jsonnetfmt = pkgs.jsonnet;
-    json_tool = pkgs.python3;
-    latexindent = pkgs.texliveMedium;
     ltrs = pkgs.languagetool-rust;
-    lua_format = pkgs.luaformatter;
     markdownlint_cli2 = pkgs.markdownlint-cli2;
     markdownlint = pkgs.nodePackages.markdownlint-cli;
     mix = pkgs.elixir;
     nimpretty = pkgs.nim;
     nixpkgs_fmt = pkgs.nixpkgs-fmt;
     opacheck = pkgs.open-policy-agent;
-    perltidy = pkgs.perlPackages.PerlTidy;
     pg_format = pkgs.pgformatter;
     phpcbf = pkgs.phpPackages.php-codesniffer;
     phpcsfixer = pkgs.phpPackages.php-cs-fixer;
     phpcs = pkgs.phpPackages.php-codesniffer;
     prismaFmt = pkgs.nodePackages.prisma;
-    protoc_gen_lint = pkgs.protobuf;
     ptop = pkgs.fpc;
-    puppet_lint = pkgs.puppet-lint;
     qmlformat = pkgs.qt6.qtdeclarative;
     qmllint = pkgs.qt6.qtdeclarative;
     racket_fixw = pkgs.racket;
     raco_fmt = pkgs.racket;
     rego = pkgs.open-policy-agent;
-    reorder_python_imports = pkgs.python3.pkgs.reorder-python-imports;
     rpmspec = pkgs.rpm;
-    ruff_format = pkgs.ruff;
     sqlformat = pkgs.python3.pkgs.sqlparse;
     staticcheck = pkgs.go-tools;
-    stylish_haskell = pkgs.stylish-haskell;
     surface = pkgs.elixir;
     swift_format = pkgs.swift-format;
     teal = pkgs.luaPackages.tl;
     terraform_fmt = pkgs.terraform;
     terraform_validate = pkgs.terraform;
     tidy = pkgs.html-tidy;
-    trim_newlines = pkgs.gawk;
-    trim_whitespace = pkgs.gawk;
-    tsc = pkgs.typescript;
     verible_verilog_format = pkgs.verible;
-    vfmt = pkgs.vlang;
     vint = pkgs.vim-vint;
     write_good = pkgs.write-good;
-    xmllint = pkgs.libxml2.bin;
-    zigfmt = pkgs.zig;
 
     # Sources not present in nixpkgs
     blade_formatter = null;
-    blue = null;
-    brittany = null;
     bsfmt = null;
     bslint = null;
     cljstyle = null;
     cueimports = null;
-    curlylint = null;
-    dtsfmt = null;
     erb_lint = null;
     forge_fmt = null;
     gccdiag = null;
     gersemi = null;
-    gospel = null;
-    jshint = null;
-    markdown_toc = null;
     markuplint = null;
-    misspell = null;
     mlint = null;
     nginx_beautifier = null;
     npm_groovy_lint = null;
@@ -266,34 +196,25 @@ with lib; let
     perlimports = null;
     pint = null;
     pretty_php = null;
-    puglint = null;
     purs_tidy = null;
-    pyflyby = null;
     pyink = null;
-    pyproject_flake8 = null;
     reek = null;
     regal = null;
     remark = null;
     rescript = null;
     saltlint = null;
-    semistandardjs = null;
     solhint = null;
     spectral = null;
     sqlfmt = null;
     sql_formatter = null;
-    standardjs = null;
-    standardrb = null;
-    standardts = null;
     styler = null;
     stylint = null;
     swiftformat = null;
     swiftlint = null;
-    terrafmt = null;
     textidote = null;
     textlint = null;
     twigcs = null;
     vacuum = null;
-    xo = null;
 
     # Sources without packages
     gitrebase = false;


### PR DESCRIPTION
Add two assertions to ensure that we declare exactly the tools that are supported upstream (no more, no less).

The big cleaning comes from https://github.com/nvimtools/none-ls.nvim/pull/77.