### PR TITLE
plugins/cmake-tools: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -70,4 +70,10 @@
     githubId = 4646110;
     name = "Nikita Shirokov";
   };
+  NathanFelber = {
+    email = "nathan@pascaline.org";
+    github = "nfelber";
+    githubId = 46248772;
+    name = "Nathan Felber";
+  };
 }

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -59,6 +59,7 @@
     ./git/octo.nix
 
     ./languages/clangd-extensions.nix
+    ./languages/cmake-tools.nix
     ./languages/debugprint.nix
     ./languages/godot.nix
     ./languages/haskell-scope-highlighting.nix

--- a/plugins/languages/cmake-tools.nix
+++ b/plugins/languages/cmake-tools.nix
@@ -1,0 +1,165 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "cmake-tools";
+  originalName = "cmake-tools.nvim";
+  defaultPackage = pkgs.vimPlugins.cmake-tools-nvim;
+
+  maintainers = [ helpers.maintainers.NathanFelber ];
+
+  settingsOptions = {
+    cmake_command = helpers.defaultNullOpts.mkStr "cmake" ''
+      This is used to specify cmake command path.
+    '';
+
+    ctest_command = helpers.defaultNullOpts.mkStr "ctest" ''
+      This is used to specify ctest command path.
+    '';
+
+    cmake_regenerate_on_save = helpers.defaultNullOpts.mkBool true ''
+      Auto generate when save CMakeLists.txt.
+    '';
+
+    cmake_generate_options =
+      helpers.defaultNullOpts.mkAttrsOf lib.types.anything { "-DCMAKE_EXPORT_COMPILE_COMMANDS" = 1; }
+        ''
+          This will be passed when invoke `CMakeGenerate`.
+        '';
+
+    cmake_build_options = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { } ''
+      This will be passed when invoke `CMakeBuild`.
+    '';
+
+    cmake_build_directory = helpers.defaultNullOpts.mkStr "out/\${variant:buildType}" ''
+      This is used to specify generate directory for cmake, allows macro expansion, relative to vim.loop.cwd().
+    '';
+
+    cmake_soft_link_compile_commands = helpers.defaultNullOpts.mkBool true ''
+      This will automatically make a soft link from compile commands file to project root dir.
+    '';
+
+    cmake_compile_commands_from_lsp = helpers.defaultNullOpts.mkBool false ''
+      This will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false.
+    '';
+
+    cmake_kits_path = helpers.defaultNullOpts.mkStr null ''
+      This is used to specify global cmake kits path, see CMakeKits for detailed usage.
+    '';
+
+    cmake_variants_message = {
+      short = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { show = true; } ''
+        Whether to show short message.
+      '';
+
+      long =
+        helpers.defaultNullOpts.mkAttrsOf lib.types.anything
+          {
+            show = true;
+            max_length = 40;
+          }
+          ''
+            Whether to show long message.
+          '';
+    };
+
+    cmake_dap_configuration = {
+      name = helpers.defaultNullOpts.mkStr "cpp" ''
+        Name of the launch configuration.
+      '';
+
+      type = helpers.defaultNullOpts.mkStr "codelldb" ''
+        Debug adapter to use.
+      '';
+
+      request = helpers.defaultNullOpts.mkStr "launch" ''
+        Session initiation method.
+      '';
+    };
+
+    cmake_executor = {
+      name = helpers.defaultNullOpts.mkStr "quickfix" ''
+        Name of the executor.
+      '';
+
+      opts = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { } ''
+        The options the executor will get, possible values depend on the executor type.
+      '';
+    };
+
+    cmake_runner = {
+      name = helpers.defaultNullOpts.mkStr "terminal" ''
+        Name of the runner.
+      '';
+
+      opts = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { } ''
+        The options the runner will get, possible values depend on the runner type.
+      '';
+    };
+
+    cmake_notifications = {
+      runner.enabled = helpers.defaultNullOpts.mkBool true "";
+
+      executor.enabled = helpers.defaultNullOpts.mkBool true "";
+
+      spinner =
+        helpers.defaultNullOpts.mkListOf lib.types.str
+          [
+            "⠋"
+            "⠙"
+            "⠹"
+            "⠸"
+            "⠼"
+            "⠴"
+            "⠦"
+            "⠧"
+            "⠇"
+            "⠏"
+          ]
+          ''
+            Icons used for progress display.
+          '';
+
+      refresh_rate_ms = helpers.defaultNullOpts.mkPositiveInt 100 ''
+        How often to iterate icons.
+      '';
+    };
+  };
+
+  settingsExample = {
+    cmake_regenerate_on_save = false;
+    cmake_build_directory = "build/\${variant:buildtype}";
+    cmake_soft_link_compile_commands = false;
+    cmake_dap_configuration = {
+      name = "Launch file";
+      type = "codelldb";
+      request = "launch";
+      program.__raw = ''
+        function()
+          return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+        end
+      '';
+      cwd = "\${workspaceFolder}";
+      stopOnEntry = false;
+    };
+    cmake_executor.name = "toggleterm";
+    cmake_runner.name = "toggleterm";
+    cmake_notifications = {
+      spinner = [
+        "▱▱▱▱▱▱▱"
+        "▰▱▱▱▱▱▱"
+        "▰▰▱▱▱▱▱"
+        "▰▰▰▱▱▱▱"
+        "▰▰▰▰▱▱▱"
+        "▰▰▰▰▰▱▱"
+        "▰▰▰▰▰▰▱"
+        "▰▰▰▰▰▰▰"
+      ];
+      refresh_rate_ms = 80;
+    };
+  };
+}

