### PR TITLE
plugins/lsp: add docker-compose-language-service language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -180,6 +180,11 @@ with lib; let
       package = pkgs.lua54Packages.digestif;
     }
     {
+      name = "docker-compose-language-service";
+      description = "docker-compose-language-service for Docker Compose";
+      serverName = "docker_compose_language_service";
+    }
+    {
       name = "dockerls";
       description = "dockerls for Dockerfile";
       package = pkgs.dockerfile-language-server-nodejs;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -119,6 +119,7 @@
           denols.enable = true;
           dhall-lsp-server.enable = true;
           digestif.enable = true;
+          docker-compose-language-service.enable = true;
           dockerls.enable = true;
           efm.enable = true;
           elmls.enable = true;


### PR DESCRIPTION
Add the [docker-compose-language-service](https://github.com/microsoft/compose-language-service) language server for Docker Compose.

Fixes #1426 