### PR TITLE
plugins/lspkind: vim_after undefined variable

### DIFF
--- a/plugins/completion/lspkind.nix
+++ b/plugins/completion/lspkind.nix
@@ -79,7 +79,7 @@ in
             function(entry, vim_item)
               local kind = require('lspkind').cmp_format(${helpers.toLuaObject options})(entry, vim_item)
 
-              return (${cfg.cmp.after})(entry, vim_after, kind)
+              return (${cfg.cmp.after})(entry, vim_item, kind)
             end
           ''
         else


### PR DESCRIPTION
I think this is what should go there, I was checking and vim_after does not exist.

If I am wrong, feel free to reject the PR.