### PR TITLE
Fix `plugins.gitsigns.base` option missing in init.lua

### DIFF
--- a/plugins/git/gitsigns.nix
+++ b/plugins/git/gitsigns.nix
@@ -340,7 +340,7 @@ in {
           then val
           else {__raw = val.function;};
         setupOptions = {
-          inherit (cfg) worktrees signcolumn numhl linehl trouble yadm;
+          inherit (cfg) worktrees signcolumn numhl linehl trouble yadm base;
           signs = mapAttrs (_: signSetupOptions) cfg.signs;
           on_attach =
             if cfg.onAttach != null


### PR DESCRIPTION
The option `plugins.gitsigns.base` to specify the ref to diff against had no effect because its value wasn't inherited in the setupOptions and thus didn't appear in `init.lua`.