### PR TITLE
lib/options: refactor and rename (non-breaking)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,8 @@ These option declarations should be in `settingsOptions` and their names should 
 There are a number of helpers to help you correctly implement them:
 
 - `helpers.defaultNullOpts.{mkBool,mkInt,mkStr,...}`: This family of helpers takes a default value and a description, and sets the Nix default to `null`. These are the main functions you should use to define options.
-- `helpers.defaultNullOpts.mkNullable`: This takes a type, a default and a description. This is useful for more complex options.
+- `helpers.defaultNullOpts.mkNullableWithRaw`: This takes a type, a default and a description. This is useful for more complex options.
+- The `helpers.defaultNullOpts` functions also have "prime variants", these use the same function arguments as `lib.mkOption`. Any unused arguments are passed through to `mkOption`; this is useful for setting an `example` or other advanced cases.
 - `helpers.nixvimTypes.rawLua`: A type to represent raw lua code. The values are of the form `{ __raw = "<code>";}`. This should not be used if the option can only be raw lua code, `mkLua`/`mkLuaFn` should be used in this case.
 
 The resulting `settings` attrs will be directly translated to `lua` and will be forwarded the plugin:

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -14,9 +14,7 @@ rec {
   mkNullOrLua = nullableOpts.mkLua;
   mkNullOrLuaFn' = nullableOpts.mkLuaFn';
   mkNullOrLuaFn = nullableOpts.mkLuaFn;
-  mkNullOrStrLuaOr' = nullableOpts.mkStrLuaOr';
   mkNullOrStrLuaOr = nullableOpts.mkStrLuaOr;
-  mkNullOrStrLuaFnOr' = nullableOpts.mkStrLuaFnOr';
   mkNullOrStrLuaFnOr = nullableOpts.mkStrLuaFnOr;
 
   # TODO: should we deprecate this?
@@ -59,8 +57,13 @@ rec {
           type = nixvimTypes.strLua;
           apply = mkRaw;
         }
+        // (optionalAttrs (args ? type) {
+          type = with nixvimTypes; either strLua args.type;
+          apply = v: if isString v then mkRaw v else v;
+        })
       );
     mkLua = description: mkLua' { inherit description; };
+    mkStrLuaOr = type: description: mkLua' { inherit type description; };
 
     mkLuaFn' =
       args:
@@ -70,30 +73,13 @@ rec {
           type = nixvimTypes.strLuaFn;
           apply = mkRaw;
         }
+        // (optionalAttrs (args ? type) {
+          type = with nixvimTypes; either strLuaFn args.type;
+          apply = v: if isString v then mkRaw v else v;
+        })
       );
     mkLuaFn = description: mkLua' { inherit description; };
