### PR TITLE
Updates flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710281778,
-        "narHash": "sha256-bvWr9vvBrAxb44kHM3H3cY/uQg+4pYP1BM/Nu3e/7V8=",
+        "lastModified": 1710714957,
+        "narHash": "sha256-eZCxuF58YWgaJMMRrn8oRkwRhxooe5kBS/s2wRVr9PA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "49a266d2ca59df8a03249550e73a54626181b65d",
+        "rev": "7b3fca5adcf6c709874a8f2e0c364fe9c58db989",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710281379,
-        "narHash": "sha256-uFo9hxt982L3nFJeweW4Gip2esiGrIQlbvEGrNTh4AY=",
+        "lastModified": 1710717205,
+        "narHash": "sha256-Wf3gHh5uV6W1TV/A8X8QJf99a5ypDSugY4sNtdJDe0A=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "d9ea313bc4851670dc99c5cc979cb79750e7d670",
+        "rev": "bcc8afd06e237df060c85bad6af7128e05fd61a3",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710272261,
-        "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
+        "lastModified": 1710631334,
+        "narHash": "sha256-rL5LSYd85kplL5othxK5lmAtjyMOBg390sGBTb3LRMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ad13a6833440b8e238947e47bea7f11071dc2b2",
+        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
         "type": "github"
       },
       "original": {

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -136,6 +136,7 @@ with lib; let
     gdformat = pkgs.gdtoolkit;
     gdlint = pkgs.gdtoolkit;
     gitsigns = pkgs.git;
+    gleam_format = pkgs.gleam;
     glslc = pkgs.shaderc;
     gn_format = pkgs.gn;
     gofmt = pkgs.go;
@@ -159,6 +160,7 @@ with lib; let
     phpcs = pkgs.phpPackages.php-codesniffer;
     prismaFmt = pkgs.nodePackages.prisma;
     ptop = pkgs.fpc;
+    puppet_lint = pkgs.puppet-lint;
     qmlformat = pkgs.qt6.qtdeclarative;
     qmllint = pkgs.qt6.qtdeclarative;
     racket_fixw = pkgs.racket;
@@ -184,6 +186,7 @@ with lib; let
     cljstyle = null;
     cueimports = null;
     erb_lint = null;
+    findent = null;
     forge_fmt = null;
     gccdiag = null;
     gersemi = null;

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -392,7 +392,7 @@ in {
         delete_to_trash = cfg.deleteToTrash;
         trash_command = cfg.trashCommand;
         prompt_save_on_select_new_entry = cfg.promptSaveOnSelectNewEntry;
-        lsp_rename_autosave = cfg.lspRenameAutosave;
+        lsp_file_methods.autosave_changes = cfg.lspRenameAutosave;
         cleanup_delay_ms = cfg.cleanupDelayMs;
         inherit (cfg) keymaps;
         use_default_keymaps = cfg.useDefaultKeymaps;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -68,6 +68,7 @@
             "dtsfmt"
             "erb_lint"
             "fixjson"
+            "findent"
             "forge_fmt"
             "gccdiag"
             "gersemi"


### PR DESCRIPTION
Updates flake.lock, adding new sources to none-ls, and changing a module option in oil.nvim which has been depreciated in nixpkgs. 