### PR TITLE
lib/options: `mkStr` should render quoted default strings

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -111,7 +111,12 @@ rec {
     # Unsigned: >=0
     mkUnsignedInt = default: mkNullableWithRaw types.ints.unsigned (toString default);
     mkBool = default: mkNullableWithRaw types.bool (if default then "true" else "false");
-    mkStr = default: mkNullableWithRaw types.str ''${builtins.toString default}'';
+    mkStr =
+      # TODO we should delegate rendering quoted string to `mkDefaultDesc`,
+      # once we remove its special case for strings.
+      default:
+      assert default == null || isString default;
+      mkNullableWithRaw types.str (generators.toPretty { } default);
     mkAttributeSet = default: mkNullable nixvimTypes.attrs ''${default}'';
     mkListOf = ty: default: mkNullable (with nixvimTypes; listOf (maybeRaw ty)) default;
     mkAttrsOf = ty: default: mkNullable (with nixvimTypes; attrsOf (maybeRaw ty)) default;


### PR DESCRIPTION
Expanding on #1544, since we can't currently let `defaultNullOpts.mkDefaultDesc` render strings properly, we can (for now) handle that in `defaultNullOpts.mkStr`.

<details><summary>Render</summary>
<p>


![image](https://github.com/nix-community/nixvim/assets/5046562/12dbec3c-49f4-45f4-bea0-a84f91f4bcc9)



</p>
</details> 

_Aside:_ looks like we should consider using `toPretty` for _type_ rendering too...