### PR TITLE
plugins/lsp: add nginx-language-server

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -417,6 +417,11 @@ with lib; let
       description = "metals for Scala";
     }
     {
+      name = "nginx-language-server";
+      description = "nginx-language-server for `nginx.conf`";
+      serverName = "nginx_language_server";
+    }
+    {
       name = "nil_ls";
       description = "nil for Nix";
       package = pkgs.nil;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -150,6 +150,7 @@
           lua-ls.enable = true;
           marksman.enable = true;
           metals.enable = true;
+          nginx-language-server.enable = true;
           nil_ls.enable = true;
           nimls.enable = true;
           nixd.enable = true;


### PR DESCRIPTION
Add support for the [nginx-language-server](https://github.com/pappasam/nginx-language-server).

Fixes #1435 