### PR TITLE
colorschemes/base16: set termguicolors to true

### DIFF
--- a/plugins/colorschemes/base16/default.nix
+++ b/plugins/colorschemes/base16/default.nix
@@ -103,6 +103,8 @@ with lib;
           plugins.airline.settings.theme = mkIf cfg.setUpBar "base16";
           plugins.lualine.theme = mkIf cfg.setUpBar "base16";
           plugins.lightline.colorscheme = null;
+
+          options.termguicolors = mkDefault true;
         }
         (mkIf (isString cfg.colorscheme) {
           colorscheme = "base16-${cfg.colorscheme}";


### PR DESCRIPTION
With the rewrite at c2cd3cb7a13c0677c49f46d55a8c65b50b7d9431, the option `useTruecolor` was removed in favor of `options.termguicolors`. `useTruecolor` was set to `true` by default, but this is not done after the removal of this option. This causes the colors to not be set properly. I have set `options.termguicolors` to `true` again to fix this.

Fixes #1264.