### PR TITLE
plugins/cmp: fix examples for snippet.expand

### DIFF
--- a/plugins/completion/cmp/options/default.nix
+++ b/plugins/completion/cmp/options/default.nix
@@ -6,7 +6,7 @@ with lib; rec {
   settingsOptions = import ./settings-options.nix {inherit lib helpers;};
 
   settingsExample = {
-    snippet.expand = "luasnip";
+    snippet.expand = "function(args) require('luasnip').lsp_expand(args.body) end";
     mapping.__raw = ''
       cmp.mapping.preset.insert({
         ['<C-b>'] = cmp.mapping.scroll_docs(-4),

--- a/tests/test-sources/plugins/completion/cmp.nix
+++ b/tests/test-sources/plugins/completion/cmp.nix
@@ -6,7 +6,7 @@
   snippet-engine = {
     plugins.cmp = {
       enable = true;
-      settings.snippet.expand = "luasnip";
+      settings.snippet.expand = "function(args) require('luasnip').lsp_expand(args.body) end";
     };
   };
 
@@ -182,7 +182,7 @@
       enable = true;
 
       settings = {
-        snippet.expand = "luasnip";
+        snippet.expand = "function(args) require('luasnip').lsp_expand(args.body) end";
         window = {
           completion.__raw = "cmp.config.window.bordered";
           documentation.__raw = "cmp.config.window.bordered";


### PR DESCRIPTION
This was not adapted to the new implementation.