### PR TITLE
helpers/toLuaObject: add support for raw keys

### DIFF
--- a/docs/user-guide/helpers.md
+++ b/docs/user-guide/helpers.md
@@ -40,3 +40,18 @@ A certain number of helpers are defined that can be useful:
 
 - `helpers.enableExceptInTests`: Evaluates to `true`, except in `mkTestDerivationFromNixvimModule`
   where it evaluates to `false`. This allows to skip instantiating plugins that can't be run in tests.
+
+- `helpers.toRawKeys attrs`: Convert the keys of the given `attrs` to raw lua.
+  ```nix
+    toRawKeys {foo = 1; bar = "hi";}
+  ```
+  will translate in lua to:
+  ```lua
+    {[foo] = 1, [bar] = 2,}
+  ```
+  Otherwise, the keys of a regular `attrs` will be interpreted as lua string:
+  ```lua
+    {['foo'] = 1, ['bar'] = 2,}
+    -- which is the same as
+    {foo = 1, bar = 2,}
+  ```

--- a/lib/to-lua.nix
+++ b/lib/to-lua.nix
@@ -15,12 +15,17 @@ rec {
         + (concatStringsSep "," (
           mapAttrsToList (
             n: v:
-            if (builtins.match "__unkeyed.*" n) != null then
-              toLuaObject v
+            let
+              valueString = toLuaObject v;
+            in
+            if hasPrefix "__unkeyed" n then
+              valueString
+            else if hasPrefix "__rawKey__" n then
+              "[${n}] = " + valueString
             else if n == "__emptyString" then
-              "[''] = " + (toLuaObject v)
+              "[''] = " + valueString
             else
-              "[${toLuaObject n}] = " + (toLuaObject v)
+              "[${toLuaObject n}] = " + valueString
           ) (filterAttrs (n: v: v != null && (toLuaObject v != "{}")) args)
         ))
         + "}"

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -11,6 +11,47 @@ with lib;
     "__empty" = null;
   };
 
+  /**
+    Turn all the keys of an attrs into raw lua.
+
+    # Example
+
+    ```nix
+    toRawKeys { foo = 1; bar = 2; }
+    => { __rawKey__foo = 1; __rawKey__bar = 2; }
+    ```
+
+    # Type
+
+    ```
+    toRawKeys :: AttrSet -> AttrSet
+    ```
+  */
+  toRawKeys = mapAttrs' (n: v: nameValuePair "__rawKey__${n}" v);
+
+  /**
+    Create a 1-element attrs with a raw lua key.
+
+    # Example
+
+    ```nix
+    mkRawKey "foo" 1
+    => { __rawKey__foo = 1; }
+    ```
+
+    # Type
+
+    ```
+    mkRawKey :: String -> String -> AttrSet
+    ```
+
+    # Arguments
+
+    - [n] The attribute name (raw lua)
+    - [v] The attribute value
+  */
+  mkRawKey = n: v: toRawKeys { "${n}" = v; };
+
   /*
        Convert a string from camelCase to snake_case
     Type: string -> string


### PR DESCRIPTION
This allows to have "raw lua" for table keys.

This:
```nix
{
  __raw__foo = 1;
  bar = 2;
}
```

Would translate into
```lua
{
  [foo] = 1;
  ['bar'] = 2;
}
```