### PR TITLE
plugins/rustaceanvim: fix onAttach option

### DIFF
--- a/plugins/languages/rust/rustaceanvim.nix
+++ b/plugins/languages/rust/rustaceanvim.nix
@@ -282,7 +282,7 @@ in
             };
             server = with server; {
               auto_attach = autoAttach;
-              on_attach = onAttach;
+              on_attach = if onAttach == null then helpers.mkRaw "__lspOnAttach" else onAttach;
               inherit
                 cmd
                 settings


### PR DESCRIPTION
The rustaceanvim plugin never attaches to lsp-format even though the documentation mentions it should:

```
plugins.rustaceanvim.server.onAttach

Function to call on attach

Plugin default: __lspOnAttach
```

but `__lspOnAttach` is never set when the option is null
