### PR TITLE
plugins/lualine: fix extensions option

### DIFF
--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -226,12 +226,7 @@ in
       processSections = mapAttrs (_: mapNullable (map processComponent));
       setupOptions = {
         options = {
-          inherit (cfg)
-            theme
-            globalstatus
-            refresh
-            extensions
-            ;
+          inherit (cfg) theme globalstatus refresh;
           icons_enabled = cfg.iconsEnabled;
           section_separators = cfg.sectionSeparators;
           component_separators = cfg.componentSeparators;
@@ -240,6 +235,7 @@ in
           always_divide_middle = cfg.alwaysDivideMiddle;
         };
 
+        inherit (cfg) extensions;
         sections = processSections cfg.sections;
         inactive_sections = processSections cfg.inactiveSections;
         tabline = processSections cfg.tabline;


### PR DESCRIPTION
Option "extensions" was incorrectly output under key "options", but it belongs to the top level of lualine's setup table.