### PR TITLE
LSP: Register keymaps on `LspAttach`

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -260,37 +260,35 @@ in {
     mkIf cfg.enable {
       extraPlugins = [pkgs.vimPlugins.nvim-lspconfig];
 
-      keymapsOnEvents = {
-        "LspAttach" = let
-          mkMaps = prefix:
-            mapAttrsToList
-            (
-              key: action: let
-                actionStr =
-                  if isString action
-                  then action
-                  else action.action;
-                actionProps =
-                  if isString action
-                  then {}
-                  else filterAttrs (n: v: n != "action") action;
-              in {
-                mode = "n";
-                inherit key;
-                action.__raw = prefix + actionStr;
+      keymapsOnEvents.LspAttach = let
+        mkMaps = prefix:
+          mapAttrsToList
+          (
+            key: action: let
+              actionStr =
+                if isString action
+                then action
+                else action.action;
+              actionProps =
+                if isString action
+                then {}
+                else filterAttrs (n: v: n != "action") action;
+            in {
+              mode = "n";
+              inherit key;
+              action = helpers.mkRaw (prefix + actionStr);
 
-                options =
-                  {
-                    inherit (cfg.keymaps) silent;
-                  }
-                  // actionProps;
-              }
-            );
-        in
-          (mkMaps "vim.diagnostic." cfg.keymaps.diagnostic)
-          ++ (mkMaps "vim.lsp.buf." cfg.keymaps.lspBuf)
-          ++ cfg.keymaps.extra;
-      };
+              options =
+                {
+                  inherit (cfg.keymaps) silent;
+                }
+                // actionProps;
+            }
+          );
+      in
+        (mkMaps "vim.diagnostic." cfg.keymaps.diagnostic)
+        ++ (mkMaps "vim.lsp.buf." cfg.keymaps.lspBuf)
+        ++ cfg.keymaps.extra;
 
       # Enable all LSP servers
       extraConfigLua = ''

--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -114,7 +114,7 @@ in {
 
         diagnostic = mkOption {
           type = with types; attrsOf (either str attrs);
-          description = "Mappings for `vim.diagnostic.<action>` functions.";
+          description = "Mappings for `vim.diagnostic.<action>` functions to be added when an LSP is attached.";
           example = {
             "<leader>k" = "goto_prev";
             "<leader>j" = "goto_next";
@@ -124,7 +124,7 @@ in {
 
         lspBuf = mkOption {
           type = with types; attrsOf (either str attrs);
-          description = "Mappings for `vim.lsp.buf.<action>` functions.";
+          description = "Mappings for `vim.lsp.buf.<action>` functions to be added when an LSP it attached.";
           example = {
             "gd" = "definition";
             "gD" = "references";
@@ -137,7 +137,10 @@ in {
 
         extra = mkOption {
           type = with types; listOf helpers.keymaps.mapOptionSubmodule;
-          description = "Extra keymaps to register on 'LspAttach'.";
+          description = ''
+            Extra keymaps to register when an LSP is attached.
+            This can be used to customise LSP behaviour, for example with "telescope" or the "Lspsaga" plugin, as seen in the examples.
+          '';
           example = [
             {
               key = "<leader>lx";

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -27,6 +27,29 @@
             desc = "Hover";
           };
         };
+
+        extra = [
+          {
+            key = "<leader>li";
+            action = "<CMD>LspInfo<Enter>";
+          }
+          {
+            key = "<leader>lx";
+            action = "<CMD>LspStop<Enter>";
+          }
+          {
+            key = "<leader>ls";
+            action = "<CMD>LspStart<Enter>";
+          }
+          {
+            key = "<leader>lr";
+            action = "<CMD>LspRestart<Enter>";
+          }
+          {
+            key = "<leader>ll";
+            action = "<CMD>LspLog<Enter>";
+          }
+        ];
       };
 
       servers = {


### PR DESCRIPTION
Register keymaps defined in `plugins.lsp.keymaps` on `LspAttach`.
Added `plugins.lsp.keymaps.extra` to register arbitrary keymaps.

Fixes #1219 