### PR TITLE
plugins/languages/texpresso: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -70,6 +70,7 @@
     ./languages/rustaceanvim.nix
     ./languages/sniprun.nix
     ./languages/tagbar.nix
+    ./languages/texpresso.nix
     ./languages/treesitter/hmts.nix
     ./languages/treesitter/rainbow-delimiters.nix
     ./languages/treesitter/treesitter-context.nix

--- a/plugins/languages/texpresso.nix
+++ b/plugins/languages/texpresso.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+# This plugin has no configuration, so we use `mkVimPlugin` without the `globalPrefix` argument to
+# avoid the creation of the `settings` option.
+  helpers.vim-plugin.mkVimPlugin config {
+    name = "texpresso";
+    originalName = "texpresso.vim";
+    defaultPackage = pkgs.vimPlugins.texpresso-vim;
+
+    maintainers = [maintainers.nickhu];
+
+    extraOptions = {
+      texpressoPackage = mkOption {
+        type = with types; nullOr package;
+        default = pkgs.texpresso;
+        example = null;
+        description = ''
+          The `texpresso` package to use.
+          Set to `null` to not install any package.
+        '';
+      };
+    };
+
+    extraConfig = cfg: {
+      extraPackages = [cfg.texpressoPackage];
+    };
+  }

--- a/tests/test-sources/plugins/languages/texpresso.nix
+++ b/tests/test-sources/plugins/languages/texpresso.nix
@@ -1,0 +1,6 @@
+{pkgs, ...}: {
+  empty = {
+    # texpresso is broken on darwin
+    plugins.texpresso.enable = !pkgs.stdenv.isDarwin;
+  };
+}


### PR DESCRIPTION
There are no configuration options for this package.
This just makes the `texpresso` binary (necessary to use this plugin) available to neovim.