### PR TITLE
flake: add the nix-community binary cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,13 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [ "https://nix-community.cachix.org" ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
   outputs =
     inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {


### PR DESCRIPTION
I wasn't aware of this `nixConfig` attribute.