### PR TITLE
plugins/lsp: nvim 0.10 inlay hints option

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -169,6 +169,8 @@ in {
         visible = false;
       };
 
+      inlayHints = mkEnableOption "LSP inlay hints.";
+
       onAttach = mkOption {
         type = types.lines;
         description = "A lua function to be run when a new LSP buffer is attached. The argument `client` and `bufnr` is provided.";
@@ -259,6 +261,15 @@ in {
       in
         (mkMaps "vim.diagnostic." cfg.keymaps.diagnostic)
         ++ (mkMaps "vim.lsp.buf." cfg.keymaps.lspBuf);
+
+      # Enable inlay-hints
+      plugins.lsp.onAttach = mkIf cfg.inlayHints ''
+        -- LSP Inlay Hints {{{
+        if client.server_capabilities.inlayHintProvider and vim.lsp.inlay_hint then
+          vim.lsp.inlay_hint.enable(bufnr, true)
+        end
+        -- }}}
+      '';
 
       # Enable all LSP servers
       extraConfigLua = ''

--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -151,7 +151,8 @@ with lib; {
       exe = getExe config.package;
       out = pkgs.runCommand "neovim-version" {} "${exe} --version > $out";
       lines = splitString "\n" (readFile out);
-    in removePrefix "NVIM v" (head lines);
+    in
+      removePrefix "NVIM v" (head lines);
   in {
     inherit initPath nvimVersion;
     type = lib.mkForce "lua";


### PR DESCRIPTION
Adds an option to enable neovim 0.10's new LSP inlay hints, on supported language servers.

Also adds a new (read-only) option that exposes nvim's version as reported by `nvim --version`. This will be needed for version-specific warnings/assertions because `lib.getVersion` does not return a useful version for nightly builds.

- [x] Basic inlay hint support (`plugins.lsp.inlayHints`)
- [ ] Tests
- [ ] `versionAtLeast "0.10.0"` warning (or assertion?)
- [x] Access nightly nvim version (can't use `lib.getVersion`)
- [ ] Consider how/if this can be configured for a specific LSP
- [ ] Consider whether this impacts existing options (should they be deprecated?)
  - [ ] [`plugins.clangd-extensions.inlayHints`](https://nix-community.github.io/nixvim/plugins/clangd-extensions/inlayHints.html)
  - [ ] [`plugins.rust-tools.inlayHints`](https://nix-community.github.io/nixvim/plugins/rust-tools/inlayHints.html)
  - [ ] [`plugins.lsp.servers.rust-analyzer.settings.inlayHints`](https://nix-community.github.io/nixvim/plugins/lsp/servers/rust-analyzer/settings/inlayHints/closingBraceHints.html)
  - [ ] Alternatively, maybe those LSPs having an option is preferable to having a global option?
- [ ] Consider how/if we should expose more advanced functionality
  - [ ] Enable only in specific modes
  - [ ] Enable for the current line
  - [ ] Etc

Pushing this draft PR for early feedback/testing, ~~and also in-case I loose interest, someone else can continue the work...~~ :eyes: 

Closes #1306 