### PR TITLE
plugins/lsp: add sqls language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -591,6 +591,10 @@ with lib; let
       package = pkgs.sourcekit-lsp;
     }
     {
+      name = "sqls";
+      description = "sqls for SQL";
+    }
+    {
       name = "svelte";
       description = "svelte language server for Svelte";
       package = pkgs.nodePackages.svelte-language-server;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -159,6 +159,7 @@
           # As of 2024-03-11, sourcekit-lsp is broken on aarch64
           # TODO: re-enable this test when fixed
           sourcekit.enable = !pkgs.stdenv.isAarch64;
+          sqls.enable = true;
           svelte.enable = true;
           tailwindcss.enable = true;
           taplo.enable = true;


### PR DESCRIPTION
Add support for the [sqls](https://github.com/sqls-server/sqls) language server for SQL.

Fixes #1231