### PR TITLE
fix: replace nixfmt

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -54,7 +54,7 @@ with lib; let
       mdformat
       mdl
       mypy
-      nixfmt
+      nixfmt-rfc-style
       pmd
       prettierd
       proselint


### PR DESCRIPTION
since `nixfmt` package was renamed, this PR replaces the package by the new `nixfmt-rfc-style`.

Related to https://github.com/nix-community/nixvim/issues/1374