### PR TITLE
helpers/mk[Neo]VimPlugin: add colorscheme argument and factor out logic

### DIFF
--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -6,7 +6,7 @@
 with lib; {
   mkVimPlugin = config: {
     name,
-    namespace ? "plugins",
+    colorscheme ? false,
     url ?
       if defaultPackage != null
       then defaultPackage.meta.homepage
@@ -29,6 +29,11 @@ with lib; {
     extraPlugins ? [],
     extraPackages ? [],
   }: let
+    namespace =
+      if colorscheme
+      then "colorschemes"
+      else "plugins";
+
     cfg = config.${namespace}.${name};
 
     # TODO support nested options!
@@ -143,6 +148,11 @@ with lib; {
             # does this evaluate package? it would not be desired to evaluate package if we use another package.
             extraPlugins = extraPlugins ++ optional (defaultPackage != null) cfg.package;
           }
+          (optionalAttrs colorscheme {
+            # We use `mkDefault` here to let individual plugins override this option.
+            # For instance, setting it to `null` a specific way of setting the coloscheme.
+            colorscheme = lib.mkDefault name;
+          })
           (extraConfig cfg)
         ]
       );

--- a/plugins/colorschemes/ayu.nix
+++ b/plugins/colorschemes/ayu.nix
@@ -8,7 +8,7 @@
 with lib;
   helpers.neovim-plugin.mkNeovimPlugin config {
     name = "ayu";
-    namespace = "colorschemes";
+    colorscheme = true;
     originalName = "neovim-ayu";
     defaultPackage = pkgs.vimPlugins.neovim-ayu;
     callSetup = false;
@@ -42,6 +42,9 @@ with lib;
     };
 
     extraConfig = cfg: {
+      # The colorscheme option is set by the `setup` function.
+      colorscheme = null;
+
       extraConfigLuaPre = ''
         local ayu = require("ayu")
         ayu.setup(${helpers.toLuaObject cfg.settings})

--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -7,7 +7,7 @@
 }:
 helpers.neovim-plugin.mkNeovimPlugin config {
   name = "gruvbox";
-  namespace = "colorschemes";
+  colorscheme = true;
   originalName = "gruvbox.nvim";
   defaultPackage = pkgs.vimPlugins.gruvbox-nvim;
 
@@ -56,9 +56,5 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       bright_blue = "#5476b2";
       bright_purple = "#fb4934";
     };
-  };
-
-  extraConfig = cfg: {
-    colorscheme = "gruvbox";
   };
 }

--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -6,8 +6,8 @@
   ...
 }:
 helpers.vim-plugin.mkVimPlugin config {
-  namespace = "colorschemes";
   name = "nord";
+  colorscheme = true;
   originalName = "nord.nvim";
   defaultPackage = pkgs.vimPlugins.nord-nvim;
   globalPrefix = "nord_";
@@ -60,9 +60,5 @@ helpers.vim-plugin.mkVimPlugin config {
     borders = true;
     disable_background = true;
     italic = false;
-  };
-
-  extraConfig = cfg: {
-    colorscheme = "nord";
   };
 }


### PR DESCRIPTION
As we will use more and more those helpers, we should include the logic regarding colorschemes.
Currently we have a `namespace` argument. This new `colorcheme` boolean argument replaces it.

If `true`, it will:
- Set the namespace to `colorschemes`
- Set the `colorscheme` option to `name` (i.e. the name of the plugin).

This will prevent further mistakes such as forgetting to set the colorscheme.