### PR TITLE
lib/options: add prime variants for the rest of `defaultNullOpts`

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -213,6 +213,9 @@ rec {
           default ? head values,
           ...
         }@args:
+        # `values` is a list and `default` is one of the values (or null)
+        assert isList values;
+        assert default == null || elem default values;
         mkNullableWithRaw' (
           (filterAttrs (n: v: n != "values") args)
           // {

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -137,7 +137,7 @@ in
 
       rightMouseCommand = helpers.defaultNullOpts.mkStr "bdelete! %d" "Command or function run when right clicking on a buffer.";
 
-      middleMouseCommand = helpers.defaultNullOpts.mkStr "null" "Command or function run when middle clicking on a buffer.";
+      middleMouseCommand = helpers.defaultNullOpts.mkStr null "Command or function run when middle clicking on a buffer.";
 
       indicator = {
         icon = helpers.defaultNullOpts.mkStr "▎" "icon";
@@ -161,7 +161,7 @@ in
         "thin"
       ] "thin" "Separator style";
 
-      nameFormatter = helpers.defaultNullOpts.mkLuaFn "null" ''
+      nameFormatter = helpers.defaultNullOpts.mkLuaFn null ''
         A lua function that can be used to modify the buffer's label.
         The argument 'buf' containing a name, path and bufnr is supplied.
       '';
@@ -178,7 +178,7 @@ in
 
       showBufferCloseIcons = helpers.defaultNullOpts.mkBool true "Show buffer close icons";
 
