### PR TITLE
plugins/lsp: add ocamllsp, the language server for OCaml

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -67,6 +67,7 @@ in {
         "nil_ls"
         "nixd"
         "nushell"
+        "ocamllsp"
         "ols"
         "omnisharp"
         "perlpls"

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -431,6 +431,11 @@ with lib; let
       cmd = cfg: ["${cfg.package}/bin/nu" "--lsp"];
     }
     {
+      name = "ocamllsp";
+      description = "ocamllsp for OCaml";
+      package = pkgs.ocamlPackages.ocaml-lsp;
+    }
+    {
       name = "ols";
       description = "ols for the Odin programming language";
       package = pkgs.ols;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -125,6 +125,7 @@
           nil_ls.enable = true;
           nixd.enable = true;
           nushell.enable = true;
+          ocamllsp.enable = true;
           ols.enable =
             # ols is not supported on aarch64-linux
             (pkgs.stdenv.hostPlatform.system != "aarch64-linux")


### PR DESCRIPTION
Add the [ocaml-lsp](https://github.com/ocaml/ocaml-lsp) language server.