### PR TITLE
github/mergify: init

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,91 @@
+# Essential reading on condition syntax:
+# https://docs.mergify.com/configuration/conditions/#testing-and-debugging-conditions
+
+
+# Using a merge queue ensures CI passes before merging;
+# rebasing is done before merge_conditions are checked.
+#
+# https://docs.mergify.com/merge-queue
+queue_rules:
+  - name: default
+    update_method: rebase
+    merge_method: fast-forward
+    merge_conditions:
+      - check-success=buildbot/nix-eval
+    queue_conditions:
+      - or:
+          # One review is enough to manually queue
+        - "#approved-reviews-by>=1"
+
+          # Allow flake.lock without any review
+        - and:
+          - "#files = 1"
+          - files = flake.lock
+          - author = GaetanLepage
+
+
+# We can apply all sorts of "rules" to help automate PRs!
+#
+# https://docs.mergify.com/workflow
+pull_request_rules:
+    # Note: this rule will auto-queue when both its AND queue_rules's conditions are met.
+    # If queue_rules's conditions are met, this rule can be bypassed by manually running `@mergify queue`
+  - name: Queue approved PRs
+    description: Add PRs to the merge queue once they've met basic requirements
+    actions:
+      queue:
+    conditions:
+      - or:
+          # Normally, require 2 reviews
+        - "#approved-reviews-by >= 2"
+
+          # Maintainers only need 1 review
+          # TODO: We could drop this lower requirement. Since we can run `@mergify queue`
+          # if we don't get the 2nd review needed to auto-queue.
+        - and:
+          - author = @nix-community/nixvim
+          - "#approved-reviews-by >= 1"
+
+          # flake.lock updates don't need approval during office hours
+        - and:
+          - "#files = 1"
+          - files = flake.lock
+          - author = GaetanLepage # Gaétan's PAT is used for the update PRs
+          - schedule = Mon-Fri 09:00-17:00[Europe/London]
+
+  - name: Create backport PRs
+    description: Create a backport PR to the specified branches
+    actions:
+      backport:
+        branches:
+          - "nixos-24.05"
+    conditions:
+      - base = main
+      - label = backport
+
+    # TODO: is this needed? We can use the `@mergify backport` command...
+    # I guess it might be nice to label a pr with `backport` and then have that happen
+    # _after_ the PR is merged?
+  - name: Queue backport PRs
+    description: Automatically queue backport PRs
+    actions:
+      queue:
+    conditions:
+      - author = mergify[bot]
+      - head ~= ^mergify/bp/
+      - base = nixos-24.05
+
+    # Open PRs that have no changes requested and have <2 reviews,
+    # should request review from @nixvim
+  - name: Request review
+    description: Request review from @nixvim if there's not enough approvals
+    actions:
+      request_reviews:
+        teams:
+          - nix-community/nixvim
+    conditions:
+      - -closed
+      - "#approved-reviews-by<2"
+      - "#changes-requested-reviews-by=0"
+      - "review-requested!=@nix-community/nixvim"
+

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -89,3 +89,11 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "review-requested!=@nix-community/nixvim"
 
+  - name: Delete merged branches
+    description: Delete head branch after merge, unless other PRs depend on it
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:
+        force: false
+


### PR DESCRIPTION
Mergify is a third-party GitHub App that improves the workflow around PRs.

The goal of this PR is to streamline the process of reviewing & merging PRs, especially the automated flake.lock updates.

### Initial setup
As per their [getting started](https://docs.mergify.com/getting-started/) instructions, we should:

- [ ] Log into the [Mergify dashboard](https://dashboard.mergify.com/) using GitHub SSO.
- [ ] Click on [`Enable Mergify on a new account`](https://github.com/apps/mergify/installations/new)
- [ ] Select the repositories you want to give Mergify access to (nix-community/nixvim).
- [ ] You will be redirected to the [dashboard](https://dashboard.mergify.com/). You can start using Mergify, using [commands](https://docs.mergify.com/commands), [writing a configuration file](https://docs.mergify.com/workflow/writing-your-first-rule) (this PR), or setting up [merge queues](https://docs.mergify.com/merge-queue).

### Branch protection 
TODO: we'll need to have branch protection rules compatible with mergify. I haven't looked into what those are yet.

We'll also need to ensure mergify itself maintains the level of protection we want through its own systems.

### Testing and debuging
Once you have nixvim linked to your mergify dashboard, you can use their "config editor" to check the config is valid and test how rules and conditions match against actual PRs. See [Testing and Debugging Conditions](https://docs.mergify.com/configuration/conditions/#testing-and-debugging-conditions) for more detail.

### "Checks"
One mergify feature I'm not currently using in this PR is the ability to [post additional "checks"](https://docs.mergify.com/workflow/actions/post_check) to a PR.

If used, this show up in the PR's "Checks" tab and alongside CI run results at the bottom (next to the merge/close buttons). Checks are a lightweight way of validating parts of a pull request without spinning up a CI workflow; one example they give is [enforcing conventional commits PR titles](https://docs.mergify.com/workflow/custom-branch-protections/#enforcing-conventional-commits), by utilising the same condition expression system used elsewhere in mergify, these lightweight checks can become fairly powerful.

I don't plan on adding any checks in this initial PR, though.

### Merge queue
The [merge queue](https://docs.mergify.com/merge-queue) is an optional mergify feature. Essentially it ensures PRs are merged into `main` one-at-a-time, after being automatically rebased (if needed) and conditions (like CI) checked against that final rebased revision before merging.

We could configure mergify to automatically merge stuff _without_ using a queue, but it looks like a good feature so currently this PR implements it.

The merge queue also opens the door to a [two stage CI](https://docs.mergify.com/merge-queue/two-step), where one round of checks must pass to be allowed into the queue and another (more intensive) round of checks must pass in order to be merged into `main`.

This PR makes buildbot's CI a requirement for merging, but review approvals are the only requirement for queuing. Nothing has changed about how we trigger CI, but we could make the pre-queue CI cheaper to run in the future, knowing that the "full thing" is required to merge queued PRs.

### Fast-forward
GitHub hates fast-forward merges. The web UI only offers squash, rebase (with forced new commit objects), and merge (with `--no-ff`).

Mergify, however, is far more flexible, supporting `merge`, `squash`, `rebase`, **or `fast-forward`!**

### Commands
Anything mergify can do automatically with [PR_rules](https://docs.mergify.com/workflow/), can also be done manually with [commands](https://docs.mergify.com/commands).

While commands completely bypass pr_rules, they _don't_ bypass any failing `post_checks` added by pr_rules, nor do they bypass `queue_rules` when attempting to add PRs to the queue.

I say _anything_, but there's actually configurable [restrictions on commands](https://docs.mergify.com/commands/restrictions). Again, more **condition** expressions :smile:. I've not looked into that yet with this PR.

### Docs
https://docs.mergify.com
[Config file format](https://docs.mergify.com/configuration/file-format)
[Conditions reference](https://docs.mergify.com/configuration/conditions)