-      getElementIcon = helpers.defaultNullOpts.mkLuaFn "null" ''
+      getElementIcon = helpers.defaultNullOpts.mkLuaFn null ''
         Lua function returning an element icon.
 
         ```
@@ -210,11 +210,11 @@ in
         ])
       ) "false" "diagnostics";
 
-      diagnosticsIndicator = helpers.defaultNullOpts.mkLuaFn "null" "Either `null` or a function that returns the diagnostics indicator.";
+      diagnosticsIndicator = helpers.defaultNullOpts.mkLuaFn null "Either `null` or a function that returns the diagnostics indicator.";
 
       diagnosticsUpdateInInsert = helpers.defaultNullOpts.mkBool true "Whether diagnostics should update in insert mode";
 
-      offsets = helpers.defaultNullOpts.mkNullable (types.listOf types.attrs) "null" "offsets";
+      offsets = helpers.defaultNullOpts.mkNullable (types.listOf types.attrs) null "offsets";
 
       groups = {
         items = helpers.defaultNullOpts.mkNullable (types.listOf types.attrs) "[]" "List of groups.";
@@ -236,7 +236,7 @@ in
         logging = helpers.defaultNullOpts.mkBool false "Whether to enable logging";
       };
 
-      customFilter = helpers.defaultNullOpts.mkLuaFn "null" ''
+      customFilter = helpers.defaultNullOpts.mkLuaFn null ''
         ```
         fun(buf: number, bufnums: number[]): boolean
         ```

--- a/plugins/dap/dap-python.nix
+++ b/plugins/dap/dap-python.nix
@@ -32,7 +32,7 @@ in
 
     includeConfigs = helpers.defaultNullOpts.mkBool true "Add default configurations.";
 
-    resolvePython = helpers.defaultNullOpts.mkLuaFn "null" ''
+    resolvePython = helpers.defaultNullOpts.mkLuaFn null ''
       Function to resolve path to python to use for program or test execution.
       By default the `VIRTUAL_ENV` and `CONDA_PREFIX` environment variables are used if present.
     '';

--- a/plugins/dap/dap-ui.nix
+++ b/plugins/dap/dap-ui.nix
@@ -185,7 +185,7 @@ in
           "Maximum number of lines to allow a value to fill before trimming.";
     };
 
-    selectWindow = helpers.defaultNullOpts.mkLuaFn "null" ''
+    selectWindow = helpers.defaultNullOpts.mkLuaFn null ''
       A function which returns a window to be used for opening buffers such as a stack frame location.
     '';
   };

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -221,11 +221,11 @@ in
         truncationCharacter = helpers.defaultNullOpts.mkStr "…" "Character to use when truncating the tab label";
 
         tabsMinWidth =
-          helpers.defaultNullOpts.mkNullable types.int "null"
+          helpers.defaultNullOpts.mkNullable types.int null
             "If int padding is added based on `contentLayout`";
 
         tabsMaxWidth =
-          helpers.defaultNullOpts.mkNullable types.int "null"
+          helpers.defaultNullOpts.mkNullable types.int null
             "This will truncate text even if `textTruncToFit = false`";
 
         padding = helpers.defaultNullOpts.mkNullable (with types; either int (attrsOf int)) "0" ''
@@ -259,11 +259,11 @@ in
                 };
               })
             )
+            null
             ''
               Set separators around the active tab.
               null falls back to `sourceSelector.separator`.
-            ''
-            "null";
+            '';
 
         showSeparatorOnEdge = helpers.defaultNullOpts.mkBool false ''
           Takes a boolean value where `false` (default) hides the separators on the far
@@ -354,7 +354,7 @@ in
           highlight = helpers.defaultNullOpts.mkStr "NeoTreeIndentMarker" "";
 
           withExpanders =
-            helpers.defaultNullOpts.mkNullable types.bool "null"
+            helpers.defaultNullOpts.mkNullable types.bool null
               "If null and file nesting is enabled, will enable expanders.";
 
           expanderCollapsed = helpers.defaultNullOpts.mkStr "" "";

--- a/plugins/git/diffview.nix
+++ b/plugins/git/diffview.nix
@@ -9,7 +9,14 @@ with lib;
 let
   cfg = config.plugins.diffview;
   mkWinConfig =
-    type: width: height: position: with helpers.defaultNullOpts; {
+    {
+      type ? null,
+      width ? null,
+      height ? null,
+      position ? null,
+    }:
+    with helpers.defaultNullOpts;
+    {
       type =
         mkEnum
           [
@@ -294,7 +301,11 @@ in
                   ${commonDesc}
                 '';
           };
-        winConfig = mkWinConfig "split" 35 "" "left";
+        winConfig = mkWinConfig {
+          type = "split";
+          width = 35;
+          position = "left";
+        };
       };
       fileHistoryPanel = {
         logOptions =
@@ -427,11 +438,15 @@ in
               multiFile = logOptions;
             };
           };
-        winConfig = mkWinConfig "split" "" 16 "bottom";
+        winConfig = mkWinConfig {
+          type = "split";
+          height = 16;
+          position = "bottom";
+        };
       };
 
       commitLogPanel = {
-        winConfig = mkWinConfig "float" "" "" "";
+        winConfig = mkWinConfig { type = "float"; };
       };
 
       defaultArgs =

--- a/plugins/languages/rust/rust-tools.nix
+++ b/plugins/languages/rust/rust-tools.nix
@@ -23,7 +23,7 @@ in
       "quickfix"
     ] "how to execute terminal commands";
 
-    onInitialized = helpers.defaultNullOpts.mkLuaFn "null" ''
+    onInitialized = helpers.defaultNullOpts.mkLuaFn null ''
       Callback to execute once rust-analyzer is done initializing the workspace
       The callback receives one parameter indicating the `health` of the server:
       "ok" | "warning" | "error"
@@ -72,11 +72,11 @@ in
       '' "rust-tools hover window" "";
 
       maxWidth =
-        helpers.defaultNullOpts.mkNullable types.int "null"
+        helpers.defaultNullOpts.mkNullable types.int null
           "Maximal width of the hover window. null means no max.";
 
       maxHeight =
-        helpers.defaultNullOpts.mkNullable types.int "null"
+        helpers.defaultNullOpts.mkNullable types.int null
           "Maximal height of the hover window. null means no max.";
 
       autoFocus = helpers.defaultNullOpts.mkBool false "whether the hover action window gets automatically focused";
@@ -88,13 +88,13 @@ in
         see: https://graphviz.org/docs/outputs/
       '';
 
-      output = helpers.defaultNullOpts.mkStr "null" "where to store the output, nil for no output stored";
+      output = helpers.defaultNullOpts.mkStr null "where to store the output, nil for no output stored";
 
       full = helpers.defaultNullOpts.mkBool true ''
         true for all crates.io and external crates, false only the local crates
       '';
 
-      enabledGraphvizBackends = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "null" ''
+      enabledGraphvizBackends = helpers.defaultNullOpts.mkNullable (types.listOf types.str) null ''
         List of backends found on: https://graphviz.org/docs/outputs/
         Is used for input validation and autocompletion
       '';

--- a/plugins/lsp/inc-rename.nix
+++ b/plugins/lsp/inc-rename.nix
@@ -25,11 +25,11 @@ with lib;
       whether to display a `Renamed m instances in n files` message after a rename operation
     '';
 
-    inputBufferType = helpers.defaultNullOpts.mkNullable (types.enum [ "dressing" ]) "null" ''
+    inputBufferType = helpers.defaultNullOpts.mkNullable (types.enum [ "dressing" ]) null ''
       the type of the external input buffer to use
     '';
 
-    postHook = helpers.defaultNullOpts.mkLuaFn "null" ''
+    postHook = helpers.defaultNullOpts.mkLuaFn null ''
       callback to run after renaming, receives the result table (from LSP handler) as an argument
     '';
   };

--- a/plugins/lsp/language-servers/nil_ls-settings.nix
+++ b/plugins/lsp/language-servers/nil_ls-settings.nix
@@ -4,20 +4,20 @@
 with lib;
 {
   formatting = {
-    command = helpers.defaultNullOpts.mkListOf types.str "null" ''
+    command = helpers.defaultNullOpts.mkListOf types.str null ''
       External formatter command (with arguments).
       It should accepts file content in stdin and print the formatted code into stdout.
     '';
   };
 
   diagnostics = {
-    ignored = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    ignored = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Ignored diagnostic kinds.
       The kind identifier is a snake_cased_string usually shown together
       with the diagnostic message.
     '';
 
-    excludedFiles = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    excludedFiles = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Files to exclude from showing diagnostics. Useful for generated files.
       It accepts an array of paths. Relative paths are joint to the workspace root.
       Glob patterns are currently not supported.

--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -42,7 +42,7 @@ in
       example = true;
     };
 
-    border = helpers.defaultNullOpts.mkBorder "null" "`:NullLsInfo` UI window." ''
+    border = helpers.defaultNullOpts.mkBorder null "`:NullLsInfo` UI window." ''
       Uses `NullLsInfoBorder` highlight group (see [Highlight Groups](#highlight-groups)).
     '';
 
@@ -80,7 +80,7 @@ in
       Specifying a timeout with a value less than zero will prevent commands from timing out.
     '';
 
-    diagnosticConfig = helpers.defaultNullOpts.mkNullable types.attrs "null" ''
+    diagnosticConfig = helpers.defaultNullOpts.mkNullable types.attrs null ''
       Specifies diagnostic display options for null-ls sources, as described in
       `:help vim.diagnostic.config()`.
       (null-ls uses separate namespaces for each source, so server-wide configuration will not work
@@ -145,23 +145,23 @@ in
       [nvim-notify](https://github.com/rcarriga/nvim-notify).
     '';
 
-    onAttach = helpers.defaultNullOpts.mkStr "null" ''
+    onAttach = helpers.defaultNullOpts.mkStr null ''
       Defines an `on_attach` callback to run whenever null-ls attaches to a buffer.
       If you have a common `on_attach` you're using for LSP servers, you can reuse that here, use a
       custom callback for null-ls, or leave this undefined.
     '';
 
-    onInit = helpers.defaultNullOpts.mkLuaFn "null" ''
+    onInit = helpers.defaultNullOpts.mkLuaFn null ''
       Defines an `on_init` callback to run when null-ls initializes. From here, you
       can make changes to the client (the first argument) or `initialize_result` (the
       second argument, which as of now is not used).
     '';
 
-    onExit = helpers.defaultNullOpts.mkLuaFn "null" ''
+    onExit = helpers.defaultNullOpts.mkLuaFn null ''
       Defines an `on_exit` callback to run when the null-ls client exits.
     '';
 
-    rootDir = helpers.defaultNullOpts.mkLuaFn "null" ''
+    rootDir = helpers.defaultNullOpts.mkLuaFn null ''
       Determines the root of the null-ls server. On startup, null-ls will call
       `root_dir` with the full path to the first file that null-ls attaches to.
 
@@ -175,7 +175,7 @@ in
       directory.
     '';
 
-    shouldAttach = helpers.defaultNullOpts.mkLuaFn "null" ''
+    shouldAttach = helpers.defaultNullOpts.mkLuaFn null ''
       A user-defined function that controls whether to enable null-ls for a given
       buffer. Receives `bufnr` as its first argument.
 
@@ -191,7 +191,7 @@ in
       ```
     '';
 
