### PR TITLE
wrappers/output: omit blank vimrc from `init.lua`

### DIFF
--- a/wrappers/modules/output.nix
+++ b/wrappers/modules/output.nix
@@ -114,11 +114,14 @@ with lib;
       );
 
       customRC =
-        ''
+        let
+          hasContent = str: (builtins.match "[[:space:]]*" str) == null;
+        in
+        (optionalString (hasContent neovimConfig.neovimRcContent) ''
           vim.cmd([[
             ${neovimConfig.neovimRcContent}
           ]])
-        ''
+        '')
         + config.content;
 
       init = helpers.writeLua "init.lua" customRC;


### PR DESCRIPTION
`makeNeovimConfig` produces a `neovimRcContent` that is _usually_ just a bunch of blank empty lines.

If it's entirely whitespace (matches the regex `[[:space:]]*`) there's no reason to include it.

It may also be nice to _trim_ the start/end of the string for blank lines too, but AFAICT this is non-trivial using nix-lang, so I haven't bothered.
