### PR TITLE
lib/keymap-helpers: refactor `mkMapOptionSubmodule`

### DIFF
--- a/plugins/lsp/wtf.nix
+++ b/plugins/lsp/wtf.nix
@@ -36,7 +36,14 @@ in
       keymaps = mapAttrs (
         action: defaults:
         helpers.mkNullOrOption (
-          with types; either str (helpers.keymaps.mkMapOptionSubmodule defaults)
+          with types;
+          either str (
+            helpers.keymaps.mkMapOptionSubmodule {
+              inherit defaults;
+              hasKey = true;
+              hasAction = true;
+            }
+          )
         ) "Keymap for the ${action} action."
       ) defaultKeymaps;
 


### PR DESCRIPTION
Make the `key` and `action` options optional, and allow configuring
whether `action` can be a raw type.

Related to #603
