### PR TITLE
plugins/trim: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -204,6 +204,7 @@
     ./utils/tmux-navigator.nix
     ./utils/todo-comments.nix
     ./utils/toggleterm.nix
+    ./utils/trim.nix
     ./utils/undotree.nix
     ./utils/vim-bbye.nix
     ./utils/vim-css-color.nix

--- a/plugins/utils/trim.nix
+++ b/plugins/utils/trim.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "trim";
+  originalName = "trim.nvim";
+  defaultPackage = pkgs.vimPlugins.trim-nvim;
+
+  maintainers = [ maintainers.GaetanLepage ];
+
+  settingsOptions = {
+    ft_blocklist = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+      Filetypes to exclude.
+    '';
+
+    patterns = mkOption {
+      type = with helpers.nixvimTypes; listOf strLua;
+      apply = map helpers.mkRaw;
+      default = [ ];
+      example = [ "[[%s/\(\n\n\)\n\+/\1/]]" ];
+      description = ''
+        Extra patterns to use for removing white spaces.
+
+        Plugin default: `[]`
+      '';
+    };
+
+    trim_on_write = helpers.defaultNullOpts.mkBool true ''
+      Whether to automatically trim on write.
+    '';
+
+    trim_trailing = helpers.defaultNullOpts.mkBool true ''
+      Whether to trim trailing whitespaces.
+    '';
+
+    trim_last_line = helpers.defaultNullOpts.mkBool true ''
+      Whether to trim trailing blank lines at the end of the file.
+    '';
+
+    trim_first_line = helpers.defaultNullOpts.mkBool true ''
+      Whether to trim blank lines at the beginning of the file.
+    '';
+
+    highlight = helpers.defaultNullOpts.mkBool false ''
+      Whether to highlight trailing whitespaces.
+    '';
+
+    highlight_bg = helpers.defaultNullOpts.mkStr "#ff0000" ''
+      Which color to use for coloring whitespaces.
+    '';
+
+    highlight_ctermbg = helpers.defaultNullOpts.mkStr "red" ''
+      Which color to use for coloring whitespaces (cterm).
+    '';
+  };
+
+  settingsExample = {
+    ft_blocklist = [ "markdown" ];
+    patterns = [ "[[%s/\(\n\n\)\n\+/\1/]]" ];
+    trim_on_write = false;
+    highlight = true;
+  };
+}

--- a/tests/test-sources/plugins/utils/trim.nix
+++ b/tests/test-sources/plugins/utils/trim.nix
@@ -1,0 +1,36 @@
+{
+  empty = {
+    plugins.trim.enable = true;
+  };
+
+  defaults = {
+    plugins.trim = {
+      enable = true;
+
+      settings = {
+        ft_blocklist = [ ];
+        patterns = [ ];
+        trim_on_write = true;
+        trim_trailing = true;
+        trim_last_line = true;
+        trim_first_line = true;
+        highlight = false;
+        highlight_bg = "#ff0000";
+        highlight_ctermbg = "red";
+      };
+    };
+  };
+
+  example = {
+    plugins.trim = {
+      enable = true;
+
+      settings = {
+        ft_blocklist = [ "markdown" ];
+        patterns = [ "[[%s/\(\n\n\)\n\+/\1/]]" ];
+        trim_on_write = false;
+        highlight = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [trim.nvim](https://github.com/cappyzawa/trim.nvim).

I didn't add a `plugins.trim.keymaps` option (for `:Trim` and `:TrimToggle`) because I didn't feel that it was necessary. I am open to adding it.

Fixes #1556