### PR TITLE
flake-modules: minor tweaks from #1629

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Git revisions added to this file will be ignored by GitHub's blame feature.
+#
+# This can also be used locally with `git blame` by configuring your "blame.ignoreRevsFile":
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Or you can this on an ad-hock basis with the `--ignore-revs-file` argument:
+# git blame --ignore-revs-file .git-blame-ignore-revs
+
+# This commit reformatted from alejandra to nixfmt-rfc-style:
+# 2024-05-05: treewide: Reformat with nixfmt
+62f32bfc711f0a3c8a52af4c0790345b4b3d2346
+

--- a/flake-modules/default.nix
+++ b/flake-modules/default.nix
@@ -11,7 +11,6 @@
     ./templates.nix
     ./tests.nix
     ./wrappers.nix
-    inputs.flake-root.flakeModule
   ];
 
   perSystem =

--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -9,8 +9,6 @@
   perSystem =
     { pkgs, config, ... }:
     {
-      formatter = config.treefmt.build.wrapper;
-
       treefmt.config = {
         projectRootFile = "flake.nix";
         package = pkgs.treefmt;

--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -8,12 +8,18 @@
 
   perSystem =
     { pkgs, config, ... }:
+    let
+      fmt = pkgs.nixfmt-rfc-style;
+    in
     {
       treefmt.config = {
         projectRootFile = "flake.nix";
 
         programs = {
-          nixfmt-rfc-style.enable = true;
+          nixfmt = {
+            enable = true;
+            package = fmt;
+          };
           statix.enable = true;
         };
       };
@@ -21,8 +27,8 @@
       pre-commit = {
         settings.hooks = {
           nixfmt = {
-            package = pkgs.nixfmt-rfc-style;
             enable = true;
+            package = fmt;
           };
           statix = {
             enable = true;

--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -11,7 +11,6 @@
     {
       treefmt.config = {
         projectRootFile = "flake.nix";
-        package = pkgs.treefmt;
 
         programs = {
           nixfmt-rfc-style.enable = true;

--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -12,7 +12,7 @@
       formatter = config.treefmt.build.wrapper;
 
       treefmt.config = {
-        inherit (config.flake-root) projectRootFile;
+        projectRootFile = "flake.nix";
         package = pkgs.treefmt;
 
         programs = {

--- a/flake.lock
+++ b/flake.lock
@@ -71,21 +71,6 @@
         "type": "github"
       }
     },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1713493429,
-        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -211,7 +196,6 @@
         "devshell": "devshell",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,6 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
-    # A flake-parts module for finding the project root directory
-    flake-root.url = "github:srid/flake-root";
     devshell = {
       url = "github:numtide/devshell";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
This PR includes the less controversial commits from #1629, as well as a couple new commits:

- flake-modules: drop flake-root
- flake-modules: explicitly set the same nixfmt for treefmt + pre-commit