### PR TITLE
plugins/tmux-navigator: Add keymap config options

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -60,11 +60,7 @@ rec {
       # ["" "n" "v" ...]
       (map ({ short, ... }: short) (attrValues modes));
 
-  mapOptionSubmodule = mkMapOptionSubmodule {
-    hasKey = true;
-    hasAction = true;
-    rawAction = true;
-  };
+  mapOptionSubmodule = mkMapOptionSubmodule { };
 
   mkModeOption =
     default:
@@ -85,9 +81,10 @@ rec {
   mkMapOptionSubmodule =
     {
       defaults ? { },
-      hasKey ? false,
-      hasAction ? false,
-      rawAction ? true,
+      # key and action can be true/false to enable/disable adding the option,
+      # or an attrset to enable the option and add/override mkOption args.
+      key ? true,
+      action ? true,
     }:
     # TODO remove assert once `lua` option is gone
     # This is here to ensure no uses of `mkMapOptionSubmodule` set a `lua` default
@@ -96,22 +93,24 @@ rec {
       with types;
       submodule {
         options =
-          (optionalAttrs hasKey {
+          (optionalAttrs (isAttrs key || key) {
             key = mkOption (
               {
                 type = str;
                 description = "The key to map.";
                 example = "<C-m>";
               }
+              // (optionalAttrs (isAttrs key) key)
               // (optionalAttrs (defaults ? key) { default = defaults.key; })
             );
           })
-          // (optionalAttrs hasAction {
+          // (optionalAttrs (isAttrs action || action) {
             action = mkOption (
               {
-                type = if rawAction then nixvimTypes.maybeRaw str else str;
+                type = nixvimTypes.maybeRaw str;
                 description = "The action to execute.";
               }
+              // (optionalAttrs (isAttrs action) action)
               // (optionalAttrs (defaults ? action) { default = defaults.action; })
             );
           })

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -67,6 +67,31 @@ with lib;
     in
     concatStrings (map processWord words);
 
+  /**
+    Capitalize a string by making the first character uppercase.
+
+    # Example
+
+    ```nix
+    upperFirstChar "hello, world!"
+    => "Hello, world!"
+    ```
+
+    # Type
+
+    ```
+    upperFirstChar :: String -> String
+    ```
+  */
+  upperFirstChar =
+    s:
+    let
+      first = substring 0 1 s;
+      rest = substring 1 (stringLength s) s;
+      result = (toUpper first) + rest;
+    in
+    optionalString (s != "") result;
+
   mkIfNonNull' = x: y: (mkIf (x != null) y);
 
   mkIfNonNull = x: (mkIfNonNull' x x);

--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -198,8 +198,6 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           mode = "n";
           action = "<Cmd>Buffer${funcName}<CR>";
         };
-        hasKey = true;
-        hasAction = true;
       }) "Keymap for function Buffer${funcName}"
     ) keymapsActions;
   };

--- a/plugins/lsp/wtf.nix
+++ b/plugins/lsp/wtf.nix
@@ -36,14 +36,7 @@ in
       keymaps = mapAttrs (
         action: defaults:
         helpers.mkNullOrOption (
-          with types;
-          either str (
-            helpers.keymaps.mkMapOptionSubmodule {
-              inherit defaults;
-              hasKey = true;
-              hasAction = true;
-            }
-          )
+          with types; either str (helpers.keymaps.mkMapOptionSubmodule { inherit defaults; })
         ) "Keymap for the ${action} action."
       ) defaultKeymaps;
 

--- a/plugins/utils/tmux-navigator.nix
+++ b/plugins/utils/tmux-navigator.nix
@@ -6,30 +6,6 @@
   ...
 }:
 with lib;
