### PR TITLE
plugins/cmp-fish: add fishPackage option

### DIFF
--- a/plugins/completion/cmp/sources/cmp-fish.nix
+++ b/plugins/completion/cmp/sources/cmp-fish.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.plugins.cmp-fish;
+in {
+  meta.maintainers = [maintainers.GaetanLepage];
+
+  options.plugins.cmp-fish = {
+    fishPackage = mkOption {
+      type = with types; nullOr package;
+      default = pkgs.fish;
+      example = "null";
+      description = ''
+        Which package to use for `fish`.
+        Set to `null` to disable its automatic installation.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    extraPackages = [cfg.fishPackage];
+  };
+}

--- a/plugins/completion/cmp/sources/default.nix
+++ b/plugins/completion/cmp/sources/default.nix
@@ -21,6 +21,7 @@ in {
     [
       ./codeium-nvim.nix
       ./copilot-cmp.nix
+      ./cmp-fish.nix
       ./cmp-tabby.nix
       ./cmp-tabnine.nix
       ./crates-nvim.nix


### PR DESCRIPTION
Auto-installs `fish` when using the `cmp-fish` completion source.