### PR TITLE
plugins/alpha: Allow `terminal` to not set `val`

### DIFF
--- a/plugins/utils/alpha.nix
+++ b/plugins/utils/alpha.nix
@@ -22,9 +22,10 @@ with lib; let
         description = "Type of section";
       };
 
-      val = mkOption {
-        type = with helpers.nixvimTypes;
-          oneOf [
+      val =
+        helpers.mkNullOrOption
+        (with helpers.nixvimTypes;
+          nullOr (oneOf [
             # "button", "text"
             str
             # "padding"
@@ -36,10 +37,8 @@ with lib; let
               # "group"
               (attrsOf anything)
             ))
-          ];
-        default = null;
-        description = "Value for section";
-      };
+          ]))
+        "Value for section";
 
       opts = mkOption {
         type = with types; attrsOf anything;

--- a/tests/test-sources/plugins/utils/alpha.nix
+++ b/tests/test-sources/plugins/utils/alpha.nix
@@ -13,6 +13,23 @@
     };
   };
 
+  terminal = {
+    plugins.alpha = {
+      enable = true;
+      layout = [
+        {
+          type = "terminal";
+          command = "thisisfine";
+          width = 46;
+          height = 25;
+          opts = {
+            redraw = true;
+          };
+        }
+      ];
+    };
+  };
+
   custom-layout = {
     plugins.alpha = {
       enable = true;


### PR DESCRIPTION
Fixes #1140