### PR TITLE
plugins/lsp: add ast-grep language server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -16,6 +16,14 @@ with lib; let
       cmd = cfg: ["${cfg.package}/bin/ansible-language-server" "--stdio"];
     }
     {
+      name = "ast-grep";
+      description = ''
+        ast-grep(sg) is a fast and polyglot tool for code structural search, lint, rewriting at large scale.
+        ast-grep LSP only works in projects that have `sgconfig.y[a]ml` in their root directories.
+      '';
+      serverName = "ast_grep";
+    }
+    {
       name = "astro";
       description = "astrols for Astro";
       package = pkgs.nodePackages."@astrojs/language-server";

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -104,6 +104,7 @@
 
         servers = {
           ansiblels.enable = true;
+          ast-grep.enable = true;
           astro.enable = true;
           bashls.enable = true;
           beancount.enable = true;


### PR DESCRIPTION
Add support for the [ast-grep](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ast_grep) language server.

Fixes #1463 