### PR TITLE
lib/options: remove `mkStr` assert

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -168,9 +168,7 @@ rec {
     mkStr =
       # TODO we should delegate rendering quoted string to `mkDefaultDesc`,
       # once we remove its special case for strings.
-      default:
-      assert default == null || isString default;
-      mkNullableWithRaw types.str (generators.toPretty { } default);
+      default: mkNullableWithRaw types.str (generators.toPretty { } default);
 
     mkAttributeSet' = args: mkNullable' (args // { type = nixvimTypes.attrs; });
     mkAttributeSet = default: description: mkAttributeSet' { inherit default description; };


### PR DESCRIPTION
Drop assert because it is no longer needed, and also blocks us from passing in raw types.

If a non-string is passed in, it'll be formatted here. This is okay
because `mkDesc` will not re-format strings anyway.
