### PR TITLE
plugins/debugprint: remove deprecated ignore_treesitter option

### DIFF
--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -160,11 +160,6 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           ```
         '';
 
-    ignore_treesitter = helpers.defaultNullOpts.mkBool false ''
-      Never use treesitter to find a variable under the cursor, always prompt for it - overrides
-      the same setting on `debugprint()` if set to true.
-    '';
-
     print_tag = helpers.defaultNullOpts.mkStr "DEBUGPRINT" ''
       The string inserted into each print statement, which can be used to uniquely identify
       statements inserted by `debugprint`.
@@ -199,7 +194,6 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         right_var = "}')";
       };
     };
-    ignore_treesitter = false;
     print_tag = "DEBUGPRINT";
   };
 }

--- a/tests/test-sources/plugins/languages/debugprint.nix
+++ b/tests/test-sources/plugins/languages/debugprint.nix
@@ -41,7 +41,6 @@
             right_var = "}')";
           };
         };
-        ignore_treesitter = false;
         print_tag = "DEBUGPRINT";
       };
     };


### PR DESCRIPTION
The `ignore_treesitter` option has been deprecated by upstream (https://github.com/andrewferrier/debugprint.nvim/issues/25#issuecomment-2081407774).
This is the first time (I think) that we have to remove an option from a RFC-42 style plugin.

In those cases, I wouldn't bother taking any extra nix-deprecation measure. The plugin is showing a warning itself at runtime. The whole goal of this paradigm change was to step back from the very tight and constrained option declaration model that we had. So I would say: no warning here.