### PR TITLE
plugins/vim-css-color: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -22,4 +22,14 @@
       {fingerprint = "7082 22EA 1808 E39A 83AC  8B18 4F91 844C ED1A 8299";}
     ];
   };
+  DanielLaing = {
+    email = "daniel@daniellaing.com";
+    matrix = "@bodleum:matrix.org";
+    github = "Bodelum";
+    githubId = 60107449;
+    name = "Daniel Laing";
+    keys = [
+      {fingerprint = "0821 8B96 DC73 85E5 BB7C  A535 D264 3BD2 13BC 0FA8";}
+    ];
+  };
 }

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -25,7 +25,7 @@
   DanielLaing = {
     email = "daniel@daniellaing.com";
     matrix = "@bodleum:matrix.org";
-    github = "Bodelum";
+    github = "Bodleum";
     githubId = 60107449;
     name = "Daniel Laing";
     keys = [

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -186,6 +186,7 @@
     ./utils/toggleterm.nix
     ./utils/undotree.nix
     ./utils/vim-bbye.nix
+    ./utils/vim-css-color.nix
     ./utils/vim-matchup.nix
     ./utils/which-key.nix
     ./utils/wilder.nix

--- a/plugins/utils/vim-css-color.nix
+++ b/plugins/utils/vim-css-color.nix
@@ -1,0 +1,13 @@
+{
+  config,
+  lib,
+  helpers,
+  pkgs,
+  ...
+}:
+helpers.vim-plugin.mkVimPlugin config {
+  name = "vim-css-color";
+  defaultPackage = pkgs.vimPlugins.vim-css-color;
+
+  maintainers = [helpers.maintainers.DanielLaing];
+}

--- a/plugins/utils/vim-css-color.nix
+++ b/plugins/utils/vim-css-color.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   helpers,
   pkgs,
   ...

--- a/tests/test-sources/plugins/utils/vim-css-color.nix
+++ b/tests/test-sources/plugins/utils/vim-css-color.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.vim-css-color.enable = true;
+  };
+}


### PR DESCRIPTION
Add support for [vim-css-color](https://github.com/ap/vim-css-color).
Fixes #1321 