### PR TITLE
plugins/lsp-format: fix setup example

### DIFF
--- a/plugins/lsp/lsp-format.nix
+++ b/plugins/lsp/lsp-format.nix
@@ -45,7 +45,7 @@ in
         });
       description = "The setup option maps |filetypes| to format options.";
       example = {
-        gopls = {
+        go = {
           exclude = [ "gopls" ];
           order = [
             "gopls"

--- a/tests/test-sources/plugins/lsp/lsp-format.nix
+++ b/tests/test-sources/plugins/lsp/lsp-format.nix
@@ -21,7 +21,7 @@
         enable = true;
 
         setup = {
-          gopls = {
+          go = {
             exclude = [ "gopls" ];
             order = [
               "gopls"


### PR DESCRIPTION
The `setup` table should have filetypes as keys, not language server names.
So it should be `go` instead of `gopls`.