### PR TITLE
ci: introduce `nixf-tidy-action`

### DIFF
--- a/.github/workflows/nixf-tidy-action.yaml
+++ b/.github/workflows/nixf-tidy-action.yaml
@@ -1,0 +1,25 @@
+name: nixf-tidy code linter
+
+on:
+  [ pull_request ]
+
+jobs:
+  nixf-tidy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        extra_nix_config: |
+          trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://nix-community.cachix.org https://cache.nixos.org/
+    - run: nix profile install github:nix-community/nixd#nixd
+    - uses: inclyc/nixf-tidy-action@v1


### PR DESCRIPTION
nixf-tidy-action is a nix linter based on libnixf. It detects deadcode, unused `rec`, and syntax errors. 

nixf-tidy-action will only report warnings on changed files in diff (thus it will not be very pedantic).

![nixf-sample](https://discourse.nixos.org/uploads/default/optimized/3X/a/f/af8abbdc32b4d27f525170e45c57812816dba674_2_986x1000.png)