### PR TITLE
Keymaps: Add onEvent key to keymaps to load keymap on specified event

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -131,6 +131,15 @@ with lib; rec {
           default = defaults.lua or false;
         };
 
+        onEvent = mkOption {
+          type = nullOr str;
+          description = ''
+            Register this keymap on the given event, or on each event in the list.
+            If not set, then the keymap will be set like normal.
+          '';
+          default = null;
+        };
+
         options = mapConfigOptions;
       };
     });

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -131,15 +131,6 @@ with lib; rec {
           default = defaults.lua or false;
         };
 
-        onEvent = mkOption {
-          type = nullOr str;
-          description = ''
-            Register this keymap on the given event, or on each event in the list.
-            If not set, then the keymap will be set like normal.
-          '';
-          default = null;
-        };
-
         options = mapConfigOptions;
       };
     });

--- a/tests/test-sources/modules/keymaps.nix
+++ b/tests/test-sources/modules/keymaps.nix
@@ -45,39 +45,37 @@
       ];
   };
 
-  mkKeymapsOnEvent = {
-    keymaps =
-      helpers.keymaps.mkKeymaps
-      {
-        mode = "x";
-        options.silent = true;
-      }
-      [
+  mkKeymapsOnEvents = {
+    keymapsOnEvents = {
+      "InsertEnter" =
+        helpers.keymaps.mkKeymaps
         {
-          mode = "n";
-          key = ",";
-          action = "<cmd>echo \"test\"<cr>";
-          onEvent = "InsertEnter";
+          mode = "x";
+          options.silent = true;
         }
-        {
-          # raw action using rawType
-          key = "<C-p>";
-          action.__raw = "function() print('hello') end";
-          onEvent = "InsertEnter";
-        }
-        {
-          key = "<C-a>";
-          action = "function() print('toto') end";
-          lua = true;
-          options.silent = false;
-          onEvent = "InsertEnter";
-        }
-        {
-          mode = ["n" "v"];
-          key = "<C-z>";
-          action = "bar";
-          onEvent = "InsertEnter";
-        }
-      ];
+        [
+          {
+            mode = "n";
+            key = ",";
+            action = "<cmd>echo \"test\"<cr>";
+          }
+          {
+            # raw action using rawType
+            key = "<C-p>";
+            action.__raw = "function() print('hello') end";
+          }
+          {
+            key = "<C-a>";
+            action = "function() print('toto') end";
+            lua = true;
+            options.silent = false;
+          }
+          {
+            mode = ["n" "v"];
+            key = "<C-z>";
+            action = "bar";
+          }
+        ];
+    };
   };
 }

--- a/tests/test-sources/modules/keymaps.nix
+++ b/tests/test-sources/modules/keymaps.nix
@@ -44,4 +44,40 @@
         }
       ];
   };
+
+  mkKeymapsOnEvent = {
+    keymaps =
+      helpers.keymaps.mkKeymaps
+      {
+        mode = "x";
+        options.silent = true;
+      }
+      [
+        {
+          mode = "n";
+          key = ",";
+          action = "<cmd>echo \"test\"<cr>";
+          onEvent = "InsertEnter";
+        }
+        {
+          # raw action using rawType
+          key = "<C-p>";
+          action.__raw = "function() print('hello') end";
+          onEvent = "InsertEnter";
+        }
+        {
+          key = "<C-a>";
+          action = "function() print('toto') end";
+          lua = true;
+          options.silent = false;
+          onEvent = "InsertEnter";
+        }
+        {
+          mode = ["n" "v"];
+          key = "<C-z>";
+          action = "bar";
+          onEvent = "InsertEnter";
+        }
+      ];
+  };
 }


### PR DESCRIPTION
What the title says.
Groups keymaps by new `onEvent` key and loads with an autocmd.
Allows for easy fix of #1219. Not done here because this PR adds a new feature.

This is definitely not the cleanest code - I've only used nix for configuration so far, so I'd appreciate help on that front! I'm also not sure about how good the tests are either.