-    tempDir = helpers.defaultNullOpts.mkStr "null" ''
+    tempDir = helpers.defaultNullOpts.mkStr null ''
       Defines the directory used to create temporary files for sources that rely on them (a
       workaround used for command-based sources that do not support `stdio`).
 

--- a/plugins/ui/noice.nix
+++ b/plugins/ui/noice.nix
@@ -156,7 +156,7 @@ with lib;
       hover = {
         enabled = helpers.defaultNullOpts.mkBool true "enable hover UI";
         view =
-          helpers.defaultNullOpts.mkNullable types.str "null"
+          helpers.defaultNullOpts.mkNullable types.str null
             "when null, use defaults from documentation";
         opts =
           helpers.defaultNullOpts.mkNullable types.anything "{}"
@@ -176,7 +176,7 @@ with lib;
         };
 
         view =
-          helpers.defaultNullOpts.mkNullable types.str "null"
+          helpers.defaultNullOpts.mkNullable types.str null
             "when null, use defaults from documentation";
         opts =
           helpers.defaultNullOpts.mkNullable types.anything "{}"

--- a/plugins/ui/statuscol.nix
+++ b/plugins/ui/statuscol.nix
@@ -29,11 +29,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Whether to right-align the cursor line number with `relativenumber` set.
     '';
 
