### PR TITLE
plugins: Add ccc

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -18,9 +18,7 @@
     github = "MattSturgeon";
     githubId = 5046562;
     name = "Matt Sturgeon";
-    keys = [
-      {fingerprint = "7082 22EA 1808 E39A 83AC  8B18 4F91 844C ED1A 8299";}
-    ];
+    keys = [{fingerprint = "7082 22EA 1808 E39A 83AC  8B18 4F91 844C ED1A 8299";}];
   };
   DanielLaing = {
     email = "daniel@daniellaing.com";
@@ -28,8 +26,14 @@
     github = "Bodleum";
     githubId = 60107449;
     name = "Daniel Laing";
-    keys = [
-      {fingerprint = "0821 8B96 DC73 85E5 BB7C  A535 D264 3BD2 13BC 0FA8";}
-    ];
+    keys = [{fingerprint = "0821 8B96 DC73 85E5 BB7C  A535 D264 3BD2 13BC 0FA8";}];
+  };
+  JanKremer = {
+    email = "mail@jankremer.eu";
+    matrix = "@jankremer:matrix.org";
+    github = "janurskremer";
+    githubId = 79042825;
+    name = "Jan Kremer";
+    keys = [{fingerprint = "20AF 0A65 9F2B 93AD 9184  15D1 A7DA 689C B3B0 78EC";}];
   };
 }

--- a/plugins/utils/ccc.nix
+++ b/plugins/utils/ccc.nix
@@ -1,0 +1,44 @@
+{
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "ccc";
+  originalName = "ccc.nvim";
+  defaultPackage = pkgs.vimPlugins.ccc-nvim;
+
+  maintainers = [helpers.maintainers.JanKremer];
+
+  settingsOptions = {
+    default_color = helpers.defaultNullOpts.mkString "#000000" ''
+      The default color used when a color cannot be picked. It must be HEX format.
+    '';
+
+    highlight_mode = helpers.defaultNullOpts.mkString "bg" ''
+      Option to highlight text foreground or background. It is used to output_line and highlighter.
+      Options: "fg" | "bg" | "foreground" | "background"
+    '';
+
+    lsp = helpers.defaultNullOpts.mkBool true ''
+      Whether to enable nvim-lsp support. The color information is updated in the background and the result is used by |:CccPick| and highlighter.
+    '';
+
+    highlighter.auto_enable = helpers.defaultNullOpts.mkBool false ''
+      Whether to enable automatically on BufEnter.
+    '';
+
+    highlighter.lsp = helpers.defaultNullOpts.mkBool true ''
+      If true, highlight using nvim-lsp. If LS with the color provider is not attached to a buffer, it falls back to highlight with pickers. See also |ccc-option-lsp|.
+    '';
+  };
+
+  settingsExample = {
+    default_color = "#FFFFFF";
+    highlight_mode = "fg";
+    lsp = false;
+    highlighter.auto_enable = true;
+    highlighter.lsp = false;
+  };
+}

--- a/tests/test-sources/plugins/utils/ccc.nix
+++ b/tests/test-sources/plugins/utils/ccc.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.ccc.enable = true;
+  };
+}


### PR DESCRIPTION
This adds [ccc.nvim](https://github.com/uga-rosa/ccc.nvim) which supports `oklab` and `oklch` colors used in modern CSS. nvim-colorizer and vim-css-colors currently don't support those. I added a few basic options. 

I had a few minor issues while testing: 
1. Checks failed with `error: a 'x86_64-linux' with features {} is required to build '/nix/store/idhlbs1ig0jbv59ix6a3dqpf9dziq8nf-nixpkgs-nixvim-doc.drv', but I am a 'x86_64-darwin' with features {apple-virt, benchmark, big-parallel, nixos-test}`. Unfortunately I don't have a Linux machine, is there a way around this?
2. `nix fmt` changed the formatting of the fingerprints in `lib/maintainers.nix`. I committed them anyway as this was the output by `nix fmt` but this could easily be reverted.