-
-    mkStrLuaOr' =
-      { type, ... }@args:
-      mkOption' (
-        args
-        // {
-          type = with nixvimTypes; either strLua type;
-          apply = v: if isString v then mkRaw v else v;
-        }
-      );
-    mkStrLuaOr = type: description: mkStrLuaOr' { inherit type description; };
-
-    mkStrLuaFnOr' =
-      { type, ... }@args:
-      mkOption' (
-        args
-        // {
-          type = with nixvimTypes; either strLuaFn type;
-          apply = v: if isString v then mkRaw v else v;
-        }
-      );
-    mkStrLuaFnOr = type: description: mkStrLuaFnOr' { inherit type description; };
+    mkStrLuaFnOr = type: description: mkLuaFn' { inherit type description; };
   };
 
   # Functions to create options that support the raw type

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -183,10 +183,13 @@ rec {
             ${defaultDesc}
           '';
 
-      mkNullable' = args: nullableOpts.mkOption' (convertArgs args);
-      mkNullable =
+      # TODO deprecate, then transition this alias to `mkNullableWithRaw`
+      mkNullable' = mkNullableNoRaw';
+      mkNullable = mkNullableNoRaw;
+      mkNullableNoRaw' = args: nullableOpts.mkOption' (convertArgs args);
+      mkNullableNoRaw =
         type: default: description:
-        mkNullable' { inherit type default description; };
+        mkNullableNoRaw' { inherit type default description; };
 
       mkNullableWithRaw' =
         { type, ... }@args: mkNullable' (args // { type = nixvimTypes.maybeRaw type; });
@@ -234,17 +237,19 @@ rec {
         );
       mkStr = default: description: mkStr' { inherit default description; };
 
-      mkAttributeSet' = args: mkNullable' (args // { type = nixvimTypes.attrs; });
+      mkAttributeSet' = args: mkNullableWithRaw' (args // { type = nixvimTypes.attrs; });
       mkAttributeSet = default: description: mkAttributeSet' { inherit default description; };
 
       mkListOf' =
-        { type, ... }@args: mkNullable' (args // { type = with nixvimTypes; listOf (maybeRaw type); });
+        { type, ... }@args:
+        mkNullableWithRaw' (args // { type = with nixvimTypes; listOf (maybeRaw type); });
       mkListOf =
         type: default: description:
         mkListOf' { inherit type default description; };
 
       mkAttrsOf' =
-        { type, ... }@args: mkNullable' (args // { type = with nixvimTypes; attrsOf (maybeRaw type); });
+        { type, ... }@args:
+        mkNullableWithRaw' (args // { type = with nixvimTypes; attrsOf (maybeRaw type); });
       mkAttrsOf =
         type: default: description:
         mkAttrsOf' { inherit type default description; };
@@ -333,7 +338,7 @@ rec {
           description ? "Highlight settings.",
           ...
         }@args:
-        mkNullable' (
+        mkNullableWithRaw' (
           args
           // {
             type = nixvimTypes.highlight;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -29,8 +29,8 @@ rec {
     );
   mkCompositeOption = description: options: mkCompositeOption' { inherit description options; };
 
-  mkNullOrStr' = args: mkNullOrOption' (args // { type = with nixvimTypes; maybeRaw str; });
-  mkNullOrStr = description: mkNullOrStr' { inherit description; };
+  # TODO: Deprecate in favor of explicitly named functions
+  inherit (rawOpts) mkNullOrStr' mkNullOrStr;
 
   mkNullOrLua' =
     args:
@@ -76,6 +76,24 @@ rec {
     );
   mkNullOrStrLuaFnOr = type: description: mkNullOrStrLuaFnOr' { inherit type description; };
 
+  # Functions to create options that support the raw type
+  rawOpts = rec {
+    mkOption' = { type, ... }@args: lib.mkOption (args // { type = nixvimTypes.maybeRaw type; });
+    mkOption = type: description: mkOption' { inherit type description; };
+
+    mkListOf' =
+      { type, ... }@args: mkOption (args // { type = with nixvimTypes; listOf (maybeRaw type); });
+    mkListOf = type: description: mkListOf' { inherit type description; };
+
+    mkAttrsOf' =
+      { type, ... }@args: mkOption (args // { type = with nixvimTypes; attrsOf (maybeRaw type); });
+    mkAttrsOf = type: description: mkAttrsOf' { inherit type description; };
+
+    mkNullOrStr' = args: mkNullOrOption' (args // { type = with nixvimTypes; maybeRaw str; });
+    mkNullOrStr = description: mkNullOrStr' { inherit description; };
+  };
+
+  # Functions to create options that default to null, also with a "plugin default"
   defaultNullOpts =
     let
       # Convert `defaultNullOpts`-style arguments into normal `mkOption`-style arguments,

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -26,6 +26,13 @@ rec {
 
   maybeRaw = type: types.either type rawLua;
 
+  freeformModule =
+    options:
+    submodule {
+      inherit options;
+      freeformType = attrsOf anything;
+    };
+
   border =
     with types;
     oneOf [
@@ -43,36 +50,31 @@ rec {
     "trace"
   ];
 
-  highlight = types.submodule {
-    # Adds flexibility for other keys
-    freeformType = types.attrs;
-
-    # :help nvim_set_hl()
-    options = with types; {
-      fg = mkNullOrStr "Color for the foreground (color name or '#RRGGBB').";
-      bg = mkNullOrStr "Color for the background (color name or '#RRGGBB').";
-      sp = mkNullOrStr "Special color (color name or '#RRGGBB').";
-      blend = mkNullOrOption (numbers.between 0 100) "Integer between 0 and 100.";
-      bold = mkNullOrOption bool "";
-      standout = mkNullOrOption bool "";
-      underline = mkNullOrOption bool "";
-      undercurl = mkNullOrOption bool "";
-      underdouble = mkNullOrOption bool "";
-      underdotted = mkNullOrOption bool "";
-      underdashed = mkNullOrOption bool "";
-      strikethrough = mkNullOrOption bool "";
-      italic = mkNullOrOption bool "";
-      reverse = mkNullOrOption bool "";
-      nocombine = mkNullOrOption bool "";
-      link = mkNullOrStr "Name of another highlight group to link to.";
-      default = mkNullOrOption bool "Don't override existing definition.";
-      ctermfg = mkNullOrStr "Sets foreground of cterm color.";
-      ctermbg = mkNullOrStr "Sets background of cterm color.";
-      cterm = mkNullOrOption (either str attrs) ''
-        cterm attribute map, like |highlight-args|.
-        If not set, cterm attributes will match those from the attribute map documented above.
-      '';
-    };
+  # :help nvim_set_hl()
+  highlight = freeformModule {
+    fg = mkNullOrStr "Color for the foreground (color name or '#RRGGBB').";
+    bg = mkNullOrStr "Color for the background (color name or '#RRGGBB').";
+    sp = mkNullOrStr "Special color (color name or '#RRGGBB').";
+    blend = mkNullOrOption (numbers.between 0 100) "Integer between 0 and 100.";
+    bold = mkNullOrOption bool "";
+    standout = mkNullOrOption bool "";
+    underline = mkNullOrOption bool "";
+    undercurl = mkNullOrOption bool "";
+    underdouble = mkNullOrOption bool "";
+    underdotted = mkNullOrOption bool "";
+    underdashed = mkNullOrOption bool "";
+    strikethrough = mkNullOrOption bool "";
+    italic = mkNullOrOption bool "";
+    reverse = mkNullOrOption bool "";
+    nocombine = mkNullOrOption bool "";
+    link = mkNullOrStr "Name of another highlight group to link to.";
+    default = mkNullOrOption bool "Don't override existing definition.";
+    ctermfg = mkNullOrStr "Sets foreground of cterm color.";
+    ctermbg = mkNullOrStr "Sets background of cterm color.";
+    cterm = mkNullOrOption (either str attrs) ''
+      cterm attribute map, like |highlight-args|.
+      If not set, cterm attributes will match those from the attribute map documented above.
+    '';
   };
 
   strLua = strLikeType "lua code string";


### PR DESCRIPTION
#### lib/types: add `nixvimTypes.freeformModule`
We often have submodules in `settings` options, most of these should be freeform although many aren't.

#### lib/options: add `rawOpts` helpers
New helpers for making non-null options that support the raw type.

#### lib/options: move top-level helpers to `nullableOpts`
Most of the top-level option helpers were actually creating nullable options. Move them into their own scope.

#### lib/options: standardise raw-type support in `defaultNullOpts`
`mkAttrsOf` (etc) didn't inject `maybeRaw` everywhere they should. Also begin transitioning `mkNullable` and `mkNullableWithRaw` by introducing `mkNullableNoRaw` alias.

#### lib/options: merge `mkNullOrStrLuaOr'` (etc)
This is the only breaking change, although I don't think anyone ever used these.

#### Other
Do we still need `mkCompositeOption`? Should we make it freeform?