-    ft_ignore = helpers.defaultNullOpts.mkListOf types.str "null" ''
+    ft_ignore = helpers.defaultNullOpts.mkListOf types.str null ''
       Lua table with 'filetype' values for which `statuscolumn` will be unset.
     '';
 
-    bt_ignore = helpers.defaultNullOpts.mkListOf types.str "null" ''
+    bt_ignore = helpers.defaultNullOpts.mkListOf types.str null ''
       Lua table with 'buftype' values for which `statuscolumn` will be unset.
     '';
 

--- a/plugins/utils/auto-session.nix
+++ b/plugins/utils/auto-session.nix
@@ -58,13 +58,13 @@ in
     };
 
     autoSave = {
-      enabled = helpers.defaultNullOpts.mkNullable types.bool "null" ''
+      enabled = helpers.defaultNullOpts.mkNullable types.bool null ''
         Whether to enable auto saving session.
       '';
     };
 
     autoRestore = {
-      enabled = helpers.defaultNullOpts.mkNullable types.bool "null" ''
+      enabled = helpers.defaultNullOpts.mkNullable types.bool null ''
         Whether to enable auto restoring session.
       '';
     };

--- a/plugins/utils/dressing.nix
+++ b/plugins/utils/dressing.nix
@@ -68,7 +68,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
         '';
 
-        width = helpers.defaultNullOpts.mkNullable intOrRatio "null" ''
+        width = helpers.defaultNullOpts.mkNullable intOrRatio null ''
           Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
         '';
 
@@ -130,7 +130,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           Used to customize the layout.
         '';
 
-        get_config = helpers.defaultNullOpts.mkLuaFn "null" ''
+        get_config = helpers.defaultNullOpts.mkLuaFn null ''
           This can be a function that accepts the opts parameter that is passed in to 'vim.select'
           or 'vim.input'. It must return either nil or config values to use in place of the global
           config values for that module.
@@ -153,8 +153,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         '';
 
         telescope =
-          helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; either strLua (attrsOf anything))
-            "null"
+          helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; either strLua (attrsOf anything)) null
             ''
               Options for telescope selector.
 
@@ -230,7 +229,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             }
           '' "An attribute set of window options.";
 
