### PR TITLE
modules/commands: allow lua commands, fix nargs

### DIFF
--- a/modules/commands.nix
+++ b/modules/commands.nix
@@ -9,7 +9,7 @@ let
   commandAttributes = types.submodule {
     options = {
       command = mkOption {
-        type = types.str;
+        type = with helpers.nixvimTypes; either str rawLua;
         description = "The command to run.";
       };
 

--- a/modules/commands.nix
+++ b/modules/commands.nix
@@ -16,8 +16,8 @@ let
       nargs =
         helpers.mkNullOrOption
           (types.enum [
-            "0"
-            "1"
+            0
+            1
             "*"
             "?"
             "+"

--- a/tests/test-sources/modules/commands.nix
+++ b/tests/test-sources/modules/commands.nix
@@ -4,6 +4,7 @@
       "W" = {
         command = ":w<CR>";
         desc = "Write file";
+        nargs = 0;
       };
       "Z" = {
         command = ":echo fooo<CR>";

--- a/tests/test-sources/modules/commands.nix
+++ b/tests/test-sources/modules/commands.nix
@@ -9,6 +9,14 @@
       "Z" = {
         command = ":echo fooo<CR>";
       };
+      "InsertHere" = {
+        command.__raw = ''
+          function(opts)
+            vim.api.nvim_put({opts.args}, 'c', true, true)
+          end
+        '';
+        nargs = 1;
+      };
     };
   };
 }


### PR DESCRIPTION
A couple of minor fixes here. Firstly, nargs needs 0 or 1, it will error if "0" or "1" are passed (as was previously the case). Secondly, `nvim_create_user_command` accepts a Lua function as its `{command}` parameter, e.g.

```lua
function(opts)
  local arg = opts.args
  ...
end
```
A simple tweak to the type of `command` is enough to fix this.