### PR TITLE
Allow `pluginDefault` arg outside of `defaultNullOpts` + remove `mkDesc`

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -166,26 +166,8 @@ rec {
         // (optionalAttrs (args ? default) { pluginDefault = args.pluginDefault or args.default; });
     in
     rec {
-      # TODO: deprecated in favor of `helpers.pluginDefaultText`
-      mkDesc =
-        default: desc:
-        let
-          defaultString = if isString default then default else generators.toPretty { } default;
-          defaultDesc =
-            "_Plugin default:_"
-            + (
-              # Detect whether `default` is multiline or inline:
-              if hasInfix "\n" defaultString then "\n\n```nix\n${defaultString}\n```" else " `${defaultString}`"
-            );
-        in
-        if desc == "" then
-          defaultDesc
-        else
-          ''
-            ${desc}
-
-            ${defaultDesc}
-          '';
+      # TODO: removed 2024-06-14; remove stub 2024-09-01
+      mkDesc = abort "mkDesc has been removed. Use the `pluginDefault` argument or `helpers.pluginDefaultText`.";
 
       mkNullable' = args: mkNullOrOption' (convertArgs args);
       mkNullable =

--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -314,7 +314,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         Use `false` to disable it.
       '';
 
-      diagnostics = mkOption {
+      diagnostics = mkOption rec {
         type = types.submodule {
           freeformType = with types; attrsOf anything;
           options =
@@ -338,45 +338,46 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         };
         apply = helpers.toRawKeys;
         default = { };
-        description =
-          helpers.defaultNullOpts.mkDesc
-            {
-              "vim.diagnostic.severity.ERROR" = {
-                enabled = false;
-                icon = " ";
-              };
-              "vim.diagnostic.severity.HINT" = {
-                enabled = false;
-                icon = "󰌶 ";
-              };
-              "vim.diagnostic.severity.INFO" = {
-                enabled = false;
-                icon = " ";
-              };
-              "vim.diagnostic.severity.WARN" = {
-                enabled = false;
-                icon = " ";
-              };
-            }
-            ''
-              Set the icon for each diagnostic level.
+        defaultText = helpers.pluginDefaultText {
+          inherit default;
+          pluginDefault = {
+            "vim.diagnostic.severity.ERROR" = {
+              enabled = false;
+              icon = " ";
+            };
+            "vim.diagnostic.severity.HINT" = {
+              enabled = false;
+              icon = "󰌶 ";
+            };
+            "vim.diagnostic.severity.INFO" = {
+              enabled = false;
+              icon = " ";
+            };
+            "vim.diagnostic.severity.WARN" = {
+              enabled = false;
+              icon = " ";
+            };
+          };
+        };
+        description = ''
+          Set the icon for each diagnostic level.
 
-              The keys will be automatically translated to raw lua:
-              ```nix
-                {
-                  "vim.diagnostic.severity.INFO".enabled = true;
-                  "vim.diagnostic.severity.WARN".enabled = true;
-                }
-              ```
-              will result in the following lua:
-              ```lua
-                {
-                  -- Note the table keys are not string literals:
-                  [vim.diagnostic.severity.INFO] = { ['enabled'] = true },
-                  [vim.diagnostic.severity.WARN] = { ['enabled'] = true },
-                }
-              ```
-            '';
+          The keys will be automatically translated to raw lua:
+          ```nix
+            {
+              "vim.diagnostic.severity.INFO".enabled = true;
+              "vim.diagnostic.severity.WARN".enabled = true;
+            }
+          ```
+          will result in the following lua:
+          ```lua
+            {
+              -- Note the table keys are not string literals:
+              [vim.diagnostic.severity.INFO] = { ['enabled'] = true },
+              [vim.diagnostic.severity.WARN] = { ['enabled'] = true },
+            }
+          ```
+        '';
       };
 
       gitsigns =

--- a/plugins/ui/edgy.nix
+++ b/plugins/ui/edgy.nix
@@ -120,7 +120,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         '' "Callback for the ending of animations.";
 
         # This option accepts an attrs or a lua string.
-        # Hence, we use `mkOption` to convert the string to raw lua in `apply`.
+        # Hence, we convert the string to raw lua in `apply`.
         spinner =
           let
             defaultFrames = [
@@ -136,30 +136,29 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               "⠏"
             ];
           in
-          mkOption {
+          helpers.mkNullOrOption' {
             type =
               with helpers.nixvimTypes;
-              nullOr (
-                either strLua (submodule {
-                  freeformType = attrsOf anything;
-                  options = {
-                    frames = helpers.defaultNullOpts.mkListOf types.str defaultFrames ''
-                      Frame characters.
-                    '';
+              either strLua (submodule {
+                freeformType = attrsOf anything;
+                options = {
+                  frames = helpers.defaultNullOpts.mkListOf types.str defaultFrames ''
+                    Frame characters.
+                  '';
 
-                    interval = helpers.defaultNullOpts.mkUnsignedInt 80 ''
-                      Interval time between two consecutive frames.
-                    '';
-                  };
-                })
-              );
+                  interval = helpers.defaultNullOpts.mkUnsignedInt 80 ''
+                    Interval time between two consecutive frames.
+                  '';
+                };
+              });
             default = null;
             example = "require('noice.util.spinners').spinners.circleFull";
             apply = v: if isString v then helpers.mkRaw v else v;
-            description = helpers.defaultNullOpts.mkDesc {
+            description = "Spinner for pinned views that are loading.";
+            pluginDefault = {
               frames = defaultFrames;
               interval = 80;
-            } "Spinner for pinned views that are loading.";
+            };
           };
       };
 
@@ -182,84 +181,81 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       } "Global window options for edgebar windows.";
 
       # This option accepts an attrs or a lua string.
-      # Hence, we use `mkOption` to convert the string to raw lua in `apply`.
-      keys = mkOption {
-        type = with helpers.nixvimTypes; attrsOf (either strLuaFn (enum [ false ]));
-        default = { };
-        apply = mapAttrs (_: v: if isString v then helpers.mkRaw v else v);
-        description =
-          helpers.defaultNullOpts.mkDesc
-            {
-              q = ''
-                function(win)
-                  win:close()
-                end
-              '';
-              "<c-q>" = ''
-                function(win)
-                  win:hide()
-                end
-              '';
-              Q = ''
-                function(win)
-                  win.view.edgebar:close()
-                end
-              '';
-              "]w" = ''
-                function(win)
-                  win:next({ visible = true, focus = true })
-                end
-              '';
-              "[w" = ''
-                function(win)
-                  win:prev({ visible = true, focus = true })
-                end
-              '';
-              "]W" = ''
-                function(win)
-                  win:next({ pinned = false, focus = true })
-                end
-              '';
-              "[W" = ''
-                function(win)
-                  win:prev({ pinned = false, focus = true })
-                end
-              '';
-              "<c-w>>" = ''
-                function(win)
-                  win:resize("width", 2)
-                end
-              '';
-              "<c-w><lt>" = ''
-                function(win)
-                  win:resize("width", -2)
-                end
-              '';
-              "<c-w>+" = ''
-                function(win)
-                  win:resize("height", 2)
-                end
-              '';
-              "<c-w>-" = ''
-                function(win)
-                  win:resize("height", -2)
-                end
-              '';
-              "<c-w>=" = ''
-                function(win)
-                  win.view.edgebar:equalize()
-                end
-              '';
-            }
-            ''
-              Buffer-local keymaps to be added to edgebar buffers.
-              Existing buffer-local keymaps will never be overridden.
+      # Hence, we convert the string to raw lua in `apply`.
+      keys = helpers.defaultNullOpts.mkAttrsOf' {
+        type = with helpers.nixvimTypes; either strLuaFn (enum [ false ]);
+        apply = x: if x == null then null else mapAttrs (_: v: if isString v then helpers.mkRaw v else v) x;
+        description = ''
+          Buffer-local keymaps to be added to edgebar buffers.
+          Existing buffer-local keymaps will never be overridden.
 
-              Each value is either:
-              - A function declaration (as a raw lua string)
-                -> `fun(win:Edgy.Window)`
-              - `false` to disable this mapping.
-            '';
+          Each value is either:
+          - A function declaration (as a raw lua string)
+            -> `fun(win:Edgy.Window)`
+          - `false` to disable this mapping.
+        '';
+        pluginDefault = {
+          q = ''
+            function(win)
+              win:close()
+            end
+          '';
+          "<c-q>" = ''
+            function(win)
+              win:hide()
+            end
+          '';
+          Q = ''
+            function(win)
+              win.view.edgebar:close()
+            end
+          '';
+          "]w" = ''
+            function(win)
+              win:next({ visible = true, focus = true })
+            end
+          '';
+          "[w" = ''
+            function(win)
+              win:prev({ visible = true, focus = true })
+            end
+          '';
+          "]W" = ''
+            function(win)
+              win:next({ pinned = false, focus = true })
+            end
+          '';
+          "[W" = ''
+            function(win)
+              win:prev({ pinned = false, focus = true })
+            end
+          '';
+          "<c-w>>" = ''
+            function(win)
+              win:resize("width", 2)
+            end
+          '';
+          "<c-w><lt>" = ''
+            function(win)
+              win:resize("width", -2)
+            end
+          '';
+          "<c-w>+" = ''
+            function(win)
+              win:resize("height", 2)
+            end
+          '';
+          "<c-w>-" = ''
+            function(win)
+              win:resize("height", -2)
+            end
+          '';
+          "<c-w>=" = ''
+            function(win)
+              win.view.edgebar:equalize()
+            end
+          '';
+        };
       };
 
       icons = {


### PR DESCRIPTION
Following up on #1667, this PR allows the `pluginDefault` argument to be passed to any of nixvim'd option factory helpers.

Taking advantage of this where possible, the 3 internal uses of `mkDesc` have been migrated either to `pluginDefault` or calling `helpers.pluginDefaultText` directly.

It might make sense to have a `helpers.mkOption`, which simply extends `lib.mkOption` with support for custom nixvim args like `pluginDefault`:

```nix
mkOption = args: lib.mkOption (processNixvimArgs args);
```

Let me know if you'd like that included in this PR, and I'll be able to simplify the plugins/barbar implementation.
Maybe we'd also consider no longer exposing `pluginDefaultText` publicly, if all use-cases are accommodated by a `mkOption` wrapper?

- **lib/options: remove `defaultNullOpts.mkDesc`**
- **lib/options: allow `pluginDefault` in any helper**
- **plugins/edgy: switch from `mkDesc` to `pluginDefault`**
- **plugins/barbar: switch from `mkDesc` to `pluginDefaultText`**

I was originally going to tackle this as part of #1665, however that PR is already _way_ too big!