-          width = helpers.defaultNullOpts.mkNullable intOrRatio "null" ''
+          width = helpers.defaultNullOpts.mkNullable intOrRatio null ''
             Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
           '';
 
@@ -252,7 +251,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
                 of total."
               '';
 
-          height = helpers.defaultNullOpts.mkNullable intOrRatio "null" ''
+          height = helpers.defaultNullOpts.mkNullable intOrRatio null ''
             Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
           '';
 
@@ -313,7 +312,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           ```
         '';
 
-        get_config = helpers.defaultNullOpts.mkLuaFn "null" ''
+        get_config = helpers.defaultNullOpts.mkLuaFn null ''
           This can be a function that accepts the opts parameter that is passed in to 'vim.select'
           or 'vim.input'. It must return either nil or config values to use in place of the global
           config values for that module.

--- a/plugins/utils/hydra/hydra-config-opts.nix
+++ b/plugins/utils/hydra/hydra-config-opts.nix
@@ -22,7 +22,7 @@ with lib;
         "warn"
         "run"
       ]
-      "null"
+      null
       ''
         Decides what to do when a key which doesn't belong to any head is pressed
         - `null`: hydra exits and foreign key behaves normally, as if the hydra wasn't active
@@ -37,14 +37,14 @@ with lib;
 
   buffer = helpers.defaultNullOpts.mkNullable (
     with types; either (enum [ true ]) ints.unsigned
-  ) "null" "Define a hydra for the given buffer, pass `true` for current buf.";
+  ) null "Define a hydra for the given buffer, pass `true` for current buf.";
 
   invoke_on_body = helpers.defaultNullOpts.mkBool false ''
     When true, summon the hydra after pressing only the `body` keys.
     Normally a head is required.
   '';
 
-  desc = helpers.defaultNullOpts.mkStr "null" ''
+  desc = helpers.defaultNullOpts.mkStr null ''
     Description used for the body keymap when `invoke_on_body` is true.
     When nil, "[Hydra] .. name" is used.
   '';

--- a/plugins/utils/neocord.nix
+++ b/plugins/utils/neocord.nix
@@ -51,7 +51,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           "warn"
           "error"
         ]
-        "null"
+        null
         ''
           Log messages at or above this level.
         '';

--- a/plugins/utils/nvim-ufo.nix
+++ b/plugins/utils/nvim-ufo.nix
@@ -20,7 +20,7 @@ in
       while opening the folded line, `0` value will disable the highlight
     '';
 
-    providerSelector = helpers.defaultNullOpts.mkLuaFn "null" ''
+    providerSelector = helpers.defaultNullOpts.mkLuaFn null ''
       A lua function as a selector for fold providers.
     '';
 
@@ -31,7 +31,7 @@ in
       run `UfoInspect` for details if your provider has extended the kinds.
     '';
 
-    foldVirtTextHandler = helpers.defaultNullOpts.mkLuaFn "null" "A lua function to customize fold virtual text";
+    foldVirtTextHandler = helpers.defaultNullOpts.mkLuaFn null "A lua function to customize fold virtual text";
 
     enableGetFoldVirtText = helpers.defaultNullOpts.mkBool false ''
       Enable a function with `lnum` as a parameter to capture the virtual text

--- a/plugins/utils/presence-nvim.nix
+++ b/plugins/utils/presence-nvim.nix
@@ -49,7 +49,7 @@ in
             "warn"
             "error"
           ]
-          "null"
+          null
           ''
             Log messages at or above this level.
           '';


### PR DESCRIPTION
Follow up to #1603

- **plugins: normalise `null` plugin-defaults**
  This first commit was needed to satisfy the assertion I added to `mkEnum'`.
  I could move this to another PR if needed.\
  We could also check each of the files touched to see if other changes ought to be made.

- **lib/options: add more `defaultNullOpts` 'variants**
  The meat of this PR - add a prime variant for each `defaultNullOpts` option factory function.

- **lib/options: add `mkEnum'` argument assertions**
  I also added some assertions to ensure `mkEnum'` is always used correctly. This could be kept or dropped (after running it through CI) depending on preference.

@GaetanLepage It'd be great if you could run CI with these changes on #1614.
