### PR TITLE
plugins/lsp: add nimls language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -436,6 +436,11 @@ with lib; let
       settings = cfg: {nil = {inherit (cfg) formatting diagnostics;};};
     }
     {
+      name = "nimls";
+      description = "nimls for Nim";
+      package = pkgs.nimlsp;
+    }
+    {
       name = "nixd";
       description = "nixd for Nix";
       package = pkgs.nixd;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -125,6 +125,7 @@
           marksman.enable = true;
           metals.enable = true;
           nil_ls.enable = true;
+          nimls.enable = true;
           nixd.enable = true;
           nushell.enable = true;
           ocamllsp.enable = true;


### PR DESCRIPTION
Add the [nimls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.txt#nimls) language server for Nim.

Fixes #1363