### PR TITLE
lib/options: delegate all non-string default rendering to `mkDefaultDesc`

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -104,20 +104,20 @@ rec {
 
     mkLuaFn = default: desc: mkNullOrLuaFn (mkDesc default desc);
 
-    mkNum = default: mkNullableWithRaw types.number (toString default);
-    mkInt = default: mkNullableWithRaw types.int (toString default);
+    mkNum = mkNullableWithRaw types.number;
+    mkInt = mkNullableWithRaw types.int;
     # Positive: >0
-    mkPositiveInt = default: mkNullableWithRaw types.ints.positive (toString default);
+    mkPositiveInt = mkNullableWithRaw types.ints.positive;
     # Unsigned: >=0
-    mkUnsignedInt = default: mkNullableWithRaw types.ints.unsigned (toString default);
-    mkBool = default: mkNullableWithRaw types.bool (if default then "true" else "false");
+    mkUnsignedInt = mkNullableWithRaw types.ints.unsigned;
+    mkBool = mkNullableWithRaw types.bool;
     mkStr =
       # TODO we should delegate rendering quoted string to `mkDefaultDesc`,
       # once we remove its special case for strings.
       default:
       assert default == null || isString default;
       mkNullableWithRaw types.str (generators.toPretty { } default);
-    mkAttributeSet = default: mkNullable nixvimTypes.attrs ''${default}'';
+    mkAttributeSet = mkNullable nixvimTypes.attrs;
     mkListOf = ty: default: mkNullable (with nixvimTypes; listOf (maybeRaw ty)) default;
     mkAttrsOf = ty: default: mkNullable (with nixvimTypes; attrsOf (maybeRaw ty)) default;
     mkEnum =

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -120,7 +120,12 @@ rec {
     mkAttributeSet = default: mkNullable nixvimTypes.attrs ''${default}'';
     mkListOf = ty: default: mkNullable (with nixvimTypes; listOf (maybeRaw ty)) default;
     mkAttrsOf = ty: default: mkNullable (with nixvimTypes; attrsOf (maybeRaw ty)) default;
-    mkEnum = enumValues: default: mkNullableWithRaw (types.enum enumValues) ''"${default}"'';
+    mkEnum =
+      enumValues: default:
+      mkNullableWithRaw (types.enum enumValues) (
+        # TODO we should remove this once `mkDefaultDesc` no longer has a special case
+        if isString default then generators.toPretty { } default else default
+      );
     mkEnumFirstDefault = enumValues: mkEnum enumValues (head enumValues);
     mkBorder =
       default: name: desc:

--- a/plugins/lsp/language-servers/ccls.nix
+++ b/plugins/lsp/language-servers/ccls.nix
@@ -51,7 +51,7 @@ in
             1
             2
           ]
-          "1"
+          1
           ''
             Change to 0 if you want to save memory, but having multiple ccls processes operating in the
             same directory may corrupt ccls's in-memory representation of the index.
@@ -206,7 +206,7 @@ in
             1
             2
           ]
-          "2"
+          2
           ''
             `ccls` can index the contents of comments associated with functions/types/variables (macros
             are not handled).
@@ -218,12 +218,11 @@ in
           '';
 
       multiVersion =
-        helpers.defaultNullOpts.mkEnum
+        helpers.defaultNullOpts.mkEnumFirstDefault
           [
             0
             1
           ]
-          "0"
           ''
             Index a file only once (`0`), or in each translation unit that includes it (`1`).
 
@@ -282,7 +281,7 @@ in
             1
             2
           ]
-          "2"
+          2
           ''
             Determine whether a file should be re-indexed when any of its dependencies changes
             timestamp.

--- a/plugins/utils/molten.nix
+++ b/plugins/utils/molten.nix
@@ -129,12 +129,11 @@ mkVimPlugin config {
     '';
 
     output_win_style =
-      helpers.defaultNullOpts.mkEnum
+      helpers.defaultNullOpts.mkEnumFirstDefault
         [
           false
           "minimal"
         ]
-        "false"
         ''
           Value passed to the style option in `:h nvim_open_win()`.
         '';


### PR DESCRIPTION
- **lib/options: `mkEnum` quote default if string**
- **lib/options: `defaultNullOpts` delegate string rendering**

Other than gradually transitioning away from passing in large pre-rendered strings to `mkNullable` (etc), and then subsequently being able to _also_ delegate string-type rendering in `mkEnum` and `mkStr`, this should conclude this series of PRs adding `toPretty` support to `mkDefaultDesc`.
