### PR TITLE
colorschemes: set the colorscheme as mkDefault to allow for overriding

### DIFF
--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -118,7 +118,7 @@ rec {
               require('${luaName}').setup(${toLuaObject cfg.settings})
             '';
           }
-          (optionalAttrs (isColorscheme && (colorscheme != null)) { inherit colorscheme; })
+          (optionalAttrs (isColorscheme && (colorscheme != null)) { colorscheme = mkDefault colorscheme; })
           (extraConfig cfg)
         ]);
     };

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -105,7 +105,7 @@ with lib;
           # does this evaluate package? it would not be desired to evaluate package if we use another package.
           extraPlugins = extraPlugins ++ optional (defaultPackage != null) cfg.package;
         }
-        (optionalAttrs (isColorscheme && (colorscheme != null)) { inherit colorscheme; })
+        (optionalAttrs (isColorscheme && (colorscheme != null)) { colorscheme = mkDefault colorscheme; })
         (extraConfig cfg)
       ]);
     };


### PR DESCRIPTION
The nightfox theme has "flavors" that the user is supposed to select from the neovim `colorscheme` option.
We should allow the user to override this value.