### PR TITLE
lib/options: multi-line plugin default strings

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -64,12 +64,13 @@ rec {
           # Assume a string default is already formatted as intended,
           # historically strings were the only type accepted here.
           # TODO consider deprecating this behavior so we can properly quote strings
-          if isString defaultValue then
-            defaultValue
-          else
-            generators.toPretty { multiline = false; } defaultValue;
+          if isString defaultValue then defaultValue else generators.toPretty { } defaultValue;
       in
-      "Plugin default: `${default}`";
+      "Plugin default:"
+      + (
+        # Detect whether `default` is multiline or inline:
+        if hasInfix "\n" default then "\n\n```nix\n${default}\n```" else " `${default}`"
+      );
 
     mkDesc =
       default: desc:


### PR DESCRIPTION
Detect whether a plugin default is multiline using `hasInfix "\n"`.

This works fairly well, but without trimming the default string we may run into some false-positives. We could borrow the implementation from https://github.com/NixOS/nixpkgs/pull/315411 or wait and see if/when that gets merged. Personally, I don't see this FIXME as a blocker, unless we find it affects a significant portion of the docs.

I also noticed some default strings seem to have excessive indentation, IDK how easily we could remove that or if we should even bother. ~~I left a TODO comment.~~

Here's a screenshot of docs built with this change:

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/nix-community/nixvim/assets/5046562/c1d81f89-3ec9-407e-8440-0e1464cf84e2)

</p>
</details> 

Note how 2/3 options have inline plugin defaults, while the first option has a multiline plugin default.