### PR TITLE
Fix statuscol.nvim option type

### DIFF
--- a/plugins/ui/statuscol.nix
+++ b/plugins/ui/statuscol.nix
@@ -43,7 +43,8 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           freeformType = with types; attrsOf anything;
           options = {
             text = mkOption {
-              type = with helpers.nixvimTypes; listOf (either str rawLua);
+              type = with helpers.nixvimTypes; nullOr (listOf (either str rawLua));
+              default = null;
               description = "Segment text.";
               example = [ "%C" ];
             };

--- a/tests/test-sources/plugins/ui/statuscol.nix
+++ b/tests/test-sources/plugins/ui/statuscol.nix
@@ -33,6 +33,11 @@
             ];
             click = "v:lua.ScLa";
           }
+          {
+            sign = {
+              name = [ ".*" ];
+            };
+          }
         ];
         clickmod = "c";
         clickhandlers = {


### PR DESCRIPTION
The `statuscol.nvim` plugin allows for segments to not specify a `text` attribute (see [example](https://user-images.githubusercontent.com/31730729/230627808-de0b1e97-116d-4016-b4ba-cb709dfcd980.png) in [the plugin's README](https://github.com/luukvbaal/statuscol.nvim/blob/main/README.md).

This PR makes the respective nixvim option nullable and sets it to null by default.