### PR TITLE
plugins/lsp: add inlay-hint option

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -112,6 +112,12 @@ in
         visible = false;
       };
 
+      inlayHints = mkEnableOption ''
+        LSP inlay-hints. Only affects language servers with inlay-hints support.
+
+        See [`:h lsp-inlay_hint`](https://neovim.io/doc/user/lsp.html#lsp-inlay_hint).
+      '';
+
       onAttach = mkOption {
         type = types.lines;
         description = "A lua function to be run when a new LSP buffer is attached. The argument `client` and `bufnr` is provided.";
@@ -195,6 +201,15 @@ in
         (mkMaps "vim.diagnostic." cfg.keymaps.diagnostic)
         ++ (mkMaps "vim.lsp.buf." cfg.keymaps.lspBuf)
         ++ cfg.keymaps.extra;
+
+      # Enable inlay-hints
+      plugins.lsp.onAttach = mkIf cfg.inlayHints ''
+        -- LSP Inlay Hints {{{
+        if client.server_capabilities.inlayHintProvider and vim.lsp.inlay_hint then
+          vim.lsp.inlay_hint.enable(bufnr, true)
+        end
+        -- }}}
+      '';
 
       # Enable all LSP servers
       extraConfigLua = ''

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -7,6 +7,7 @@
   example = {
     plugins.lsp = {
       enable = true;
+      inlayHints = true;
 
       keymaps = {
         silent = true;


### PR DESCRIPTION
Following up on #1313, this PR adds a the `plugins.lsp.inlayHints` option, which enables the capability in `plugins.lsp.onAttach`.

Unlike the original PR, no attempt is made to detect the neovim version used by `finalPackage`.

I still haven't considered if/how this should impact any existing server-specific options:
- [x] Basic inlay hint support (`plugins.lsp.inlayHints`)
- [ ] Consider how/if this can be configured for a specific LSP
- [ ] Consider whether this impacts existing options (should they be deprecated?)
  - [ ] [`plugins.clangd-extensions.inlayHints`](https://nix-community.github.io/nixvim/plugins/clangd-extensions/inlayHints.html)
  - [ ] [`plugins.rust-tools.inlayHints`](https://nix-community.github.io/nixvim/plugins/rust-tools/inlayHints.html)
  - [ ] [`plugins.lsp.servers.rust-analyzer.settings.inlayHints`](https://nix-community.github.io/nixvim/plugins/lsp/servers/rust-analyzer/settings/inlayHints/closingBraceHints.html)
  - [ ] Alternatively, maybe those LSPs having an option is preferable to having a global option?
  - [ ] (This can be moved to its own issue)
- [ ] Consider how/if we should expose more advanced functionality
  - [ ] Enable only in specific modes
  - [ ] Enable for the current line
  - [ ] Etc
  - [ ] Maybe use an `enum ([ true false "line" ] ++ modes)`?
  - [ ] (This can be moved to its own issue)

Fixes #1306