### PR TITLE
modules/keymaps: more verbose `lua` deprecation

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -68,7 +68,10 @@ with lib;
                 count = length def.value;
                 plural = count > 1;
               in
-              "Found ${toString count} use${optionalString plural "s"} in ${def.file}"
+              ''
+                Found ${toString count} use${optionalString plural "s"} in ${def.file}:
+                ${generators.toPretty { } def.value}
+              ''
             ))
           ];
         in


### PR DESCRIPTION
Since @GaetanLepage reported false positives, and since I discovered `toPretty` while working on #1580, it may be useful to show users the exact definition that is triggering the warning.

My config now produces the following warning:

```
trace: warning: Nixvim (keymaps): the `lua` keymap option is deprecated.

This option will be removed in 24.11. You should use a "raw" `action` instead;
e.g. `action.__raw = "<lua code>"` or `action = helpers.mkRaw "<lua code>"`.

Found 1 use in /nix/store/14kwid826pc2cm1gbaj7kbp0yvsmf0md-source/nvim/config/main.nix:
[
  {
    action = ''
      function() require("telescope").extensions.refactoring.refactors() end
    '';
    key = "<leader>rr";
    lua = true;
    mode = "n";
    options = {
      desc = "Select refactor";
    };
  }
]

```
