### PR TITLE
colorschemes/cyberdream: init

### DIFF
--- a/plugins/colorschemes/cyberdream.nix
+++ b/plugins/colorschemes/cyberdream.nix
@@ -1,0 +1,88 @@
+{
+  config,
+  lib,
+  helpers,
+  pkgs,
+  ...
+}:
+with lib;
+  helpers.neovim-plugin.mkNeovimPlugin config {
+    name = "cyberdream";
+    isColorscheme = true;
+    originalName = "cyberdream.nvim";
+    defaultPackage = pkgs.vimPlugins.cyberdream-nvim;
+
+    maintainers = [helpers.maintainers.AndresBermeoMarinelli];
+
+    settingsOptions = {
+      transparent = helpers.defaultNullOpts.mkBool false ''
+        Enable transparent background.
+      '';
+
+      italic_comments = helpers.defaultNullOpts.mkBool false ''
+        Enable italics comments.
+      '';
+
+      hide_fillchars = helpers.defaultNullOpts.mkBool false ''
+        Replace all fillchars with ' ' for the ultimate clean look.
+      '';
+
+      borderless_telescope = helpers.defaultNullOpts.mkBool true ''
+        Modern borderless telescope theme.
+      '';
+
+      terminal_colors = helpers.defaultNullOpts.mkBool true ''
+        Set terminal colors used in `:terminal`.
+      '';
+
+      theme = {
+        highlights = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight "{}" ''
+          Highlight groups to override, adding new groups is also possible.
+          See `:h highlight-groups` for a list of highlight groups.
+
+          Example:
+
+          ```nix
+          {
+            Comment = {
+              fg = "#696969";
+              bg = "NONE";
+              italic = true;
+            };
+          }
+          ```
+
+          Complete list can be found in `lua/cyberdream/theme.lua` in upstream repository.
+        '';
+
+        colors = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+          Override the default colors used.
+
+          For a full list of colors, see upstream documentation.
+        '';
+      };
+    };
+
+    settingsExample = {
+      transparent = true;
+      italic_comments = true;
+      hide_fillchars = true;
+      borderless_telescope = true;
+      terminal_colors = true;
+
+      theme = {
+        highlights = {
+          Comment = {
+            fg = "#696969";
+            bg = "NONE";
+            italic = true;
+          };
+        };
+        colors = {
+          bg = "#000000";
+          green = "#00ff00";
+          magenta = "#ff00ff";
+        };
+      };
+    };
+  }

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -8,6 +8,7 @@
     ./colorschemes/ayu.nix
     ./colorschemes/base16
     ./colorschemes/catppuccin.nix
+    ./colorschemes/cyberdream.nix
     ./colorschemes/dracula.nix
     ./colorschemes/gruvbox.nix
     ./colorschemes/kanagawa.nix

--- a/tests/test-sources/plugins/colorschemes/cyberdream.nix
+++ b/tests/test-sources/plugins/colorschemes/cyberdream.nix
@@ -1,0 +1,67 @@
+{
+  empty = {
+    colorschemes.cyberdream.enable = true;
+  };
+
+  defaults = {
+    colorschemes.cyberdream = {
+      enable = true;
+
+      settings = {
+        transparent = false;
+        italic_comments = false;
+        hide_fillchars = false;
+
+        borderless_telescope = true;
+        terminal_colors = true;
+
+        theme = {
+          highlights = {};
+          colors = {};
+        };
+      };
+    };
+  };
+
+  example = {
+    colorschemes.cyberdream = {
+      enable = true;
+
+      settings = {
+        transparent = false;
+        italic_comments = false;
+        hide_fillchars = false;
+
+        borderless_telescope = true;
+        terminal_colors = true;
+
+        theme = {
+          highlights = {
+            Comment = {
+              fg = "#696969";
+              bg = "NONE";
+              italic = true;
+            };
+            SpellBad = {
+              fg = "red";
+              style = "undercurl,underdashed,italic";
+            };
+            ErrorMsg = {
+              fg = "#000000";
+              bg = "#000000";
+              style = {
+                undercurl = true;
+                italic = true;
+              };
+            };
+          };
+          colors = {
+            bg = "#000000";
+            green = "#00ff00";
+            magenta = "#ff00ff";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
This PR adds the [cyberdream.nvim](https://github.com/scottmckendry/cyberdream.nvim) colorscheme.

closes #1471 