### PR TITLE
plugins/cmp: add missing renamed-option-module for autoEnableSources

### DIFF
--- a/plugins/completion/cmp/deprecations.nix
+++ b/plugins/completion/cmp/deprecations.nix
@@ -115,6 +115,11 @@ in {
         (newPluginBasePath ++ ["enable"])
       )
       (
+        mkRenamedOptionModule
+        (oldPluginBasePath ++ ["autoEnableSources"])
+        (newPluginBasePath ++ ["autoEnableSources"])
+      )
+      (
         mkRemovedOptionModule
         (oldPluginBasePath ++ ["preselect"])
         ''


### PR DESCRIPTION
As pointed out in #1272, we were lacking the rename warning for `plugins.nvim-cmp.autoEnableSources`.