### PR TITLE
modules/keymaps: deprecate `lua` option

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -106,8 +106,12 @@ rec {
             description = ''
               If true, `action` is considered to be lua code.
               Thus, it will not be wrapped in `""`.
+
+              This option is deprecated and will be removed in 24.11.
+              You should use a "raw" action instead, e.g. `action.__raw = ""`.
             '';
             default = defaults.lua or false;
+            visible = false;
           };
 
           options = mapConfigOptions;


### PR DESCRIPTION
This PR deprecates the `lua` keymap submodule option, in favour of using a "raw string" directly on the `action` option.

Since we're not ready to remove it outright just yet the existing option declaration needs to stay, but it can be marked `visible = false`.

A warning will be displayed if the option is defined anyware in a nixvim config, even if explicitly setting `lua = false`.

This warning is printed when using this branch with my config:

```
trace: warning: Nixvim (keymaps): the `lua` keymap option is deprecated.

This option will be removed in 24.11. You should use a "raw" `action` instead;
e.g. `action.__raw = "<lua code>"` or `action = helpers.mkRaw "<lua code>"`.

Found 1 use in /nix/store/7lsacy6wira1l2y6xpxq1nxcigrkxaqp-source/nvim/config/main.nix

```

This PR builds on #1004 and #1010
