### PR TITLE
modules/clipboard: use md link in description

### DIFF
--- a/modules/clipboard.nix
+++ b/modules/clipboard.nix
@@ -14,7 +14,7 @@ in
       register = mkOption {
         description = ''
           Sets the register to use for the clipboard.
-          Learn more at https://neovim.io/doc/user/options.html#'clipboard'.
+          Learn more in [`:h 'clipboard'`](https://neovim.io/doc/user/options.html#'clipboard').
         '';
         type = with types; nullOr (either str (listOf str));
         default = null;


### PR DESCRIPTION
Use a markdown-syntax link so that the docs show a clickable-link.
