### PR TITLE
Format init.lua using StyLua

### DIFF
--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  pkgs,
+}: {
+  /*
+  Write a lua file to the nix store, formatted using stylua.
+
+  # Type
+
+  ```
+  writeLua :: String -> String -> Derivation
+  ```
+
+  # Arguments
+
+  - [name] The name of the derivation
+  - [text] The content of the lua file
+  */
+  writeLua = name: text:
+    pkgs.runCommand name {inherit text;} ''
+      echo -n "$text" > "$out"
+
+      ${lib.getExe pkgs.stylua} \
+        --no-editorconfig \
+        --line-endings Unix \
+        --indent-type Spaces \
+        --indent-width 4 \
+        "$out"
+    '';
+}

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -4,6 +4,7 @@
   _nixvimTests,
   ...
 }: let
+  nixvimBuilders = import ./builders.nix {inherit lib pkgs;};
   nixvimTypes = import ./types.nix {inherit lib nixvimOptions;};
   nixvimUtils = import ./utils.nix {inherit lib _nixvimTests;};
   nixvimOptions = import ./options.nix {inherit lib nixvimTypes nixvimUtils;};
@@ -20,3 +21,4 @@ in
   }
   // nixvimUtils
   // nixvimOptions
+  // nixvimBuilders

--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -2,6 +2,7 @@
   pkgs,
   config,
   lib,
+  helpers,
   ...
 }:
 with lib; {
@@ -115,7 +116,7 @@ with lib; {
       ''
       + config.content;
 
-    init = pkgs.writeText "init.lua" customRC;
+    init = helpers.writeLua "init.lua" customRC;
     initPath = toString init;
 
     extraWrapperArgs = builtins.concatStringsSep " " (


### PR DESCRIPTION
@GaetanLepage mentioned it'd be nice to format `init.lua` using stylua. This PR does that by introducing a new derivation builder `helpers.writeLua`.

The options parameter is mostly there to allow for unforeseen future use-cases. It's currently unused.

This is currently only used for `init.lua`, the other files (e.g. ftplugins) will also need to migrate to `writeLua` to benefit.

In the future, we could expose an option to have either raw, minified, or prettified lua files, although this probably isn't really necessary.
