### PR TITLE
docs: consolidate standalone usage

### DIFF
--- a/docs/man/default.nix
+++ b/docs/man/default.nix
@@ -34,11 +34,11 @@
       cat \
         ${./nixvim-header-start.5} \
         ${mkMDSection ../user-guide/helpers.md} \
-        ${mkMDSection ../user-guide/extending-config.md} \
         ${mkMDSection ../user-guide/faq.md} \
         ${./nixvim-header-end.5} \
         >$out/nixvim-header.5
     '';
+  # FIXME add platform specific docs to manpage
 in
   runCommand "nixvim-configuration-reference-manpage" {
     nativeBuildInputs = [installShellFiles nixos-render-docs];

--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -4,12 +4,12 @@
 
 - [Installation](./user-guide/install.md)
 - [Helpers](./user-guide/helpers.md)
-- [Extending a standalone configuration](./user-guide/extending-config.md)
 - [FAQ](./user-guide/faq.md)
 
-# Module Specific Options
+# Platforms
 
 - [Home Manager Usage](./modules/hm.md)
+- [Standalone Usage](./modules/standalone.md)
 
 # Options
 

--- a/docs/modules/standalone.md
+++ b/docs/modules/standalone.md
@@ -7,6 +7,21 @@ This is unlike the other modules which typically use a `programs.nixvim.*` prefi
 
 There are **no** standalone-specific options available.
 
+## Using in another configuration
+
+Here is an example on how to integrate into a NixOS or Home-manager configuration when using flakes.
+
+The example assumes your standalone config is the `default` package of a flake, and you've named the input "`nixvim-config`".
+```nix
+{ inputs, system, ... }:
+{
+  # NixOS
+  environment.systemPackages = [ inputs.nixvim-config.packages.${system}.default ];
+  # home-manager
+  home.packages = [ inputs.nixvim-config.packages.${system}.default ];
+}
+```
+
 ## Extending an existing configuration
 
 Given a `nvim` derivation obtained from `makeNixvim` or `makeNivxmiWithModule` it is possible to create a new derivation with additional options.

--- a/docs/modules/standalone.md
+++ b/docs/modules/standalone.md
@@ -1,4 +1,13 @@
-# Extending a standalone configuration
+# Standalone Usage
+
+## Options
+
+When used standalone, nixvim's options are available directly, without any prefix/namespace.
+This is unlike the other modules which typically use a `programs.nixvim.*` prefix.
+
+There are **no** standalone-specific options available.
+
+## Extending an existing configuration
 
 Given a `nvim` derivation obtained from `makeNixvim` or `makeNivxmiWithModule` it is possible to create a new derivation with additional options.
 
@@ -6,7 +15,7 @@ This is done through the `nvim.nixvimExtend` function. This function takes a Nix
 
 This attribute is recursive, meaning that it can be applied an arbitrary number of times.
 
-## Example
+### Example
 
 ```nix
 {makeNixvimWithModule}: let
@@ -24,3 +33,4 @@ in
 ```
 
 This will generate a `init.lua` that will contain the three comments from each stages.
+

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -73,15 +73,6 @@ There are also some helper functions in `<nixvim>.lib.${system}` like:
 
 The nixvim derivation can then be used like any other package!
 
-For more information you can look at the [nixvim standalone flake template](https://github.com/nix-community/nixvim/blob/main/templates/simple/flake.nix).
+For an example, see the [nixvim standalone flake template](https://github.com/nix-community/nixvim/blob/main/templates/simple/flake.nix).
 
-Here is an example on how to integrate into a NixOS or Home-manager configuration when using flake parts (assuming your standalone flake's input is `nixvim-config`):
-```nix
-{ inputs, system, ... }:
-{
-  # NixOS
-  environment.systemPackages = [ inputs.nixvim-config.packages.${system}.default ];
-  # home-manager
-  home.packages = [ inputs.nixvim-config.packages.${system}.default ];
-}
-```
+For more information see [Standalone Usage](../modules/standalone.md).

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -40,9 +40,19 @@ When using flakes you can simply add `nixvim` to the inputs:
 
     # outputs...
 }
+
 ```
 
-## Usage as a module (NixOS, Home-Manager, nix-darwin)
+## Usage
+
+NixVim can be used standalone or as a module for NixOS, home-manager, or nix-darwin.
+
+When used standalone, a custom NixVim derivation is produced that can be used like any other package.
+
+When used as a module, NixVim can be enabled though `programs.nixvim.enable`.
+
+
+### Usage as a module (NixOS, home-manager, nix-darwin)
 
 When using NixVim as a module you must import the NixVim module into your module system.
 The three imports are:
@@ -60,7 +70,9 @@ options as `programs.nixvim.<path>.<to>.<option> = <value>`.
 When you use nixvim as a module, an additional module argument is passed on allowing you to peek through the configuration with `hmConfig`, `nixosConfig`, and `darwinConfig` for home-manager, NixOS, and nix-darwin respectively.
 This is useful is you use nixvim both as part of an environment and as standalone.
 
-## Standalone usage
+If using the home-manager module, see [Home Manager Usage](../modules/hm.md) for more information.
+
+### Standalone usage
 
 When using nixvim as a standalone derivation you can use the following functions, located in `<nixvim>.legacyPackages.${system}`:
 - `makeNixvim`: This function takes an attribute set of options values as arguments


### PR DESCRIPTION
Building on #1355 and in preparation for documenting #1356, attempt to consolidate some of the standalone usage information into a new platform specific guide.

- **Move standalone usage to modules section**
- **move standalone example to platform usage**
- **add usage tldr**
