### PR TITLE
plugins/lsp/ccls: fix initOptions

### DIFF
--- a/plugins/lsp/language-servers/ccls.nix
+++ b/plugins/lsp/language-servers/ccls.nix
@@ -268,6 +268,6 @@ in {
   config =
     mkIf cfg.enable
     {
-      plugins.lsp.servers.pylsp.extraOptions.init_options = cfg.initOptions;
+      plugins.lsp.servers.ccls.extraOptions.init_options = cfg.initOptions;
     };
 }


### PR DESCRIPTION
ccls wasn't passing the init options to it's own configuration so they were being ignored..