### PR TITLE
plugins/wakatime: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -218,6 +218,7 @@
     ./utils/vim-bbye.nix
     ./utils/vim-css-color.nix
     ./utils/vim-matchup.nix
+    ./utils/wakatime.nix
     ./utils/which-key.nix
     ./utils/wilder.nix
     ./utils/yanky.nix

--- a/plugins/utils/wakatime.nix
+++ b/plugins/utils/wakatime.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+with lib;
+helpers.vim-plugin.mkVimPlugin config {
+  name = "wakatime";
+  originalName = "vim-wakatime";
+  defaultPackage = pkgs.vimPlugins.vim-wakatime;
+
+  maintainers = [ maintainers.GaetanLepage ];
+}

--- a/tests/test-sources/plugins/utils/wakatime.nix
+++ b/tests/test-sources/plugins/utils/wakatime.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.wakatime.enable = true;
+  };
+}


### PR DESCRIPTION
Add support for [vim-wakatime](https://github.com/wakatime/vim-wakatime).
This module is quite barebone, but at the same time, there is no need to do much.

Fixes #1649