### PR TITLE
plugins/lsp: add lexical language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -316,6 +316,10 @@ with lib; let
       description = "lemminx for XML";
     }
     {
+      name = "lexical";
+      description = "lexical for Elixir";
+    }
+    {
       name = "ltex";
       description = "ltex-ls for LanguageTool";
       package = pkgs.ltex-ls;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -143,6 +143,7 @@
           kotlin-language-server.enable = true;
           leanls.enable = true;
           lemminx.enable = true;
+          lexical.enable = true;
           ltex.enable = true;
           lua-ls.enable = true;
           marksman.enable = true;


### PR DESCRIPTION
Add support for the [lexical](https://github.com/lexical-lsp/lexical) language server (for Elixir).