### PR TITLE
plugins/neotest: add playwright adapter

### DIFF
--- a/plugins/neotest/adapters-list.nix
+++ b/plugins/neotest/adapters-list.nix
@@ -46,6 +46,10 @@
   phpunit = {
     treesitter-parser = "php";
   };
+  playwright = {
+    treesitter-parser = "typescript";
+    settingsSuffix = settingsLua: ".adapter(${settingsLua})";
+  };
   plenary = {
     treesitter-parser = "lua";
   };

--- a/plugins/neotest/adapters.nix
+++ b/plugins/neotest/adapters.nix
@@ -8,7 +8,10 @@
 with lib; let
   supportedAdapters = import ./adapters-list.nix;
 
-  mkAdapter = name: {treesitter-parser}: {
+  mkAdapter = name: {
+    treesitter-parser,
+    settingsSuffix ? settingsLua: "(${settingsLua})",
+  }: {
     options.plugins.neotest.adapters.${name} = {
       enable = mkEnableOption name;
 
@@ -37,7 +40,7 @@ with lib; let
           settingsString =
             optionalString
             (cfg.settings != {})
-            "(${helpers.toLuaObject cfg.settings})";
+            (settingsSuffix (helpers.toLuaObject cfg.settings));
         in [
           "require('neotest-${name}')${settingsString}"
         ];

--- a/tests/test-sources/plugins/neotest/default.nix
+++ b/tests/test-sources/plugins/neotest/default.nix
@@ -24,6 +24,7 @@
           minitest.enable = true;
           pest.enable = true;
           phpunit.enable = true;
+          playwright.enable = true;
           plenary.enable = true;
           python.enable = true;
           rspec.enable = true;

--- a/tests/test-sources/plugins/neotest/playwright.nix
+++ b/tests/test-sources/plugins/neotest/playwright.nix
@@ -1,0 +1,47 @@
+{
+  example = {
+    plugins = {
+      treesitter.enable = true;
+      neotest = {
+        enable = true;
+
+        adapters.playwright = {
+          enable = true;
+
+          settings.options = {
+            persist_project_selection = false;
+            enable_dynamic_test_discovery = false;
+            preset = "none";
+            get_playwright_binary.__raw = ''
+              function()
+                return vim.loop.cwd() + "/node_modules/.bin/playwright"
+              end
+            '';
+            get_playwright_config.__raw = ''
+              function()
+                return vim.loop.cwd() + "/playwright.config.ts"
+              end
+            '';
+            get_cwd.__raw = ''
+              function()
+                return vim.loop.cwd()
+              end
+            '';
+            env = {};
+            extra_args = [];
+            filter_dir.__raw = ''
+              function(name, rel_path, root)
+                return name ~= "node_modules"
+              end
+            '';
+            is_test_file.__raw = ''
+              function(file_path)
+                return string.match(file_path, "my-project's-vitest-tests-folder")
+              end
+            '';
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add the playwright neotest adapter.
This one requires the ability to call the adapter differently in the neotest config.