### PR TITLE
readme: minor streamlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,38 @@ as fast as possible.
 Since everything is disabled by default, it will be as snappy as you want it to
 be.
 
+### Plugin settings
+Most plugins have a `settings` option, which accepts _any_ nix attribute set
+and translate it into a lua table. This is then passed to the plugin's `setup`
+function. In practice this means if a plugin has a `settings` option, any plugin
+option can be configured, even if we don't explicitly have a corresponding nix
+option.
+
+### Raw lua
+If you just want to add additional lines of lua to your `init.lua`, you can use
+`extraConfigLua`, `extraConfigLuaPre`, and `extraConfigLuaPost`.
+
+If you want to assign lua code to an option that'd normally accept another type
+(string, int, etc), you can use nixvim's "raw type", `{ __raw = "lua code"; }`.
+
+<details>
+  <summary>Example</summary>
+
+This nix code:
+```nix
+{
+  some_option.__raw = "function() print('hello, world!') end";
+}
+```
+Will produce the following lua:
+```lua
+{
+  ['some_option'] = function() print('hello, world!') end,
+}
+```
+
+</details>
+
 ## Support/Questions
 If you have any question, please use the [discussions page](https://github.com/nix-community/nixvim/discussions/categories/q-a)! Alternatively, join the Matrix channel at [#nixvim:matrix.org](https://matrix.to/#/#nixvim:matrix.org)!
 

--- a/README.md
+++ b/README.md
@@ -128,12 +128,14 @@ and standalone through the `makeNixvim` function. To use the modules, just impor
 `nixvim.nixosModules.nixvim` modules, depending on which system
 you're using.
 
+For more detail, see the [Usage](https://nix-community.github.io/nixvim/user-guide/install.html#usage) section of our documentation.
+
 If you want to use it standalone, you can use the `makeNixvim` function:
 
 ```nix
 { pkgs, nixvim, ... }: {
   environment.systemModules = [
-    (nixvim.legacyPackages."${system}".makeNixvim {
+    (nixvim.legacyPackages."${pkgs.system}".makeNixvim {
       colorschemes.gruvbox.enable = true;
     })
   ];

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ you're using.
 
 For more detail, see the [Usage](https://nix-community.github.io/nixvim/user-guide/install.html#usage) section of our documentation.
 
+### Standalone Usage
+
 If you want to use it standalone, you can use the `makeNixvim` function:
 
 ```nix
@@ -198,6 +200,25 @@ can use the following:
 You can then run neovim using `nix run .# -- <file>`. This can be useful to test
 config changes easily.
 
+### Advanced Usage
+
+You may want more control over the nixvim modules, like:
+
+- Splitting your configuration in multiple files
+- Adding custom nix modules to enhance nixvim
+- Change the nixpkgs used by nixvim
+
+In this case, you can use the `makeNixvimWithModule` function.
+
+It takes a set with the following keys:
+- `pkgs`: The nixpkgs to use (defaults to the nixpkgs pointed at by the nixvim flake)
+- `module`: The nix module definition used to extend nixvim.
+  This is useful to pass additional module machinery like `options` or `imports`.
+- `extraSpecialArgs`: Extra arguments to pass to the modules when using functions.
+  Can be `self` in a flake, for example.
+
+For more detail, see the [Standalone Usage](https://nix-community.github.io/nixvim/modules/standalone.html) section of our documentation.
+
 ### With a `devShell`
 
 You can also use nixvim to define an instance which will only be available inside a Nix `devShell`:
@@ -216,23 +237,6 @@ in pkgs.mkShell {
 ```
 
 </details>
-
-### Advanced Usage
-
-You may want more control over the nixvim modules, like:
-
-- Splitting your configuration in multiple files
-- Adding custom nix modules to enhance nixvim
-- Change the nixpkgs used by nixvim
-
-In this case, you can use the `makeNixvimWithModule` function.
-
-It takes a set with the following keys:
-- `pkgs`: The nixpkgs to use (defaults to the nixpkgs pointed at by the nixvim flake)
-- `module`: The nix module definition used to extend nixvim.
-  This is useful to pass additional module machinery like `options` or `imports`.
-- `extraSpecialArgs`: Extra arguments to pass to the modules when using functions.
-  Can be `self` in a flake, for example.
 
 ## How does it work?
 When you build the module (probably using home-manager), it will install all

--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ If you have any question, please use the [discussions page](https://github.com/n
 >
 > If you want to use NixVim with nixpkgs 23.11 you should use the `nixos-23.11` branch.
 
-### Without flakes
+For more detail, see the [Installation](https://nix-community.github.io/nixvim/install.html#installation) section of our documentation.
+
+<details>
+  <summary><strong>Without flakes</strong></summary>
+
 NixVim now ships with `flake-compat`, which makes it usable from any system.
 
 To install it, edit your home-manager (or NixOS) configuration:
@@ -76,7 +80,11 @@ in
 }
 ```
 
-### Using flakes
+</details>
+
+<details>
+  <summary><strong>Using flakes</strong></summary>
+
 This is the recommended method if you are already using flakes to manage your
 system. To enable flakes, add this to `/etc/nixos/configuration.nix`
 
@@ -110,6 +118,8 @@ flakes, just add the nixvim input:
 You can now access the module using `inputs.nixvim.homeManagerModules.nixvim`,
 for a home-manager installation, `inputs.nixvim.nixosModules.nixvim`, for NixOS,
 and `inputs.nixvim.nixDarwinModules.nixvim` for nix-darwin.
+
+</details>
 
 ## Usage
 NixVim can be used in four ways: through the home-manager, nix-darwin, NixOS modules,

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ gruvbox as the colorscheme, no extra configuration required!
 
 Check out [this list of real world nixvim configs](https://nix-community.github.io/nixvim/user-guide/config-examples.html)!
 
+## How does it work?
+When you build the module (probably using home-manager), it will install all
+your plugins and generate a lua config for NeoVim with all the options
+specified. Because it uses lua, this ensures that your configuration will load
+as fast as possible.
+
+Since everything is disabled by default, it will be as snappy as you want it to
+be.
+
 ## Support/Questions
 If you have any question, please use the [discussions page](https://github.com/nix-community/nixvim/discussions/categories/q-a)! Alternatively, join the Matrix channel at [#nixvim:matrix.org](https://matrix.to/#/#nixvim:matrix.org)!
 
@@ -237,15 +246,6 @@ in pkgs.mkShell {
 ```
 
 </details>
-
-## How does it work?
-When you build the module (probably using home-manager), it will install all
-your plugins and generate a lua config for NeoVim with all the options
-specified. Because it uses lua, this ensures that your configuration will load
-as fast as possible.
-
-Since everything is disabled by default, it will be as snappy as you want it to
-be.
 
 # Documentation
 Documentation is available on this project's GitHub Pages page:


### PR DESCRIPTION
- **readme: put installation instruction in `<details>`**
- **readme: use `pkgs.system` in standalone example**
- **readme: move "advanced usage" next to "standalone usage"**
- **readme: move "how it works" near the top**
- **readme: add "plugin settings" and "raw lua" sections**

This PR is an attempt to streamline the README slightly and add relevant links to the documentation.

I also made the "how it works" section more prominent and added additional sub-headings to it to hopefully give a clearer first-impression.

Final render https://github.com/MattSturgeon/nixvim/blob/readme/README.md
