### PR TITLE
lib/options: defaultNullOpts support non-string defaults

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -57,7 +57,20 @@ rec {
 
   defaultNullOpts = rec {
     # Description helpers
-    mkDefaultDesc = defaultValue: "Plugin default: `${toString defaultValue}`";
+    mkDefaultDesc =
+      defaultValue:
+      let
+        default =
+          # Assume a string default is already formatted as intended,
+          # historically strings were the only type accepted here.
+          # TODO consider deprecating this behavior so we can properly quote strings
+          if isString defaultValue then
+            defaultValue
+          else
+            generators.toPretty { multiline = false; } defaultValue;
+      in
+      "Plugin default: `${default}`";
+
     mkDesc =
       default: desc:
       let


### PR DESCRIPTION
As mentioned previously, it'd be nice for functions like `defaultNullOpts.mkNullable` to accept actual nix values and correctly render it in the docs.

We can achieve this using [`lib.generators.toPretty`](https://github.com/NixOS/nixpkgs/blob/b873fdcdb4a44081c9041878f6d4dc4f2f4e55c6/lib/generators.nix#L326-L341), however I've added a check for `isString` because we currently assume we can pass stringified nix code and have it render as-is. It'd be nice to change that in the future, but the work would be significant to do that now.

I may also push a followup commit to this PR changing `defaultNullOpts.mkStr`'s behaviour to quote & escape the default string using `toPretty`, as I think [`"quoted"`](https://github.com/NixOS/nixpkgs/blob/b873fdcdb4a44081c9041878f6d4dc4f2f4e55c6/lib/tests/misc.nix#L1395) values will make more sense in the docs.  
If preferred, that could be done in a separate PR.
