### PR TITLE
modules/keymaps: doc: add backticks around special arguments

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -17,9 +17,9 @@ rec {
 
     unique = nixvimOptions.defaultNullOpts.mkBool false "Whether to fail if the map is already defined. Equivalent to adding `<unique>` to a map.";
 
-    noremap = nixvimOptions.defaultNullOpts.mkBool true "Whether to use the 'noremap' variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
+    noremap = nixvimOptions.defaultNullOpts.mkBool true "Whether to use the `noremap` variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
 
-    remap = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping recursive. Inverses \"noremap\"";
+    remap = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping recursive. Inverses `noremap`.";
 
     desc = nixvimOptions.mkNullOrOption types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
 

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -7,15 +7,15 @@ with lib;
 rec {
   # These are the configuration options that change the behavior of each mapping.
   mapConfigOptions = {
-    silent = nixvimOptions.defaultNullOpts.mkBool false "Whether this mapping should be silent. Equivalent to adding <silent> to a map.";
+    silent = nixvimOptions.defaultNullOpts.mkBool false "Whether this mapping should be silent. Equivalent to adding `<silent>` to a map.";
 
-    nowait = nixvimOptions.defaultNullOpts.mkBool false "Whether to wait for extra input on ambiguous mappings. Equivalent to adding <nowait> to a map.";
+    nowait = nixvimOptions.defaultNullOpts.mkBool false "Whether to wait for extra input on ambiguous mappings. Equivalent to adding `<nowait>` to a map.";
 
-    script = nixvimOptions.defaultNullOpts.mkBool false "Equivalent to adding <script> to a map.";
+    script = nixvimOptions.defaultNullOpts.mkBool false "Equivalent to adding `<script>` to a map.";
 
-    expr = nixvimOptions.defaultNullOpts.mkBool false "Means that the action is actually an expression. Equivalent to adding <expr> to a map.";
+    expr = nixvimOptions.defaultNullOpts.mkBool false "Means that the action is actually an expression. Equivalent to adding `<expr>` to a map.";
 
-    unique = nixvimOptions.defaultNullOpts.mkBool false "Whether to fail if the map is already defined. Equivalent to adding <unique> to a map.";
+    unique = nixvimOptions.defaultNullOpts.mkBool false "Whether to fail if the map is already defined. Equivalent to adding `<unique>` to a map.";
 
     noremap = nixvimOptions.defaultNullOpts.mkBool true "Whether to use the 'noremap' variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
 
@@ -23,7 +23,7 @@ rec {
 
     desc = nixvimOptions.mkNullOrOption types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
 
-    buffer = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding <buffer> to a map.";
+    buffer = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
   };
 
   modes = {


### PR DESCRIPTION
As mentioned here: https://github.com/nix-community/nixvim/pull/1565#discussion_r1614916649