-let
-  # TODO: Introduced 2024-03-19, remove on 2024-05-19
-  deprecations =
-    let
-      pluginPath = [
-        "plugins"
-        "tmux-navigator"
-      ];
-      option = s: pluginPath ++ [ s ];
-      setting =
-        s:
-        pluginPath
-        ++ [
-          "settings"
-          s
-        ];
-      settingStr = s: concatStringsSep "." (setting s);
-    in
-    [
-      (mkRenamedOptionModule (option "tmuxNavigatorSaveOnSwitch") (setting "save_on_switch"))
-      (mkRemovedOptionModule (option "tmuxNavigatorDisableWhenZoomed") "Use `${settingStr "disable_when_zoomed"}` option.")
-      (mkRemovedOptionModule (option "tmuxNavigatorNoWrap") "Use `${settingStr "no_wrap"}` option.")
-    ];
-in
 helpers.vim-plugin.mkVimPlugin config {
   name = "tmux-navigator";
   originalName = "vim-tmux-navigator";
@@ -89,8 +65,6 @@ helpers.vim-plugin.mkVimPlugin config {
     [no_mappings]: ./settings.html#pluginstmux-navigatorsettingsno_mappings
     [upstream docs]: https://github.com/christoomey/vim-tmux-navigator#installation
   '';
-
-  imports = deprecations;
 
   settingsOptions = {
     save_on_switch =

--- a/plugins/utils/tmux-navigator.nix
+++ b/plugins/utils/tmux-navigator.nix
@@ -121,38 +121,72 @@ helpers.vim-plugin.mkVimPlugin config {
     '';
 
     no_mappings = helpers.defaultNullOpts.mkBool false ''
-      By default `<C-h>`, `<C-j>`, `<C-k>`, `<C-l>`, & `<C-\\>` are mapped to navigating left, down, up, right, & previous, respectively.
+      By default `<C-h>`, `<C-j>`, `<C-k>`, `<C-l>`, & `<C-\\>`
+      are mapped to navigating left, down, up, right, & previous, respectively.
 
       This option disables those default mappings being created.
 
-      You can use the plugin's five commands to define your own custom mappings:
-
-      ```nix
-        keymaps = [
-          {
-            key = "<C-w>h";
-            action = "<cmd>TmuxNavigateLeft<cr>";
-          }
-          {
-            key = "<C-w>j";
-            action = "<cmd>TmuxNavigateDown<cr>";
-          }
-          {
-            key = "<C-w>k";
-            action = "<cmd>TmuxNavigateUp<cr>";
-          }
-          {
-            key = "<C-w>l";
-            action = "<cmd>TmuxNavigateRight<cr>";
-          }
-          {
-            key = "<C-w>\\";
-            action = "<cmd>TmuxNavigatePrevious<cr>";
-          }
-        ];
-      ```
-
-      You will also need to update your tmux bindings to match.
+      You can use `plugins.tmux-navigator.keymaps` to define your own custom mappings.
+      You will also need to **update your tmux bindings** separately,
+      if you want them to match.
     '';
+  };
+
+  extraOptions = {
+    keymaps = mkOption {
+      description = ''
+        Keymaps for the `:TmuxNavigate*` commands.
+
+        Note: by default, tmux-navigator adds its own keymaps.
+        If you wish to disable that behaviour, use `settings.no_mappings`.
+
+        You will also need to **update your tmux bindings** separately,
+        if you want them to match.
+      '';
+      example = [
+        {
+          key = "<C-w>h";
+          action = "left";
+        }
+        {
+          key = "<C-w>j";
+          action = "down";
+        }
+        {
+          key = "<C-w>k";
+          action = "up";
+        }
+        {
+          key = "<C-w>l";
+          action = "right";
+        }
+        {
+          key = "<C-w>\\";
+          action = "previous";
+        }
+      ];
+      default = [ ];
+      type = types.listOf (
+        helpers.keymaps.mkMapOptionSubmodule {
+          action = {
+            description = "The direction in which to navigate.";
+            type = types.enum [
+              "left"
+              "down"
+              "up"
+              "right"
+              "previous"
+            ];
+            example = "left";
+          };
+        }
+      );
+    };
+  };
+
+  extraConfig = cfg: {
+    keymaps = map (
+      mapping: mapping // { action = "<cmd>TmuxNavigate${helpers.upperFirstChar mapping.action}<cr>"; }
+    ) cfg.keymaps;
   };
 }

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -113,6 +113,23 @@ let
       };
       expected = ''{["c"] = { },["d"] = {["g"] = { }}}'';
     };
+
+    testUpperFirstChar = {
+      expr = map helpers.upperFirstChar [
+        "foo"
+        " foo"
+        "foo bar"
+        "UPPER"
+        "mIxEd"
+      ];
+      expected = [
+        "Foo"
+        " foo"
+        "Foo bar"
+        "UPPER"
+        "MIxEd"
+      ];
+    };
   };
 in
 if results == [ ] then

--- a/tests/test-sources/plugins/utils/tmux-navigator.nix
+++ b/tests/test-sources/plugins/utils/tmux-navigator.nix
@@ -9,6 +9,8 @@
     plugins.tmux-navigator = {
       enable = true;
 
+      keymaps = [ ];
+
       settings = {
         save_on_switch = 2;
         disable_when_zoomed = true;
@@ -16,6 +18,37 @@
         no_wrap = true;
         no_mappings = true;
       };
+    };
+  };
+
+  with-keymap = {
+    plugins.tmux-navigator = {
+      enable = true;
+
+      keymaps = [
+        {
+          key = "<C-w>h";
+          action = "left";
+        }
+        {
+          key = "<C-w>j";
+          action = "down";
+        }
+        {
+          key = "<C-w>k";
+          action = "up";
+        }
+        {
+          key = "<C-w>l";
+          action = "right";
+        }
+        {
+          key = "<C-w>\\";
+          action = "previous";
+        }
+      ];
+
+      settings.no_mappings = true;
     };
   };
 }


### PR DESCRIPTION
First time opening a PR here, so let me know if I've missed some etiquette.

#### Summary

- New option `tmuxNavigatorNoMappings` maps to global [`tmux_navigator_no_mappings`](https://github.com/christoomey/vim-tmux-navigator?tab=readme-ov-file#custom-key-bindings)
- New attrset `keymaps` maps keymaps to the various `:TmuxNavigate*` commands
  - Set of either `enum` or `mapConfigOptions` submodule (with some tweaks)

#### Future refactoring

I don't see why the various options should include the `tmuxNavigator` prefix; that is surely implied by being in the tmux-navigator plugin...

I also think that the `null` or `1` options could be refactored as `bool` options, to make more sense in nix...

I can open this as a separate issue/PR if it warrants discussion, or I could lump it into this PR if that's easier to review?