### PR TITLE
docs/lsp: Display server URLs

### DIFF
--- a/flake-modules/modules.nix
+++ b/flake-modules/modules.nix
@@ -26,20 +26,17 @@
           with lib;
           {
             # Attribute may contain the following fields:
-            #  - name: Name of the module
-            #  - kind: Either colorschemes or plugins
+            #  - path: Path to the module, e.g. [ "plugins" "<name>" ]
             #  - description: A short description of the plugin
             #  - url: Url for the plugin
-            #
-            #  [kind name] will identify the plugin
             #
             # We need to use an attrs instead of a submodule to handle the merge.
             options.meta.nixvimInfo = mkOption {
               type = (types.nullOr types.attrs) // {
                 # This will create an attrset of the form:
-                # {
-                #    "path"."to"."plugin" = { "<name>" = <info>; };
-                # }
+                #
+                # { path.to.plugin.name = <info>; }
+                #
                 #
                 # Where <info> is an attrset of the form:
                 # {
@@ -52,12 +49,13 @@
                   lib.foldl'
                     (
                       acc: def:
-                      lib.recursiveUpdate acc {
-                        "${def.value.kind}"."${def.value.name}" = {
-                          inherit (def.value) url description;
+                      lib.recursiveUpdate acc (
+                        setAttrByPath def.value.path {
                           inherit (def) file;
-                        };
-                      }
+                          url = def.value.url or null;
+                          description = def.value.description or null;
+                        }
+                      )
                     )
                     {
                       plugins = { };

--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -65,8 +65,11 @@ rec {
       meta = {
         inherit maintainers;
         nixvimInfo = {
-          inherit description name url;
-          kind = namespace;
+          inherit description url;
+          path = [
+            namespace
+            name
+          ];
         };
       };
 

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -68,8 +68,11 @@ with lib;
       meta = {
         inherit maintainers;
         nixvimInfo = {
-          inherit description name url;
-          kind = namespace;
+          inherit description url;
+          path = [
+            namespace
+            name
+          ];
         };
       };
       options.${namespace}.${name} = {

--- a/plugins/lsp/language-servers/_mk-lsp.nix
+++ b/plugins/lsp/language-servers/_mk-lsp.nix
@@ -10,6 +10,7 @@
   description ? "Enable ${name}.",
   serverName ? name,
   package ? pkgs.${name},
+  url ? package.meta.homepage or null,
   cmd ? (cfg: null),
   settings ? (cfg: cfg),
   settingsOptions ? { },
@@ -30,6 +31,17 @@ let
   cfg = config.plugins.lsp.servers.${name};
 in
 {
+  meta.nixvimInfo = {
+    # TODO: description
+    inherit url;
+    path = [
+      "plugins"
+      "lsp"
+      "servers"
+      name
+    ];
+  };
+
   options = {
     plugins.lsp.servers.${name} = {
       enable = mkEnableOption description;


### PR DESCRIPTION
- **meta: extend `meta.nixvimInfo` support treewide**
- **docs/lsp: Show LSP server homepage URLs**

![image](https://github.com/nix-community/nixvim/assets/5046562/f6055319-a15b-4baf-8da1-c16dd792bdb3)

