### PR TITLE
lib/options: move "plugin default" into `defaultText`

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -6,6 +6,65 @@
 with lib;
 with nixvimUtils;
 rec {
+  # Render a plugin default string
+  pluginDefaultText =
+    let
+      # Assume a string `default` is already formatted as intended,
+      # TODO: remove this behavior so we can quote strings properly
+      # historically strings were the only type accepted by mkDesc.
+      legacyRenderOptionValue =
+        v:
+        literalExpression (
+          if isString v then
+            v
+          else
+            generators.toPretty {
+              allowPrettyValues = true;
+              multiline = true;
+            } v
+        );
+    in
+    {
+      # plugin default: any value or literal expression
+      pluginDefault,
+      # nix option default value, used if `nixDefaultText` is missing
+      default ? null,
+      # nix option default string or literal expression
+      defaultText ? (options.renderOptionValue default) // {
+        __lang = "nix";
+      },
+      ...
+    }:
+    let
+      # Only add `__lang` if `pluginDefault` is not already a literal type
+      pluginDefaultText =
+        if pluginDefault ? _type && pluginDefault ? text then
+          pluginDefault
+        else
+          (legacyRenderOptionValue pluginDefault) // { __lang = "nix"; };
+
+      # Format text using markdown code block or inline code
+      # Handle `v` being a literalExpression or literalMD type
+      toMD =
+        v:
+        let
+          value = options.renderOptionValue v;
+          multiline = hasInfix "\n" value.text;
+          lang = value.__lang or ""; # `__lang` is added internally when parsed in argument defaults
+        in
+        if value._type == "literalMD" then
+          if multiline then "\n${value.text}" else " ${value.text}"
+        else if multiline then
+          "\n```${lang}\n${value.text}\n```"
+        else
+          " `${value.text}`";
+    in
+    literalMD ''
+      ${toMD defaultText}
+
+      _Plugin default:_${toMD pluginDefaultText}
+    '';
+
   # Creates an option with a nullable type that defaults to null.
   mkNullOrOption' =
     {
@@ -79,55 +138,39 @@ rec {
   defaultNullOpts =
     let
       # Convert `defaultNullOpts`-style arguments into normal `mkOption`-style arguments,
-      # i.e. moves `default` into `description` using `defaultNullOpts.mkDesc`
+      # i.e. merge `default` or `defaultText` into `defaultText`.
       #
-      # "Plugin default" is only added if `args` has a `default` attribute
+      # "Plugin default" is only added if `args` has either a `default` or `defaultText` attribute.
       convertArgs =
         args:
         (
-          args
+          # TODO filter pluginDefault
+          (filterAttrs (
+            n: _:
+            !(elem n [
+              "pluginDefault"
+              "defaultText"
+            ])
+          ) args)
           // {
+            # TODO assert that args didn't attempt to set `default` or `defaultText`
             default = null;
           }
-          // (optionalAttrs (args ? default) {
-            description = defaultNullOpts.mkDesc args.default (args.description or "");
+          // (optionalAttrs (args ? pluginDefault || args ? default || args ? defaultText) {
+            defaultText = pluginDefaultText {
+              # TODO: this is here for backwards compatibility:
+              # once `defaultNullOpts` migrates from `default` to `pluginDefault`
+              # then we can pass in `args` unmodified or simply inherit `pluginDefault`
+              pluginDefault = args.pluginDefault or args.defaultText or args.default;
+            };
           })
         );
     in
     rec {
-      /**
-        Build a description with a plugin default.
-
-        The [default] can be any value, and it will be formatted using `lib.generators.toPretty`.
-
-        If [default] is a String, it will not be formatted.
-        This behavior will likely change in the future.
-
-        # Example
-        ```nix
-        mkDesc 1 "foo"
-        => ''
-          foo
-
-          Plugin default: `1`
-        ''
-        ```
-
-        # Type
-        ```
-        mkDesc :: Any -> String -> String
-        ```
-
-        # Arguments
-        - [default] The plugin's default
-        - [desc] The option's description
-      */
+      # TODO: deprecated in favor of `helpers.pluginDefaultText`
       mkDesc =
         default: desc:
         let
-          # Assume a string default is already formatted as intended,
-          # historically strings were the only type accepted here.
-          # TODO deprecate this behavior so we can properly quote strings
           defaultString = if isString default then default else generators.toPretty { } default;
           defaultDesc =
             "_Plugin default:_"


### PR DESCRIPTION
### Summary

Introduce a **new** `helpers.pluginDefaultText` and **deprecate** `helpers.defaultNullOpts.mkDesc`.

### Motivation

Displaying the "plugin default" within `defaultText` ensures that both defaults are grouped together in the docs.

### Related changes
This blocks #1665:
- That PR could also do a treewide migration away from `mkDesc`
- Pre-formatted defaults (e.g. `1000 / 30`) could be passed as plugin-`defaultText`
- That PR should also remove the special case `pluginDefaultText` inherited from `mkDesc`

### Rendered docs
<details><summary>Options <strong>affected</strong> by this PR</summary>
<p>

![image](https://github.com/nix-community/nixvim/assets/5046562/27acb332-4f8b-4d9e-a27a-e6bca3ce358d)


</p>
</details>

<details><summary>Option manually adding "plugin default" (currently <strong>not</strong> affected)</summary>
<p>

![image](https://github.com/nix-community/nixvim/assets/5046562/9b857c40-1de6-4da5-b06c-fd71de0dcdf8)


</p>
</details> 

<details><summary>Option using deprecated <code>mkDesc</code> (currently <strong>not</strong> affected)</summary>
<p>

![image](https://github.com/nix-community/nixvim/assets/5046562/2590efbf-2ed1-428d-9be0-c0e85ee51426)


</p>
</details> 