### PR TITLE
plugins/dashboard: switch to mkNeovimPlugin + update options

### DIFF
--- a/tests/test-sources/plugins/utils/dashboard.nix
+++ b/tests/test-sources/plugins/utils/dashboard.nix
@@ -1,0 +1,195 @@
+{
+  empty = {
+    plugins.dashboard = {
+      enable = true;
+    };
+  };
+
+  defaults = {
+    plugins.dashboard = {
+      enable = true;
+
+      settings = {
+        theme = "hyper";
+        disable_move = false;
+        shortcut_type = "letter";
+        buffer_name = "Dashboard";
+        change_to_vcs_root = false;
+
+        config = {
+          disable_move = false;
+
+          week_header = {
+            enable = false;
+            concat = "";
+            append = [ ];
+          };
+          header = [
+            ""
+            " ██████╗  █████╗ ███████╗██╗  ██╗██████╗  ██████╗  █████╗ ██████╗ ██████╗  "
+            " ██╔══██╗██╔══██╗██╔════╝██║  ██║██╔══██╗██╔═══██╗██╔══██╗██╔══██╗██╔══██╗ "
+            " ██║  ██║███████║███████╗███████║██████╔╝██║   ██║███████║██████╔╝██║  ██║ "
+            " ██║  ██║██╔══██║╚════██║██╔══██║██╔══██╗██║   ██║██╔══██║██╔══██╗██║  ██║ "
+            " ██████╔╝██║  ██║███████║██║  ██║██████╔╝╚██████╔╝██║  ██║██║  ██║██████╔╝ "
+            " ╚═════╝ ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝  "
+            ""
+          ];
+        };
+
+        hide = {
+          statusline = true;
+          tabline = true;
+        };
+
+        preview = {
+          command = "";
+          file_path = null;
+          file_height = 0;
+          file_width = 0;
+        };
+      };
+    };
+  };
+
+  hyper_options = {
+    plugins.dashboard = {
+      enable = true;
+
+      settings = {
+        theme = "hyper";
+
+        config = {
+          packages.enable = true;
+
+          shortcut = [
+            {
+              desc = "string";
+              group = "highlight group";
+              key = "shortcut key";
+              action = "action when you press key";
+            }
+          ];
+
+          project = {
+            enable = true;
+            limit = 8;
+            icon = "your icon";
+            label = "";
+            action = "Telescope find_files cwd=";
+          };
+
+          mru = {
+            limit = 10;
+            icon = "your icon";
+            label = "";
+            cwd_only = false;
+          };
+
+          footer = [ ];
+        };
+      };
+    };
+  };
+
+  doom_options = {
+    plugins.dashboard = {
+      enable = true;
+
+      settings = {
+        theme = "hyper";
+
+        config = {
+          center = [
+            {
+              icon = "";
+              icon_hl = "group";
+              desc = "description";
+              desc_hl = "group";
+              key = "shortcut key in dashboard buffer not keymap !!";
+              key_hl = "group";
+              key_format = " [%s]";
+              action = "";
+            }
+          ];
+          footer = [ ];
+        };
+      };
+    };
+  };
+
+  hyper_example = {
+    plugins.dashboard = {
+      enable = true;
+
+      settings = {
+        theme = "hyper";
+        change_to_vcs_root = true;
+
+        config = {
+          week_header.enable = true;
+          project.enable = false;
+          mru.limit = 20;
+
+          shortcut = [
+            {
+              icon = " ";
+              icon_hl = "@variable";
+              desc = "Files";
+              group = "Label";
+              action.__raw = "function(path) vim.cmd('Telescope find_files') end";
+              key = "f";
+            }
+            {
+              desc = " Apps";
+              group = "DiagnosticHint";
+              action = "Telescope app";
+              key = "a";
+            }
+            {
+              desc = " dotfiles";
+              group = "Number";
+              action = "Telescope dotfiles";
+              key = "d";
+            }
+          ];
+        };
+      };
+    };
+  };
+
+  doom_example = {
+    plugins.dashboard = {
+      enable = true;
+
+      settings = {
+        theme = "doom";
+
+        config = {
+          header = [ "Your header" ];
+          center = [
+            {
+              icon = " ";
+              icon_hl = "Title";
+              desc = "Find File           ";
+              desc_hl = "String";
+              key = "b";
+              keymap = "SPC f f";
+              key_hl = "Number";
+              key_format = " %s";
+              action = "lua print(2)";
+            }
+            {
+              icon = " ";
+              desc = "Find Dotfiles";
+              key = "f";
+              keymap = "SPC f d";
+              key_format = " %s";
+              action.__raw = "function() print(3) end";
+            }
+          ];
+          footer = [ "Your footer" ];
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Switch [nvimdev/dashboard-nvim](https://github.com/nvimdev/dashboard-nvim/blob/master/README.md) to use `mkNeovimPlugin` and update how it is configured from the old `dashboard.<option>` to the current `setup(config)` style (this changed upstream Jan 2023).

Added a few test-cases based on examples in upstream's README, as well as documented defaults and a couple undocumented defaults lifted from the lua implementation.

- [x] define test cases for documented examples & defaults
- [x] ensure old options are deprecated correctly
- [x] define (most) settings options
- [x] define (most) theme-specific options
- [ ] warn when theme-specific options are used incorrectly
- [ ] check if nvim-web-devicons is an actual requirement (it's in upstream's examples)

It hasn't been easy to document the options or establish their defaults, as the upstream documentation is kinda vague. For some options I've had to dig into the source code to find the actual defaults.

Fixes #1432
