### PR TITLE
plugins/cmp: fix example for cmdline option

### DIFF
--- a/plugins/completion/cmp/options/default.nix
+++ b/plugins/completion/cmp/options/default.nix
@@ -64,17 +64,13 @@ with lib; rec {
       ":" = {
         mapping.__raw = "cmp.mapping.preset.cmdline()";
         sources = [
-          [
-            {name = "path";}
-          ]
-          [
-            {
-              name = "cmdline";
-              option = {
-                ignore_cmds = ["Man" "!"];
-              };
-            }
-          ]
+          {name = "path";}
+          {
+            name = "cmdline";
+            option = {
+              ignore_cmds = ["Man" "!"];
+            };
+          }
         ];
       };
     };


### PR DESCRIPTION
This example was invalid.
Fixes #1224