### PR TITLE
fix(hmts): correct error message on no `treesitter`

### DIFF
--- a/plugins/languages/treesitter/hmts.nix
+++ b/plugins/languages/treesitter/hmts.nix
@@ -20,7 +20,7 @@ in
 
   config = mkIf cfg.enable {
     warnings = optional (!config.plugins.treesitter.enable) [
-      "Nixvim: treesitter-refactor needs treesitter to function as intended"
+      "Nixvim: hmts needs treesitter to function as intended"
     ];
 
     extraPlugins = [ cfg.package ];


### PR DESCRIPTION
# Description

This fixes the invalid message in `hmts` plugin whose declaration probably derived from that of the other plugin.