### PR TITLE
plugins/cmp: allow negative values in `col_offset`

### DIFF
--- a/plugins/completion/cmp/options/settings-options.nix
+++ b/plugins/completion/cmp/options/settings-options.nix
@@ -300,7 +300,7 @@ with lib; {
         See |'scrolloff'|.
       '';
 
-      col_offset = helpers.defaultNullOpts.mkUnsignedInt 0 ''
+      col_offset = helpers.defaultNullOpts.mkInt 0 ''
         Offsets the completion window relative to the cursor.
       '';
 


### PR DESCRIPTION
An update broke my configuration. I used a negative int in this option before, everything worked fine 🙂 