### PR TITLE
docs: optionally add a description to plugins

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -68,9 +68,9 @@ with lib; let
           maintainers = lib.unique (options.config.meta.maintainers."${info.file}" or []);
         in
           "# ${lib.last path}\n\n"
+          + (lib.optionalString (info.url != null) "Url: [${info.url}](${info.url})\n\n")
           + (lib.optionalString (builtins.length maintainers > 0)
             "Maintainers: ${lib.concatStringsSep ", " (builtins.map (m: m.name) maintainers)}\n\n")
-          + (lib.optionalString (info.url != null) "Url: [${info.url}](${info.url})\n\n")
         else null;
     };
 

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -65,12 +65,14 @@ with lib; let
         if builtins.length path >= 2 && lib.hasAttrByPath path nixvimInfo
         then let
           info = lib.getAttrFromPath path nixvimInfo;
-          maintainers = lib.unique (options.config.meta.maintainers."${info.file}" or []);
+          maintainers = lib.unique (options.config.meta.maintainers.${info.file} or []);
+          maintainersNames = builtins.map (m: m.name) maintainers;
         in
           "# ${lib.last path}\n\n"
-          + (lib.optionalString (info.url != null) "Url: [${info.url}](${info.url})\n\n")
+          + (lib.optionalString (info.description != null) "${info.description}\n\n")
+          + (lib.optionalString (info.url != null) "**Url:** [${info.url}](${info.url})\n\n")
           + (lib.optionalString (builtins.length maintainers > 0)
-            "Maintainers: ${lib.concatStringsSep ", " (builtins.map (m: m.name) maintainers)}\n\n")
+            "**Maintainers:** ${lib.concatStringsSep ", " maintainersNames}\n\n")
         else null;
     };
 

--- a/flake-modules/modules.nix
+++ b/flake-modules/modules.nix
@@ -22,6 +22,7 @@
           # Attribute may contain the following fields:
           #  - name: Name of the module
           #  - kind: Either colorschemes or plugins
+          #  - description: A short description of the plugin
           #  - url: Url for the plugin
           #
           #  [kind name] will identify the plugin
@@ -37,12 +38,16 @@
                 # }
                 #
                 # Where <info> is an attrset of the form:
-                # {file = "path"; url = null or "<URL>";}
+                # {
+                #   file = "path";
+                #   description = null or "<DESCRIPTION>";
+                #   url = null or "<URL>";
+                # }
                 merge = _: defs:
                   lib.foldl' (acc: def:
                     lib.recursiveUpdate acc {
                       "${def.value.kind}"."${def.value.name}" = {
-                        inherit (def.value) url;
+                        inherit (def.value) url description;
                         inherit (def) file;
                       };
                     }) {

--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -35,6 +35,7 @@ with lib; rec {
     maintainers,
     url ? defaultPackage.meta.homepage,
     imports ? [],
+    description ? null,
     # deprecations
     deprecateExtraOptions ? false,
     optionsRenamedToSettings ? [],
@@ -62,7 +63,11 @@ with lib; rec {
     meta = {
       inherit maintainers;
       nixvimInfo = {
-        inherit name url;
+        inherit
+          description
+          name
+          url
+          ;
         kind = namespace;
       };
     };

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -12,6 +12,7 @@ with lib; {
       else null,
     maintainers,
     imports ? [],
+    description ? null,
     # deprecations
     deprecateExtraConfig ? false,
     optionsRenamedToSettings ? [],
@@ -72,7 +73,11 @@ with lib; {
     meta = {
       inherit maintainers;
       nixvimInfo = {
-        inherit name url;
+        inherit
+          description
+          name
+          url
+          ;
         kind = namespace;
       };
     };


### PR DESCRIPTION
This adds the `description` field to the `nixvimInfo` attrs.
If not empty, it is then used in the documentation generation.