### PR TITLE
lib/options: `defaultNullOpts` no longer requires a "default" or "description"

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -130,7 +130,7 @@ rec {
           # TODO deprecate this behavior so we can properly quote strings
           defaultString = if isString default then default else generators.toPretty { } default;
           defaultDesc =
-            "Plugin default:"
+            "_Plugin default:_"
             + (
               # Detect whether `default` is multiline or inline:
               if hasInfix "\n" defaultString then "\n\n```nix\n${defaultString}\n```" else " `${defaultString}`"


### PR DESCRIPTION
- **lib/options: `defaultNullOpts` don't require having a default**

Made the `default` and `description` arguments optional for all **prime variants** of `defaultNullOpts` functions.

If neither `default` nor `description` are provided, the option will have no description.

The "Plugin default" line is only added when a `default` argument is present (`args ? default`).

This means we can now use `defaultNullOpts`, even when we explicitly _do not_ want to document a "plugin default".

- **docs: emphasise "Plugin default" to match nixpkgs**

Match the style of similar headings that come from nixpkgs. This tiny commit could be **backported** to 24.05.

<details><summary><strong>Docs render</strong></summary>
<p>

![image](https://github.com/nix-community/nixvim/assets/5046562/bf2a3660-105a-4686-8421-2a6e18108814)


</p>
</details> 