### PR TITLE
unstable: update to gdtoolkit_4

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -121,8 +121,8 @@ let
     erb_format = pkgs.rubyPackages.erb-formatter;
     fish_indent = pkgs.fish;
     format_r = pkgs.R;
-    gdformat = pkgs.gdtoolkit;
-    gdlint = pkgs.gdtoolkit;
+    gdformat = pkgs.gdtoolkit_4;
+    gdlint = pkgs.gdtoolkit_4;
     gitsigns = pkgs.git;
     gleam_format = pkgs.gleam;
     glslc = pkgs.shaderc;


### PR DESCRIPTION
there is now gdtoolkit_3 and gdtoolkit_4 in unstable
could also do
```
    gdformat = pkgs.gdtoolkit_3;
    gdlint = pkgs.gdtoolkit_3;
    gdformat_4 = pkgs.gdtoolkit_4;
    gdlint_4 = pkgs.gdtoolkit_4;
```
or 
```
    gdformat_3 = pkgs.gdtoolkit_3;
    gdlint_3 = pkgs.gdtoolkit_3;
    gdformat_4 = pkgs.gdtoolkit_4;
    gdlint_4 = pkgs.gdtoolkit_4;
```
or maybe
```
    gdformat = pkgs.gdtoolkit_3;
    gdlint = pkgs.gdtoolkit_3;
    gdformat_3 = pkgs.gdtoolkit_3;
    gdlint_3 = pkgs.gdtoolkit_3;
    gdformat_4 = pkgs.gdtoolkit_4;
    gdlint_4 = pkgs.gdtoolkit_4;
```
and then somehow output a warning for gdformat and gdlint for a while before removing it