### PR TITLE
docs: Add a section on module specific options

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -69,6 +69,16 @@
       })
     ]
     ++ (rawModules pkgsDoc);
+
+  hmOptions =
+    builtins.removeAttrs
+    (lib.evalModules {
+      modules = [
+        (import ../wrappers/modules/hm.nix {inherit lib;})
+      ];
+    })
+    .options
+    ["_module"];
 in
   rec {
     options-json =
@@ -93,6 +103,6 @@ in
     docs = pkgsDoc.callPackage ./mdbook {
       inherit transformOptions;
       modules = topLevelModules;
-      inherit helpers;
+      inherit helpers hmOptions;
     };
   }

--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -7,6 +7,10 @@
 - [Extending a standalone configuration](./user-guide/extending-config.md)
 - [FAQ](./user-guide/faq.md)
 
+# Module Specific Options
+
+- [Home Manager Usage](./modules/hm.md)
+
 # Options
 
 @NIXVIM_OPTIONS@

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -5,6 +5,7 @@
   helpers,
   nixosOptionsDoc,
   transformOptions,
+  hmOptions,
 }:
 with lib; let
   options = lib.evalModules {
@@ -246,6 +247,7 @@ with lib; let
     cp -r --no-preserve=all $inputs/* ./
     cp ${../../CONTRIBUTING.md} ./CONTRIBUTING.md
     cp -r ${../user-guide} ./user-guide
+    cp -r ${../modules} ./modules
 
     # Copy the generated MD docs into the build directory
     # Using pkgs.writeShellScript helps to avoid the "bash: argument list too long" error
@@ -254,7 +256,10 @@ with lib; let
     # Prepare SUMMARY.md for mdBook
     # Using pkgs.writeText helps to avoid the same error as above
     substituteInPlace ./SUMMARY.md \
-      --replace "@NIXVIM_OPTIONS@" "$(cat ${pkgs.writeText "nixvim-options-summary.md" mdbook.nixvimOptions})"
+      --replace-fail "@NIXVIM_OPTIONS@" "$(cat ${pkgs.writeText "nixvim-options-summary.md" mdbook.nixvimOptions})"
+
+    substituteInPlace ./modules/hm.md \
+      --replace-fail "@HM_OPTIONS@" "$(cat ${mkMDDoc hmOptions})"
   '';
 in
   pkgs.stdenv.mkDerivation {

--- a/docs/modules/hm.md
+++ b/docs/modules/hm.md
@@ -1,0 +1,6 @@
+# Home Manager Usage
+
+All nixvim options are available at `programs.nixvim.*` when nixvim is used in home-manager.
+There are a few home-manager specific options that are documented here.
+
+@HM_OPTIONS@

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -29,12 +29,9 @@ in {
         };
         modules =
           [
-            {
-              options = {
-                enable = mkEnableOption "nixvim";
-                defaultEditor = mkEnableOption "nixvim as the default editor";
-              };
-            }
+            (import ./modules/hm.nix {
+              inherit lib;
+            })
           ]
           ++ shared.topLevelModules;
       };

--- a/wrappers/modules/hm.nix
+++ b/wrappers/modules/hm.nix
@@ -1,0 +1,7 @@
+{lib}:
+with lib; {
+  options = {
+    enable = mkEnableOption "nixvim";
+    defaultEditor = mkEnableOption "nixvim as the default editor";
+  };
+}


### PR DESCRIPTION
This commit only adds Home-Manager specific options, we should add sections for the different kind of modules too.

This is _not_ added to the man docs, as it is more complex. If need arises we could look into how to do it.