### PR TITLE
Add 'setFile' option to plugins.harpoon.keymaps

### DIFF
--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -56,6 +56,18 @@ in
         };
       '';
 
+      setFile = helpers.mkNullOrOption (with types; attrsOf str) ''
+        Keymaps for setting a specific mark.
+
+          Examples:
+          setFile = {
+            "1" = "<C-j>";
+            "2" = "<C-k>";
+            "3" = "<C-l>";
+            "4" = "<C-m>";
+          };
+      '';
+
       navNext = helpers.mkNullOrOption types.str ''
         Keymap for navigating to next mark.";
       '';
@@ -239,6 +251,7 @@ in
           allMappings =
             simpleMappings
             ++ (mkNavMappings "navFile" (id: "function() require('harpoon.ui').nav_file(${id}) end"))
+            ++ (mkNavMappings "setFile" (id: "function() require('harpoon.mark').set_current_at(${id}) end"))
             ++ (mkNavMappings "gotoTerminal" (id: "function() require('harpoon.term').gotoTerminal(${id}) end"))
             ++ (mkNavMappings "tmuxGotoTerminal" (
               id: "function() require('harpoon.tmux').gotoTerminal(${id}) end"

--- a/tests/test-sources/plugins/utils/harpoon.nix
+++ b/tests/test-sources/plugins/utils/harpoon.nix
@@ -29,6 +29,12 @@
           "3" = "<C-l>";
           "4" = "<C-m>";
         };
+        setFile = {
+          "1" = "<A-j>";
+          "2" = "<A-k>";
+          "3" = "<A-l>";
+          "4" = "<A-m>";
+        };
         navNext = "<leader>b";
         navPrev = "<leader>c";
         gotoTerminal = {


### PR DESCRIPTION
Harpoon allows appending buffers to the jump list, which is implemented in nixvim via `plugins.harpoon.keymaps.addFile`

There is also a secondary option, that allows to directly set an entry on the jump list via `require('harpoon.mark').set_current_at(<index>)`. This functionality is currently missing from nixvim

This PR aims to add that functionality via `plugins.harpoon.keamaps.setFile`

Please note that this is my first ever pull request, so any feedback is greatly appreciated!
(e.g. I'm unsure about reusing `mkNavMappings`, since this is not technically navigation itself)

`nix flake check --all-systems` runs through `x86_64-linux` and `aarch64-linux`, but then stops at `x86_64-darwin` and `aarch64-darwin`, since I'm not on a darwin system. If there is a way for me to run these checks, feel free to let me know and I will do so.