### PR TITLE
misc: allow null in extraPackages

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -1,7 +1,6 @@
 {
   lib,
   config,
-  pkgs,
   ...
 }:
 with lib; let
@@ -34,9 +33,10 @@ in {
     };
 
     extraPackages = mkOption {
-      type = types.listOf types.package;
+      type = with types; listOf (nullOr package);
       default = [];
       description = "Extra packages to be made available to neovim";
+      apply = builtins.filter (p: p != null);
     };
 
     extraPython3Packages = mkOption {

--- a/plugins/git/gitsigns/default.nix
+++ b/plugins/git/gitsigns/default.nix
@@ -150,6 +150,6 @@ with lib;
           `plugins.trouble.enable` is `false`.
           You should maybe enable the `trouble` plugin.
         '';
-      extraPackages = optional (cfg.gitPackage != null) cfg.gitPackage;
+      extraPackages = [cfg.gitPackage];
     };
   }

--- a/plugins/languages/godot.nix
+++ b/plugins/languages/godot.nix
@@ -36,9 +36,6 @@ with lib;
     };
 
     extraConfig = cfg: {
-      extraPackages =
-        optional
-        (cfg.godotPackage != null)
-        cfg.godotPackage;
+      extraPackages = [cfg.godotPackage];
     };
   }

--- a/plugins/languages/lean.nix
+++ b/plugins/languages/lean.nix
@@ -252,7 +252,7 @@ in {
       }
     ];
 
-    extraPackages = optional (cfg.leanPackage != null) cfg.leanPackage;
+    extraPackages = [cfg.leanPackage];
 
     extraConfigLua = let
       setupOptions = with cfg;

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -48,7 +48,7 @@ with helpers.vim-plugin;
     };
 
     extraConfig = cfg: {
-      extraPackages = optional (cfg.ledgerPackage != null) cfg.ledgerPackage;
+      extraPackages = [cfg.ledgerPackage];
     };
 
     settingsOptions = {

--- a/plugins/languages/rust-tools.nix
+++ b/plugins/languages/rust-tools.nix
@@ -133,7 +133,7 @@ in {
     };
   config = mkIf cfg.enable {
     extraPlugins = with pkgs.vimPlugins; [nvim-lspconfig cfg.package];
-    extraPackages = optional (cfg.serverPackage != null) cfg.serverPackage;
+    extraPackages = [cfg.serverPackage];
 
     plugins.lsp.postConfig = let
       options =

--- a/plugins/languages/rustaceanvim.nix
+++ b/plugins/languages/rustaceanvim.nix
@@ -238,10 +238,7 @@ in {
   config = mkIf cfg.enable {
     extraPlugins = [cfg.package];
 
-    extraPackages =
-      optional
-      (cfg.rustAnalyzerPackage != null)
-      cfg.rustAnalyzerPackage;
+    extraPackages = [cfg.rustAnalyzerPackage];
 
     plugins.lsp.postConfig = let
       globalOptions = with cfg;

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -213,12 +213,11 @@ in {
         if cfg.nixGrammars
         then [(cfg.package.withPlugins (_: cfg.grammarPackages))]
         else [cfg.package];
-      extraPackages = with pkgs;
-        [
-          tree-sitter
-          nodejs
-        ]
-        ++ optional (cfg.gccPackage != null) cfg.gccPackage;
+      extraPackages = with pkgs; [
+        tree-sitter
+        nodejs
+        cfg.gccPackage
+      ];
 
       opts = mkIf cfg.folding {
         foldmethod = "expr";

--- a/plugins/languages/vimtex.nix
+++ b/plugins/languages/vimtex.nix
@@ -87,11 +87,9 @@ with lib;
           .${cfg.settings.view_method}
           or [];
       in
-        (
-          optional
-          (cfg.texlivePackage != null)
+        [
           cfg.texlivePackage
-        )
+        ]
         ++ viewerPackages;
     };
   }

--- a/plugins/lsp/helpers.nix
+++ b/plugins/lsp/helpers.nix
@@ -86,10 +86,7 @@
       config =
         mkIf cfg.enable
         {
-          extraPackages =
-            optional
-            (cfg.package != null)
-            cfg.package;
+          extraPackages = [cfg.package];
 
           plugins.lsp.enabledServers = [
             {

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -363,11 +363,9 @@ in {
         )
         enabledSources;
       plugins.gitsigns.enable = mkIf gitsignsEnabled true;
-      extraPackages = builtins.filter (p: p != null) (
-        builtins.map (
-          source: source.package or null
-        )
-        enabledSources
-      );
+      extraPackages =
+        map
+        (source: source.package or null)
+        enabledSources;
     };
 }

--- a/plugins/utils/clipboard-image.nix
+++ b/plugins/utils/clipboard-image.nix
@@ -134,10 +134,7 @@ in {
   config = mkIf cfg.enable {
     extraPlugins = [cfg.package];
 
-    extraPackages =
-      optional
-      (cfg.clipboardPackage != null)
-      cfg.clipboardPackage;
+    extraPackages = [cfg.clipboardPackage];
 
     extraConfigLua = let
       setupOptions =

--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -271,7 +271,7 @@ in {
   in
     mkIf cfg.enable {
       extraPlugins = [cfg.package];
-      extraPackages = optional (cfg.ripgrepPackage != null) cfg.ripgrepPackage;
+      extraPackages = [cfg.ripgrepPackage];
       extraConfigLua = ''
         require("todo-comments").setup${helpers.toLuaObject setupOptions}
       '';


### PR DESCRIPTION
=> This is a proposal and expects discussion.

## Current situation
Currently, the `extraPackages` option has type `listOf package`.
Furthermore, we often rely on _optional_ package options (i.e. typed as `nullOr package`) where `null` means: "do not install any package".

Then, the implementation looks like this:
```nix
extraPackages =
  optional
  (cfg.fooPackage == null)
  cfg.fooPackage;
```

## Proposition:
Have `extraOptions` to be typed `listOf (nullOr package)`. I.e., make it accept `null`.

### Pros:
- Further reduce boilerplate. Simplify the snippet above to
```nix
extraPackages = [cfg.fooPackage];
```

### Cons:
- Reduction in clarity. -> More prone to errors/omission.

What is your opinion about this ?