### PR TITLE
plugins/telescope: support non-builtin keymaps

### DIFF
--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -90,7 +90,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       {
         mode = mapping.mode or "n";
         inherit key;
-        action.__raw = "require('telescope.builtin').${actionStr}";
+        action = "<cmd>Telescope ${actionStr}<cr>";
 
         options = {
           silent = cfg.keymapsSilent;

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -20,7 +20,19 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   deprecateExtraOptions = true;
   optionsRenamedToSettings = [ "defaults" ];
 
-  imports = [ ./extensions ];
+  imports = [
+    ./extensions
+
+    # TODO introduced 2024-05-24: remove 2024-08-24
+    (mkRemovedOptionModule
+      [
+        "plugins"
+        "telescope"
+        "keymapsSilent"
+      ]
+      "This option no longer has any effect now that the `plugin.telescope.keymaps` implementation uses `<cmd>`."
+    )
+  ];
 
   extraOptions = {
     keymaps = mkOption {
@@ -44,12 +56,6 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           options.desc = "Telescope Git Files";
         };
       };
-    };
-
-    keymapsSilent = mkOption {
-      type = types.bool;
-      description = "Whether telescope keymaps should be silent";
-      default = false;
     };
 
     highlightTheme = mkOption {
@@ -91,10 +97,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         mode = mapping.mode or "n";
         inherit key;
         action = "<cmd>Telescope ${actionStr}<cr>";
-
-        options = {
-          silent = cfg.keymapsSilent;
-        } // (mapping.options or { });
+        options = mapping.options or { };
       }
     ) cfg.keymaps;
 

--- a/tests/test-sources/plugins/telescope/default.nix
+++ b/tests/test-sources/plugins/telescope/default.nix
@@ -14,7 +14,6 @@
           options.desc = "Telescope Git Files";
         };
       };
-      keymapsSilent = true;
       highlightTheme = "gruvbox";
     };
   };


### PR DESCRIPTION
Use the `:Telescope` command instead of relying directly on
`require("telescope.builtin")`.

To quote [upstream docs](https://github.com/nvim-telescope/telescope.nvim?tab=readme-ov-file#vim-commands):

> All `telescope.nvim` functions are wrapped in vim commands for easy access, tab completions and setting options.

Fixes #1493