### PR TITLE
plugins/filetrees/neo-tree: remove deprecated lib.mdDoc call

### DIFF
--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -660,7 +660,7 @@ in {
           '';
       };
       filesystem = {
-        window = mkWindowMappingsOption (lib.mdDoc ''
+        window = mkWindowMappingsOption ''
           ```nix
             {
               H = "toggle_hidden";
@@ -677,7 +677,7 @@ in {
               "]g" = "next_git_modified";
             }
           ```
-        '');
+        '';
         asyncDirectoryScan = helpers.defaultNullOpts.mkEnumFirstDefault ["auto" "always" "never"] ''
           - "auto" means refreshes are async, but it's synchronous when called from the Neotree
           commands.


### PR DESCRIPTION
Per NixOS/nixpkgs#237557, which was merged 10 months ago, lib.mdDoc is a no-op. NixOS/nixpkgs#303841 was recently merged which removes the function and now causes an error in plugins/filetrees/neo-tree.nix. This PR simply removes the wrapping lib.mdDoc function.