### PR TITLE
plugins/lsp: add fortls

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -212,6 +212,7 @@ with lib; let
     }
     {
       name = "fortls";
+      description = "fortls for Fortran";
       cmd = cfg: [
         "${cfg.package}/bin/fortls"
         "--hover_signature"

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -211,6 +211,17 @@ with lib; let
       cmd = cfg: ["${cfg.package}/bin/elixir-ls"];
     }
     {
+      name = "fortls";
+      package = pkgs.fortls;
+      cmd = cfg: [
+        "${cfg.package}/bin/fortls"
+        "--notify_init"
+        "--hover_signature"
+        "--hover_language=fortran"
+        "--use_signature_help"
+      ];
+    }
+    {
       name = "fsautocomplete";
       description = "fsautocomplete for F#";
       package = pkgs.fsautocomplete;

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -212,7 +212,6 @@ with lib; let
     }
     {
       name = "fortls";
-      package = pkgs.fortls;
       cmd = cfg: [
         "${cfg.package}/bin/fortls"
         "--hover_signature"

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -215,7 +215,6 @@ with lib; let
       package = pkgs.fortls;
       cmd = cfg: [
         "${cfg.package}/bin/fortls"
-        "--notify_init"
         "--hover_signature"
         "--hover_language=fortran"
         "--use_signature_help"


### PR DESCRIPTION
Add `fortls` LSP plugin. 

This plugin features numerous options, some of which are experimental. At the moment, I haven't implemented any `settingsOptions` because I'm not sure it's necessary given that the LSP is entirely configured by its command line arguments (it could then be configured through `fortls.cmd = [ ... ]`. Plus, it can be configured via a configuration file. Adding the options in nixvim would add significant maintenance work. However, I'm not closed to the idea of adding the options if you think it's necessary (as mentioned in the contribution guideline).

As for the default options, I've chosen those selected by [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/fortls.lua) (except for the initialization notification one