### PR TITLE
wrappers/output: fix `initContent` formatting

### DIFF
--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -122,7 +122,6 @@ with lib;
         + config.content;
 
       init = helpers.writeLua "init.lua" customRC;
-      initPath = toString init;
 
       extraWrapperArgs = builtins.concatStringsSep " " (
         (optional (config.extraPackages != [ ]) ''--prefix PATH : "${makeBinPath config.extraPackages}"'')
@@ -140,17 +139,14 @@ with lib;
     {
       type = lib.mkForce "lua";
       finalPackage = wrappedNeovim;
-      initContent = customRC;
-      inherit initPath;
+      initContent = readFile init;
+      initPath = "${init}";
 
       printInitPackage = pkgs.writeShellApplication {
         name = "nixvim-print-init";
-        runtimeInputs = with pkgs; [
-          stylua
-          bat
-        ];
+        runtimeInputs = [ pkgs.bat ];
         text = ''
-          stylua - <"${initPath}" | bat --language=lua
+          bat --language=lua "${init}"
         '';
       };
 


### PR DESCRIPTION
This PR fixes an oversight in #1409 that meant the un-formatted `customRC` was still used to set the config option `initContent`, even though `initPath` was pointing to the formatted file.

I also removed the (now redundant) formatting from the `nixvim-print-init` command.

Hopefully, this should mean the `init.lua` is formatted consistently by all wrapper/platforms now 🤞
