### PR TITLE
plugins/refactoring: switch to mkNeovimPlugin & add telescope support option

### DIFF
--- a/plugins/utils/refactoring.nix
+++ b/plugins/utils/refactoring.nix
@@ -22,6 +22,24 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     "extractVarStatements"
   ];
 
+  extraOptions = {
+    enableTelescope = mkEnableOption "telescope integration";
+  };
+
+  extraConfig = cfg: {
+    assertions = [
+      {
+        assertion = cfg.enableTelescope -> config.plugins.telescope.enable;
+        message = ''
+          Nixvim: You have enabled the `telescope` integration with refactoring-nvim.
+          However, you have not enabled the `telescope` plugin itself (`plugins.telescope.enable = true`).
+        '';
+      }
+    ];
+
+    plugins.telescope.enabledExtensions = mkIf cfg.enableTelescope [ "refactoring" ];
+  };
+
   settingsOptions = with helpers.nixvimTypes; {
     prompt_func_return_type =
       helpers.defaultNullOpts.mkAttrsOf bool

--- a/plugins/utils/refactoring.nix
+++ b/plugins/utils/refactoring.nix
@@ -136,5 +136,13 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         }
       ```
     '';
+
+    show_success_message = helpers.defaultNullOpts.mkBool false ''
+      Shows a message with information about the refactor on success. Such as:
+
+      ```
+        [Refactor] Inlined 3 variable occurrences
+      ```
+    '';
   };
 }

--- a/tests/test-sources/plugins/utils/refactoring.nix
+++ b/tests/test-sources/plugins/utils/refactoring.nix
@@ -23,6 +23,7 @@
         extract_var_statements = {
           go = "%s := %s // poggers";
         };
+        show_success_message = true;
       };
     };
   };
@@ -53,6 +54,7 @@
         printf_statements = { };
         print_var_statements = { };
         extract_var_statements = { };
+        show_success_message = false;
       };
     };
   };

--- a/tests/test-sources/plugins/utils/refactoring.nix
+++ b/tests/test-sources/plugins/utils/refactoring.nix
@@ -28,6 +28,15 @@
     };
   };
 
+  withTelescope = {
+    plugins.telescope.enable = true;
+
+    plugins.refactoring = {
+      enable = true;
+      enableTelescope = true;
+    };
+  };
+
   defaults = {
     plugins.refactoring = {
       enable = true;

--- a/tests/test-sources/plugins/utils/refactoring.nix
+++ b/tests/test-sources/plugins/utils/refactoring.nix
@@ -3,23 +3,56 @@
     plugins.refactoring.enable = true;
   };
 
+  example = {
+    plugins.refactoring = {
+      enable = true;
+
+      settings = {
+        prompt_func_return_type = {
+          go = true;
+        };
+        prompt_func_param_type = {
+          go = true;
+        };
+        printf_statements = {
+          cpp = [ "std::cout << \"%s\" << std::endl;" ];
+        };
+        print_var_statements = {
+          cpp = [ "printf(\"a custom statement %%s %s\", %s)" ];
+        };
+        extract_var_statements = {
+          go = "%s := %s // poggers";
+        };
+      };
+    };
+  };
+
   defaults = {
     plugins.refactoring = {
       enable = true;
-      promptFuncReturnType = {
-        go = true;
-      };
-      promptFuncParamType = {
-        go = true;
-      };
-      printVarStatements = {
-        cpp = [ "printf(\"a custom statement %%s %s\", %s)" ];
-      };
-      printfStatements = {
-        cpp = [ "std::cout << \"%s\" << std::endl;" ];
-      };
-      extractVarStatements = {
-        go = "%s := %s // poggers";
+
+      settings = {
+        prompt_func_return_type = {
+          go = false;
+          java = false;
+          cpp = false;
+          c = false;
+          h = false;
+          hpp = false;
+          cxx = false;
+        };
+        prompt_func_param_type = {
+          go = false;
+          java = false;
+          cpp = false;
+          c = false;
+          h = false;
+          hpp = false;
+          cxx = false;
+        };
+        printf_statements = { };
+        print_var_statements = { };
+        extract_var_statements = { };
       };
     };
   };


### PR DESCRIPTION
- [x] Switch to `mkNeovimPlugin`
- [x] Check settings options are up-to-date
- [x] Update tests
- [x] Add option to enable telescope extension 
- [x] Update option descriptions in line with current style and upstream readme

Fixes #1218