### PR TITLE
plugins/coq: Switch to mkNeovimPlugin

### DIFF
--- a/plugins/completion/coq.nix
+++ b/plugins/completion/coq.nix
@@ -22,7 +22,7 @@ with lib;
       };
     };
 
-    # Introduced 12-03-2022, remove 12-05-2022
+    # TODO: Introduced 12-03-2022, remove 12-05-2022
     optionsRenamedToSettings = [
       "xdg"
       "autoStart"

--- a/tests/test-sources/plugins/completion/coq.nix
+++ b/tests/test-sources/plugins/completion/coq.nix
@@ -1,0 +1,25 @@
+{
+  empty = {
+    plugins.coq-nvim.enable = true;
+  };
+
+  nixvim-defaults = {
+    plugins.coq-nvim = {
+      enable = true;
+
+      settings = {
+        xdg = true;
+        auto_start = true;
+        keymap.recommended = true;
+        completion.always = true;
+      };
+    };
+  };
+
+  artifacts = {
+    plugins.coq-nvim = {
+      enable = true;
+      installArtifacts = true;
+    };
+  };
+}


### PR DESCRIPTION
This allows the user to define additional options unpackaged by nixvim. No new options were defined, nor any old option was deleted.

Fixes #1114