### PR TITLE
Backport `opts` alias to 23.11

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -19,6 +19,12 @@ with lib; {
     };
   };
 
+  # Added to main 2024-03-29
+  # Backported 2024-04-22
+  imports = [
+    (mkAliasOptionModule ["opts"] ["options"])
+  ];
+
   config = {
     extraConfigLuaPre =
       optionalString (config.globals != {}) ''

--- a/tests/test-sources/modules/options.nix
+++ b/tests/test-sources/modules/options.nix
@@ -1,0 +1,10 @@
+{
+  opts-backport = {
+    opts = {};
+  };
+
+  example = {
+    options = {};
+    globals = {};
+  };
+}


### PR DESCRIPTION
To minimize confusion for users following the docs, we could add an `opts` alias to the stable branches.

Unlike the unstable branch, there's no deprecation warning here.

This should be easy to cherry-pick onto older branches if desired.

See #1324