### PR TITLE
colorschemes/onedark: switch to onedark.nvim + tests

### DIFF
--- a/plugins/colorschemes/onedark.nix
+++ b/plugins/colorschemes/onedark.nix
@@ -5,23 +5,42 @@
   pkgs,
   ...
 }:
-with lib; let
-  cfg = config.colorschemes.onedark;
-in {
-  options = {
-    colorschemes.onedark = {
-      enable = mkEnableOption "onedark";
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "onedark";
+  isColorscheme = true;
+  originalName = "onedark.nvim";
+  defaultPackage = pkgs.vimPlugins.onedark-nvim;
 
-      package = helpers.mkPackageOption "one" pkgs.vimPlugins.onedark-vim;
+  maintainers = [lib.maintainers.GaetanLepage];
+
+  settingsExample = {
+    colors = {
+      bright_orange = "#ff8800";
+      green = "#00ffaa";
+    };
+    highlights = {
+      "@keyword".fg = "$green";
+      "@string" = {
+        fg = "$bright_orange";
+        bg = "#00ff00";
+        fmt = "bold";
+      };
+      "@function" = {
+        fg = "#0000ff";
+        sp = "$cyan";
+        fmt = "underline,italic";
+      };
+      "@function.builtin".fg = "#0059ff";
     };
   };
 
-  config = mkIf cfg.enable {
-    colorscheme = "onedark";
-    extraPlugins = [cfg.package];
-
-    options = {
-      termguicolors = true;
-    };
+  callSetup = false;
+  colorscheme = null;
+  extraConfig = cfg: {
+    extraConfigLuaPre = ''
+      _onedark = require('onedark')
+      _onedark.setup(${helpers.toLuaObject cfg.settings})
+      _onedark.load()
+    '';
   };
 }

--- a/tests/test-sources/plugins/colorschemes/onedark.nix
+++ b/tests/test-sources/plugins/colorschemes/onedark.nix
@@ -1,0 +1,73 @@
+{
+  empty = {
+    colorschemes.onedark.enable = true;
+  };
+
+  example = {
+    colorschemes.onedark = {
+      enable = true;
+
+      settings = {
+        colors = {
+          bright_orange = "#ff8800";
+          green = "#00ffaa";
+        };
+        highlights = {
+          "@keyword".fg = "$green";
+          "@string" = {
+            fg = "$bright_orange";
+            bg = "#00ff00";
+            fmt = "bold";
+          };
+          "@function" = {
+            fg = "#0000ff";
+            sp = "$cyan";
+            fmt = "underline,italic";
+          };
+          "@function.builtin".fg = "#0059ff";
+        };
+      };
+    };
+  };
+
+  defaults = {
+    colorschemes.onedark = {
+      enable = true;
+
+      settings = {
+        style = "dark";
+        transparent = false;
+        term_colors = true;
+        ending_tildes = false;
+        cmp_itemkind_reverse = false;
+        toggle_style_key = null;
+        toggle_style_list = [
+          "dark"
+          "darker"
+          "cool"
+          "deep"
+          "warm"
+          "warmer"
+          "light"
+        ];
+        code_style = {
+          comments = "italic";
+          keywords = "none";
+          functions = "none";
+          strings = "none";
+          variables = "none";
+        };
+        lualine = {
+          transparent = false;
+        };
+        colors = {};
+        highlights = {};
+        diagnostics = {
+          darker = true;
+          undercurl = true;
+          background = true;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Switch the onedark colorscheme to the [onedark.nvim plugin](https://github.com/navarasu/onedark.nvim).

Fixes #1228 