### PR TITLE
plugins/lsp: add vhdl-ls

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -645,6 +645,11 @@ with lib; let
       package = pkgs.vala-language-server;
     }
     {
+      name = "vhdl-ls";
+      description = "vhdl_ls for VHDL";
+      serverName = "vhdl_ls";
+    }
+    {
       name = "vls";
       description = "vls for V";
       # The v language server has to be installed from v and thus is not packaged "as is" in

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -170,6 +170,7 @@
           typos-lsp.enable = true;
           typst-lsp.enable = true;
           vala-ls.enable = true;
+          vhdl-ls.enable = true;
           vls.enable = true;
           vuels.enable = true;
           yamlls.enable = true;


### PR DESCRIPTION
Add support for the [vhdl_ls](https://github.com/VHDL-LS/rust_hdl) language server for VHDL.

Fixes #1312