### PR TITLE
modules/keymaps: fix false-positive `lua` warning

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -80,6 +80,9 @@ rec {
 
   mkMapOptionSubmodule =
     defaults:
+    # TODO remove assert once `lua` option is gone
+    # This is here to ensure no uses of `mkMapOptionSubmodule` set a `lua` default
+    assert !(defaults ? lua);
     (
       with types;
       submodule {
@@ -104,7 +107,7 @@ rec {
           );
 
           lua = mkOption {
-            type = bool;
+            type = nullOr bool;
             description = ''
               If true, `action` is considered to be lua code.
               Thus, it will not be wrapped in `""`.
@@ -112,7 +115,7 @@ rec {
               This option is deprecated and will be removed in 24.11.
               You should use a "raw" action instead, e.g. `action.__raw = ""`.
             '';
-            default = defaults.lua or false;
+            default = null;
             visible = false;
           };
 

--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -44,10 +44,15 @@ with lib;
 
   config =
     let
+      # TODO remove `normalizeMapping` once `lua` option is gone
       normalizeMapping = keyMapping: {
         inherit (keyMapping) mode key options;
 
-        action = if keyMapping.lua then helpers.mkRaw keyMapping.action else keyMapping.action;
+        action =
+          if keyMapping.lua != null && keyMapping.lua then
+            helpers.mkRaw keyMapping.action
+          else
+            keyMapping.action;
       };
     in
     {
@@ -59,7 +64,7 @@ with lib;
           luaDefs = pipe options.keymaps.definitionsWithLocations [
             (map (def: {
               inherit (def) file;
-              value = filter (hasAttr "lua") def.value;
+              value = filter (v: (v.lua or null) != null) def.value;
             }))
             (filter (def: def.value != [ ]))
             (map (


### PR DESCRIPTION
It appears that submodule options for list-of submodules are considered "defined" when _actually_ defined, while "plane" submodules (i.e. `plugins.wtf.keymaps`) seem to behave differently...

To work around the issue, I've made the (hidden and deprecated) `lua` keymap option "`nullOr bool`", so that we can assume "`null`" means "unset"...

This could cause an edge-case if a user is _reading_ the `lua` value in their config and assuming it is a non-null boolean though.
