### PR TITLE
wrappers/hm: add vimdiffAlias option

### DIFF
--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -53,5 +53,10 @@ in
       inherit (cfg) warnings assertions;
       home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
     }
+    {
+      programs.bash.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
+      programs.fish.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
+      programs.zsh.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
+    }
   ]);
 }

--- a/wrappers/modules/hm.nix
+++ b/wrappers/modules/hm.nix
@@ -4,5 +4,13 @@ with lib;
   options = {
     enable = mkEnableOption "nixvim";
     defaultEditor = mkEnableOption "nixvim as the default editor";
+
+    vimdiffAlias = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Alias `vimdiff` to `nvim -d`.
+      '';
+    };
   };
 }


### PR DESCRIPTION
Implement the `programs.neovim.vimdiffAlias` option from HM in nixvim.
Note: this only applies to the HM module.

Fixes #1351 