--- a/tests/test-sources/plugins/languages/cmake-tools.nix
+++ b/tests/test-sources/plugins/languages/cmake-tools.nix
@@ -1,0 +1,190 @@
+{
+  empty = {
+    plugins.cmake-tools.enable = true;
+  };
+
+  default = {
+    plugins.cmake-tools = {
+      enable = true;
+
+      settings = {
+        cmake_command = "cmake";
+        ctest_command = "ctest";
+        cmake_regenerate_on_save = true;
+        cmake_generate_options = {
+          "-DCMAKE_EXPORT_COMPILE_COMMANDS" = 1;
+        };
+        cmake_build_options = { };
+        cmake_build_directory = "out/\${variant:buildType}";
+        cmake_soft_link_compile_commands = true;
+        cmake_compile_commands_from_lsp = false;
+        cmake_kits_path = null;
+
+        cmake_variants_message = {
+          short = {
+            show = true;
+          };
+          long = {
+            show = true;
+            max_length = 40;
+          };
+        };
+
+        cmake_dap_configuration = {
+          name = "cpp";
+          type = "codelldb";
+          request = "launch";
+          stopOnEntry = false;
+          runInTerminal = true;
+          console = "integratedTerminal";
+        };
+
+        cmake_executor = {
+          name = "quickfix";
+          opts = { };
+          default_opts = {
+            quickfix = {
+              show = "always";
+              position = "belowright";
+              size = 10;
+              encoding = "utf-8";
+              auto_close_when_success = true;
+            };
+
+            toggleterm = {
+              direction = "float";
+              close_on_exit = false;
+              auto_scroll = true;
+            };
+
+            overseer = {
+              new_task_opts = {
+                strategy.__unkeyed-1 = "terminal";
+              };
+              on_new_task.__raw = ''
+                function(task) end
+              '';
+            };
+
+            terminal = {
+              name = "Main Terminal";
+              prefix_name = "[CMakeTools]: ";
+              split_direction = "horizontal";
+              split_size = 11;
+
+              single_terminal_per_instance = true;
+              single_terminal_per_tab = true;
+              keep_terminal_static_location = true;
+
+              start_insert = false;
+              focus = false;
+            };
+          };
+        };
+
+        cmake_runner = {
+          name = "terminal";
+          opts = { };
+          default_opts = {
+            quickfix = {
+              show = "always";
+              position = "belowright";
+              size = 10;
+              encoding = "utf-8";
+              auto_close_when_success = true;
+            };
+
+            toggleterm = {
+              direction = "float";
+              close_on_exit = false;
+              auto_scroll = true;
+            };
+
+            overseer = {
+              new_task_opts = {
+                strategy.__unkeyed-1 = "terminal";
+              };
+              on_new_task.__raw = ''
+                function(task) end
+              '';
+            };
+
+            terminal = {
+              name = "Main Terminal";
+              prefix_name = "[CMakeTools]: ";
+              split_direction = "horizontal";
+              split_size = 11;
+              single_terminal_per_instance = true;
+              single_terminal_per_tab = true;
+              keep_terminal_static_location = true;
+              start_insert = false;
+              focus = false;
+            };
+          };
+        };
+
+        cmake_notifications = {
+          runner.enabled = true;
+          executor.enabled = true;
+          spinner = [
+            "⠋"
+            "⠙"
+            "⠹"
+            "⠸"
+            "⠼"
+            "⠴"
+            "⠦"
+            "⠧"
+            "⠇"
+            "⠏"
+          ];
+          refresh_rate_ms = 100;
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.toggleterm.enable = true;
+
+    plugins.cmake-tools = {
+      enable = true;
+
+      settings = {
+        cmake_regenerate_on_save = false;
+        cmake_build_directory = "build/\${variant:buildtype}";
+        cmake_soft_link_compile_commands = false;
+
+        cmake_dap_configuration = {
+          name = "Launch file";
+          type = "codelldb";
+          request = "launch";
+          program.__raw = ''
+            function()
+              return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+            end
+          '';
+          cwd = "\${workspaceFolder}";
+          stopOnEntry = false;
+        };
+
+        cmake_executor.name = "toggleterm";
+        cmake_runner.name = "toggleterm";
+
+        cmake_notifications = {
+          spinner = [
+            "▱▱▱▱▱▱▱"
+            "▰▱▱▱▱▱▱"
+            "▰▰▱▱▱▱▱"
+            "▰▰▰▱▱▱▱"
+            "▰▰▰▰▱▱▱"
+            "▰▰▰▰▰▱▱"
+            "▰▰▰▰▰▰▱"
+            "▰▰▰▰▰▰▰"
+          ];
+          refresh_rate_ms = 80;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
This PR adds the cmake-tools plugin to nixvim.

A substantial part of this plugin's default config sets options for external plugins such as dap or overseer (optional), therefore I didn't create nixvim options for these and used generic attribute sets instead as they seem to be beyond the scope of cmake-tools itself and aren't exhaustive. Please let me know if this is not the right approach - one issue I noticed is that large attribute set default values don't render well in the docs.