### PR TITLE
plugins/lsp: use `attrsOf anything` instead of `attrs` for extraOptions

### DIFF
--- a/plugins/lsp/helpers.nix
+++ b/plugins/lsp/helpers.nix
@@ -77,7 +77,7 @@
 
           extraOptions = mkOption {
             default = {};
-            type = types.attrs;
+            type = types.attrsOf types.anything;
             description = "Extra options for the ${name} language server.";
           };
         };


### PR DESCRIPTION
`attrs` is not merged correctly, this can introduce conflicts with efmls-configs for example when trying to register `efm` sources not defined by efmls-configs.