### PR TITLE
plugins/lsp: add golangci-lint-langserver

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -235,6 +235,12 @@ with lib; let
       description = "gopls for Go";
     }
     {
+      name = "golangci-lint-ls";
+      description = "golangci-lint-ls for Go";
+      serverName = "golangci_lint_ls";
+      package = pkgs.golangci-lint-langserver;
+    }
+    {
       name = "graphql";
       description = "graphql for GraphQL";
       package = pkgs.nodePackages.graphql-language-service-cli;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -107,6 +107,7 @@
           futhark-lsp.enable = true;
           gleam.enable = true;
           gopls.enable = true;
+          golangci-lint-ls.enable = true;
           graphql.enable = true;
           helm-ls.enable = true;
           hls.enable = true;


### PR DESCRIPTION
Adds setup for [golangci-lint-langserver](https://github.com/nametake/golangci-lint-langserver).