### PR TITLE
[23.11] colorschemes/gruvbox: switch to vimPlugins.gruvbox plugin

### DIFF
--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -13,7 +13,7 @@ in {
     colorschemes.gruvbox = {
       enable = mkEnableOption "gruvbox";
 
-      package = helpers.mkPackageOption "gruvbox" pkgs.vimPlugins.gruvbox-nvim;
+      package = helpers.mkPackageOption "gruvbox" pkgs.vimPlugins.gruvbox;
 
       italics = mkEnableOption "italics";
       bold = mkEnableOption "bold text";


### PR DESCRIPTION
The `gruvbox` module wrongly uses the lua `gruvbox.nvim` plugin. Hence, the module is ineffective.

Fixes #1424