### PR TITLE
modules/keymaps: add "buffer" option to mapConfigOptions

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -22,6 +22,8 @@ rec {
     remap = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping recursive. Inverses \"noremap\"";
 
     desc = nixvimOptions.mkNullOrOption types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
+
+    buffer = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding <buffer> to a map.";
   };
 
   modes = {


### PR DESCRIPTION
This allows to define buffer-local keymaps, which is specially useful when combined with `keymapsOnEvents`.