### PR TITLE
treewide: remove pre-formatted string defaults

### DIFF
--- a/plugins/bufferlines/barbecue.nix
+++ b/plugins/bufferlines/barbecue.nix
@@ -24,13 +24,19 @@ in
       Whether to create winbar updater autocmd.
     '';
 
-    includeBuftypes = mkListStr ''[""]'' ''
+    includeBuftypes = mkListStr [ "" ] ''
       Buftypes to enable winbar in.
     '';
 
-    excludeFiletypes = mkListStr ''["netrw" "toggleterm"]'' ''
-      Filetypes not to enable winbar in.
-    '';
+    excludeFiletypes =
+      mkListStr
+        [
+          "netrw"
+          "toggleterm"
+        ]
+        ''
+          Filetypes not to enable winbar in.
+        '';
 
     modifiers = {
       dirname = helpers.defaultNullOpts.mkStr ":~:." ''

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -208,7 +208,7 @@ in
           "nvim_lsp"
           "coc"
         ])
-      ) "false" "diagnostics";
+      ) false "diagnostics";
 
       diagnosticsIndicator = helpers.defaultNullOpts.mkLuaFn null "Either `null` or a function that returns the diagnostics indicator.";
 
@@ -217,7 +217,7 @@ in
       offsets = helpers.defaultNullOpts.mkNullable (types.listOf types.attrs) null "offsets";
 
       groups = {
-        items = helpers.defaultNullOpts.mkNullable (types.listOf types.attrs) "[]" "List of groups.";
+        items = helpers.defaultNullOpts.mkListOf types.attrs [ ] "List of groups.";
 
         options = {
           toggleHiddenOnEnter = helpers.defaultNullOpts.mkBool true "Re-open hidden groups on bufenter.";
@@ -227,7 +227,7 @@ in
       hover = {
         enabled = mkEnableOption "hover";
 
-        reveal = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" "reveal";
+        reveal = helpers.defaultNullOpts.mkListOf types.str [ ] "reveal";
 
         delay = helpers.defaultNullOpts.mkInt 200 "delay";
       };

--- a/plugins/bufferlines/navic.nix
+++ b/plugins/bufferlines/navic.nix
@@ -49,11 +49,17 @@ in
         Enable to have nvim-navic automatically attach to every LSP for current buffer. Its disabled by default.
       '';
 
-      preference = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
-        Table ranking lsp_servers. Lower the index, higher the priority of the server. If there are more than one server attached to a buffer. In the example below will prefer clangd over pyright
-
-        Example: `[ "clangd" "pyright" ]`.
-      '';
+      preference = helpers.defaultNullOpts.mkListOf' {
+        type = types.str;
+        pluginDefault = [ ];
+        example = [
+          "clangd"
+          "pyright"
+        ];
+        description = ''
+          Table ranking lsp_servers. Lower the index, higher the priority of the server. If there are more than one server attached to a buffer. In the example below will prefer clangd over pyright
+        '';
+      };
     };
 
     highlight = helpers.defaultNullOpts.mkBool false ''

--- a/plugins/colorschemes/ayu.nix
+++ b/plugins/colorschemes/ayu.nix
@@ -28,7 +28,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Set to `true` to use `mirage` variant instead of `dark` for dark background.
     '';
 
-    overrides = helpers.defaultNullOpts.mkStrLuaOr (with helpers.nixvimTypes; attrsOf highlight) "{}" ''
+    overrides = helpers.defaultNullOpts.mkStrLuaOr (with helpers.nixvimTypes; attrsOf highlight) { } ''
       A dictionary of group names, each associated with a dictionary of parameters
       (`bg`, `fg`, `sp` and `style`) and colors in hex.
 

--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -124,7 +124,9 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       ];
     in
     {
-      compile_path = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath 'cache' .. '/catppuccin'";}'' "Set the compile cache directory.";
+      compile_path = helpers.defaultNullOpts.mkStr {
+        __raw = "vim.fn.stdpath 'cache' .. '/catppuccin'";
+      } "Set the compile cache directory.";
 
       flavour = helpers.mkNullOrOption (types.enum (flavours ++ [ "auto" ])) ''
         Theme flavour.
@@ -165,7 +167,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           Sets the shade to apply to the inactive split or window or buffer.
         '';
 
-        percentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.15" ''
+        percentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.15 ''
           percentage of the shade to apply to the inactive window, split or buffer.
         '';
       };
@@ -183,58 +185,58 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       '';
 
       styles = {
-        comments = helpers.defaultNullOpts.mkListOf types.str ''["italic"]'' ''
+        comments = helpers.defaultNullOpts.mkListOf types.str [ "italic" ] ''
           Define comments highlight properties.
         '';
 
-        conditionals = helpers.defaultNullOpts.mkListOf types.str ''["italic"]'' ''
+        conditionals = helpers.defaultNullOpts.mkListOf types.str [ "italic" ] ''
           Define conditionals highlight properties.
         '';
 
-        loops = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        loops = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define loops highlight properties.
         '';
 
-        functions = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        functions = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define functions highlight properties.
         '';
 
-        keywords = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        keywords = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define keywords highlight properties.
         '';
 
-        strings = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        strings = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define strings highlight properties.
         '';
 
-        variables = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        variables = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define variables highlight properties.
         '';
 
-        numbers = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        numbers = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define numbers highlight properties.
         '';
 
-        booleans = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        booleans = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define booleans highlight properties.
         '';
 
-        properties = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        properties = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define properties highlight properties.
         '';
 
-        types = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        types = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define types highlight properties.
         '';
 
-        operators = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        operators = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define operators highlight properties.
         '';
       };
 
       color_overrides = genAttrs (flavours ++ [ "all" ]) (
         flavour:
-        helpers.defaultNullOpts.mkAttrsOf types.str "{}" (
+        helpers.defaultNullOpts.mkAttrsOf types.str { } (
           if flavour == "all" then
             "Override colors for all the flavours."
           else

--- a/plugins/colorschemes/cyberdream.nix
+++ b/plugins/colorschemes/cyberdream.nix
@@ -36,7 +36,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     '';
 
     theme = {
-      highlights = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight "{}" ''
+      highlights = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight { } ''
         Highlight groups to override, adding new groups is also possible.
         See `:h highlight-groups` for a list of highlight groups.
 
@@ -55,7 +55,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         Complete list can be found in `lua/cyberdream/theme.lua` in upstream repository.
       '';
 
-      colors = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+      colors = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
         Override the default colors used.
 
         For a full list of colors, see upstream documentation.

--- a/plugins/colorschemes/kanagawa.nix
+++ b/plugins/colorschemes/kanagawa.nix
@@ -86,23 +86,23 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Enable undercurls.
     '';
 
-    commentStyle = helpers.defaultNullOpts.mkAttrsOf types.anything "{italic = true;}" ''
+    commentStyle = helpers.defaultNullOpts.mkAttrsOf types.anything { italic = true; } ''
       Highlight options for comments.
     '';
 
-    functionStyle = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+    functionStyle = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
       Highlight options for functions.
     '';
 
-    keywordStyle = helpers.defaultNullOpts.mkAttrsOf types.anything "{italic = true;}" ''
+    keywordStyle = helpers.defaultNullOpts.mkAttrsOf types.anything { italic = true; } ''
       Highlight options for keywords.
     '';
 
-    statementStyle = helpers.defaultNullOpts.mkAttrsOf types.anything "{bold = true;}" ''
+    statementStyle = helpers.defaultNullOpts.mkAttrsOf types.anything { bold = true; } ''
       Highlight options for statements.
     '';
 
-    typeStyle = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+    typeStyle = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
       Highlight options for types.
     '';
 
@@ -121,14 +121,12 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     colors = {
       theme =
         helpers.defaultNullOpts.mkAttrsOf types.attrs
-          ''
-            {
-              wave = {};
-              lotus = {};
-              dragon = {};
-              all = {};
-            }
-          ''
+          {
+            wave = { };
+            lotus = { };
+            dragon = { };
+            all = { };
+          }
           ''
             Change specific usages for a certain theme, or for all of them
 
@@ -156,7 +154,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             ```
           '';
 
-      palette = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+      palette = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
         Change all usages of these colors.
 
         Example:

--- a/plugins/colorschemes/modus.nix
+++ b/plugins/colorschemes/modus.nix
@@ -51,19 +51,19 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     '';
 
     styles = {
-      comments = helpers.defaultNullOpts.mkHighlight "{italic = true;}" "" ''
+      comments = helpers.defaultNullOpts.mkHighlight { italic = true; } "" ''
         Define comments highlight properties.
       '';
 
-      keywords = helpers.defaultNullOpts.mkHighlight "{italic = true;}" "" ''
+      keywords = helpers.defaultNullOpts.mkHighlight { italic = true; } "" ''
         Define keywords highlight properties.
       '';
 
-      functions = helpers.defaultNullOpts.mkHighlight "{}" "" ''
+      functions = helpers.defaultNullOpts.mkHighlight { } "" ''
         Define functions highlight properties.
       '';
 
-      variables = helpers.defaultNullOpts.mkHighlight "{}" "" ''
+      variables = helpers.defaultNullOpts.mkHighlight { } "" ''
         Define variables highlight properties.
       '';
     };

--- a/plugins/colorschemes/nightfox.nix
+++ b/plugins/colorschemes/nightfox.nix
@@ -35,9 +35,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
   settingsOptions = {
     options = {
-      compile_path = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath('cache') .. '/nightfox'";}'' ''
-        The output directory path where the compiled results will be written to.
-      '';
+      compile_path =
+        helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath('cache') .. '/nightfox'"; }
+          ''
+            The output directory path where the compiled results will be written to.
+          '';
 
       compile_file_suffix = helpers.defaultNullOpts.mkStr "_compiled" ''
         The string appended to the compiled file.
@@ -65,57 +67,51 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         The default value of a module that has not been overridden in the modules table.
       '';
 
-      styles =
-        helpers.defaultNullOpts.mkAttrsOf types.str
-          ''
-            {
-              comments = "NONE";
-              conditionals = "NONE";
-              constants = "NONE";
-              functions = "NONE";
-              keywords = "NONE";
-              numbers = "NONE";
-              operators = "NONE";
-              preprocs = "NONE";
-              strings = "NONE";
-              types = "NONE";
-              variables = "NONE";
-            }
-          ''
-          ''
-            A table that contains a list of syntax components and their corresponding style.
-            These styles can be any combination of `|highlight-args|`.
-            The list of syntax components are:
-              - comments
-              - conditionals
-              - constants
-              - functions
-              - keywords
-              - numbers
-              - operators
-              - preprocs
-              - strings
-              - types
-              - variables
+      styles = helpers.defaultNullOpts.mkAttrsOf' {
+        type = types.str;
+        description = ''
+          A table that contains a list of syntax components and their corresponding style.
+          These styles can be any combination of `|highlight-args|`.
 
-            Example:
-            ```nix
-              {
-                comments = "italic";
-                functions = "italic,bold";
-              }
-            ```
-          '';
+          The list of syntax components are:
+            - comments
+            - conditionals
+            - constants
+            - functions
+            - keywords
+            - numbers
+            - operators
+            - preprocs
+            - strings
+            - types
+            - variables
+        '';
+        example = {
+          comments = "italic";
+          functions = "italic,bold";
+        };
+        pluginDefault = {
+          comments = "NONE";
+          conditionals = "NONE";
+          constants = "NONE";
+          functions = "NONE";
+          keywords = "NONE";
+          numbers = "NONE";
+          operators = "NONE";
+          preprocs = "NONE";
+          strings = "NONE";
+          types = "NONE";
+          variables = "NONE";
+        };
+      };
 
       inverse =
         helpers.defaultNullOpts.mkAttrsOf types.bool
-          ''
-            {
-              match_paren = false;
-              visual = false;
-              search = false;
-            }
-          ''
+          {
+            match_paren = false;
+            visual = false;
+            search = false;
+          }
           ''
             A table that contains a list of highlight types.
             If a highlight type is enabled it will inverse the foreground and background colors
@@ -139,7 +135,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           mapAttrs
             (
               name: color:
-              helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0" ''
+              helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0 ''
                 Severity [0, 1] for ${name} (${color}).
               ''
             )
@@ -152,26 +148,24 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
       modules =
         helpers.defaultNullOpts.mkAttrsOf types.anything
-          ''
-            {
-              coc = {
-                background = true;
-              };
-              diagnostic = {
-                enable = true;
-                background = true;
-              };
-              native_lsp = {
-                enable = true;
-                background = true;
-              };
-              treesitter = true;
-              lsp_semantic_tokens = true;
-              leap = {
-                background = true;
-              };
-            }
-          ''
+          {
+            coc = {
+              background = true;
+            };
+            diagnostic = {
+              enable = true;
+              background = true;
+            };
+            native_lsp = {
+              enable = true;
+              background = true;
+            };
+            treesitter = true;
+            lsp_semantic_tokens = true;
+            leap = {
+              background = true;
+            };
+          }
           ''
             `modules` store configuration information for various plugins and other neovim modules.
             A module can either be a boolean or a table that contains additional configuration for

--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -61,7 +61,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
                 }
               );
             })
-            "{}"
+            { }
             ''
               Custom palettes for ${name} colors.
             ''
@@ -110,7 +110,9 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Whether to enable caching.
     '';
 
-    cache_dir = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath('cache') .. '/palette'";}'' "Cache directory.";
+    cache_dir = helpers.defaultNullOpts.mkStr {
+      __raw = "vim.fn.stdpath('cache') .. '/palette'";
+    } "Cache directory.";
   };
 
   settingsExample = { };

--- a/plugins/colorschemes/poimandres.nix
+++ b/plugins/colorschemes/poimandres.nix
@@ -58,7 +58,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       default: see [source](https://github.com/olivercederborg/poimandres.nvim/blob/main/lua/poimandres/init.lua)
     '';
 
-    highlight_groups = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+    highlight_groups = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
       Highlight groups.
     '';
   };

--- a/plugins/colorschemes/rose-pine.nix
+++ b/plugins/colorschemes/rose-pine.nix
@@ -115,7 +115,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       default: see [source](https://github.com/rose-pine/neovim/blob/main/lua/rose-pine/config.lua)
     '';
 
-    highlight_groups = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight "{}" ''
+    highlight_groups = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight { } ''
       Custom highlight groups.
     '';
 

--- a/plugins/colorschemes/tokyonight.nix
+++ b/plugins/colorschemes/tokyonight.nix
@@ -87,19 +87,19 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           ] "Background style for ${name}";
       in
       {
-        comments = helpers.defaultNullOpts.mkHighlight "{italic = true;}" "" ''
+        comments = helpers.defaultNullOpts.mkHighlight { italic = true; } "" ''
           Define comments highlight properties.
         '';
 
-        keywords = helpers.defaultNullOpts.mkHighlight "{italic = true;}" "" ''
+        keywords = helpers.defaultNullOpts.mkHighlight { italic = true; } "" ''
           Define keywords highlight properties.
         '';
 
-        functions = helpers.defaultNullOpts.mkHighlight "{}" "" ''
+        functions = helpers.defaultNullOpts.mkHighlight { } "" ''
           Define functions highlight properties.
         '';
 
-        variables = helpers.defaultNullOpts.mkHighlight "{}" "" ''
+        variables = helpers.defaultNullOpts.mkHighlight { } "" ''
           Define variables highlight properties.
         '';
 
@@ -108,11 +108,17 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         floats = mkBackgroundStyle "floats";
       };
 
-    sidebars = helpers.defaultNullOpts.mkListOf types.str ''["qf" "help"]'' ''
-      Set a darker background on sidebar-like windows.
-    '';
+    sidebars =
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "qf"
+          "help"
+        ]
+        ''
+          Set a darker background on sidebar-like windows.
+        '';
 
-    day_brightness = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.3" ''
+    day_brightness = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.3 ''
       Adjusts the brightness of the colors of the **Day** style.
       Number between 0 and 1, from dull to vibrant colors.
     '';

--- a/plugins/colorschemes/vscode.nix
+++ b/plugins/colorschemes/vscode.nix
@@ -21,13 +21,13 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     italic_comments = helpers.defaultNullOpts.mkBool false "Whether to enable italic comments";
     underline_links = helpers.defaultNullOpts.mkBool false "Whether to underline links";
     disable_nvimtree_bg = helpers.defaultNullOpts.mkBool true "Whether to disable nvim-tree background";
-    color_overrides = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+    color_overrides = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
       A dictionary of color overrides.
       See https://github.com/Mofiqul/vscode.nvim/blob/main/lua/vscode/colors.lua for color names.
     '';
     group_overrides =
       with helpers;
-      defaultNullOpts.mkAttrsOf nixvimTypes.highlight "{}" ''
+      defaultNullOpts.mkAttrsOf nixvimTypes.highlight { } ''
         A dictionary of group names, each associated with a dictionary of parameters
         (`bg`, `fg`, `sp` and `style`) and colors in hex.
       '';

--- a/plugins/completion/cmp/options/settings-options.nix
+++ b/plugins/completion/cmp/options/settings-options.nix
@@ -117,7 +117,7 @@ with lib;
     autocomplete =
       helpers.defaultNullOpts.mkNullable
         (with helpers.nixvimTypes; either (enum [ false ]) (listOf strLua))
-        ''["require('cmp.types').cmp.TriggerEvent.TextChanged"]''
+        [ "require('cmp.types').cmp.TriggerEvent.TextChanged" ]
         ''
           The event to trigger autocompletion.
           If set to `false`, then completion is only invoked manually (e.g. by calling `cmp.complete`).
@@ -148,9 +148,16 @@ with lib;
       Boolean to show the `~` expandable indicator in cmp's floating window.
     '';
 
-    fields = helpers.defaultNullOpts.mkListOf types.str ''["abbr" "kind" "menu"]'' ''
-      An array of completion fields to specify their order.
-    '';
+    fields =
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "abbr"
+          "kind"
+          "menu"
+        ]
+        ''
+          An array of completion fields to specify their order.
+        '';
 
     format =
       helpers.defaultNullOpts.mkLuaFn
@@ -234,12 +241,10 @@ with lib;
   view = {
     entries =
       helpers.defaultNullOpts.mkNullable (with types; either str (attrsOf anything))
-        ''
-          {
-            name = "custom";
-            selection_order = "top_down";
-          }
-        ''
+        {
+          name = "custom";
+          selection_order = "top_down";
+        }
         ''
           The view class used to customize nvim-cmp's appearance.
         '';
@@ -267,9 +272,7 @@ with lib;
     in
     {
       completion = {
-        border =
-          helpers.defaultNullOpts.mkBorder ''[ "" "" "" "" "" "" "" "" ]'' "nvim-cmp completion popup menu"
-            "";
+        border = helpers.defaultNullOpts.mkBorder (genList (_: "") 8) "nvim-cmp completion popup menu" "";
 
         winhighlight = mkWinhighlightOption "Normal:Pmenu,FloatBorder:Pmenu,CursorLine:PmenuSel,Search:None";
 
@@ -294,10 +297,9 @@ with lib;
       };
 
       documentation = {
-        border =
-          helpers.defaultNullOpts.mkBorder ''[ "" "" "" " " "" "" "" " " ]''
-            "nvim-cmp documentation popup menu"
-            "";
+        border = helpers.defaultNullOpts.mkBorder (genList (
+          _: ""
+        ) 8) "nvim-cmp documentation popup menu" "";
 
         winhighlight = mkWinhighlightOption "FloatBorder:NormalFloat";
 

--- a/plugins/completion/cmp/sources/codeium-nvim.nix
+++ b/plugins/completion/cmp/sources/codeium-nvim.nix
@@ -15,9 +15,13 @@ in
   options.plugins.codeium-nvim = helpers.neovim-plugin.extraOptionsOptions // {
     package = helpers.mkPluginPackageOption "codeium.nvim" pkgs.vimPlugins.codeium-nvim;
 
-    configPath = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath('cache') .. '/codeium/config.json'";}'' "The path to the config file, used to store the API key.";
+    configPath = helpers.defaultNullOpts.mkStr {
+      __raw = "vim.fn.stdpath('cache') .. '/codeium/config.json'";
+    } "The path to the config file, used to store the API key.";
 
-    binPath = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath('cache') .. '/codeium/bin'";}'' "The path to the directory where the Codeium server will be downloaded to.";
+    binPath = helpers.defaultNullOpts.mkStr {
+      __raw = "vim.fn.stdpath('cache') .. '/codeium/bin'";
+    } "The path to the directory where the Codeium server will be downloaded to.";
 
     api = {
       host = helpers.defaultNullOpts.mkStr "server.codeium.com" ''

--- a/plugins/completion/cmp/sources/copilot-cmp.nix
+++ b/plugins/completion/cmp/sources/copilot-cmp.nix
@@ -12,7 +12,11 @@ in
 {
   options.plugins.copilot-cmp = helpers.neovim-plugin.extraOptionsOptions // {
     event =
-      helpers.defaultNullOpts.mkNullable (with types; listOf str) ''["InsertEnter" "LspAttach"]''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "InsertEnter"
+          "LspAttach"
+        ]
         ''
           Configures when the source is registered.
           Unless you have a unique problem for your particular configuration you probably don't want

--- a/plugins/completion/codeium-vim.nix
+++ b/plugins/completion/codeium-vim.nix
@@ -65,14 +65,12 @@ helpers.vim-plugin.mkVimPlugin config {
 
     filetypes =
       helpers.defaultNullOpts.mkAttrsOf types.bool
-        ''
-          {
-            help = false;
-            gitcommit = false;
-            gitrebase = false;
-            "." = false;
-          }
-        ''
+        {
+          help = false;
+          gitcommit = false;
+          gitrebase = false;
+          "." = false;
+        }
         ''
           A dictionary mapping whether codeium should be enabled or disabled in certain filetypes.
           This can be used to opt out of completions for certain filetypes.

--- a/plugins/completion/copilot-lua.nix
+++ b/plugins/completion/copilot-lua.nix
@@ -40,19 +40,18 @@ in
 
           layout = {
             position =
-              helpers.defaultNullOpts.mkEnum
+              helpers.defaultNullOpts.mkEnumFirstDefault
                 [
                   "bottom"
                   "top"
                   "left"
                   "right"
                 ]
-                "bottom"
                 ''
                   The panel position.
                 '';
 
-            ratio = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.4" ''
+            ratio = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.4 ''
               The panel ratio.
             '';
           };
@@ -68,9 +67,9 @@ in
           keymap = {
             accept = keymapOption "<M-l>" "Keymap for accepting the suggestion.";
 
-            acceptWord = keymapOption "false" "Keymap for accepting a word suggestion.";
+            acceptWord = keymapOption false "Keymap for accepting a word suggestion.";
 
-            acceptLine = keymapOption "false" "Keymap for accepting a line suggestion.";
+            acceptLine = keymapOption false "Keymap for accepting a line suggestion.";
 
             next = keymapOption "<M-]>" "Keymap for accepting the next suggestion.";
 
@@ -81,20 +80,18 @@ in
         };
 
         filetypes =
-          helpers.defaultNullOpts.mkNullable (with types; attrsOf (either bool helpers.nixvimTypes.rawLua))
-            ''
-              {
-                yaml = false;
-                markdown = false;
-                help = false;
-                gitcommit = false;
-                gitrebase = false;
-                hgcommit = false;
-                svn = false;
-                cvs = false;
-                "." = false;
-              }
-            ''
+          helpers.defaultNullOpts.mkAttrsOf types.bool
+            {
+              yaml = false;
+              markdown = false;
+              help = false;
+              gitcommit = false;
+              gitrebase = false;
+              hgcommit = false;
+              svn = false;
+              cvs = false;
+              "." = false;
+            }
             ''
               Specify filetypes for attaching copilot.
               Each value can be either a boolean or a lua function that returns a boolean.
@@ -137,30 +134,30 @@ in
           '';
         };
 
-        serverOptsOverrides = helpers.defaultNullOpts.mkNullable types.attrs "{}" ''
-          Override copilot lsp client `settings`.
-          The settings field is where you can set the values of the options defined in
-          https://github.com/zbirenbaum/copilot.lua/blob/master/SettingsOpts.md.
-          These options are specific to the copilot lsp and can be used to customize its behavior.
+        serverOptsOverrides = helpers.defaultNullOpts.mkAttrsOf' {
+          type = types.anything;
+          pluginDefault = { };
+          description = ''
+            Override copilot lsp client `settings`.
+            The settings field is where you can set the values of the options defined in
+            https://github.com/zbirenbaum/copilot.lua/blob/master/SettingsOpts.md.
+            These options are specific to the copilot lsp and can be used to customize its behavior.
 
-          Ensure that the `name` field is not overridden as is is used for efficiency reasons in
-          numerous checks to verify copilot is actually running.
+            Ensure that the `name` field is not overridden as is is used for efficiency reasons in
+            numerous checks to verify copilot is actually running.
 
-          See `:h vim.lsp.start_client` for list of options.
-
-          Example:
-          ```nix
-            {
-              trace = "verbose";
-              settings = {
-                advanced = {
-                  listCount = 10; # number of completions for panel
-                  inlineSuggestCount = 3; # number of completions for getCompletions
-                };
+            See `:h vim.lsp.start_client` for list of options.
+          '';
+          example = {
+            trace = "verbose";
+            settings = {
+              advanced = {
+                listCount = 10; # number of completions for panel
+                inlineSuggestCount = 3; # number of completions for getCompletions
               };
-            }
-          ```
-        '';
+            };
+          };
+        };
       };
   };
 

--- a/plugins/dap/dap-ui.nix
+++ b/plugins/dap/dap-ui.nix
@@ -15,9 +15,9 @@ let
     name:
     mapAttrs (
       key: default:
-      helpers.defaultNullOpts.mkNullable (with types; either str (listOf str)) "${
-        default
-      }" "Map `${key}` for ${name}"
+      helpers.defaultNullOpts.mkNullable (
+        with types; either str (listOf str)
+      ) default "Map `${key}` for ${name}"
     );
 
   elementOption = types.submodule {
@@ -90,7 +90,10 @@ in
       types.submodule {
         options = mkKeymapOptions "element mapping overrides" {
           edit = "e";
-          expand = ''["<CR>" "<2-LeftMouse>"]'';
+          expand = [
+            "<CR>"
+            "<2-LeftMouse>"
+          ];
           open = "o";
           remove = "d";
           repl = "r";
@@ -109,7 +112,12 @@ in
       border = helpers.defaultNullOpts.mkBorder "single" "dap-ui floating window" "";
 
       mappings = helpers.mkNullOrOption (types.submodule {
-        options = mkKeymapOptions "dap-ui floating" { close = ''["<ESC>" "q"]''; };
+        options = mkKeymapOptions "dap-ui floating" {
+          close = [
+            "<ESC>"
+            "q"
+          ];
+        };
       }) "Keys to trigger actions in elements.";
     };
 
@@ -121,53 +129,52 @@ in
       expanded = helpers.defaultNullOpts.mkStr "" "";
     };
 
-    layouts = helpers.defaultNullOpts.mkNullable (types.listOf layoutOption) ''
-      ```nix
-        [
+    layouts = helpers.defaultNullOpts.mkListOf layoutOption [
+      {
+        elements = [
           {
-            elements = [
-              {
-                id = "scopes";
-                size = 0.25;
-              }
-              {
-                id = "breakpoints";
-                size = 0.25;
-              }
-              {
-                id = "stacks";
-                size = 0.25;
-              }
-              {
-                id = "watches";
-                size = 0.25;
-              }
-            ];
-            position = "left";
-            size = 40;
+            id = "scopes";
+            size = 0.25;
           }
           {
-            elements = [
-              {
-                id = "repl";
-                size = 0.5;
-              }
-              {
-                id = "console";
-                size = 0.5;
-              }
-            ];
-            position = "bottom";
-            size = 10;
+            id = "breakpoints";
+            size = 0.25;
+          }
+          {
+            id = "stacks";
+            size = 0.25;
+          }
+          {
+            id = "watches";
+            size = 0.25;
           }
         ];
-      ```
-    '' "List of layouts for dap-ui.";
+        position = "left";
+        size = 40;
+      }
+      {
+        elements = [
+          {
+            id = "repl";
+            size = 0.5;
+          }
+          {
+            id = "console";
+            size = 0.5;
+          }
+        ];
+        position = "bottom";
+        size = 10;
+      }
+    ] "List of layouts for dap-ui.";
 
     mappings = helpers.mkNullOrOption (types.submodule {
       options = mkKeymapOptions "dap-ui" {
         edit = "e";
-        expand = ''["<CR>" "<2-LeftMouse>"]'';
+        expand = [
+          "<CR>"
+          "<2-LeftMouse>"
+        ];
         open = "o";
         remove = "d";
         repl = "r";

--- a/plugins/filetrees/chadtree.nix
+++ b/plugins/filetrees/chadtree.nix
@@ -27,11 +27,19 @@ in
       '';
 
       mimetypes = {
-        warn = mkListStr ''["audio" "font" "image" "video"]'' ''
-          Show a warning before opening these datatypes.
-        '';
+        warn =
+          mkListStr
+            [
+              "audio"
+              "font"
+              "image"
+              "video"
+            ]
+            ''
+              Show a warning before opening these datatypes.
+            '';
 
-        allowExts = mkListStr ''[".ts"]'' ''
+        allowExts = mkListStr [ ".ts" ] ''
           Skip warning for these extensions.
         '';
       };
@@ -58,16 +66,24 @@ in
       '';
 
       ignore = {
-        nameExact = mkListStr ''[".DS_Store" ".directory" "thumbs.db" ".git"]'' ''
-          Files whose name match these exactly will be ignored.
-        '';
+        nameExact =
+          mkListStr
+            [
+              ".DS_Store"
+              ".directory"
+              "thumbs.db"
+              ".git"
+            ]
+            ''
+              Files whose name match these exactly will be ignored.
+            '';
 
-        nameGlob = mkListStr "[]" ''
+        nameGlob = mkListStr [ ] ''
           Files whose name match these glob patterns will be ignored.
           ie. `*.py` will match all python files
         '';
 
-        pathGlob = mkListStr "[]" ''
+        pathGlob = mkListStr [ ] ''
           Files whose full path match these glob patterns will be ignored.
         '';
       };
@@ -85,12 +101,19 @@ in
             Which way does CHADTree open?
           '';
 
-      sortBy = mkListStr ''["is_folder" "ext" "file_name"]'' ''
-        CHADTree can sort by the following criterion.
-        Reorder them if you want a different sorting order.
-        legal keys: some of
-        `["is_folder" "ext" "file_name"]`
-      '';
+      sortBy =
+        mkListStr
+          [
+            "is_folder"
+            "ext"
+            "file_name"
+          ]
+          ''
+            CHADTree can sort by the following criterion.
+            Reorder them if you want a different sorting order.
+            legal keys: some of
+            `["is_folder" "ext" "file_name"]`
+          '';
 
       width = helpers.defaultNullOpts.mkInt 40 ''
         How big is CHADTree when initially opened?
@@ -184,123 +207,141 @@ in
 
     keymap = {
       windowManagement = {
-        quit = mkListStr ''["q"]'' ''
+        quit = mkListStr [ "q" ] ''
           Close CHADTree window, quit if it is the last window.
         '';
 
-        bigger = mkListStr ''["+" "="]'' ''
-          Resize CHADTree window bigger.
-        '';
+        bigger =
+          mkListStr
+            [
+              "+"
+              "="
+            ]
+            ''
+              Resize CHADTree window bigger.
+            '';
 
-        smaller = mkListStr ''["-" "_"]'' ''
-          Resize CHADTree window smaller.
-        '';
+        smaller =
+          mkListStr
+            [
+              "-"
+              "_"
+            ]
+            ''
+              Resize CHADTree window smaller.
+            '';
 
-        refresh = mkListStr ''["<c-r>"]'' ''
+        refresh = mkListStr [ "<c-r>" ] ''
           Refresh CHADTree.
         '';
       };
 
       rerooting = {
-        changeDir = mkListStr ''["b"]'' ''
+        changeDir = mkListStr [ "b" ] ''
           Change vim's working directory.
         '';
 
-        changeFocus = mkListStr ''["c"]'' ''
+        changeFocus = mkListStr [ "c" ] ''
           Set CHADTree's root to folder at cursor. Does not change working directory.
         '';
 
-        changeFocusUp = mkListStr ''["C"]'' ''
+        changeFocusUp = mkListStr [ "C" ] ''
           Set CHADTree's root one level up.
         '';
       };
 
       openFileFolder = {
-        primary = mkListStr ''["<enter>"]'' ''
+        primary = mkListStr [ "<enter>" ] ''
           Open file at cursor.
         '';
 
-        secondary = mkListStr ''["<tab> <2-leftmouse>"]'' ''
+        secondary = mkListStr [ "<tab> <2-leftmouse>" ] ''
           Open file at cursor, keep cursor in CHADTree's window.
         '';
 
-        tertiary = mkListStr ''["<m-enter>" <middlemouse>]'' ''
-          Open file at cursor in a new tab.
-        '';
+        tertiary =
+          mkListStr
+            [
+              "<m-enter>"
+              "<middlemouse>"
+            ]
+            ''
+              Open file at cursor in a new tab.
+            '';
 
-        vSplit = mkListStr ''["w"]'' ''
+        vSplit = mkListStr [ "w" ] ''
           Open file at cursor in vertical split.
         '';
 
-        hSplit = mkListStr ''["W"]'' ''
+        hSplit = mkListStr [ "W" ] ''
           Open file at cursor in horizontal split.
         '';
 
-        openSys = mkListStr ''["o"]'' ''
+        openSys = mkListStr [ "o" ] ''
           Open file with GUI tools using `open` or `xdg open`.
           This will open third party tools such as Finder or KDE Dolphin or GNOME nautilus, etc.
           Depends on platform and user setup.
         '';
 
-        collapse = mkListStr ''["o"]'' ''
+        collapse = mkListStr [ "o" ] ''
           Collapse all subdirectories for directory at cursor.
         '';
       };
 
       cursor = {
-        refocus = mkListStr ''["~"]'' ''
+        refocus = mkListStr [ "~" ] ''
           Put cursor at the root of CHADTree.
         '';
 
-        jumpToCurrent = mkListStr ''["J"]'' ''
+        jumpToCurrent = mkListStr [ "J" ] ''
           Position cursor in CHADTree at currently open buffer, if the buffer points to a location visible under CHADTree.
         '';
 
-        stat = mkListStr ''["K"]'' ''
+        stat = mkListStr [ "K" ] ''
           Print `ls --long` stat for file under cursor.
         '';
 
-        copyName = mkListStr ''["y"]'' ''
+        copyName = mkListStr [ "y" ] ''
           Copy paths of files under cursor or visual block.
         '';
 
-        copyBasename = mkListStr ''["Y"]'' ''
+        copyBasename = mkListStr [ "Y" ] ''
           Copy names of files under cursor or visual block.
         '';
 
-        copyRelname = mkListStr ''["<c-y>"]'' ''
+        copyRelname = mkListStr [ "<c-y>" ] ''
           Copy relative paths of files under cursor or visual block.
         '';
       };
 
       filtering = {
-        filter = mkListStr ''["f"]'' ''
+        filter = mkListStr [ "f" ] ''
           Set a glob pattern to narrow down visible files.
         '';
 
-        clearFilter = mkListStr ''["F"]'' ''
+        clearFilter = mkListStr [ "F" ] ''
           Clear filter.
         '';
       };
 
       bookmarks = {
-        bookmarkGoto = mkListStr ''["m"]'' ''
+        bookmarkGoto = mkListStr [ "m" ] ''
           Goto bookmark `A-Z`.
         '';
       };
 
       selecting = {
-        select = mkListStr ''["s"]'' ''
+        select = mkListStr [ "s" ] ''
           Select files under cursor or visual block.
         '';
 
-        clearSelection = mkListStr ''["S"]'' ''
+        clearSelection = mkListStr [ "S" ] ''
           Clear selection.
         '';
       };
 
       fileOperations = {
-        new = mkListStr ''["a"]'' ''
+        new = mkListStr [ "a" ] ''
           Create new file at location under cursor. Files ending with platform specific path separator will be folders.
 
           Intermediary folders are created automatically.
@@ -308,7 +349,7 @@ in
           ie. `uwu/owo/` under unix will create `uwu/` then `owo/` under it. Both are folders.
         '';
 
-        link = mkListStr ''["A"]'' ''
+        link = mkListStr [ "A" ] ''
           Create links at location under cursor from selection.
 
           Links are always relative.
@@ -316,44 +357,44 @@ in
           Intermediary folders are created automatically.
         '';
 
-        rename = mkListStr ''["r"]'' ''
+        rename = mkListStr [ "r" ] ''
           Rename file under cursor.
         '';
 
-        toggleExec = mkListStr ''["X"]'' ''
+        toggleExec = mkListStr [ "X" ] ''
           Toggle all the `+x` bits of the selected / highlighted files.
 
           Except for directories, where `-x` will prevent reading.
         '';
 
-        copy = mkListStr ''["p"]'' ''
+        copy = mkListStr [ "p" ] ''
           Copy the selected files to location under cursor.
         '';
 
-        cut = mkListStr ''["x"]'' ''
+        cut = mkListStr [ "x" ] ''
           Move the selected files to location under cursor.
         '';
 
-        delete = mkListStr ''["d"]'' ''
+        delete = mkListStr [ "d" ] ''
           Delete the selected files. Items deleted cannot be recovered.
         '';
 
-        trash = mkListStr ''[t]'' ''
+        trash = mkListStr [ "t" ] ''
           Trash the selected files using platform specific `trash` command, if they are available.
           Items trashed may be recovered.
         '';
       };
 
       toggles = {
-        toggleHidden = mkListStr ''["."]'' ''
+        toggleHidden = mkListStr [ "." ] ''
           Toggle show_hidden on and off. See `chadtree.showHidden` for details.
         '';
 
-        toggleFollow = mkListStr ''["u"]'' ''
+        toggleFollow = mkListStr [ "u" ] ''
           Toggle `follow` on and off. See `chadtree.follow` for details.
         '';
 
-        toggleVersionControl = mkListStr ''["i"]'' ''
+        toggleVersionControl = mkListStr [ "i" ] ''
           Toggle version control integration on and off.
         '';
       };

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -58,8 +58,12 @@ in
       package = helpers.mkPluginPackageOption "neo-tree" pkgs.vimPlugins.neo-tree-nvim;
 
       sources =
-        helpers.defaultNullOpts.mkNullable (types.listOf types.str)
-          ''["filesystem" "buffers" "git_status"]''
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "filesystem"
+            "buffers"
+            "git_status"
+          ]
           ''
             If a user has a sources list it will replace this one.
             Only sources listed here will be loaded.
@@ -122,12 +126,12 @@ in
       ] "info" "";
 
       logToFile =
-        helpers.defaultNullOpts.mkNullable (types.either types.bool types.str) "false"
+        helpers.defaultNullOpts.mkNullable (types.either types.bool types.str) false
           "use :NeoTreeLogs to show the file";
 
       openFilesInLastWindow = helpers.defaultNullOpts.mkBool true "If `false`, open files in top left window";
 
-      popupBorderStyle = helpers.defaultNullOpts.mkEnum [
+      popupBorderStyle = helpers.defaultNullOpts.mkEnumFirstDefault [
         "NC"
         "double"
         "none"
@@ -135,7 +139,7 @@ in
         "shadow"
         "single"
         "solid"
-      ] "NC" "";
+      ] "";
 
       resizeTimerInterval = helpers.defaultNullOpts.mkInt 500 ''
         In ms, needed for containers to redraw right aligned and faded content.
@@ -228,7 +232,7 @@ in
           helpers.defaultNullOpts.mkNullable types.int null
             "This will truncate text even if `textTruncToFit = false`";
 
-        padding = helpers.defaultNullOpts.mkNullable (with types; either int (attrsOf int)) "0" ''
+        padding = helpers.defaultNullOpts.mkNullable (with types; either int (attrsOf int)) 0 ''
           Defines the global padding of the source selector.
           It can be an integer or an attrs with keys `left` and `right`.
           Setting `padding = 2` is exactly the same as `{ left = 2; right = 2; }`.
@@ -236,16 +240,23 @@ in
           Example: `{ left = 2; right = 0; }`
         '';
 
-        separator = helpers.defaultNullOpts.mkNullable (
-          with types;
-          either str (submodule {
-            options = {
-              left = helpers.defaultNullOpts.mkStr "▏" "";
-              right = helpers.defaultNullOpts.mkStr "\\" "";
-              override = helpers.defaultNullOpts.mkStr null "";
-            };
-          })
-        ) "Can be a string or a table" ''{ left = "▏"; right= "▕"; }'';
+        separator =
+          helpers.defaultNullOpts.mkNullable
+            (
+              with types;
+              either str (submodule {
+                options = {
+                  left = helpers.defaultNullOpts.mkStr "▏" "";
+                  right = helpers.defaultNullOpts.mkStr "\\" "";
+                  override = helpers.defaultNullOpts.mkStr null "";
+                };
+              })
+            )
+            {
+              left = "▏";
+              right = "▕";
+            }
+            "Can be a string or a table";
 
         separatorActive =
           helpers.defaultNullOpts.mkNullable
@@ -416,113 +427,105 @@ in
       };
 
       renderers = {
-        directory = mkRendererComponentListOption ''
-          [
-            "indent"
-            "icon"
-            "current_filter"
-            {
-              name = "container";
-              content = [
-                {
-                  name = "name";
-                  zindex = 10;
-                }
-                {
-                  name = "clipboard";
-                  zindex = 10;
-                }
-                {
-                  name = "diagnostics";
-                  errors_only = true;
-                  zindex = 20;
-                  align = "right";
-                  hide_when_expanded = true;
-                }
-                {
-                  name = "git_status";
-                  zindex = 20;
-                  align = "right";
-                  hide_when_expanded = true;
-                }
-              ];
-            }
-          ]
-        '' "directory renderers";
+        directory = mkRendererComponentListOption [
+          "indent"
+          "icon"
+          "current_filter"
+          {
+            name = "container";
+            content = [
+              {
+                name = "name";
+                zindex = 10;
+              }
+              {
+                name = "clipboard";
+                zindex = 10;
+              }
+              {
+                name = "diagnostics";
+                errors_only = true;
+                zindex = 20;
+                align = "right";
+                hide_when_expanded = true;
+              }
+              {
+                name = "git_status";
+                zindex = 20;
+                align = "right";
+                hide_when_expanded = true;
+              }
+            ];
+          }
+        ] "directory renderers";
 
-        file = mkRendererComponentListOption ''
-          [
-            "indent"
-            "icon"
-            {
-              name = "container";
-              content = [
-                {
-                  name = "name";
-                  zindex = 10;
-                }
-                {
-                  name = "clipboard";
-                  zindex = 10;
-                }
-                {
-                  name = "bufnr";
-                  zindex = 10;
-                }
-                {
-                  name = "modified";
-                  zindex = 20;
-                  align = "right";
-                }
-                {
-                  name = "diagnostics";
-                  zindex = 20;
-                  align = "right";
-                }
-                {
-                  name = "git_status";
-                  zindex = 20;
-                  align = "right";
-                }
-              ];
-            }
-          ]
-        '' "file renderers";
+        file = mkRendererComponentListOption [
+          "indent"
+          "icon"
+          {
+            name = "container";
+            content = [
+              {
+                name = "name";
+                zindex = 10;
+              }
+              {
+                name = "clipboard";
+                zindex = 10;
+              }
+              {
+                name = "bufnr";
+                zindex = 10;
+              }
+              {
+                name = "modified";
+                zindex = 20;
+                align = "right";
+              }
+              {
+                name = "diagnostics";
+                zindex = 20;
+                align = "right";
+              }
+              {
+                name = "git_status";
+                zindex = 20;
+                align = "right";
+              }
+            ];
+          }
+        ] "file renderers";
 
-        message = mkRendererComponentListOption ''
-          [
-            {
-              name = "indent";
-              with_markers = false;
-            }
-            {
-              name = "name";
-              highlight = "NeoTreeMessage";
-            }
-          ]
-        '' "message renderers";
+        message = mkRendererComponentListOption [
+          {
+            name = "indent";
+            with_markers = false;
+          }
+          {
+            name = "name";
+            highlight = "NeoTreeMessage";
+          }
+        ] "message renderers";
 
-        terminal = mkRendererComponentListOption ''
-          [
-            "indent"
-            "icon"
-            "name"
-            "bufnr"
-          ]
-        '' "message renderers";
+        terminal = mkRendererComponentListOption [
+          "indent"
+          "icon"
+          "name"
+          "bufnr"
+        ] "message renderers";
       };
 
-      nestingRules = helpers.defaultNullOpts.mkNullable (types.attrsOf types.str) "{}" "nesting rules";
+      nestingRules = helpers.defaultNullOpts.mkAttrsOf types.str { } "nesting rules";
 
       window = {
-        position = helpers.defaultNullOpts.mkEnum [
+        position = helpers.defaultNullOpts.mkEnumFirstDefault [
           "left"
           "right"
           "top"
           "bottom"
           "float"
           "current"
-        ] "left" "position";
+        ] "position";
 
         width = helpers.defaultNullOpts.mkInt 40 "Applies to left and right positions";
 
@@ -572,7 +575,7 @@ in
           nowait = helpers.defaultNullOpts.mkBool true "nowait";
         };
 
-        mappings = mkMappingsOption ''
+        mappings = mkMappingsOption (literalMD ''
           ```nix
             {
               "<space>" = {
@@ -622,10 +625,10 @@ in
               ">" = "next_source";
             }
           ```
-        '';
+        '');
       };
       filesystem = {
-        window = mkWindowMappingsOption ''
+        window = mkWindowMappingsOption (literalMD ''
           ```nix
             {
               H = "toggle_hidden";
@@ -642,7 +645,7 @@ in
               "]g" = "next_git_modified";
             }
           ```
-        '';
+        '');
         asyncDirectoryScan =
           helpers.defaultNullOpts.mkEnumFirstDefault
             [
@@ -688,39 +691,44 @@ in
 
           hideHidden = helpers.defaultNullOpts.mkBool true "only works on Windows for hidden files/directories";
 
-          hideByName =
-            helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''[".DS_Store" "thumbs.db"]''
-              "hide by name";
+          hideByName = helpers.defaultNullOpts.mkListOf types.str [
+            ".DS_Store"
+            "thumbs.db"
+          ] "hide by name";
 
-          hideByPattern = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
-            Hide by pattern.
+          hideByPattern = helpers.defaultNullOpts.mkListOf' {
+            type = types.str;
+            pluginDefault = [ ];
+            description = "Hide by pattern.";
+            example = [
+              "*.meta"
+              "*/src/*/tsconfig.json"
+            ];
+          };
 
-            Example:
-            ```nix
-              [
-                "*.meta"
-                "*/src/*/tsconfig.json"
-              ]
-            ```
-          '';
+          alwaysShow = helpers.defaultNullOpts.mkListOf' {
+            type = types.str;
+            pluginDefault = [ ];
+            description = "Files/folders to always show.";
+            example = [ ".gitignore" ];
+          };
 
-          alwaysShow = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
-            Files/folders to always show.
+          neverShow = helpers.defaultNullOpts.mkListOf' {
+            type = types.str;
+            pluginDefault = [ ];
+            description = "Files/folders to never show.";
+            example = [
+              ".DS_Store"
+              "thumbs.db"
+            ];
+          };
 
-            Example: `[".gitignore"]`
-          '';
-
-          neverShow = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
-            Files/folders to never show.
-
-            Example: `[".DS_Store" "thumbs.db"]`
-          '';
-
-          neverShowByPattern = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
-            Files/folders to never show (by pattern).
-
-            Example: `[".null-ls_*"]`
-          '';
+          neverShowByPattern = helpers.defaultNullOpts.mkListOf' {
+            type = types.str;
+            pluginDefault = [ ];
+            description = "Files/folders to never show (by pattern).";
+            example = [ ".null-ls_*" ];
+          };
         };
 
         findByFullPathWords = helpers.defaultNullOpts.mkBool false ''
@@ -737,14 +745,12 @@ in
           helpers.mkNullOrStrLuaFnOr
             (types.submodule {
               options = {
-                fd = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''
-                  [
-                    "--exclude"
-                    ".git"
-                    "--exclude"
-                    "node_modules"
-                  ]
-                '' "You can specify extra args to pass to the find command.";
+                fd = helpers.defaultNullOpts.mkListOf types.str [
+                  "--exclude"
+                  ".git"
+                  "--exclude"
+                  "node_modules"
+                ] "You can specify extra args to pass to the find command.";
               };
             })
             ''
@@ -824,51 +830,43 @@ in
 
         groupEmptyDirs = helpers.defaultNullOpts.mkBool true "When true, empty directories will be grouped together.";
 
-        window = mkWindowMappingsOption ''
-          {
-            "<bs>" = "navigate_up";
-            "." = "set_root";
-            bd = "buffer_delete";
-          }
-        '';
+        window = mkWindowMappingsOption {
+          "<bs>" = "navigate_up";
+          "." = "set_root";
+          bd = "buffer_delete";
+        };
       };
 
       gitStatus = {
-        window = mkWindowMappingsOption ''
-          {
-            A = "git_add_all";
-            gu = "git_unstage_file";
-            ga = "git_add_file";
-            gr = "git_revert_file";
-            gc = "git_commit";
-            gp = "git_push";
-            gg = "git_commit_and_push";
-          }
-        '';
+        window = mkWindowMappingsOption {
+          A = "git_add_all";
+          gu = "git_unstage_file";
+          ga = "git_add_file";
+          gr = "git_revert_file";
+          gc = "git_commit";
+          gp = "git_push";
+          gg = "git_commit_and_push";
+        };
       };
 
       example = {
         renderers = {
-          custom = mkRendererComponentListOption ''
-            [
-              "indent"
-              {
-                name = "icon";
-                default = "C";
-              }
-              "custom"
-              "name"
-            ]
-          '' "custom renderers";
+          custom = mkRendererComponentListOption [
+            "indent"
+            {
+              name = "icon";
+              default = "C";
+            }
+            "custom"
+            "name"
+          ] "custom renderers";
         };
 
-        window = mkWindowMappingsOption ''
-          {
-            "<cr>" = "toggle_node";
-            "<C-e>" = "example_command";
-            d = "show_debug_info";
-          }
-        '';
+        window = mkWindowMappingsOption {
+          "<cr>" = "toggle_node";
+          "<C-e>" = "example_command";
+          d = "show_debug_info";
+        };
       };
 
       documentSymbols = {
@@ -913,7 +911,7 @@ in
             https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol
           '';
         };
-        window = mkWindowMappingsOption "{}";
+        window = mkWindowMappingsOption { };
       };
     };
 

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -11,19 +11,15 @@ let
   inherit (helpers) ifNonNull';
 
   openWinConfigOption =
-    helpers.defaultNullOpts.mkNullable
-      # Type
-      types.attrs
+    helpers.defaultNullOpts.mkAttributeSet
       # Default
-      ''
-        {
-          col = 1;
-          row = 1;
-          relative = "cursor";
-          border = "shadow";
-          style = "minimal";
-        }
-      ''
+      {
+        col = 1;
+        row = 1;
+        relative = "cursor";
+        border = "shadow";
+        style = "minimal";
+      }
       # Description
       ''
         Floating window config for file_popup. See |nvim_open_win| for more details.
@@ -97,14 +93,13 @@ in
     '';
 
     sortBy =
-      helpers.defaultNullOpts.mkNullable
-        (types.either (types.enum [
+      helpers.defaultNullOpts.mkEnumFirstDefault
+        [
           "name"
           "case_sensitive"
           "modification_time"
           "extension"
-        ]) helpers.nixvimTypes.rawLua)
-        "name"
+        ]
         ''
           Changes how files within the same directory are sorted.
           Can be one of `name`, `case_sensitive`, `modification_time`, `extension` or a
@@ -139,7 +134,7 @@ in
       Keeps the cursor on the first letter of the filename when moving in the tree.
     '';
 
-    rootDirs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+    rootDirs = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Preferred root directories.
       Only relevant when `updateFocusedFile.updateRoot` is `true`.
     '';
@@ -187,7 +182,7 @@ in
         Only relevant when `updateFocusedFile.enable` is `true`
       '';
 
-      ignoreList = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      ignoreList = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         List of buffer names and filetypes that will not update the root dir of the tree if the
         file isn't found under the current root directory.
         Only relevant when `updateFocusedFile.updateRoot` and `updateFocusedFile.enable` are
@@ -205,7 +200,7 @@ in
           Windows: "`cmd"`
       '';
 
-      args = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      args = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         Optional argument list.
 
         Leave empty for OS specific default:
@@ -310,7 +305,7 @@ in
         Idle milliseconds between filesystem change and action.
       '';
 
-      ignoreDirs = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      ignoreDirs = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         List of vim regex for absolute directory paths that will not be watched.
         Backslashes must be escaped e.g. `"my-project/\\.build$"`.
         See |string-match|.
@@ -389,7 +384,7 @@ in
               })
             ]
           )
-          "30"
+          30
           ''
             Width of the window: can be a `%` string, a number representing columns or a table.
             A table indicates that the view should be dynamically sized based on the longest line.
@@ -421,13 +416,12 @@ in
       '';
 
       signcolumn =
-        helpers.defaultNullOpts.mkEnum
+        helpers.defaultNullOpts.mkEnumFirstDefault
           [
             "yes"
             "auto"
             "no"
           ]
-          "yes"
           ''
             Show diagnostic sign column. Value can be `"yes"`, `"auto"`, `"no"`.
           '';
@@ -570,13 +564,12 @@ in
             '';
 
         modifiedPlacement =
-          helpers.defaultNullOpts.mkEnum
+          helpers.defaultNullOpts.mkEnumFirstDefault
             [
               "after"
               "before"
               "signcolumn"
             ]
-            "after"
             ''
               Place where the modified icon will be rendered.
               Can be `"after"` or `"before"` filename (after the file/folders icons) or `"signcolumn"`
@@ -682,10 +675,12 @@ in
         };
       };
 
-      specialFiles =
-        helpers.defaultNullOpts.mkNullable (types.listOf types.str)
-          "[ \"Cargo.toml\" \"Makefile\" \"README.md\" \"readme.md\" ]"
-          "A list of filenames that gets highlighted with `NvimTreeSpecialFile`.";
+      specialFiles = helpers.defaultNullOpts.mkListOf types.str [
+        "Cargo.toml"
+        "Makefile"
+        "README.md"
+        "readme.md"
+      ] "A list of filenames that gets highlighted with `NvimTreeSpecialFile`.";
 
       symlinkDestination = helpers.defaultNullOpts.mkBool true ''
         Whether to show the destination of the symlink.
@@ -711,13 +706,13 @@ in
         A reload or filesystem event will result in an update.
       '';
 
-      custom = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      custom = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         Custom list of vim regex for file/directory names that will not be shown.
         Backslashes must be escaped e.g. "^\\.git". See |string-match|.
         Toggle via the `toggle_custom` action, default mapping `U`.
       '';
 
-      exclude = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      exclude = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         List of directories or files to exclude from filtering: always show them.
         Overrides `git.ignore`, `filters.dotfiles` and `filters.custom`.
       '';
@@ -753,7 +748,7 @@ in
           Avoids hanging neovim when running this action on very large folders.
         '';
 
-        exclude = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        exclude = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           A list of directories that should not be expanded automatically.
           E.g `[ ".git" "target" "build" ]` etc.
         '';
@@ -781,29 +776,39 @@ in
           tree.
         '';
 
-        picker =
-          helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "default"
-            ''
-              Change the default window picker, can be a string `"default"` or a function.
-              The function should return the window id that will open the node, or `nil` if an
-              invalid window is picked or user cancelled the action.
+        picker = helpers.defaultNullOpts.mkStr' {
+          pluginDefault = "default";
+          description = ''
+            Change the default window picker. This can either be a string or a function (see example).
 
-              This can be both a string or a function (see example below).
-              picker = { __raw = "require('window-picker').pick_window"; };
-            '';
+            The function should return the window id that will open the node, or `nil` if an
+            invalid window is picked or user cancelled the action.
+          '';
+          example.__raw = "require('window-picker').pick_window";
+        };
 
         chars = helpers.defaultNullOpts.mkStr "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890" ''
           A string of chars used as identifiers by the window picker.
         '';
 
         exclude =
-          helpers.defaultNullOpts.mkNullable (with types; attrsOf (listOf str))
-            ''
-              {
-                filetype = [ "notify" "lazy" "packer" "qf" "diff" "fugitive" "fugitiveblame" ];
-                buftype = [ "nofile" "terminal" "help" ];
-              };
-            ''
+          helpers.defaultNullOpts.mkAttrsOf (with types; listOf str)
+            {
+              filetype = [
+                "notify"
+                "lazy"
+                "packer"
+                "qf"
+                "diff"
+                "fugitive"
+                "fugitiveblame"
+              ];
+              buftype = [
+                "nofile"
+                "terminal"
+                "help"
+              ];
+            }
             ''
               Table of buffer option names mapped to a list of option values that indicates to
               the picker that the buffer's window should not be selectable.
@@ -845,7 +850,7 @@ in
           Closes the tree across all tabpages when the tree is closed.
         '';
 
-        ignore = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        ignore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of filetypes or buffer names on new tab that will prevent
           |nvim-tree.tab.sync.open| and |nvim-tree.tab.sync.close|
         '';

--- a/plugins/git/diffview.nix
+++ b/plugins/git/diffview.nix
@@ -73,7 +73,7 @@ let
         current window.
       '';
 
-      winOpts = mkAttributeSet "{}" ''
+      winOpts = mkAttributeSet { } ''
         Table of window local options (see |vim.opt_local|).
         These options are applied whenever the window is opened.
       '';
@@ -96,11 +96,11 @@ in
         See ':h diffview-config-enhanced_diff_hl'
       '';
 
-      gitCmd = mkNullable (types.listOf types.str) ''[ "git" ]'' ''
+      gitCmd = mkListOf types.str [ "git" ] ''
         The git executable followed by default args.
       '';
 
-      hgCmd = mkNullable (types.listOf types.str) ''[ "hg" ]'' ''
+      hgCmd = mkListOf types.str [ "hg" ] ''
         The hg executable followed by default args.
       '';
 
@@ -323,7 +323,7 @@ in
                 List only the commits in the specified revision range.
               '';
 
-              pathArgs = mkNullable (types.listOf types.str) "[]" ''
+              pathArgs = mkListOf types.str [ ] ''
                 Limit the target files to only the files matching the given
                 path arguments (git pathspec is supported).
               '';
@@ -381,7 +381,7 @@ in
                 Limit the number of commits.
               '';
 
-              l = mkNullable (types.listOf types.str) "[]" ''
+              l = mkListOf types.str [ ] ''
                 `{ ("<start>,<end>:<file>" | ":<funcname>:<file>")... }`
 
                 Trace the evolution of the line range given by <start>,<end>,
@@ -454,9 +454,9 @@ in
           commonDesc = "Default args prepended to the arg-list for the listed commands";
         in
         {
-          diffviewOpen = mkNullable (types.listOf types.str) "[ ]" commonDesc;
+          diffviewOpen = mkListOf types.str [ ] commonDesc;
 
-          diffviewFileHistory = mkNullable (types.listOf types.str) "[ ]" commonDesc;
+          diffviewFileHistory = mkListOf types.str [ ] commonDesc;
         };
 
       hooks =

--- a/plugins/git/git-conflict.nix
+++ b/plugins/git/git-conflict.nix
@@ -24,7 +24,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
   settingsOptions = {
     default_mappings =
-      helpers.defaultNullOpts.mkNullable (with types; either bool (attrsOf str)) "true"
+      helpers.defaultNullOpts.mkNullable (with types; either bool (attrsOf str)) true
         ''
           This plugin offers default buffer local mappings inside conflicted files.
           This is primarily because applying these mappings only to relevant buffers is impossible

--- a/plugins/git/gitblame.nix
+++ b/plugins/git/gitblame.nix
@@ -24,23 +24,21 @@ in
 
       highlightGroup = helpers.defaultNullOpts.mkStr "Comment" "The highlight group for virtual text.";
 
-      displayVirtualText =
-        helpers.defaultNullOpts.mkNullable (types.nullOr types.bool) (toString true)
-          "If the blame message should be displayed as virtual text. You may want to disable this if you display the blame message in statusline.";
+      displayVirtualText = helpers.defaultNullOpts.mkBool true "If the blame message should be displayed as virtual text. You may want to disable this if you display the blame message in statusline.";
 
-      ignoredFiletypes = helpers.defaultNullOpts.mkNullable (types.listOf types.str) (toString
-        [ ]
-      ) "A list of filetypes for which gitblame information will not be displayed.";
+      ignoredFiletypes =
+        helpers.defaultNullOpts.mkListOf types.str [ ]
+          "A list of filetypes for which gitblame information will not be displayed.";
 
       delay =
         helpers.defaultNullOpts.mkUnsignedInt 0
           "The delay in milliseconds after which the blame info will be displayed.";
 
       virtualTextColumn =
-        helpers.defaultNullOpts.mkNullable types.ints.unsigned (toString null)
+        helpers.defaultNullOpts.mkNullable types.ints.unsigned null
           "Have the blame message start at a given column instead of EOL. If the current line is longer than the specified column value the blame message will default to being displayed at EOL.";
 
-      extmarkOptions = helpers.defaultNullOpts.mkAttributeSet (toString null) "nvim_buf_set_extmark optional parameters. (Warning: overwriting id and virt_text will break the plugin behavior)";
+      extmarkOptions = helpers.defaultNullOpts.mkAttributeSet null "nvim_buf_set_extmark optional parameters. (Warning: overwriting id and virt_text will break the plugin behavior)";
     };
   };
 

--- a/plugins/git/gitlinker.nix
+++ b/plugins/git/gitlinker.nix
@@ -39,24 +39,21 @@ with lib;
     mappings = helpers.defaultNullOpts.mkStr "<leader>gy" "Mapping to call url generation.";
 
     callbacks =
-      helpers.defaultNullOpts.mkNullable (with types; attrsOf (either str helpers.nixvimTypes.rawLua))
+      helpers.defaultNullOpts.mkAttrsOf types.str
+        {
+          "github.com" = "get_github_type_url";
+          "gitlab.com" = "get_gitlab_type_url";
+          "try.gitea.io" = "get_gitea_type_url";
+          "codeberg.org" = "get_gitea_type_url";
+          "bitbucket.org" = "get_bitbucket_type_url";
+          "try.gogs.io" = "get_gogs_type_url";
+          "git.sr.ht" = "get_srht_type_url";
+          "git.launchpad.net" = "get_launchpad_type_url";
+          "repo.or.cz" = "get_repoorcz_type_url";
+          "git.kernel.org" = "get_cgit_type_url";
+          "git.savannah.gnu.org" = "get_cgit_type_url";
+        }
         ''
-          {
-            "github.com" = "get_github_type_url";
-            "gitlab.com" = "get_gitlab_type_url";
-            "try.gitea.io" = "get_gitea_type_url";
-            "codeberg.org" = "get_gitea_type_url";
-            "bitbucket.org" = "get_bitbucket_type_url";
-            "try.gogs.io" = "get_gogs_type_url";
-            "git.sr.ht" = "get_srht_type_url";
-            "git.launchpad.net" = "get_launchpad_type_url";
-            "repo.or.cz" = "get_repoorcz_type_url";
-            "git.kernel.org" = "get_cgit_type_url";
-            "git.savannah.gnu.org" = "get_cgit_type_url";
-          }
-        ''
-        ''
-
           Each key can be
             - the name of a built-in callback. Example: `"get_gitlab_type_url";` is setting
             ```lua

--- a/plugins/git/gitmessenger.nix
+++ b/plugins/git/gitmessenger.nix
@@ -84,7 +84,7 @@ with lib;
       Note: Word diff is enabled by typing "r" in a popup window.
     '';
 
-    floatingWinOps = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" ''
+    floatingWinOps = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
       Options passed to nvim_open_win() on opening a popup window. This is useful when you want to
       override some window options.
     '';

--- a/plugins/git/gitsigns/options.nix
+++ b/plugins/git/gitsigns/options.nix
@@ -225,20 +225,18 @@ with lib;
 
   count_chars =
     helpers.defaultNullOpts.mkAttrsOf types.str
-      ''
-        {
-          "__unkeyed_1" = "1";
-          "__unkeyed_2" = "2";
-          "__unkeyed_3" = "3";
-          "__unkeyed_4" = "4";
-          "__unkeyed_5" = "5";
-          "__unkeyed_6" = "6";
-          "__unkeyed_7" = "7";
-          "__unkeyed_8" = "8";
-          "__unkeyed_9" = "9";
-          "+" = ">";
-        }
-      ''
+      {
+        "__unkeyed_1" = "1";
+        "__unkeyed_2" = "2";
+        "__unkeyed_3" = "3";
+        "__unkeyed_4" = "4";
+        "__unkeyed_5" = "5";
+        "__unkeyed_6" = "6";
+        "__unkeyed_7" = "7";
+        "__unkeyed_8" = "8";
+        "__unkeyed_9" = "9";
+        "+" = ">";
+      }
       ''
         The count characters used when `signs.*.show_count` is enabled.
         The `+` entry is used as a fallback. With the default, any count outside of 1-9 uses the `>`
@@ -272,15 +270,13 @@ with lib;
 
   preview_config =
     helpers.defaultNullOpts.mkAttrsOf types.anything
-      ''
-        {
-          border = "single";
-          style = "minimal";
-          relative = "cursor";
-          row = 0;
-          col = 1;
-        }
-      ''
+      {
+        border = "single";
+        style = "minimal";
+        relative = "cursor";
+        row = 0;
+        col = 1;
+      }
       ''
         Option overrides for the Gitsigns preview window.
         Table is passed directly to `nvim_open_win`.

--- a/plugins/git/lazygit.nix
+++ b/plugins/git/lazygit.nix
@@ -15,17 +15,24 @@ helpers.vim-plugin.mkVimPlugin config {
   maintainers = [ helpers.maintainers.AndresBermeoMarinelli ];
 
   settingsOptions = {
-    floating_window_winblend = helpers.defaultNullOpts.mkNullable (types.ints.between 0 100) "0" ''
+    floating_window_winblend = helpers.defaultNullOpts.mkNullable (types.ints.between 0 100) 0 ''
       Set the transparency of the floating window.
     '';
 
     floating_window_scaling_factor =
-      helpers.defaultNullOpts.mkNullable types.numbers.nonnegative "0.9"
+      helpers.defaultNullOpts.mkNullable types.numbers.nonnegative 0.9
         "Set the scaling factor for floating window.";
 
-    floating_window_border_chars =
-      helpers.defaultNullOpts.mkListOf types.str ''["╭" "─" "╮" "│" "╯" "─" "╰" "│"]''
-        "Customize lazygit popup window border characters.";
+    floating_window_border_chars = helpers.defaultNullOpts.mkListOf types.str [
+      "╭"
+      "─"
+      "╮"
+      "│"
+      "╯"
+      "─"
+      "╰"
+      "│"
+    ] "Customize lazygit popup window border characters.";
 
     floating_window_use_plenary = helpers.defaultNullOpts.mkBool false ''
       Whether to use plenary.nvim to manage floating window if available.
@@ -41,7 +48,7 @@ helpers.vim-plugin.mkVimPlugin config {
 
     config_file_path = helpers.defaultNullOpts.mkNullable (
       with types; either str (listOf str)
-    ) "[]" "Custom config file path or list of custom config file paths.";
+    ) [ ] "Custom config file path or list of custom config file paths.";
   };
 
   settingsExample = {

--- a/plugins/git/neogit/options.nix
+++ b/plugins/git/neogit/options.nix
@@ -42,13 +42,11 @@ in
     Disables signs for sections/items/hunks.
   '';
 
-  git_services = helpers.defaultNullOpts.mkAttrsOf types.str ''
-    {
-      "github.com" = "https://github.com/$\{owner}/$\{repository}/compare/$\{branch_name}?expand=1";
-      "bitbucket.org" = "https://bitbucket.org/$\{owner}/$\{repository}/pull-requests/new?source=$\{branch_name}&t=1";
-      "gitlab.com" = "https://gitlab.com/$\{owner}/$\{repository}/merge_requests/new?merge_request[source_branch]=$\{branch_name}";
-    }
-  '' "Used to generate URL's for branch popup action 'pull request'.";
+  git_services = helpers.defaultNullOpts.mkAttrsOf types.str {
+    "github.com" = "https://github.com/$\{owner}/$\{repository}/compare/$\{branch_name}?expand=1";
+    "bitbucket.org" = "https://bitbucket.org/$\{owner}/$\{repository}/pull-requests/new?source=$\{branch_name}&t=1";
+    "gitlab.com" = "https://gitlab.com/$\{owner}/$\{repository}/merge_requests/new?merge_request[source_branch]=$\{branch_name}";
+  } "Used to generate URL's for branch popup action 'pull request'.";
 
   fetch_after_checkout = helpers.defaultNullOpts.mkBool false ''
     Perform a fetch if the newly checked out branch has an upstream or pushRemote set.
@@ -174,9 +172,14 @@ in
     mapAttrs
       (
         n: v:
-        helpers.defaultNullOpts.mkListOf types.str ''["${v.closed}" "${v.opened}"]'' ''
-          The icons to use for open and closed ${n}s.
-        ''
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "${v.closed}"
+            "${v.opened}"
+          ]
+          ''
+            The icons to use for open and closed ${n}s.
+          ''
       )
       {
         hunk = {
@@ -284,15 +287,13 @@ in
 
   ignored_settings =
     helpers.defaultNullOpts.mkListOf types.str
-      ''
-        [
-          "NeogitPushPopup--force-with-lease"
-          "NeogitPushPopup--force"
-          "NeogitPullPopup--rebase"
-          "NeogitCommitPopup--allow-empty"
-          "NeogitRevertPopup--no-edit"
-        ]
-      ''
+      [
+        "NeogitPushPopup--force-with-lease"
+        "NeogitPushPopup--force"
+        "NeogitPullPopup--rebase"
+        "NeogitCommitPopup--allow-empty"
+        "NeogitRevertPopup--no-edit"
+      ]
       ''
         Table of settings to never persist.
         Uses format "Filetype--cli-value".
@@ -303,127 +304,113 @@ in
       mkMappingOption = helpers.defaultNullOpts.mkAttrsOf (with types; either str (enum [ false ]));
     in
     {
-      commit_editor = mkMappingOption ''
-        {
-          q = "Close";
-          "<c-c><c-c>" = "Submit";
-          "<c-c><c-k>" = "Abort";
-          "<m-p>" = "PrevMessage";
-          "<m-n>" = "NextMessage";
-          "<m-r>" = "ResetMessage";
-        }
-      '' "Mappings for the commit editor.";
+      commit_editor = mkMappingOption {
+        q = "Close";
+        "<c-c><c-c>" = "Submit";
+        "<c-c><c-k>" = "Abort";
+        "<m-p>" = "PrevMessage";
+        "<m-n>" = "NextMessage";
+        "<m-r>" = "ResetMessage";
+      } "Mappings for the commit editor.";
 
-      commit_editor_I = mkMappingOption ''
-        {
-          "<c-c><c-c>" = "Submit";
-          "<c-c><c-k>" = "Abort";
-        }
-      '' "Mappings for the commit editor (insert mode)";
+      commit_editor_I = mkMappingOption {
+        "<c-c><c-c>" = "Submit";
+        "<c-c><c-k>" = "Abort";
+      } "Mappings for the commit editor (insert mode)";
 
-      rebase_editor = mkMappingOption ''
-        {
-          p = "Pick";
-          r = "Reword";
-          e = "Edit";
-          s = "Squash";
-          f = "Fixup";
-          x = "Execute";
-          d = "Drop";
-          b = "Break";
-          q = "Close";
-          "<cr>" = "OpenCommit";
-          gk = "MoveUp";
-          gj = "MoveDown";
-          "<c-c><c-c>" = "Submit";
-          "<c-c><c-k>" = "Abort";
-          "[c" = "OpenOrScrollUp";
-          "]c" = "OpenOrScrollDown";
-        }
-      '' "Mappings for the rebase editor.";
+      rebase_editor = mkMappingOption {
+        p = "Pick";
+        r = "Reword";
+        e = "Edit";
+        s = "Squash";
+        f = "Fixup";
+        x = "Execute";
+        d = "Drop";
+        b = "Break";
+        q = "Close";
+        "<cr>" = "OpenCommit";
+        gk = "MoveUp";
+        gj = "MoveDown";
+        "<c-c><c-c>" = "Submit";
+        "<c-c><c-k>" = "Abort";
+        "[c" = "OpenOrScrollUp";
+        "]c" = "OpenOrScrollDown";
+      } "Mappings for the rebase editor.";
 
-      rebase_editor_I = mkMappingOption ''
-        {
-          "<c-c><c-c>" = "Submit";
-          "<c-c><c-k>" = "Abort";
-        }
-      '' "Mappings for the rebase editor (insert mode).";
+      rebase_editor_I = mkMappingOption {
+        "<c-c><c-c>" = "Submit";
+        "<c-c><c-k>" = "Abort";
+      } "Mappings for the rebase editor (insert mode).";
 
-      finder = mkMappingOption ''
-        {
-          "<cr>" = "Select";
-          "<c-c>" = "Close";
-          "<esc>" = "Close";
-          "<c-n>" = "Next";
-          "<c-p>" = "Previous";
-          "<down>" = "Next";
-          "<up>" = "Previous";
-          "<tab>" = "MultiselectToggleNext";
-          "<s-tab>" = "MultiselectTogglePrevious";
-          "<c-j>" = "NOP";
-          "<ScrollWheelDown>" = "ScrollWheelDown";
-          "<ScrollWheelUp>" = "ScrollWheelUp";
-          "<ScrollWheelLeft>" = "NOP";
-          "<ScrollWheelRight>" = "NOP";
-          "<LeftMouse>" = "MouseClick";
-          "<2-LeftMouse>" = "NOP";
-        }
-      '' "Mappings for the finder.";
+      finder = mkMappingOption {
+        "<cr>" = "Select";
+        "<c-c>" = "Close";
+        "<esc>" = "Close";
+        "<c-n>" = "Next";
+        "<c-p>" = "Previous";
+        "<down>" = "Next";
+        "<up>" = "Previous";
+        "<tab>" = "MultiselectToggleNext";
+        "<s-tab>" = "MultiselectTogglePrevious";
+        "<c-j>" = "NOP";
+        "<ScrollWheelDown>" = "ScrollWheelDown";
+        "<ScrollWheelUp>" = "ScrollWheelUp";
+        "<ScrollWheelLeft>" = "NOP";
+        "<ScrollWheelRight>" = "NOP";
+        "<LeftMouse>" = "MouseClick";
+        "<2-LeftMouse>" = "NOP";
+      } "Mappings for the finder.";
 
-      popup = mkMappingOption ''
-        {
-          "?" = "HelpPopup";
-          A = "CherryPickPopup";
-          d = "DiffPopup";
-          M = "RemotePopup";
-          P = "PushPopup";
-          X = "ResetPopup";
-          Z = "StashPopup";
-          i = "IgnorePopup";
-          t = "TagPopup";
-          b = "BranchPopup";
-          B = "BisectPopup";
-          w = "WorktreePopup";
-          c = "CommitPopup";
-          f = "FetchPopup";
-          l = "LogPopup";
-          m = "MergePopup";
-          p = "PullPopup";
-          r = "RebasePopup";
-          v = "RevertPopup";
-        }
-      '' "Mappings for popups.";
+      popup = mkMappingOption {
+        "?" = "HelpPopup";
+        A = "CherryPickPopup";
+        d = "DiffPopup";
+        M = "RemotePopup";
+        P = "PushPopup";
+        X = "ResetPopup";
+        Z = "StashPopup";
+        i = "IgnorePopup";
+        t = "TagPopup";
+        b = "BranchPopup";
+        B = "BisectPopup";
+        w = "WorktreePopup";
+        c = "CommitPopup";
+        f = "FetchPopup";
+        l = "LogPopup";
+        m = "MergePopup";
+        p = "PullPopup";
+        r = "RebasePopup";
+        v = "RevertPopup";
+      } "Mappings for popups.";
 
-      status = mkMappingOption ''
-        {
-          q = "Close";
-          I = "InitRepo";
-          "1" = "Depth1";
-          "2" = "Depth2";
-          "3" = "Depth3";
-          "4" = "Depth4";
-          "<tab>" = "Toggle";
-          x = "Discard";
-          s = "Stage";
-          S = "StageUnstaged";
-          "<c-s>" = "StageAll";
-          u = "Unstage";
-          K = "Untrack";
-          U = "UnstageStaged";
-          y = "ShowRefs";
-          "$" = "CommandHistory";
-          Y = "YankSelected";
-          "<c-r>" = "RefreshBuffer";
-          "<cr>" = "GoToFile";
-          "<c-v>" = "VSplitOpen";
-          "<c-x>" = "SplitOpen";
-          "<c-t>" = "TabOpen";
-          "{" = "GoToPreviousHunkHeader";
-          "}" = "GoToNextHunkHeader";
-          "[c" = "OpenOrScrollUp";
-          "]c" = "OpenOrScrollDown";
-        }
-      '' "Mappings for status.";
+      status = mkMappingOption {
+        q = "Close";
+        I = "InitRepo";
+        "1" = "Depth1";
+        "2" = "Depth2";
+        "3" = "Depth3";
+        "4" = "Depth4";
+        "<tab>" = "Toggle";
+        x = "Discard";
+        s = "Stage";
+        S = "StageUnstaged";
+        "<c-s>" = "StageAll";
+        u = "Unstage";
+        K = "Untrack";
+        U = "UnstageStaged";
+        y = "ShowRefs";
+        "$" = "CommandHistory";
+        Y = "YankSelected";
+        "<c-r>" = "RefreshBuffer";
+        "<cr>" = "GoToFile";
+        "<c-v>" = "VSplitOpen";
+        "<c-x>" = "SplitOpen";
+        "<c-t>" = "TabOpen";
+        "{" = "GoToPreviousHunkHeader";
+        "}" = "GoToNextHunkHeader";
+        "[c" = "OpenOrScrollUp";
+        "]c" = "OpenOrScrollDown";
+      } "Mappings for status.";
     };
 
   notification_icon = helpers.defaultNullOpts.mkStr "󰊢" ''

--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -47,26 +47,24 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   settingsOptions = {
     keymaps =
       helpers.defaultNullOpts.mkAttrsOf (with helpers.nixvimTypes; attrsOf (either str rawLua))
-        ''
-          {
-            normal = {
-              plain_below = "g?p";
-              plain_above = "g?P";
-              variable_below = "g?v";
-              variable_above = "g?V";
-              variable_below_alwaysprompt.__raw = "nil";
-              variable_above_alwaysprompt.__raw = "nil";
-              textobj_below = "g?o";
-              textobj_above = "g?O";
-              toggle_comment_debug_prints.__raw = "nil";
-              delete_debug_prints.__raw = "nil";
-            };
-            visual = {
-              variable_below = "g?v";
-              variable_above = "g?V";
-            };
-          }
-        ''
+        {
+          normal = {
+            plain_below = "g?p";
+            plain_above = "g?P";
+            variable_below = "g?v";
+            variable_above = "g?V";
+            variable_below_alwaysprompt.__raw = "nil";
+            variable_above_alwaysprompt.__raw = "nil";
+            textobj_below = "g?o";
+            textobj_above = "g?O";
+            toggle_comment_debug_prints.__raw = "nil";
+            delete_debug_prints.__raw = "nil";
+          };
+          visual = {
+            variable_below = "g?v";
+            variable_above = "g?V";
+          };
+        }
         ''
           By default, the plugin will create some keymappings for use 'out of the box'.
           There are also some function invocations which are not mapped to any keymappings by
@@ -83,12 +81,10 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
     commands =
       helpers.defaultNullOpts.mkAttrsOf types.str
-        ''
-          {
-            toggle_comment_debug_prints = "ToggleCommentDebugPrints";
-            delete_debug_prints = "DeleteDebugPrints";
-          }
-        ''
+        {
+          toggle_comment_debug_prints = "ToggleCommentDebugPrints";
+          delete_debug_prints = "DeleteDebugPrints";
+        }
         ''
           By default, the plugin will create some commands for use 'out of the box'.
           There are also some function invocations which are not mapped to any commands by default,
@@ -140,7 +136,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             };
           })
         )
-        "{}"
+        { }
         ''
           Custom filetypes.
           Your new file format will be merged in with those that already exist.

--- a/plugins/languages/lean.nix
+++ b/plugins/languages/lean.nix
@@ -44,7 +44,7 @@ in
           '';
         };
       }
-    ) "{}" "LSP settings.";
+    ) { } "LSP settings.";
 
     ft = {
       default = helpers.defaultNullOpts.mkStr "lean" ''
@@ -66,7 +66,7 @@ in
         Whether to enable expanding of unicode abbreviations.
       '';
 
-      extra = helpers.defaultNullOpts.mkNullable (with types; attrsOf str) "{}" ''
+      extra = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
         Additional abbreviations.
 
         Example:
@@ -159,20 +159,18 @@ in
 
       useWidgets = helpers.defaultNullOpts.mkBool true "Whether to use widgets.";
 
-      mappings = helpers.defaultNullOpts.mkNullable (with types; attrsOf str) ''
-        {
-          K = "click";
-          "<CR>" = "click";
-          gd = "go_to_def";
-          gD = "go_to_decl";
-          gy = "go_to_type";
-          I = "mouse_enter";
-          i = "mouse_leave";
-          "<Esc>" = "clear_all";
-          C = "clear_all";
-          "<LocalLeader><Tab>" = "goto_last_window";
-        }
-      '' "Mappings.";
+      mappings = helpers.defaultNullOpts.mkAttrsOf types.str {
+        K = "click";
+        "<CR>" = "click";
+        gd = "go_to_def";
+        gD = "go_to_decl";
+        gy = "go_to_type";
+        I = "mouse_enter";
+        i = "mouse_leave";
+        "<Esc>" = "clear_all";
+        C = "clear_all";
+        "<LocalLeader><Tab>" = "goto_last_window";
+      } "Mappings.";
     };
 
     progressBars = {
@@ -222,7 +220,7 @@ in
           on_attach = helpers.mkNullOrOption types.str "The LSP handler.";
         };
       }
-    ) "{}" "Legacy Lean3 LSP settings.";
+    ) { } "Legacy Lean3 LSP settings.";
   };
 
   config = mkIf cfg.enable {

--- a/plugins/languages/markdown-preview.nix
+++ b/plugins/languages/markdown-preview.nix
@@ -97,19 +97,19 @@ mkVimPlugin config {
       freeformType = types.attrs;
 
       options = {
-        mkit = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        mkit = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           `markdown-it` options for render.
         '';
 
-        katex = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        katex = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           `katex` options for math.
         '';
 
-        uml = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        uml = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           `markdown-it-plantuml` options.
         '';
 
-        maid = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        maid = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           `mermaid` options.
         '';
 
@@ -135,11 +135,11 @@ mkVimPlugin config {
           Hide yaml metadata.
         '';
 
-        sequence_diagrams = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        sequence_diagrams = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           `js-sequence-diagrams` options.
         '';
 
-        flowchart_diagrams = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        flowchart_diagrams = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           `flowcharts` diagrams options.
         '';
 
@@ -151,7 +151,7 @@ mkVimPlugin config {
           Disable filename header for the preview page.
         '';
 
-        toc = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        toc = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Toc options.
         '';
       };
@@ -182,20 +182,20 @@ mkVimPlugin config {
       Use a custom location for images.
     '';
 
-    filetypes = helpers.defaultNullOpts.mkListOf types.str ''["markdown"]'' ''
+    filetypes = helpers.defaultNullOpts.mkListOf types.str [ "markdown" ] ''
       Recognized filetypes. These filetypes will have `MarkdownPreview...` commands.
     '';
 
-    theme =
-      helpers.mkNullOrOption
-        (types.enum [
-          "dark"
-          "light"
-        ])
-        ''
-          Default theme (dark or light).
-          By default the theme is define according to the preferences of the system.
-        '';
+    theme = helpers.defaultNullOpts.mkEnum' {
+      values = [
+        "dark"
+        "light"
+      ];
+      description = ''
+        Default theme (dark or light).
+      '';
+      pluginDefault = literalMD "chosen based on system preferences";
+    };
 
     combine_preview = helpers.defaultNullOpts.mkBool false ''
       Combine preview window.

--- a/plugins/languages/nvim-jdtls.nix
+++ b/plugins/languages/nvim-jdtls.nix
@@ -62,8 +62,8 @@ in
     };
 
     rootDir =
-      helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua)
-        ''{ __raw = "require('jdtls.setup').find_root({'.git', 'mvnw', 'gradlew'})"; }''
+      helpers.defaultNullOpts.mkStr
+        { __raw = "require('jdtls.setup').find_root({'.git', 'mvnw', 'gradlew'})"; }
         ''
           This is the default if not provided, you can remove it. Or adjust as needed.
           One dedicated LSP server & client will be started per unique root_dir

--- a/plugins/languages/openscad.nix
+++ b/plugins/languages/openscad.nix
@@ -20,7 +20,7 @@ in
       "fzf"
     ] defaultFuzzyFinder "fuzzy finder to find documentation";
 
-    cheatsheetWindowBlend = helpers.defaultNullOpts.mkNullable (types.ints.between 0 100) "15" "";
+    cheatsheetWindowBlend = helpers.defaultNullOpts.mkNullable (types.ints.between 0 100) 15 "";
 
     loadSnippets = helpers.defaultNullOpts.mkBool false "";
 

--- a/plugins/languages/python/jupytext.nix
+++ b/plugins/languages/python/jupytext.nix
@@ -32,7 +32,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Default filetype. Don't change unless you know what you are doing.
     '';
 
-    custom_language_formatting = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+    custom_language_formatting = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
       By default we use the auto mode of jupytext.
       This will create a script with the correct extension for each language.
       However, this can be overridden in a per language basis if you want to.

--- a/plugins/languages/qmk.nix
+++ b/plugins/languages/qmk.nix
@@ -74,29 +74,27 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             `variant=qmk`).
           '';
 
-      keymap_overrides = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+      keymap_overrides = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
         A dictionary of key codes to text replacements, any provided value will be merged with the
         existing dictionary, see [key_map.lua](https://github.com/codethread/qmk.nvim/blob/main/lua/qmk/config/key_map.lua) for details.
       '';
 
       symbols =
         helpers.defaultNullOpts.mkAttrsOf types.str
-          ''
-            {
-              space = " ";
-              horz = "─";
-              vert = "│";
-              tl = "┌";
-              tm = "┬";
-              tr = "┐";
-              ml = "├";
-              mm = "┼";
-              mr = "┤";
-              bl = "└";
-              bm = "┴";
-              br = "┘";
-            }
-          ''
+          {
+            space = " ";
+            horz = "─";
+            vert = "│";
+            tl = "┌";
+            tm = "┬";
+            tr = "┐";
+            ml = "├";
+            mm = "┼";
+            mr = "┤";
+            bl = "└";
+            bm = "┴";
+            br = "┘";
+          }
           ''
             A dictionary of symbols used for the preview comment border chars see [default.lua](https://github.com/codethread/qmk.nvim/blob/main/lua/qmk/config/default.lua) for details.
           '';

--- a/plugins/languages/rust/rust-tools.nix
+++ b/plugins/languages/rust/rust-tools.nix
@@ -47,7 +47,7 @@ in
       maxLenAlign = helpers.defaultNullOpts.mkBool false "whether to align to the length of the longest line in the file";
 
       maxLenAlignPadding =
-        helpers.defaultNullOpts.mkInt 1
+        helpers.defaultNullOpts.mkUnsignedInt 1
           "padding from the left if max_len_align is true";
 
       rightAlign = helpers.defaultNullOpts.mkBool false "whether to align to the extreme right or not";
@@ -58,26 +58,44 @@ in
     };
 
     hoverActions = {
-      border = helpers.defaultNullOpts.mkBorder ''
+      border = helpers.defaultNullOpts.mkBorder [
         [
-          [ "╭" "FloatBorder" ]
-          [ "─" "FloatBorder" ]
-          [ "╮" "FloatBorder" ]
-          [ "│" "FloatBorder" ]
-          [ "╯" "FloatBorder" ]
-          [ "─" "FloatBorder" ]
-          [ "╰" "FloatBorder" ]
-          [ "│" "FloatBorder" ]
+          "╭"
+          "FloatBorder"
         ]
-      '' "rust-tools hover window" "";
+        [
+          "─"
+          "FloatBorder"
+        ]
+        [
+          "╮"
+          "FloatBorder"
+        ]
+        [
+          "│"
+          "FloatBorder"
+        ]
+        [
+          "╯"
+          "FloatBorder"
+        ]
+        [
+          "─"
+          "FloatBorder"
+        ]
+        [
+          "╰"
+          "FloatBorder"
+        ]
+        [
+          "│"
+          "FloatBorder"
+        ]
+      ] "rust-tools hover window" "";
 
-      maxWidth =
-        helpers.defaultNullOpts.mkNullable types.int null
-          "Maximal width of the hover window. null means no max.";
+      maxWidth = helpers.defaultNullOpts.mkUnsignedInt null "Maximal width of the hover window. null means no max.";
 
-      maxHeight =
-        helpers.defaultNullOpts.mkNullable types.int null
-          "Maximal height of the hover window. null means no max.";
+      maxHeight = helpers.defaultNullOpts.mkUnsignedInt null "Maximal height of the hover window. null means no max.";
 
       autoFocus = helpers.defaultNullOpts.mkBool false "whether the hover action window gets automatically focused";
     };

--- a/plugins/languages/rust/rustaceanvim/settings-options.nix
+++ b/plugins/languages/rust/rustaceanvim/settings-options.nix
@@ -137,15 +137,62 @@ with lib;
 
         enabled_graphviz_backends =
           helpers.defaultNullOpts.mkListOf types.str
-            ''
-              [
-                "bmp" "cgimage" "canon" "dot" "gv" "xdot" "xdot1.2" "xdot1.4" "eps" "exr" "fig" "gd"
-                "gd2" "gif" "gtk" "ico" "cmap" "ismap" "imap" "cmapx" "imap_np" "cmapx_np" "jpg"
-                "jpeg" "jpe" "jp2" "json" "json0" "dot_json" "xdot_json" "pdf" "pic" "pct" "pict"
-                "plain" "plain-ext" "png" "pov" "ps" "ps2" "psd" "sgi" "svg" "svgz" "tga" "tiff"
-                "tif" "tk" "vml" "vmlz" "wbmp" "webp" "xlib" "x11"
-              ]
-            ''
+            [
+              "bmp"
+              "cgimage"
+              "canon"
+              "dot"
+              "gv"
+              "xdot"
+              "xdot1.2"
+              "xdot1.4"
+              "eps"
+              "exr"
+              "fig"
+              "gd"
+              "gd2"
+              "gif"
+              "gtk"
+              "ico"
+              "cmap"
+              "ismap"
+              "imap"
+              "cmapx"
+              "imap_np"
+              "cmapx_np"
+              "jpg"
+              "jpeg"
+              "jpe"
+              "jp2"
+              "json"
+              "json0"
+              "dot_json"
+              "xdot_json"
+              "pdf"
+              "pic"
+              "pct"
+              "pict"
+              "plain"
+              "plain-ext"
+              "png"
+              "pov"
+              "ps"
+              "ps2"
+              "psd"
+              "sgi"
+              "svg"
+              "svgz"
+              "tga"
+              "tiff"
+              "tif"
+              "tk"
+              "vml"
+              "vmlz"
+              "wbmp"
+              "webp"
+              "xlib"
+              "x11"
+            ]
             ''
               Override the enabled graphviz backends list, used for input validation and autocompletion.
             '';
@@ -235,7 +282,7 @@ with lib;
       Disabling it may improve rust-analyzer's startup time.
     '';
 
-    logfile = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.tempname() .. '-rust-analyzer.log'";}'' ''
+    logfile = helpers.defaultNullOpts.mkStr { __raw = "vim.fn.tempname() .. '-rust-analyzer.log'"; } ''
       The path to the rust-analyzer log file.
     '';
 

--- a/plugins/languages/treesitter/rainbow-delimiters.nix
+++ b/plugins/languages/treesitter/rainbow-delimiters.nix
@@ -12,79 +12,68 @@ with lib;
 
     package = helpers.mkPluginPackageOption "rainbow-delimiters.nvim" pkgs.vimPlugins.rainbow-delimiters-nvim;
 
-    strategy =
-      helpers.defaultNullOpts.mkNullable
-        (
-          with types;
-          attrsOf (
-            either helpers.nixvimTypes.rawLua (enum [
-              "global"
-              "local"
-              "noop"
-            ])
-          )
-        )
-        ''
-          {
-            default = "global";
-          }
-        ''
-        ''
-          Attrs mapping Tree-sitter language names to strategies.
-          See `|rb-delimiters-strategy|` for more information about strategies.
+    strategy = helpers.defaultNullOpts.mkAttrsOf' {
+      type = types.enum [
+        "global"
+        "local"
+        "noop"
+      ];
+      pluginDefault = {
+        default = "global";
+      };
+      description = ''
+        Attrs mapping Tree-sitter language names to strategies.
+        See `|rb-delimiters-strategy|` for more information about strategies.
+      '';
+      example = literalMD ''
+        ```nix
+        {
+          # Use global strategy by default
+          default = "global";
 
-          Example:
-          ```nix
-            {
-              # Use global strategy by default
-              default = "global";
+          # Use local for HTML
+          html = "local";
 
-              # Use local for HTML
-              html = "local";
-
-              # Pick the strategy for LaTeX dynamically based on the buffer size
-              latex.__raw = \'\'
-                function()
-                  -- Disabled for very large files, global strategy for large files,
-                  -- local strategy otherwise
-                  if vim.fn.line('$') > 10000 then
-                      return nil
-                  elseif vim.fn.line('$') > 1000 then
-                      return require 'rainbow-delimiters'.strategy['global']
-                  end
-                  return require 'rainbow-delimiters'.strategy['local']
-                end
-              \'\';
-            }
-          ```
-        '';
+          # Pick the strategy for LaTeX dynamically based on the buffer size
+          latex.__raw = '''
+            function()
+              -- Disabled for very large files, global strategy for large files,
+              -- local strategy otherwise
+              if vim.fn.line('$') > 10000 then
+                  return nil
+              elseif vim.fn.line('$') > 1000 then
+                  return require 'rainbow-delimiters'.strategy['global']
+              end
+              return require 'rainbow-delimiters'.strategy['local']
+            end
+          ''';
+        }
+        ```
+      '';
+    };
 
     query =
-      helpers.defaultNullOpts.mkNullable (with types; attrsOf str)
-        ''
-          {
-            default = "rainbow-delimiters";
-            lua = "rainbow-blocks";
-          }
-        ''
+      helpers.defaultNullOpts.mkAttrsOf types.str
+        {
+          default = "rainbow-delimiters";
+          lua = "rainbow-blocks";
+        }
         ''
           Attrs mapping Tree-sitter language names to queries.
           See `|rb-delimiters-query|` for more information about queries.
         '';
 
     highlight =
-      helpers.defaultNullOpts.mkNullable (with types; listOf str)
-        ''
-          [
-            "RainbowDelimiterRed"
-            "RainbowDelimiterYellow"
-            "RainbowDelimiterBlue"
-            "RainbowDelimiterOrange"
-            "RainbowDelimiterGreen"
-            "RainbowDelimiterViolet"
-            "RainbowDelimiterCyan"
-          ]
-        ''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "RainbowDelimiterRed"
+          "RainbowDelimiterYellow"
+          "RainbowDelimiterBlue"
+          "RainbowDelimiterOrange"
+          "RainbowDelimiterGreen"
+          "RainbowDelimiterViolet"
+          "RainbowDelimiterCyan"
+        ]
         ''
           List of names of the highlight groups to use for highlighting, for more information see
           `|rb-delimiters-colors|`.
@@ -102,12 +91,7 @@ with lib;
 
     log = {
       file =
-        helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-          ''
-            {
-              __raw = "vim.fn.stdpath('log') .. '/rainbow-delimiters.log'";
-            }
-          ''
+        helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath('log') .. '/rainbow-delimiters.log'"; }
           ''
             Path to the log file, default is `rainbow-delimiters.log` in your standard log path
             (see `|standard-path|`).

--- a/plugins/languages/treesitter/treesitter-textobjects.nix
+++ b/plugins/languages/treesitter/treesitter-textobjects.nix
@@ -9,35 +9,33 @@ with lib;
 {
   options.plugins.treesitter-textobjects =
     let
-      disable = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+      disable = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         List of languages to disable this module for.
       '';
 
       mkKeymapsOption =
         desc:
-        helpers.defaultNullOpts.mkNullable (
+        helpers.defaultNullOpts.mkAttrsOf (
           with types;
-          attrsOf (
-            either str (submodule {
-              options = {
-                query = mkOption {
-                  type = str;
-                  description = "";
-                  example = "@class.inner";
-                };
-
-                queryGroup = helpers.mkNullOrOption str ''
-                  You can also use captures from other query groups like `locals.scm`
-                '';
-
-                desc = helpers.mkNullOrOption str ''
-                  You can optionally set descriptions to the mappings (used in the `desc`
-                  parameter of `nvim_buf_set_keymap`) which plugins like _which-key_ display.
-                '';
+          either str (submodule {
+            options = {
+              query = mkOption {
+                type = str;
+                description = "";
+                example = "@class.inner";
               };
-            })
-          )
-        ) "{}" desc;
+
+              queryGroup = helpers.mkNullOrOption str ''
+                You can also use captures from other query groups like `locals.scm`
+              '';
+
+              desc = helpers.mkNullOrOption str ''
+                You can optionally set descriptions to the mappings (used in the `desc`
+                parameter of `nvim_buf_set_keymap`) which plugins like _which-key_ display.
+              '';
+            };
+          })
+        ) { } desc;
     in
     helpers.neovim-plugin.extraOptionsOptions
     // {
@@ -65,22 +63,22 @@ with lib;
         '';
 
         selectionModes =
-          helpers.defaultNullOpts.mkNullable
+          helpers.defaultNullOpts.mkAttrsOf
             (
               with types;
-              attrsOf (enum [
+              enum [
                 "v"
                 "V"
                 "<c-v>"
-              ])
+              ]
             )
-            "{}"
+            { }
             ''
               Map of capture group to `v`(charwise), `V`(linewise), or `<c-v>`(blockwise), choose a
               selection mode per capture, default is `v`(charwise).
             '';
 
-        includeSurroundingWhitespace = helpers.defaultNullOpts.mkStrLuaFnOr types.bool "`false`" ''
+        includeSurroundingWhitespace = helpers.defaultNullOpts.mkStrLuaFnOr types.bool false ''
           `true` or `false`, when `true` textobjects are extended to include preceding or
           succeeding whitespace.
 
@@ -177,7 +175,7 @@ with lib;
           (when https://github.com/neovim/neovim/pull/12720 or its successor is merged).
         '';
 
-        floatingPreviewOpts = helpers.defaultNullOpts.mkNullable (with types; attrsOf anything) "{}" ''
+        floatingPreviewOpts = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
           Options to pass to `vim.lsp.util.open_floating_preview`.
           For example, `maximum_height`.
         '';

--- a/plugins/languages/typescript-tools.nix
+++ b/plugins/languages/typescript-tools.nix
@@ -141,9 +141,15 @@ in
         enable = helpers.defaultNullOpts.mkBool false ''
           Functions similarly to `nvim-ts-autotag`. This is disabled by default to avoid conflicts.
         '';
-        filetypes = helpers.defaultNullOpts.mkListOf types.str ''["javascriptreact" "typescriptreact"]'' ''
-          Filetypes this should apply to.
-        '';
+        filetypes =
+          helpers.defaultNullOpts.mkListOf types.str
+            [
+              "javascriptreact"
+              "typescriptreact"
+            ]
+            ''
+              Filetypes this should apply to.
+            '';
       };
     };
   };

--- a/plugins/lsp/conform-nvim.nix
+++ b/plugins/lsp/conform-nvim.nix
@@ -15,74 +15,74 @@ in
 
     package = helpers.mkPluginPackageOption "conform-nvim" pkgs.vimPlugins.conform-nvim;
 
-    formattersByFt =
-      helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "see documentation"
-        ''
-          ```nix
-            # Map of filetype to formatters
-            formattersByFt =
-              {
-                lua = [ "stylua" ];
-                # Conform will run multiple formatters sequentially
-                python = [ "isort" "black" ];
-                # Use a sub-list to run only the first available formatter
-                javascript = [ [ "prettierd" "prettier" ] ];
-                # Use the "*" filetype to run formatters on all filetypes.
-                "*" = [ "codespell" ];
-                # Use the "_" filetype to run formatters on filetypes that don't
-                # have other formatters configured.
-                "_" = [ "trim_whitespace" ];
-               };
-          ```
-        '';
-
-    formatOnSave =
-      helpers.defaultNullOpts.mkNullable
-        (
-          with helpers.nixvimTypes;
-          either strLuaFn (submodule {
-            options = {
-              lspFallback = mkOption {
-                type = types.bool;
-                default = true;
-                description = "See :help conform.format for details.";
-              };
-              timeoutMs = mkOption {
-                type = types.int;
-                default = 500;
-                description = "See :help conform.format for details.";
-              };
+    formattersByFt = helpers.defaultNullOpts.mkAttrsOf' {
+      type = types.anything;
+      # Unknown plugin default
+      description = ''
+        ```nix
+          # Map of filetype to formatters
+          formattersByFt =
+            {
+              lua = [ "stylua" ];
+              # Conform will run multiple formatters sequentially
+              python = [ "isort" "black" ];
+              # Use a sub-list to run only the first available formatter
+              javascript = [ [ "prettierd" "prettier" ] ];
+              # Use the "*" filetype to run formatters on all filetypes.
+              "*" = [ "codespell" ];
+              # Use the "_" filetype to run formatters on filetypes that don't
+              # have other formatters configured.
+              "_" = [ "trim_whitespace" ];
             };
-          })
-        )
-        "see documentation"
-        ''
-          If this is set, Conform will run the formatter on save.
-          It will pass the table to conform.format().
-          This can also be a function that returns the table.
-          See :help conform.format for details.
-        '';
+        ```
+      '';
+    };
 
-    formatAfterSave =
-      helpers.defaultNullOpts.mkNullable
-        (
-          with helpers.nixvimTypes;
-          either strLuaFn (submodule {
-            options = {
-              lspFallback = mkOption {
-                type = types.bool;
-                default = true;
-                description = "See :help conform.format for details.";
-              };
+    formatOnSave = helpers.defaultNullOpts.mkNullable' {
+      type =
+        with helpers.nixvimTypes;
+        either strLuaFn (submodule {
+          options = {
+            lspFallback = mkOption {
+              type = types.bool;
+              default = true;
+              description = "See :help conform.format for details.";
             };
-          })
-        )
-        "see documentation"
-        ''
-          If this is set, Conform will run the formatter asynchronously after save.
-          It will pass the table to conform.format().
-          This can also be a function that returns the table.
-        '';
+            timeoutMs = mkOption {
+              type = types.int;
+              default = 500;
+              description = "See :help conform.format for details.";
+            };
+          };
+        });
+      # Unknown plugin default
+      description = ''
+        If this is set, Conform will run the formatter on save.
+        It will pass the table to conform.format().
+        This can also be a function that returns the table.
+        See :help conform.format for details.
+      '';
+    };
+
+    formatAfterSave = helpers.defaultNullOpts.mkNullable' {
+      type =
+        with helpers.nixvimTypes;
+        either strLuaFn (submodule {
+          options = {
+            lspFallback = mkOption {
+              type = types.bool;
+              default = true;
+              description = "See :help conform.format for details.";
+            };
+          };
+        });
+      # Unknown plugin default
+      description = ''
+        If this is set, Conform will run the formatter asynchronously after save.
+        It will pass the table to conform.format().
+        This can also be a function that returns the table.
+      '';
+    };
 
     logLevel = helpers.defaultNullOpts.mkLogLevel "error" ''
       Set the log level. Use `:ConformInfo` to see the location of the log file.
@@ -90,9 +90,11 @@ in
 
     notifyOnError = helpers.defaultNullOpts.mkBool true "Conform will notify you when a formatter errors";
 
-    formatters =
-      helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "see documentation"
-        "Custom formatters and changes to built-in formatters";
+    formatters = helpers.defaultNullOpts.mkAttrsOf' {
+      type = types.anything;
+      # Unknown plugin default
+      description = "Custom formatters and changes to built-in formatters";
+    };
   };
 
   config =

--- a/plugins/lsp/fidget.nix
+++ b/plugins/lsp/fidget.nix
@@ -149,7 +149,7 @@ in
 
       # Options related to LSP progress subsystem
       progress = {
-        pollRate = helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) number) "0" ''
+        pollRate = helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) number) 0 ''
           How and when to poll for progress messages.
 
           Set to `0` to immediately poll on each `|LspProgress|` event.
@@ -232,22 +232,20 @@ in
               will be installed).
             '';
 
-        ignore = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        ignore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of LSP servers to ignore.
         '';
 
         # Options related to how LSP progress messages are displayed as notifications
         display = {
-          renderLimit =
-            helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) number) "16"
-              ''
-                How many LSP messages to show at once.
+          renderLimit = helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) number) 16 ''
+            How many LSP messages to show at once.
 
-                If `false`, no limit.
+            If `false`, no limit.
 
-                This is used to configure each LSP notification group, so by default, this is a
-                per-server limit.
-              '';
+            This is used to configure each LSP notification group, so by default, this is a
+            per-server limit.
+          '';
 
           doneTtl = helpers.defaultNullOpts.mkStrLuaOr types.ints.unsigned "3" ''
             How long a message should persist after completion.
@@ -316,14 +314,12 @@ in
           formatGroupName = helpers.defaultNullOpts.mkLuaFn "function(group) return tostring(group) end" "How to format a progress notification group's name.";
 
           overrides =
-            helpers.defaultNullOpts.mkNullable (with types; attrsOf notificationConfigType)
-              ''
-                {
-                  rust_analyzer = {
-                    name = "rust-analyzer";
-                  };
-                }
-              ''
+            helpers.defaultNullOpts.mkAttrsOf notificationConfigType
+              {
+                rust_analyzer = {
+                  name = "rust-analyzer";
+                };
+              }
               ''
                 Override options from the default notification config.
                 Keys of the table are each notification group's `key`.
@@ -379,12 +375,8 @@ in
         '';
 
         configs =
-          helpers.defaultNullOpts.mkNullable (with types; attrsOf (either notificationConfigType str))
-            ''
-              {
-                default = "require('fidget.notification').default_config";
-              }
-            ''
+          helpers.defaultNullOpts.mkAttrsOf (with types; either str notificationConfigType)
+            { default = "require('fidget.notification').default_config"; }
             ''
               How to configure notification groups when instantiated.
 
@@ -551,11 +543,11 @@ in
 
         floatPrecision = helpers.defaultNullOpts.mkNullable (
           with types; numbers.between 0.0 1.0
-        ) "0.01" "Limit the number of decimals displayed for floats.";
+        ) 1.0e-2 "Limit the number of decimals displayed for floats.";
 
         path =
-          helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-            ''{__raw = "string.format('%s/fidget.nvim.log', vim.fn.stdpath('cache'))";}''
+          helpers.defaultNullOpts.mkStr
+            { __raw = "string.format('%s/fidget.nvim.log', vim.fn.stdpath('cache'))"; }
             ''
               Where Fidget writes its logs to.
 

--- a/plugins/lsp/language-servers/ccls.nix
+++ b/plugins/lsp/language-servers/ccls.nix
@@ -69,13 +69,13 @@ in
     };
 
     clang = {
-      extraArgs = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+      extraArgs = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         Additional arguments for `compile_commands.json` entries.
 
         Example: `["-frounding-math"]`
       '';
 
-      excludeArgs = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+      excludeArgs = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         Excluded arguments for `compile_commands.json` entries.
 
         If your compiler is not Clang and it supports arguments which Clang doesn't understand, then
@@ -84,7 +84,7 @@ in
         Example: `["-frounding-math"]`
       '';
 
-      pathMappings = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+      pathMappings = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         A list of `src>dest` path conversions used to remap the paths of files in the project.
         This can be used to move a project to a new location without re-indexing.
 
@@ -238,7 +238,7 @@ in
             Also consider using `index.multiVersionBlacklist` to exclude system headers.
           '';
 
-      multiVersionBlacklist = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+      multiVersionBlacklist = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         A list of regular expressions matching files that should not be indexed via multi-version
         if `index.multiVersion` is set to `1`.
 
@@ -248,7 +248,7 @@ in
         Example: `["^/usr/include"]`
       '';
 
-      initialBlacklist = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+      initialBlacklist = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         A list of regular expressions matching files that should not be indexed when the `ccls`
         server starts up, but will still be indexed if a client opens them.
         If there are areas of the project that you have no interest in indexing you can use this to

--- a/plugins/lsp/language-servers/pylsp.nix
+++ b/plugins/lsp/language-servers/pylsp.nix
@@ -44,7 +44,7 @@ in
           Setting this explicitly to `true` will install the dependency for this plugin (flake8).
         '';
 
-        exclude = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        exclude = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of files or directories to exclude.
         '';
 
@@ -60,7 +60,7 @@ in
           Hang closing bracket instead of matching indentation of opening bracket's line.
         '';
 
-        ignore = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        ignore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of errors and warnings to ignore (or skip).
         '';
 
@@ -76,7 +76,7 @@ in
           Set indentation spaces.
         '';
 
-        perFileIgnores = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        perFileIgnores = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           A pairing of filenames and violation codes that defines which violations to ignore in a
           particular file.
 
@@ -89,11 +89,11 @@ in
       };
 
       jedi = {
-        auto_import_modules =
-          helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[ \"numpy\" ]"
-            "List of module names for `jedi.settings.auto_import_modules`.";
+        auto_import_modules = helpers.defaultNullOpts.mkListOf types.str [
+          "numpy"
+        ] "List of module names for `jedi.settings.auto_import_modules`.";
 
-        extra_paths = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        extra_paths = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Define extra paths for jedi.Script.
         '';
 
@@ -129,10 +129,12 @@ in
           How many labels and snippets (at most) should be resolved.
         '';
 
-        cache_for =
-          helpers.defaultNullOpts.mkNullable (types.listOf types.str)
-            "[ \"pandas\" \"numpy\" \"tensorflow\" \"matplotlib\" ]"
-            "Modules for which labels and snippets should be cached.";
+        cache_for = helpers.defaultNullOpts.mkListOf types.str [
+          "pandas"
+          "numpy"
+          "tensorflow"
+          "matplotlib"
+        ] "Modules for which labels and snippets should be cached.";
       };
 
       jedi_definition = {
@@ -189,7 +191,7 @@ in
       preload = {
         enabled = helpers.defaultNullOpts.mkBool true "Enable or disable the plugin.";
 
-        modules = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        modules = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of modules to import on startup.
         '';
       };
@@ -201,11 +203,11 @@ in
           (pycodestyle).
         '';
 
-        exclude = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        exclude = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Exclude files or directories which match these patterns.
         '';
 
-        filename = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        filename = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           When parsing directories, only check filenames matching these patterns.
         '';
 
@@ -213,7 +215,7 @@ in
           Select errors and warnings.
         '';
 
-        ignore = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        ignore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Ignore errors and warnings.
         '';
 
@@ -244,15 +246,15 @@ in
           "None"
         ]) "Choose the basic list of checked errors by specifying an existing convention.";
 
-        addIgnore = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        addIgnore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Ignore errors and warnings in addition to the specified convention.
         '';
 
-        addSelect = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        addSelect = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Select errors and warnings in addition to the specified convention.
         '';
 
-        ignore = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        ignore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Ignore errors and warnings.
         '';
 
@@ -284,7 +286,7 @@ in
           Setting this explicitly to `true` will install the dependency for this plugin (pylint).
         '';
 
-        args = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        args = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Arguments to pass to pylint.
         '';
 
@@ -352,31 +354,21 @@ in
           This option often is too strict to be useful.
         '';
 
-        overrides =
-          helpers.defaultNullOpts.mkNullable
-            (types.listOf (
-              types.oneOf [
-                types.bool
-                types.str
-                helpers.nixvimTypes.rawLua
-              ]
-            ))
-            "[true]"
-            ''
-              Specifies a list of alternate or supplemental command-line options.
-              This modifies the options passed to mypy or the mypy-specific ones passed to dmypy run.
-              When present, the special boolean member true is replaced with the command-line options that
-              would've been passed had overrides not been specified.
-              Later options take precedence, which allows for replacing or negating individual default
-              options (see mypy.main:process_options and mypy --help | grep inverse).
-            '';
+        overrides = helpers.defaultNullOpts.mkListOf (with types; either bool str) [ true ] ''
+          Specifies a list of alternate or supplemental command-line options.
+          This modifies the options passed to mypy or the mypy-specific ones passed to dmypy run.
+          When present, the special boolean member true is replaced with the command-line options that
+          would've been passed had overrides not been specified.
+          Later options take precedence, which allows for replacing or negating individual default
+          options (see `mypy.main:process_options` and `mypy --help | grep inverse`).
+        '';
 
         dmypy_status_file = helpers.defaultNullOpts.mkStr ".dmypy.json" ''
           Specifies which status file dmypy should use.
           This modifies the --status-file option passed to dmypy given dmypy is active.
         '';
 
-        config_sub_paths = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+        config_sub_paths = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Specifies sub paths under which the mypy configuration file may be found.
           For each directory searched for the mypy config file, this also searches the sub paths
           specified here.
@@ -449,7 +441,7 @@ in
 
         config = helpers.mkNullOrOption types.str "Path to optional pyproject.toml file.";
 
-        exclude = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        exclude = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Exclude files from being checked by ruff.
         '';
 
@@ -457,11 +449,11 @@ in
           Path to the ruff executable. Assumed to be in PATH by default.
         '';
 
-        ignore = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        ignore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Error codes to ignore.
         '';
 
-        extendIgnore = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        extendIgnore = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Same as ignore, but append to existing ignores.
         '';
 
@@ -471,15 +463,15 @@ in
           File-specific error codes to be ignored.
         '';
 
-        select = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        select = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of error codes to enable.
         '';
 
-        extendSelect = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        extendSelect = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Same as select, but append to existing error codes.
         '';
 
-        format = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        format = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of error codes to fix during formatting.
           The default is ["I"], any additional codes are appended to this list.
         '';

--- a/plugins/lsp/language-servers/tinymist-settings.nix
+++ b/plugins/lsp/language-servers/tinymist-settings.nix
@@ -50,7 +50,7 @@ with lib;
     If set to null or not set, the extension will use the default behavior of the Typst compiler.
   '';
 
-  fontPaths = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+  fontPaths = helpers.defaultNullOpts.mkListOf types.str [ ] ''
     Font paths, which doesn't allow for dynamic configuration.
     Note: you can use vscode variables in the path, e.g. `$\{workspaceFolder}/fonts`.
   '';
@@ -69,7 +69,7 @@ with lib;
         server level.
       '';
 
-  typstExtraArgs = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+  typstExtraArgs = helpers.defaultNullOpts.mkListOf types.str [ ] ''
     You can pass any arguments as you like, and we will try to follow behaviors of the
     **same version** of typst-cli.
 

--- a/plugins/lsp/lsp-status.nix
+++ b/plugins/lsp/lsp-status.nix
@@ -22,7 +22,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         '';
     in
     {
-      kind_labels = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+      kind_labels = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
         An optional map from LSP symbol kinds to label symbols. Used to decorate the current function name.
       '';
 

--- a/plugins/lsp/lspsaga.nix
+++ b/plugins/lsp/lspsaga.nix
@@ -66,21 +66,25 @@ in
 
         actionfix = helpers.defaultNullOpts.mkStr "" "Action fix icon.";
 
-        lines = helpers.defaultNullOpts.mkNullable (
-          with types; listOf str
-        ) ''["┗" "┣" "┃" "━" "┏"]'' "Symbols used in virtual text connect.";
+        lines = helpers.defaultNullOpts.mkListOf types.str [
+          "┗"
+          "┣"
+          "┃"
+          "━"
+          "┏"
+        ] "Symbols used in virtual text connect.";
 
-        kind = helpers.defaultNullOpts.mkNullable types.attrs "{}" "LSP kind custom table.";
+        kind = helpers.defaultNullOpts.mkAttrsOf types.anything { } "LSP kind custom table.";
 
         impSign = helpers.defaultNullOpts.mkStr "󰳛 " "Implement icon.";
       };
 
       hover = {
-        maxWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.9" ''
+        maxWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.9 ''
           Defines float window width.
         '';
 
-        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.8" ''
+        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.8 ''
           Defines float window height.
         '';
 
@@ -107,19 +111,19 @@ in
           Enable number shortcuts to execute code action quickly.
         '';
 
-        maxWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.8" ''
+        maxWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.8 ''
           Diagnostic jump window max width.
         '';
 
-        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.6" ''
+        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.6 ''
           Diagnostic jump window max height.
         '';
 
-        maxShowWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.9" ''
+        maxShowWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.9 ''
           Show window max width when layout is float.
         '';
 
-        maxShowHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.6" ''
+        maxShowHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.6 ''
           Show window max height when layout is float.
         '';
 
@@ -201,19 +205,19 @@ in
       };
 
       finder = {
-        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.5" ''
+        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.5 ''
           `max_height` of the finder window (float layout).
         '';
 
-        leftWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.3" ''
+        leftWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.3 ''
           Width of the left finder window (float layout).
         '';
 
-        rightWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.3" ''
+        rightWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.3 ''
           Width of the right finder window (float layout).
         '';
 
-        methods = helpers.defaultNullOpts.mkNullable (with types; attrsOf str) "{}" ''
+        methods = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
           Keys are alias of LSP methods.
           Values are LSP methods, which you want show in finder.
 
@@ -243,7 +247,7 @@ in
           If it’s true, it will disable show the no response message.
         '';
 
-        filter = helpers.defaultNullOpts.mkNullable (with types; attrsOf str) "{}" ''
+        filter = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
           Keys are LSP methods.
           Values are a filter handler.
           Function parameter are `client_id` and `result`.
@@ -269,11 +273,11 @@ in
       };
 
       definition = {
-        width = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.6" ''
+        width = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.6 ''
           Defines float window width.
         '';
 
-        height = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.5" ''
+        height = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.5 ''
           Defines float window height.
         '';
 
@@ -309,11 +313,11 @@ in
 
         projectMaxWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
           1.0
-        ) "0.5" "Width for the `project_replace` float window.";
+        ) 0.5 "Width for the `project_replace` float window.";
 
         projectMaxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
           1.0
-        ) "0.5" "Height for the `project_replace` float window.";
+        ) 0.5 "Height for the `project_replace` float window.";
 
         keys = {
           quit = mkKeymapOption "<C-k>" "Quit rename window or `project_replace` window.";
@@ -369,15 +373,15 @@ in
             ]
             ''
               `float` or `normal`.
-              Default is normal.
+
               If set to float, above options will ignored.
             '';
 
-        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.5" ''
+        maxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.5 ''
           Height of outline float layout.
         '';
 
-        leftWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.3" ''
+        leftWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.3 ''
           Width of outline float layout left window.
         '';
 

--- a/plugins/lsp/nvim-lightbulb.nix
+++ b/plugins/lsp/nvim-lightbulb.nix
@@ -127,7 +127,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         Highlight group to highlight the floating window.
       '';
 
-      win_opts = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+      win_opts = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
         Window options.
         See |vim.lsp.util.open_floating_preview| and |nvim_open_win|.
         Note that some options may be overridden by |open_floating_preview|.
@@ -176,22 +176,28 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         Set to a negative value to avoid setting the updatetime.
       '';
 
-      pattern = helpers.defaultNullOpts.mkListOf types.str ''["*"]'' ''
+      pattern = helpers.defaultNullOpts.mkListOf types.str [ "*" ] ''
         See |nvim_create_autocmd| and |autocmd-pattern|.
       '';
 
-      events = helpers.defaultNullOpts.mkListOf types.str ''["CursorHold" "CursorHoldI"]'' ''
-        See |nvim_create_autocmd|.
-      '';
+      events =
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "CursorHold"
+            "CursorHoldI"
+          ]
+          ''
+            See |nvim_create_autocmd|.
+          '';
     };
 
     ignore = {
-      clients = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+      clients = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         LSP client names to ignore.
         Example: {"null-ls", "lua_ls"}
       '';
 
-      ft = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+      ft = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         Filetypes to ignore.
         Example: {"neo-tree", "lua"}
       '';

--- a/plugins/lsp/trouble.nix
+++ b/plugins/lsp/trouble.nix
@@ -180,23 +180,26 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             description = "Manually refresh";
           };
           jump = {
-            default = "[ \"<cr>\" \"<tab>\" ]";
+            default = [
+              "<cr>"
+              "<tab>"
+            ];
             description = "Jump to the diagnostic or open / close folds";
           };
           open_split = {
-            default = "[ \"<c-x>\" ]";
+            default = [ "<c-x>" ];
             description = "Open buffer in new split";
           };
           open_vsplit = {
-            default = "[ \"<c-v>\" ]";
+            default = [ "<c-v>" ];
             description = "Open buffer in new vsplit";
           };
           open_tab = {
-            default = "[ \"<c-t>\" ]";
+            default = [ "<c-t>" ];
             description = "Open buffer in new tab";
           };
           jump_close = {
-            default = "[ \"o\" ]";
+            default = [ "o" ];
             description = "Jump to the diagnostic and close the list";
           };
           toggle_mode = {
@@ -216,15 +219,24 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             description = "Preview the diagnostic location";
           };
           close_folds = {
-            default = "[ \"zM\" \"zm\" ]";
+            default = [
+              "zM"
+              "zm"
+            ];
             description = "Close all folds";
           };
           open_folds = {
-            default = "[ \"zR\" \"zr\" ]";
+            default = [
+              "zR"
+              "zr"
+            ];
             description = "Open all folds";
           };
           toggle_fold = {
-            default = "[ \"zA\" \"za\" ]";
+            default = [
+              "zA"
+              "za"
+            ];
             description = "Toggle fold of current file";
           };
           previous = {
@@ -241,11 +253,9 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Add an indent guide below the fold icons.
     '';
 
-    win_config = helpers.defaultNullOpts.mkAttrsOf types.anything ''
-      {
-        border = "single";
-      }
-    '' "Configuration for floating windows. See `|nvim_open_win()|`.";
+    win_config = helpers.defaultNullOpts.mkAttrsOf types.anything {
+      border = "single";
+    } "Configuration for floating windows. See `|nvim_open_win()|`.";
 
     auto_open = helpers.defaultNullOpts.mkBool false ''
       Automatically open the list when you have diagnostics.
@@ -264,14 +274,15 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Automatically fold a file trouble list at creation.
     '';
 
-    auto_jump = helpers.defaultNullOpts.mkListOf types.str ''["lsp_definitions"]'' ''
+    auto_jump = helpers.defaultNullOpts.mkListOf types.str [ "lsp_definitions" ] ''
       For the given modes, automatically jump if there is only a single result.
     '';
 
-    include_declaration =
-      helpers.defaultNullOpts.mkListOf types.str
-        ''["lsp_references" "lsp_implementations" "lsp_definitions"]''
-        "For the given modes, include the declaration of the current symbol in the results.";
+    include_declaration = helpers.defaultNullOpts.mkListOf types.str [
+      "lsp_references"
+      "lsp_implementations"
+      "lsp_definitions"
+    ] "For the given modes, include the declaration of the current symbol in the results.";
 
     signs =
       mapAttrs

--- a/plugins/lsp/wtf.nix
+++ b/plugins/lsp/wtf.nix
@@ -41,18 +41,17 @@ in
       ) defaultKeymaps;
 
       popupType =
-        helpers.defaultNullOpts.mkEnum
+        helpers.defaultNullOpts.mkEnumFirstDefault
           [
             "popup"
             "horizontal"
             "vertical"
           ]
-          "popup"
           ''
             Default AI popup type.
           '';
 
-      openaiApiKey = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
+      openaiApiKey = helpers.defaultNullOpts.mkStr null ''
         An alternative way to set your API key.
       '';
 
@@ -66,12 +65,12 @@ in
 
       additionalInstructions = helpers.mkNullOrOption types.str "Any additional instructions.";
 
-      searchEngine = helpers.defaultNullOpts.mkEnum [
+      searchEngine = helpers.defaultNullOpts.mkEnumFirstDefault [
         "google"
         "duck_duck_go"
         "stack_overflow"
         "github"
-      ] "google" "Default search engine.";
+      ] "Default search engine.";
 
       hooks = {
         requestStarted = helpers.defaultNullOpts.mkLuaFn "nil" "Callback for request start.";

--- a/plugins/neotest/options.nix
+++ b/plugins/neotest/options.nix
@@ -38,65 +38,70 @@ with lib;
     Minimum log levels.
   '';
 
-  consumers = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.rawLua "{}" ''
+  consumers = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.strLuaFn { } ''
     key: string
     value: lua function
   '';
 
-  icons = helpers.defaultNullOpts.mkAttrsOf (with types; either str (listOf str)) ''
-    {
-      child_indent = "│";
-      child_prefix = "├";
-      collapsed = "─";
-      expanded = "╮";
-      failed = "";
-      final_child_indent = " ";
-      final_child_prefix = "╰";
-      non_collapsible = "─";
-      passed = "";
-      running = "";
-      running_animated = ["/" "|" "\\" "-" "/" "|" "\\" "-"];
-      skipped = "";
-      unknown = "";
-      watching = "";
-    }
-  '' "Icons used throughout the UI. Defaults use VSCode's codicons.";
+  icons = helpers.defaultNullOpts.mkAttrsOf (with types; either str (listOf str)) {
+    child_indent = "│";
+    child_prefix = "├";
+    collapsed = "─";
+    expanded = "╮";
+    failed = "";
+    final_child_indent = " ";
+    final_child_prefix = "╰";
+    non_collapsible = "─";
+    passed = "";
+    running = "";
+    running_animated = [
+      "/"
+      "|"
+      "\\"
+      "-"
+      "/"
+      "|"
+      "\\"
+      "-"
+    ];
+    skipped = "";
+    unknown = "";
+    watching = "";
+  } "Icons used throughout the UI. Defaults use VSCode's codicons.";
 
-  highlights = helpers.defaultNullOpts.mkAttrsOf types.str ''
-    {
-      adapter_name = "NeotestAdapterName";
-      border = "NeotestBorder";
-      dir = "NeotestDir";
-      expand_marker = "NeotestExpandMarker";
-      failed = "NeotestFailed";
-      file = "NeotestFile";
-      focused = "NeotestFocused";
-      indent = "NeotestIndent";
-      marked = "NeotestMarked";
-      namespace = "NeotestNamespace";
-      passed = "NeotestPassed";
-      running = "NeotestRunning";
-      select_win = "NeotestWinSelect";
-      skipped = "NeotestSkipped";
-      target = "NeotestTarget";
-      test = "NeotestTest";
-      unknown = "NeotestUnknown";
-      watching = "NeotestWatching";
-    }
-  '' "";
+  highlights = helpers.defaultNullOpts.mkAttrsOf types.str {
+    adapter_name = "NeotestAdapterName";
+    border = "NeotestBorder";
+    dir = "NeotestDir";
+    expand_marker = "NeotestExpandMarker";
+    failed = "NeotestFailed";
+    file = "NeotestFile";
+    focused = "NeotestFocused";
+    indent = "NeotestIndent";
+    marked = "NeotestMarked";
+    namespace = "NeotestNamespace";
+    passed = "NeotestPassed";
+    running = "NeotestRunning";
+    select_win = "NeotestWinSelect";
+    skipped = "NeotestSkipped";
+    target = "NeotestTarget";
+    test = "NeotestTest";
+    unknown = "NeotestUnknown";
+    watching = "NeotestWatching";
+  } "";
 
   floating = {
     border = helpers.defaultNullOpts.mkStr "rounded" "Border style.";
 
-    max_height = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.6" ''
+    max_height = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.6 ''
       Max height of window as proportion of NeoVim window.
     '';
 
-    max_width = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.6" ''
+    max_width = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.6 ''
       Max width of window as proportion of NeoVim window.
     '';
 
-    options = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+    options = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
       Window local options to set on floating windows (e.g. winblend).
     '';
   };
@@ -122,28 +127,29 @@ with lib;
 
     expandErrors = helpers.defaultNullOpts.mkBool true "Expand all failed positions.";
 
-    mappings = helpers.defaultNullOpts.mkAttrsOf (with types; either str (listOf str)) ''
-      {
-        attach = "a";
-        clear_marked = "M";
-        clear_target = "T";
-        debug = "d";
-        debug_marked = "D";
-        expand = ["<CR>" "<2-LeftMouse>"];
-        expand_all = "e";
-        jumpto = "i";
-        mark = "m";
-        next_failed = "J";
-        output = "o";
-        prev_failed = "K";
-        run = "r";
-        run_marked = "R";
-        short = "O";
-        stop = "u";
-        target = "t";
-        watch = "w";
-      }
-    '' "Buffer mappings for summary window.";
+    mappings = helpers.defaultNullOpts.mkAttrsOf (with types; either str (listOf str)) {
+      attach = "a";
+      clear_marked = "M";
+      clear_target = "T";
+      debug = "d";
+      debug_marked = "D";
+      expand = [
+        "<CR>"
+        "<2-LeftMouse>"
+      ];
+      expand_all = "e";
+      jumpto = "i";
+      mark = "m";
+      next_failed = "J";
+      output = "o";
+      prev_failed = "K";
+      run = "r";
+      run_marked = "R";
+      short = "O";
+      stop = "u";
+      target = "t";
+      watch = "w";
+    } "Buffer mappings for summary window.";
 
     open = helpers.defaultNullOpts.mkStr "botright vsplit | vertical resize 50" ''
       A command or function to open a window for the summary.
@@ -171,7 +177,7 @@ with lib;
   quickfix = {
     enabled = helpers.defaultNullOpts.mkBool true "Enable quickfix.";
 
-    open = helpers.defaultNullOpts.mkNullable (with types; either bool str) "`false`" ''
+    open = helpers.defaultNullOpts.mkNullable (with types; either bool str) false ''
       Set to true to open quickfix on startup, or a function to be called when the quickfix
       results are set.
     '';

--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -46,7 +46,7 @@ in
       Uses `NullLsInfoBorder` highlight group (see [Highlight Groups](#highlight-groups)).
     '';
 
-    cmd = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["nvim"]'' ''
+    cmd = helpers.defaultNullOpts.mkListOf types.str [ "nvim" ] ''
       Defines the command used to start the null-ls server. If you do not have an
       `nvim` binary available on your `$PATH`, you should change this to an absolute
       path to the binary.

--- a/plugins/statuslines/airline.nix
+++ b/plugins/statuslines/airline.nix
@@ -120,7 +120,7 @@ mkVimPlugin config {
               (enum [ "flag" ])
             ]
           )
-          "true"
+          true
           ''
             Display spelling language when spell detection is enabled (if enough space is
             available).

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -69,7 +69,7 @@ let
                   };
                 };
               }
-            )) "1" "Adds padding to the left and right of components.";
+            )) 1 "Adds padding to the left and right of components.";
 
             fmt = helpers.mkNullOrLuaFn ''
               A lua function to format the component string.
@@ -129,16 +129,16 @@ in
       };
 
       disabledFiletypes = {
-        statusline = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        statusline = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Only ignores the ft for statusline.
         '';
 
-        winbar = helpers.defaultNullOpts.mkNullable (with types; listOf str) "[]" ''
+        winbar = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Only ignores the ft for winbar.
         '';
       };
 
-      ignoreFocus = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      ignoreFocus = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         If current filetype is in this list it'll always be drawn as inactive statusline and the
         last window will be drawn as active statusline.
 

--- a/plugins/telescope/extensions/file-browser.nix
+++ b/plugins/telescope/extensions/file-browser.nix
@@ -83,12 +83,12 @@ telescopeHelpers.mkExtension {
       Custom theme, will use your global theme by default.
     '';
 
-    path = helpers.defaultNullOpts.mkStr ''{__raw = "vim.loop.cwd()";}'' ''
+    path = helpers.defaultNullOpts.mkStr { __raw = "vim.loop.cwd()"; } ''
       Directory to browse files from.
       `vim.fn.expanded` automatically.
     '';
 
-    cwd = helpers.defaultNullOpts.mkStr ''{__raw = "vim.loop.cwd()";}'' ''
+    cwd = helpers.defaultNullOpts.mkStr { __raw = "vim.loop.cwd()"; } ''
       Directory to browse folders from.
       `vim.fn.expanded` automatically.
     '';
@@ -134,12 +134,10 @@ telescopeHelpers.mkExtension {
             };
           })
         )
-        ''
-          {
-            file_browser = false;
-            folder_browser = false;
-          }
-        ''
+        {
+          file_browser = false;
+          folder_browser = false;
+        }
         "Determines whether to show hidden files or not.";
 
     respect_gitignore = helpers.defaultNullOpts.mkBool false ''
@@ -170,13 +168,11 @@ telescopeHelpers.mkExtension {
       Change the highlight group of dir icon.
     '';
 
-    display_stat = helpers.defaultNullOpts.mkAttrsOf types.anything ''
-      {
-        date = true;
-        size = true;
-        mode = true;
-      }
-    '' "Ordered stat; see upstream for more info.";
+    display_stat = helpers.defaultNullOpts.mkAttrsOf types.anything {
+      date = true;
+      size = true;
+      mode = true;
+    } "Ordered stat; see upstream for more info.";
 
     hijack_netrw = helpers.defaultNullOpts.mkBool false ''
       Use telescope file browser when opening directory paths.

--- a/plugins/telescope/extensions/frecency.nix
+++ b/plugins/telescope/extensions/frecency.nix
@@ -49,7 +49,7 @@ with lib;
         If true, it removes stale entries count over than `db_validate_threshold`.
       '';
 
-      db_root = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath 'data'";}'' ''
+      db_root = helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath 'data'"; } ''
         Path to parent directory of custom database location.
         Defaults to `$XDG_DATA_HOME/nvim` if unset.
       '';
@@ -82,13 +82,11 @@ with lib;
 
       ignore_patterns =
         helpers.defaultNullOpts.mkListOf types.str
-          ''
-            [
-              "*.git/*"
-              "*/tmp/*"
-              "term://*"
-            ]
-          ''
+          [
+            "*.git/*"
+            "*/tmp/*"
+            "term://*"
+          ]
           ''
             Patterns in this table control which files are indexed (and subsequently which you'll see
             in the finder results).
@@ -104,7 +102,7 @@ with lib;
       '';
 
       show_filter_column =
-        helpers.defaultNullOpts.mkNullable (with types; either bool (listOf str)) "true"
+        helpers.defaultNullOpts.mkNullable (with types; either bool (listOf str)) true
           ''
             Show the path of the active filter before file paths.
             In default, it uses the tail of paths for `'LSP'` and `'CWD'` tags.
@@ -140,7 +138,7 @@ with lib;
             If you prefer Native Lua code, set `workspace_scan_cmd.__raw = "LUA"`.
           '';
 
-      workspaces = helpers.defaultNullOpts.mkAttrsOf types.str "{}" ''
+      workspaces = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
         This attrs contains mappings of `workspace_tag` -> `workspace_directory`.
         The key corresponds to the `:tag_name` used to select the filter in queries.
         The value corresponds to the top level directory by which results will be filtered.

--- a/plugins/telescope/extensions/media-files.nix
+++ b/plugins/telescope/extensions/media-files.nix
@@ -122,16 +122,14 @@ with lib;
     };
 
     settingsOptions = {
-      filetypes = helpers.defaultNullOpts.mkListOf types.str ''
-        [
-          "png"
-          "jpg"
-          "gif"
-          "mp4"
-          "webm"
-          "pdf"
-        ]
-      '' "Filetypes whitelist.";
+      filetypes = helpers.defaultNullOpts.mkListOf types.str [
+        "png"
+        "jpg"
+        "gif"
+        "mp4"
+        "webm"
+        "pdf"
+      ] "Filetypes whitelist.";
 
       find_cmd = helpers.defaultNullOpts.mkStr "fd" ''
         Which find command to use.

--- a/plugins/ui/image.nix
+++ b/plugins/ui/image.nix
@@ -56,9 +56,12 @@ in
         };
       in
       mapAttrs mkIntegrationOptions {
-        markdown = ''["markdown" "vimwiki"]'';
-        neorg = ''["norg"]'';
-        syslang = ''["syslang"]'';
+        markdown = [
+          "markdown"
+          "vimwiki"
+        ];
+        neorg = [ "norg" ];
+        syslang = [ "syslang" ];
       };
 
     maxWidth = helpers.mkNullOrOption types.ints.unsigned "Image maximum width.";
@@ -78,7 +81,12 @@ in
     '';
 
     windowOverlapClearFtIgnore =
-      helpers.defaultNullOpts.mkListOf types.str ''["cmp_menu" "cmp_docs" ""]''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "cmp_menu"
+          "cmp_docs"
+          ""
+        ]
         ''
           Toggles images when windows are overlapped.
         '';
@@ -92,7 +100,14 @@ in
     '';
 
     hijackFilePatterns =
-      helpers.defaultNullOpts.mkListOf types.str ''["*.png" "*.jpg" "*.jpeg" "*.gif" "*.webp"]''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "*.png"
+          "*.jpg"
+          "*.jpeg"
+          "*.gif"
+          "*.webp"
+        ]
         ''
           Render image files as images when opened.
         '';

--- a/plugins/ui/neoscroll.nix
+++ b/plugins/ui/neoscroll.nix
@@ -16,19 +16,17 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   settingsOptions = {
     mappings =
       helpers.defaultNullOpts.mkListOf types.str
-        ''
-          [
-            "<C-u>"
-            "<C-d>"
-            "<C-b>"
-            "<C-f>"
-            "<C-y>"
-            "<C-e>"
-            "zt"
-            "zz"
-            "zb"
-          ]
-        ''
+        [
+          "<C-u>"
+          "<C-d>"
+          "<C-b>"
+          "<C-f>"
+          "<C-y>"
+          "<C-e>"
+          "zt"
+          "zz"
+          "zb"
+        ]
         ''
           All the keys defined in this option will be mapped to their corresponding default
           scrolling animation. To no map any key pass an empty table:

--- a/plugins/ui/noice.nix
+++ b/plugins/ui/noice.nix
@@ -22,20 +22,43 @@ with lib;
     cmdline = {
       enabled = helpers.defaultNullOpts.mkBool true "enables Noice cmdline UI";
       view = helpers.defaultNullOpts.mkStr "cmdline_popup" "";
-      opts = helpers.defaultNullOpts.mkNullable types.anything "{}" "";
+      opts = helpers.defaultNullOpts.mkAttrsOf types.anything { } "";
       format =
-        helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything)
-          ''
-            {
-              cmdline = {pattern = "^:"; icon = ""; lang = "vim";};
-              search_down = {kind = "search"; pattern = "^/"; icon = " "; lang = "regex";};
-              search_up = {kind = "search"; pattern = "?%?"; icon = " "; lang = "regex";};
-              filter = {pattern = "^:%s*!"; icon = "$"; lang = "bash";};
-              lua = {pattern = "^:%s*lua%s+"; icon = ""; lang = "lua";};
-              help = {pattern = "^:%s*he?l?p?%s+"; icon = "";};
-              input = {};
-            }
-          ''
+        helpers.defaultNullOpts.mkAttrsOf types.anything
+          {
+            cmdline = {
+              pattern = "^:";
+              icon = "";
+              lang = "vim";
+            };
+            search_down = {
+              kind = "search";
+              pattern = "^/";
+              icon = " ";
+              lang = "regex";
+            };
+            search_up = {
+              kind = "search";
+              pattern = "?%?";
+              icon = " ";
+              lang = "regex";
+            };
+            filter = {
+              pattern = "^:%s*!";
+              icon = "$";
+              lang = "bash";
+            };
+            lua = {
+              pattern = "^:%s*lua%s+";
+              icon = "";
+              lang = "lua";
+            };
+            help = {
+              pattern = "^:%s*he?l?p?%s+";
+              icon = "";
+            };
+            input = { };
+          }
           ''
             conceal: (default=true) This will hide the text in the cmdline that matches the pattern.
             view: (default is cmdline view)
@@ -64,55 +87,80 @@ with lib;
         "nui"
         "cmp"
       ] "";
-      kindIcons = helpers.defaultNullOpts.mkNullable (types.either types.bool (
-        types.attrsOf types.anything
-      )) "{}" "Icons for completion item kinds. set to `false` to disable icons";
+      kindIcons = helpers.defaultNullOpts.mkNullable (
+        with types; either bool (attrsOf anything)
+      ) { } "Icons for completion item kinds. set to `false` to disable icons";
     };
 
-    redirect = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) ''
-      {
-        view = "popup";
-        filter = {event = "msg_show";};
-      }
-    '' "default options for require('noice').redirect";
+    redirect = helpers.defaultNullOpts.mkAttrsOf types.anything {
+      view = "popup";
+      filter = {
+        event = "msg_show";
+      };
+    } "default options for require('noice').redirect";
 
-    commands = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) ''
-      {
-        history = {
-          view = "split";
-          opts = {enter = true; format = "details";};
-          filter = {
-            any = [
-              {event = "notify";}
-              {error = true;}
-              {warning = true;}
-              {event = "msg_show"; kind = [""];}
-              {event = "lsp"; kind = "message";}
-            ];
-          };
+    commands = helpers.defaultNullOpts.mkAttrsOf types.anything {
+      history = {
+        view = "split";
+        opts = {
+          enter = true;
+          format = "details";
         };
-        last = {
-          view = "popup";
-          opts = {enter = true; format = "details";};
-          filter = {
-            any = [
-              {event = "notify";}
-              {error = true;}
-              {warning = true;}
-              {event = "msg_show"; kind = [""];}
-              {event = "lsp"; kind = "message";}
-            ];
-          };
-          filter_opts = {count = 1;};
+        filter = {
+          any = [
+            { event = "notify"; }
+            { error = true; }
+            { warning = true; }
+            {
+              event = "msg_show";
+              kind = [ "" ];
+            }
+            {
+              event = "lsp";
+              kind = "message";
+            }
+          ];
         };
-        errors = {
-          view = "popup";
-          opts = {enter = true; format = "details";};
-          filter = {error = true;};
-          filter_opts = {reverse = true;};
+      };
+      last = {
+        view = "popup";
+        opts = {
+          enter = true;
+          format = "details";
         };
-      }
-    '' "You can add any custom commands that will be available with `:Noice command`";
+        filter = {
+          any = [
+            { event = "notify"; }
+            { error = true; }
+            { warning = true; }
+            {
+              event = "msg_show";
+              kind = [ "" ];
+            }
+            {
+              event = "lsp";
+              kind = "message";
+            }
+          ];
+        };
+        filter_opts = {
+          count = 1;
+        };
+      };
+      errors = {
+        view = "popup";
+        opts = {
+          enter = true;
+          format = "details";
+        };
+        filter = {
+          error = true;
+        };
+        filter_opts = {
+          reverse = true;
+        };
+      };
+    } "You can add any custom commands that will be available with `:Noice command`";
 
     notify = {
       enabled = helpers.defaultNullOpts.mkBool true ''
@@ -131,35 +179,27 @@ with lib;
       progress = {
         enabled = helpers.defaultNullOpts.mkBool true "enable LSP progress";
 
-        format =
-          helpers.defaultNullOpts.mkNullable (types.either types.str types.anything) ''"lsp_progress"''
-            ''
-              Lsp Progress is formatted using the builtins for lsp_progress
-            '';
-        formatDone =
-          helpers.defaultNullOpts.mkNullable (types.either types.str types.anything) ''"lsp_progress"''
-            "";
+        format = helpers.defaultNullOpts.mkNullable (with types; either str anything) "lsp_progress" ''
+          Lsp Progress is formatted using the builtins for lsp_progress
+        '';
+        formatDone = helpers.defaultNullOpts.mkNullable (with types; either str anything) "lsp_progress" "";
 
-        throttle = helpers.defaultNullOpts.mkNum "1000 / 30" "frequency to update lsp progress message";
+        throttle = helpers.defaultNullOpts.mkNum (literalExpression "1000 / 30") "frequency to update lsp progress message";
 
         view = helpers.defaultNullOpts.mkStr "mini" "";
       };
 
-      override = helpers.defaultNullOpts.mkNullable (types.attrsOf types.bool) ''
-        {
-          "vim.lsp.util.convert_input_to_markdown_lines" = false;
-          "vim.lsp.util.stylize_markdown" = false;
-          "cmp.entry.get_documentation" = false;
-        }
-      '' "";
+      override = helpers.defaultNullOpts.mkAttrsOf types.bool {
+        "vim.lsp.util.convert_input_to_markdown_lines" = false;
+        "vim.lsp.util.stylize_markdown" = false;
+        "cmp.entry.get_documentation" = false;
+      } "";
 
       hover = {
         enabled = helpers.defaultNullOpts.mkBool true "enable hover UI";
-        view =
-          helpers.defaultNullOpts.mkNullable types.str null
-            "when null, use defaults from documentation";
+        view = helpers.defaultNullOpts.mkStr (literalMD "use defaults from documentation") ""; # TODO: description
         opts =
-          helpers.defaultNullOpts.mkNullable types.anything "{}"
+          helpers.defaultNullOpts.mkAttrsOf types.anything { }
             "merged with defaults from documentation";
       };
 
@@ -175,11 +215,9 @@ with lib;
           '';
         };
 
-        view =
-          helpers.defaultNullOpts.mkNullable types.str null
-            "when null, use defaults from documentation";
+        view = helpers.defaultNullOpts.mkStr null "when null, use defaults from documentation";
         opts =
-          helpers.defaultNullOpts.mkNullable types.anything "{}"
+          helpers.defaultNullOpts.mkAttrsOf types.anything { }
             "merged with defaults from documentation";
       };
 
@@ -187,42 +225,39 @@ with lib;
         enabled = helpers.defaultNullOpts.mkBool true "enable display of messages";
 
         view = helpers.defaultNullOpts.mkStr "notify" "";
-        opts = helpers.defaultNullOpts.mkNullable types.anything "{}" "";
+        opts = helpers.defaultNullOpts.mkAttrsOf types.anything { } "";
       };
 
       documentation = {
         view = helpers.defaultNullOpts.mkStr "hover" "";
 
-        opts = helpers.defaultNullOpts.mkNullable types.anything ''
-          {
-            lang = "markdown";
-            replace = true;
-            render = "plain";
-            format = ["{message}"];
-            win_options = { concealcursor = "n"; conceallevel = 3; };
-          }
-        '' "";
+        opts = helpers.defaultNullOpts.mkAttrsOf types.anything {
+          lang = "markdown";
+          replace = true;
+          render = "plain";
+          format = [ "{message}" ];
+          win_options = {
+            concealcursor = "n";
+            conceallevel = 3;
+          };
+        } "";
       };
     };
 
     markdown = {
-      hover = helpers.defaultNullOpts.mkNullable (types.attrsOf types.str) ''
-        {
-          "|(%S-)|" = helpers.mkRaw "vim.cmd.help"; // vim help links
-          "%[.-%]%((%S-)%)" = helpers.mkRaw "require("noice.util").open"; // markdown links
-        }
-      '' "set handlers for hover (lua code)";
+      hover = helpers.defaultNullOpts.mkAttrsOf types.str {
+        "|(%S-)|".__raw = "vim.cmd.help"; # vim help links
+        "%[.-%]%((%S-)%)".__raw = "require('noice.util').open"; # markdown links
+      } "set handlers for hover (lua code)";
 
-      highlights = helpers.defaultNullOpts.mkNullable (types.attrsOf types.str) ''
-        {
-          "|%S-|" = "@text.reference";
-          "@%S+" = "@parameter";
-          "^%s*(Parameters:)" = "@text.title";
-          "^%s*(Return:)" = "@text.title";
-          "^%s*(See also:)" = "@text.title";
-          "{%S-}" = "@parameter";
-        }
-      '' "set highlight groups";
+      highlights = helpers.defaultNullOpts.mkAttrsOf types.str {
+        "|%S-|" = "@text.reference";
+        "@%S+" = "@parameter";
+        "^%s*(Parameters:)" = "@text.title";
+        "^%s*(Return:)" = "@text.title";
+        "^%s*(See also:)" = "@text.title";
+        "{%S-}" = "@parameter";
+      } "set highlight groups";
     };
 
     health = {
@@ -235,37 +270,40 @@ with lib;
         You can disable this behaviour here
       '';
       excludedFiletypes =
-        helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''[ "cmp_menu" "cmp_docs" "notify"]''
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "cmp_menu"
+            "cmp_docs"
+            "notify"
+          ]
           ''
             add any filetypes here, that shouldn't trigger smart move
           '';
     };
 
     presets =
-      helpers.defaultNullOpts.mkNullable (types.either types.bool types.anything)
-        ''
-          {
-            bottom_search = false;
-            command_palette = false;
-            long_message_to_split = false;
-            inc_rename = false;
-            lsp_doc_border = false;
-          }
-        ''
+      helpers.defaultNullOpts.mkNullable (with types; either bool anything)
+        {
+          bottom_search = false;
+          command_palette = false;
+          long_message_to_split = false;
+          inc_rename = false;
+          lsp_doc_border = false;
+        }
         "
         you can enable a preset by setting it to true, or a table that will override the preset
         config. you can also add custom presets that you can enable/disable with enabled=true
       ";
 
-    throttle = helpers.defaultNullOpts.mkNum "1000 / 30" ''
+    throttle = helpers.defaultNullOpts.mkNum (literalExpression "1000 / 30") ''
       how frequently does Noice need to check for ui updates? This has no effect when in blocking
       mode
     '';
 
-    views = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" "";
-    routes = helpers.defaultNullOpts.mkNullable (types.listOf (types.attrsOf types.anything)) "[]" "";
-    status = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" "";
-    format = helpers.defaultNullOpts.mkNullable (types.attrsOf types.anything) "{}" "";
+    views = helpers.defaultNullOpts.mkAttrsOf types.anything { } "";
+    routes = helpers.defaultNullOpts.mkListOf (types.attrsOf types.anything) [ ] "";
+    status = helpers.defaultNullOpts.mkAttrsOf types.anything { } "";
+    format = helpers.defaultNullOpts.mkAttrsOf types.anything { } "";
   };
 
   config =

--- a/plugins/ui/statuscol.nix
+++ b/plugins/ui/statuscol.nix
@@ -21,7 +21,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       benefit from the performance optimizations in this plugin.
     '';
 
-    thousands = helpers.defaultNullOpts.mkNullable (with types; either str (enum [ false ])) "false" ''
+    thousands = helpers.defaultNullOpts.mkNullable (with types; either str (enum [ false ])) false ''
       `false` or line number thousands separator string ("." / ",").
     '';
 
@@ -62,15 +62,15 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             ) "Table of booleans or functions returning a boolean.";
 
             sign = {
-              name = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+              name = helpers.defaultNullOpts.mkListOf types.str [ ] ''
                 List of lua patterns to match the sign name against.
               '';
 
-              text = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+              text = helpers.defaultNullOpts.mkListOf types.str [ ] ''
                 List of lua patterns to match the extmark sign text against.
               '';
 
-              namespace = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+              namespace = helpers.defaultNullOpts.mkListOf types.str [ ] ''
                 List of lua patterns to match the extmark sign namespace against.
               '';
 
@@ -98,29 +98,27 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           };
         };
       in
-      helpers.defaultNullOpts.mkListOf segmentType ''
-        [
-          {
-            text = ["%C"];
-            click = "v:lua.ScFa";
-          }
-          {
-            text = ["%s"];
-            click = "v:lua.ScSa";
-          }
-          {
-            text = [
-              {__raw = "require('statuscol.builtin').lnumfunc";}
-              " "
-            ];
-            condition = [
-              true
-              {__raw = "require('statuscol.builtin').not_empty";}
-            ];
-            click = "v:lua.ScLa";
-          }
-        ]
-      '' "The statuscolumn can be customized through the `segments` option.";
+      helpers.defaultNullOpts.mkListOf segmentType [
+        {
+          text = [ "%C" ];
+          click = "v:lua.ScFa";
+        }
+        {
+          text = [ "%s" ];
+          click = "v:lua.ScSa";
+        }
+        {
+          text = [
+            { __raw = "require('statuscol.builtin').lnumfunc"; }
+            " "
+          ];
+          condition = [
+            true
+            { __raw = "require('statuscol.builtin').not_empty"; }
+          ];
+          click = "v:lua.ScLa";
+        }
+      ] "The statuscolumn can be customized through the `segments` option.";
 
     clickmod = helpers.defaultNullOpts.mkStr "c" ''
       Modifier used for certain actions in the builtin clickhandlers:

--- a/plugins/ui/transparent.nix
+++ b/plugins/ui/transparent.nix
@@ -16,44 +16,42 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   settingsOptions = {
     groups =
       helpers.defaultNullOpts.mkListOf types.str
-        ''
-          [
-            "Normal"
-            "NormalNC"
-            "Comment"
-            "Constant"
-            "Special"
-            "Identifier"
-            "Statement"
-            "PreProc"
-            "Type"
-            "Underlined"
-            "Todo"
-            "String"
-            "Function"
-            "Conditional"
-            "Repeat"
-            "Operator"
-            "Structure"
-            "LineNr"
-            "NonText"
-            "SignColumn"
-            "CursorLine"
-            "CursorLineNr"
-            "StatusLine"
-            "StatusLineNC"
-            "EndOfBuffer"
-          ]
-        ''
+        [
+          "Normal"
+          "NormalNC"
+          "Comment"
+          "Constant"
+          "Special"
+          "Identifier"
+          "Statement"
+          "PreProc"
+          "Type"
+          "Underlined"
+          "Todo"
+          "String"
+          "Function"
+          "Conditional"
+          "Repeat"
+          "Operator"
+          "Structure"
+          "LineNr"
+          "NonText"
+          "SignColumn"
+          "CursorLine"
+          "CursorLineNr"
+          "StatusLine"
+          "StatusLineNC"
+          "EndOfBuffer"
+        ]
         ''
           The list of transparent groups.
         '';
 
-    extra_groups = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    extra_groups = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Additional groups that should be cleared.
     '';
 
-    exclude_groups = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    exclude_groups = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Groups that you don't want to clear.
     '';
   };

--- a/plugins/ui/twilight.nix
+++ b/plugins/ui/twilight.nix
@@ -15,13 +15,19 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
   settingsOptions = {
     dimming = {
-      alpha = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.25" ''
+      alpha = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.25 ''
         Amount of dimming.
       '';
 
-      color = helpers.defaultNullOpts.mkListOf types.str ''["Normal" "#ffffff"]'' ''
-        Highlight groups / colors to use.
-      '';
+      color =
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "Normal"
+            "#ffffff"
+          ]
+          ''
+            Highlight groups / colors to use.
+          '';
 
       term_bg = helpers.defaultNullOpts.mkStr "#000000" ''
         If `guibg=NONE`, this will be used to calculate text color.
@@ -42,16 +48,14 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       the types of nodes that should always be fully expanded.
     '';
 
-    expand = helpers.defaultNullOpts.mkListOf types.str ''
-      [
-        "function"
-        "method"
-        "table"
-        "if_statement"
-      ]
-    '' "For treesitter, we will always try to expand to the top-most ancestor with these types.";
+    expand = helpers.defaultNullOpts.mkListOf types.str [
+      "function"
+      "method"
+      "table"
+      "if_statement"
+    ] "For treesitter, we will always try to expand to the top-most ancestor with these types.";
 
-    exclude = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    exclude = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Exclude these filetypes.
     '';
   };

--- a/plugins/ui/virt-column.nix
+++ b/plugins/ui/virt-column.nix
@@ -18,7 +18,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Enables or disables virt-column.
     '';
 
-    char = helpers.defaultNullOpts.mkNullable (with types; either str (listOf str)) ''["┃"]'' ''
+    char = helpers.defaultNullOpts.mkNullable (with types; either str (listOf str)) [ "┃" ] ''
       Character, or list of characters, that get used to display the virtual column.
       Each character has to have a display width of 0 or 1.
     '';
@@ -32,26 +32,22 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     '';
 
     exclude = {
-      filetypes = helpers.defaultNullOpts.mkListOf types.str ''
-        [
-          "lspinfo"
-          "packer"
-          "checkhealth"
-          "help"
-          "man"
-          "TelescopePrompt"
-          "TelescopeResults"
-        ]
-      '' "List of `filetype`s for which virt-column is disabled.";
+      filetypes = helpers.defaultNullOpts.mkListOf types.str [
+        "lspinfo"
+        "packer"
+        "checkhealth"
+        "help"
+        "man"
+        "TelescopePrompt"
+        "TelescopeResults"
+      ] "List of `filetype`s for which virt-column is disabled.";
 
-      buftypes = helpers.defaultNullOpts.mkListOf types.str ''
-        [
-          "nofile"
-          "quickfix"
-          "terminal"
-          "prompt"
-        ]
-      '' "List of `buftype`s for which virt-column is disabled.";
+      buftypes = helpers.defaultNullOpts.mkListOf types.str [
+        "nofile"
+        "quickfix"
+        "terminal"
+        "prompt"
+      ] "List of `buftype`s for which virt-column is disabled.";
     };
   };
 

--- a/plugins/ui/zen-mode.nix
+++ b/plugins/ui/zen-mode.nix
@@ -16,7 +16,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   # Optionally, explicitly declare some options. You don't have to.
   settingsOptions = {
     window = {
-      backdrop = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) "0.95" ''
+      backdrop = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.95 ''
         Shade the backdrop of the Zen window.
         Set to 1 to keep the same as Normal.
       '';
@@ -31,7 +31,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               rawLua
             ]
           )
-          "120"
+          120
           ''
             Width of the zen window.
 
@@ -51,7 +51,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               rawLua
             ]
           )
-          "1"
+          1
           ''
             Height of the Zen window.
 
@@ -61,7 +61,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             - a function that returns the width or the height
           '';
 
-      options = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+      options = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
         By default, no options are changed for the Zen window.
         You can set any `vim.wo` option here.
 
@@ -82,14 +82,12 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     plugins = {
       options =
         helpers.defaultNullOpts.mkAttrsOf types.anything
-          ''
-            {
-              enabled = true;
-              ruler = false;
-              showcmd = false;
-              laststatus = 0;
-            }
-          ''
+          {
+            enabled = true;
+            ruler = false;
+            showcmd = false;
+            laststatus = 0;
+          }
           ''
             Disable some global vim options (`vim.o`...).
           '';

--- a/plugins/utils/arrow.nix
+++ b/plugins/utils/arrow.nix
@@ -100,17 +100,15 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
     window =
       helpers.defaultNullOpts.mkAttrsOf types.anything
-        ''
-          {
-            relative = "editor";
-            width = "auto";
-            height = "auto";
-            row = "auto";
-            col = "auto";
-            style = "minimal";
-            border = "single";
-          }
-        ''
+        {
+          relative = "editor";
+          width = "auto";
+          height = "auto";
+          row = "auto";
+          col = "auto";
+          style = "minimal";
+          border = "single";
+        }
         ''
           Controls the appearance and position of an arrow window.
           See `:h nvim_open_win()` for all options.
@@ -161,7 +159,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Keys mapped to bookmark index.
     '';
 
-    full_path_list = helpers.defaultNullOpts.mkListOf types.str ''[ "update_stuff" ]'' ''
+    full_path_list = helpers.defaultNullOpts.mkListOf types.str [ "update_stuff" ] ''
       Filenames on this list will ALWAYS show the file path too
     '';
   };

--- a/plugins/utils/auto-save.nix
+++ b/plugins/utils/auto-save.nix
@@ -31,16 +31,14 @@ in
 
     executionMessage = {
       message =
-        helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-          ''
-            {
-              __raw = \'\'
-                function()
-                  return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
-                end
-              \'\';
-            }
-          ''
+        helpers.defaultNullOpts.mkStr
+          {
+            __raw = ''
+              function()
+                return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
+              end
+            '';
+          }
           ''
             The message to print en save.
             This can be a lua function that returns a string.
@@ -48,7 +46,7 @@ in
 
       dim = helpers.defaultNullOpts.mkNullable (types.numbers.between 0
         1
-      ) "0.18" "Dim the color of `message`.";
+      ) 0.18 "Dim the color of `message`.";
 
       cleaningInterval = helpers.defaultNullOpts.mkInt 1250 ''
         Time (in milliseconds) to wait before automatically cleaning MsgArea after displaying
@@ -58,7 +56,11 @@ in
     };
 
     triggerEvents =
-      helpers.defaultNullOpts.mkNullable (with types; listOf str) ''["InsertLeave" "TextChanged"]''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "InsertLeave"
+          "TextChanged"
+        ]
         ''
           Vim events that trigger auto-save.
           See `:h events`.

--- a/plugins/utils/auto-session.nix
+++ b/plugins/utils/auto-session.nix
@@ -31,13 +31,10 @@ in
         Whether to enable the "last session" feature.
       '';
 
-      rootDir =
-        helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-          "{__raw = \"vim.fn.stdpath 'data' .. '/sessions/'\";}"
-          ''
-            Root directory for session files.
-            Can be either a string or lua code (using `{__raw = 'foo';}`).
-          '';
+      rootDir = helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath 'data' .. '/sessions/'"; } ''
+        Root directory for session files.
+        Can be either a string or lua code (using `{__raw = 'foo';}`).
+      '';
 
       createEnabled = helpers.mkNullOrOption types.bool ''
         Whether to enable auto creating new sessions
@@ -91,7 +88,7 @@ in
             };
           })
         )
-        "false"
+        false
         ''
           Config for handling the DirChangePre and DirChanged autocmds.
           Set to `false` to disable the feature.
@@ -108,9 +105,10 @@ in
         `require("auto-session").setup_session_lens()` if they want to use session-lens.
       '';
 
-      themeConf =
-        helpers.defaultNullOpts.mkNullable types.attrs "{winblend = 10; border = true;}"
-          "Theme configuration.";
+      themeConf = helpers.defaultNullOpts.mkAttrsOf types.anything {
+        winblend = 10;
+        border = true;
+      } "Theme configuration.";
 
       previewer = helpers.defaultNullOpts.mkBool false ''
         Use default previewer config by setting the value to `null` if some sets previewer to
@@ -123,8 +121,7 @@ in
 
       sessionControl = {
         controlDir =
-          helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-            "\"vim.fn.stdpath 'data' .. '/auto_session/'\""
+          helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath 'data' .. '/auto_session/'"; }
             ''
               Auto session control dir, for control files, like alternating between two sessions
               with session-lens.

--- a/plugins/utils/autoclose.nix
+++ b/plugins/utils/autoclose.nix
@@ -35,7 +35,7 @@ in
     '';
 
     options = {
-      disabledFiletypes = helpers.defaultNullOpts.mkListOf types.str ''["text"]'' ''
+      disabledFiletypes = helpers.defaultNullOpts.mkListOf types.str [ "text" ] ''
         The plugin will be disabled under the filetypes in this table.
       '';
 

--- a/plugins/utils/ccc.nix
+++ b/plugins/utils/ccc.nix
@@ -153,14 +153,14 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           Whether to enable automatically on `BufEnter`.
         '';
 
-        filetypes = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        filetypes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           File types for which highlighting is enabled.
           It is only used for automatic highlighting by `ccc-option-highlighter-auto-enable`, and is
           ignored for manual activation.
           An empty table means all file types.
         '';
 
-        excludes = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        excludes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           Used only when `ccc-option-highlighter-filetypes` is empty table.
           You can specify file types to be excludes.
         '';

--- a/plugins/utils/clipboard-image.nix
+++ b/plugins/utils/clipboard-image.nix
@@ -37,7 +37,9 @@ let
       ]
     ) "img" "Dir that will be inserted into text/buffer.";
 
-    imgName = helpers.defaultNullOpts.mkStr ''{__raw = "function() return os.date('%Y-%m-%d-%H-%M-%S') end";}'' "Image's name.";
+    imgName = helpers.defaultNullOpts.mkStr {
+      __raw = "function() return os.date('%Y-%m-%d-%H-%M-%S') end";
+    } "Image's name.";
 
     imgHandler = helpers.defaultNullOpts.mkLuaFn "function(img) end" ''
       Function that will handle image after pasted.

--- a/plugins/utils/cloak.nix
+++ b/plugins/utils/cloak.nix
@@ -64,16 +64,14 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             '';
           };
         })
-        ''
-          [
-            {
+        [
+          {
 
-              file_pattern = ".env*";
-              cloak_pattern = "=.+";
-              replace = null;
-            }
-          ]
-        ''
+            file_pattern = ".env*";
+            cloak_pattern = "=.+";
+            replace = null;
+          }
+        ]
         ''
           List of pattern configurations.
         '';

--- a/plugins/utils/comment.nix
+++ b/plugins/utils/comment.nix
@@ -203,12 +203,10 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             };
           })
         )
-        ''
-          {
-            basic = true;
-            extra = true;
-          }
-        ''
+        {
+          basic = true;
+          extra = true;
+        }
         ''
           Enables keybindings.
           NOTE: If given 'false', then the plugin won't create any mappings.

--- a/plugins/utils/competitest.nix
+++ b/plugins/utils/competitest.nix
@@ -41,7 +41,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
                 type = str;
                 description = "Command to execute";
               };
-              args = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+              args = helpers.defaultNullOpts.mkListOf types.str [ ] ''
                 Arguments to the command.
               '';
             };
@@ -66,7 +66,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
                 type = str;
                 description = "Command to execute.";
               };
-              args = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+              args = helpers.defaultNullOpts.mkListOf types.str [ ] ''
                 Arguments to the command.
               '';
             };

--- a/plugins/utils/coverage.nix
+++ b/plugins/utils/coverage.nix
@@ -81,53 +81,53 @@ in
     commands = helpers.defaultNullOpts.mkBool true "If true, create commands.";
 
     highlights = {
-      covered =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{fg = "#B7F071";}''
-          "Highlight group for covered signs.";
+      covered = helpers.defaultNullOpts.mkAttributeSet {
+        fg = "#B7F071";
+      } "Highlight group for covered signs.";
 
-      uncovered =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{fg = "#F07178";}''
-          "Highlight group for uncovered signs.";
+      uncovered = helpers.defaultNullOpts.mkAttributeSet {
+        fg = "#F07178";
+      } "Highlight group for uncovered signs.";
 
-      partial =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{fg = "#AA71F0";}''
-          "Highlight group for partial coverage signs.";
+      partial = helpers.defaultNullOpts.mkAttributeSet {
+        fg = "#AA71F0";
+      } "Highlight group for partial coverage signs.";
 
-      summaryBorder =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{link = "FloatBorder";}''
-          "Border highlight group of the summary pop-up.";
+      summaryBorder = helpers.defaultNullOpts.mkAttributeSet {
+        link = "FloatBorder";
+      } "Border highlight group of the summary pop-up.";
 
-      summaryNormal =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{link = "NormalFloat";}''
-          "Normal text highlight group of the summary pop-up.";
+      summaryNormal = helpers.defaultNullOpts.mkAttributeSet {
+        link = "NormalFloat";
+      } "Normal text highlight group of the summary pop-up.";
 
-      summaryCursorLine =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{link = "CursorLine";}''
-          "Cursor line highlight group of the summary pop-up.";
+      summaryCursorLine = helpers.defaultNullOpts.mkAttributeSet {
+        link = "CursorLine";
+      } "Cursor line highlight group of the summary pop-up.";
 
-      summaryHeader =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{ style = "bold,underline"; sp = "bg"; }''
-          "Header text highlight group of the summary pop-up.";
+      summaryHeader = helpers.defaultNullOpts.mkAttributeSet {
+        style = "bold,underline";
+        sp = "bg";
+      } "Header text highlight group of the summary pop-up.";
 
-      summaryPass =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{link = "CoverageCovered";}''
-          "Pass text highlight group of the summary pop-up.";
+      summaryPass = helpers.defaultNullOpts.mkAttributeSet {
+        link = "CoverageCovered";
+      } "Pass text highlight group of the summary pop-up.";
 
-      summaryFail =
-        helpers.defaultNullOpts.mkNullable types.attrs ''{link = "CoverageUncovered";}''
-          "Fail text highlight group of the summary pop-up.";
+      summaryFail = helpers.defaultNullOpts.mkAttributeSet {
+        link = "CoverageUncovered";
+      } "Fail text highlight group of the summary pop-up.";
     };
 
-    loadCoverageCb = helpers.defaultNullOpts.mkLuaFn "nil" ''
-      A lua function that will be called when a coverage file is loaded.
-
-      Example:
-      ```
-        function (ftype)
+    loadCoverageCb = helpers.defaultNullOpts.mkLuaFn' {
+      description = "A lua function that will be called when a coverage file is loaded.";
+      pluginDefault = "nil";
+      example = ''
+        function(ftype)
           vim.notify("Loaded " .. ftype .. " coverage")
         end
-      ```
-    '';
+      '';
+    };
 
     signs =
       mapAttrs
@@ -173,11 +173,11 @@ in
     summary = {
       widthPercentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
         1.0
-      ) "0.70" "Width of the pop-up window.";
+      ) 0.7 "Width of the pop-up window.";
 
       heightPercentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
         1.0
-      ) "0.50" "Height of the pop-up window.";
+      ) 0.5 "Height of the pop-up window.";
 
       borders = mapAttrs (optionName: default: helpers.defaultNullOpts.mkStr default "") {
         topleft = "╭";
@@ -191,31 +191,31 @@ in
         highlight = "Normal:CoverageSummaryBorder";
       };
 
-      minCoverage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0 100) "80" ''
+      minCoverage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0 100) 80 ''
         Minimum coverage percentage.
         Values below this are highlighted with the fail group, values above are highlighted with
         the pass group.
       '';
     };
 
-    lang = helpers.defaultNullOpts.mkNullable types.attrs "see upstream documentation" ''
-      Each key corresponds with the `filetype` of the language and maps to an attrs of
-      configuration values that differ.
-      See plugin documentation for language specific options.
+    lang = helpers.defaultNullOpts.mkAttributeSet' {
+      description = ''
+        Each key corresponds with the `filetype` of the language and maps to an attrs of
+        configuration values that differ.
 
-      Example:
-      ```nix
-        {
-          python = {
-            coverage_file = ".coverage";
-            coverage_command = "coverage json --fail-under=0 -q -o -";
-          };
-          ruby = {
-              coverage_file = "coverage/coverage.json";
-          };
-        }
-      ```
-    '';
+        See plugin documentation for language specific options.
+      '';
+
+      example = {
+        python = {
+          coverage_file = ".coverage";
+          coverage_command = "coverage json --fail-under=0 -q -o -";
+        };
+        ruby = {
+          coverage_file = "coverage/coverage.json";
+        };
+      };
+    };
 
     lcovFile = helpers.mkNullOrOption types.str "File that the plugin will try to read lcov coverage from.";
   };

--- a/plugins/utils/cursorline.nix
+++ b/plugins/utils/cursorline.nix
@@ -27,9 +27,9 @@ in
 
       minLength = helpers.defaultNullOpts.mkInt 3 "Minimum length for underlined words.";
 
-      hl =
-        helpers.defaultNullOpts.mkNullable types.attrs "{underline = true;}"
-          "Highliht definition map for cursorword highlighting.";
+      hl = helpers.defaultNullOpts.mkAttrsOf types.anything {
+        underline = true;
+      } "Highliht definition map for cursorword highlighting.";
     };
   };
 

--- a/plugins/utils/dressing.nix
+++ b/plugins/utils/dressing.nix
@@ -64,7 +64,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               If 'editor' or 'win', will default to being centered.
             '';
 
-        prefer_width = helpers.defaultNullOpts.mkNullable intOrRatio "40" ''
+        prefer_width = helpers.defaultNullOpts.mkNullable intOrRatio 40 ''
           Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
         '';
 
@@ -73,7 +73,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         '';
 
         max_width =
-          helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) "[140 0.9]"
+          helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+            [
+              140
+              0.9
+            ]
             ''
               Max width of window.
 
@@ -82,7 +86,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             '';
 
         min_width =
-          helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) "[20 0.2]"
+          helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+            [
+              20
+              0.2
+            ]
             ''
               Min width of window.
 
@@ -90,35 +98,31 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               total."
             '';
 
-        buf_options = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+        buf_options = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
           An attribute set of neovim buffer options.
         '';
 
-        win_options = helpers.defaultNullOpts.mkAttrsOf types.anything ''
-          {
-            wrap = false;
-            list = true;
-            listchars = "precedes:...,extends:...";
-            sidescrolloff = 0;
-          }
-        '' "An attribute set of window options.";
+        win_options = helpers.defaultNullOpts.mkAttrsOf types.anything {
+          wrap = false;
+          list = true;
+          listchars = "precedes:...,extends:...";
+          sidescrolloff = 0;
+        } "An attribute set of window options.";
 
         mappings =
           helpers.defaultNullOpts.mkAttrsOf (with types; attrsOf (either str (enum [ false ])))
-            ''
-              {
-                n = {
-                  "<Esc>" = "Close";
-                  "<CR>" = "Confirm";
-                };
-                i = {
-                  "<C-c>" = "Close";
-                  "<CR>" = "Confirm";
-                  "<Up>" = "HistoryPrev";
-                  "<Down>" = "HistoryNext";
-                };
-              }
-            ''
+            {
+              n = {
+                "<Esc>" = "Close";
+                "<CR>" = "Confirm";
+              };
+              i = {
+                "<C-c>" = "Close";
+                "<CR>" = "Confirm";
+                "<Up>" = "HistoryPrev";
+                "<Down>" = "HistoryNext";
+              };
+            }
             ''
               Mappings for defined modes.
 
@@ -144,9 +148,13 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           Enable the vim.ui.select implementation.
         '';
 
-        backend = helpers.defaultNullOpts.mkListOf types.str ''
-          ["telescope" "fzf_lua" "fzf" "builtin" "nui"]
-        '' "Priority list of preferred vim.select implementations. ";
+        backend = helpers.defaultNullOpts.mkListOf types.str [
+          "telescope"
+          "fzf_lua"
+          "fzf"
+          "builtin"
+          "nui"
+        ] "Priority list of preferred vim.select implementations. ";
 
         trim_prompt = helpers.defaultNullOpts.mkBool true ''
           Trim trailing `:` from prompt.
@@ -165,39 +173,35 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             '';
 
         fzf = {
-          window = helpers.defaultNullOpts.mkAttrsOf types.anything ''
-            {
-              width = 0.5;
-              height = 0.4;
-            }
-          '' "Window options for fzf selector. ";
+          window = helpers.defaultNullOpts.mkAttrsOf types.anything {
+            width = 0.5;
+            height = 0.4;
+          } "Window options for fzf selector. ";
         };
 
-        fzf_lua = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+        fzf_lua = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
           Options for fzf-lua selector.
         '';
 
-        nui = helpers.defaultNullOpts.mkAttrsOf types.anything ''
-          {
-            position = "50%";
-            size = null;
-            relative = "editor";
-            border = {
-              style = "rounded";
-            };
-            buf_options = {
-              swapfile = false;
-              filetype = "DressingSelect";
-            };
-            win_options = {
-              winblend = 0;
-            };
-            max_width = 80;
-            max_height = 40;
-            min_width = 40;
-            min_height = 10;
-          }
-        '' "Options for nui selector. ";
+        nui = helpers.defaultNullOpts.mkAttrsOf types.anything {
+          position = "50%";
+          size = null;
+          relative = "editor";
+          border = {
+            style = "rounded";
+          };
+          buf_options = {
+            swapfile = false;
+            filetype = "DressingSelect";
+          };
+          win_options = {
+            winblend = 0;
+          };
+          max_width = 80;
+          max_height = 40;
+          min_width = 40;
+          min_height = 10;
+        } "Options for nui selector. ";
 
         builtin = {
           show_numbers = helpers.defaultNullOpts.mkBool true ''
@@ -218,23 +222,25 @@ helpers.neovim-plugin.mkNeovimPlugin config {
                 If 'editor' or 'win', will default to being centered.
               '';
 
-          buf_options = helpers.defaultNullOpts.mkAttrsOf types.anything "{}" ''
+          buf_options = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
             An attribute set of buffer options.
           '';
 
-          win_options = helpers.defaultNullOpts.mkAttrsOf types.anything ''
-            {
-              cursorline = true;
-              cursorlineopt = "both";
-            }
-          '' "An attribute set of window options.";
+          win_options = helpers.defaultNullOpts.mkAttrsOf types.anything {
+            cursorline = true;
+            cursorlineopt = "both";
+          } "An attribute set of window options.";
 
           width = helpers.defaultNullOpts.mkNullable intOrRatio null ''
             Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
           '';
 
           max_width =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) "[140 0.8]"
+            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+              [
+                140
+                0.8
+              ]
               ''
                 Max width of window.
 
@@ -243,7 +249,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               '';
 
           min_width =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) "[40 0.2]"
+            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+              [
+                40
+                0.2
+              ]
               ''
                 Min width of window.
 
@@ -256,7 +266,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           '';
 
           max_height =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) "0.9"
+            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) 0.9
               ''
                 Max height of window.
 
@@ -265,7 +275,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               '';
 
           min_height =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) "[10 0.2]"
+            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+              [
+                10
+                0.2
+              ]
               ''
                 Min height of window.
 
@@ -275,13 +289,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
           mappings =
             helpers.defaultNullOpts.mkAttrsOf (with types; either str (enum [ false ]))
-              ''
-                {
-                  "<Esc>" = "Close";
-                  "<C-c>" = "Close";
-                  "<CR>" = "Confirm";
-                }
-              ''
+              {
+                "<Esc>" = "Close";
+                "<C-c>" = "Close";
+                "<CR>" = "Confirm";
+              }
               ''
                 Mappings in normal mode for the builtin selector.
 
@@ -294,7 +306,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           '';
         };
 
-        format_item_override = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.strLuaFn "{}" ''
+        format_item_override = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.strLuaFn { } ''
           Override the formatting/display for a specific "kind" when using vim.ui.select.
           For example, code actions from vim.lsp.buf.code_action use a kind="codeaction".
           You can override the format function when selecting for that kind, e.g.

--- a/plugins/utils/hardtime.nix
+++ b/plugins/utils/hardtime.nix
@@ -44,55 +44,104 @@ in
         Whether the plugin in enabled by default or not.
       '';
 
-      resettingKeys = helpers.mkNullOrOption (with types; attrsOf (listOf str)) ''
-        Keys in what modes that reset the count.
+      resettingKeys = helpers.defaultNullOpts.mkAttrsOf (with types; listOf str) {
+        "1" = [
+          "n"
+          "x"
+        ];
+        "2" = [
+          "n"
+          "x"
+        ];
+        "3" = [
+          "n"
+          "x"
+        ];
+        "4" = [
+          "n"
+          "x"
+        ];
+        "5" = [
+          "n"
+          "x"
+        ];
+        "6" = [
+          "n"
+          "x"
+        ];
+        "7" = [
+          "n"
+          "x"
+        ];
+        "8" = [
+          "n"
+          "x"
+        ];
+        "9" = [
+          "n"
+          "x"
+        ];
+        "c" = [ "n" ];
+        "C" = [ "n" ];
+        "d" = [ "n" ];
+        "x" = [ "n" ];
+        "X" = [ "n" ];
+        "y" = [ "n" ];
+        "Y" = [ "n" ];
+        "p" = [ "n" ];
+        "P" = [ "n" ];
+      } "Keys in what modes that reset the count.";
 
-        default:
-        ```nix
-        {
-          "1" = [ "n" "x" ];
-          "2" = [ "n" "x" ];
-          "3" = [ "n" "x" ];
-          "4" = [ "n" "x" ];
-          "5" = [ "n" "x" ];
-          "6" = [ "n" "x" ];
-          "7" = [ "n" "x" ];
-          "8" = [ "n" "x" ];
-          "9" = [ "n" "x" ];
-          "c" = [ "n" ];
-          "C" = [ "n" ];
-          "d" = [ "n" ];
-          "x" = [ "n" ];
-          "X" = [ "n" ];
-          "y" = [ "n" ];
-          "Y" = [ "n" ];
-          "p" = [ "n" ];
-          "P" = [ "n" ];
-        }
-        ```
-      '';
-
-      restrictedKeys = helpers.mkNullOrOption (with types; attrsOf (listOf str)) ''
-        Keys in what modes triggering the count mechanism.
-
-        default:
-        ```nix
-        {
-          "h" = [ "n" "x" ];
-          "j" = [ "n" "x" ];
-          "k" = [ "n" "x" ];
-          "l" = [ "n" "x" ];
-          "-" = [ "n" "x" ];
-          "+" = [ "n" "x" ];
-          "gj" = [ "n" "x" ];
-          "gk" = [ "n" "x" ];
-          "<CR>" = [ "n" "x" ];
-          "<C-M>" = [ "n" "x" ];
-          "<C-N>" = [ "n" "x" ];
-          "<C-P>" = [ "n" "x" ];
-        }
-        ```
-      '';
+      restrictedKeys = helpers.defaultNullOpts.mkAttrsOf (with types; listOf str) {
+        "h" = [
+          "n"
+          "x"
+        ];
+        "j" = [
+          "n"
+          "x"
+        ];
+        "k" = [
+          "n"
+          "x"
+        ];
+        "l" = [
+          "n"
+          "x"
+        ];
+        "-" = [
+          "n"
+          "x"
+        ];
+        "+" = [
+          "n"
+          "x"
+        ];
+        "gj" = [
+          "n"
+          "x"
+        ];
+        "gk" = [
+          "n"
+          "x"
+        ];
+        "<CR>" = [
+          "n"
+          "x"
+        ];
+        "<C-M>" = [
+          "n"
+          "x"
+        ];
+        "<C-N>" = [
+          "n"
+          "x"
+        ];
+        "<C-P>" = [
+          "n"
+          "x"
+        ];
+      } "Keys in what modes triggering the count mechanism.";
 
       restrictionMode =
         helpers.defaultNullOpts.mkEnumFirstDefault
@@ -104,28 +153,32 @@ in
             The behavior when `restricted_keys` trigger count mechanism.
           '';
 
-      disabledKeys = helpers.mkNullOrOption (with types; attrsOf (listOf str)) ''
-        Keys in what modes are disabled.
+      disabledKeys = helpers.defaultNullOpts.mkAttrsOf (with types; listOf str) {
+        "<Up>" = [
+          ""
+          "i"
+        ];
+        "<Down>" = [
+          ""
+          "i"
+        ];
+        "<Left>" = [
+          ""
+          "i"
+        ];
+        "<Right>" = [
+          ""
+          "i"
+        ];
+      } "Keys in what modes are disabled.";
 
-        default:
-        ```nix
-        {
-          "<Up>" = [ "" "i" ];
-          "<Down>" = [ "" "i" ];
-          "<Left>" = [ "" "i" ];
-          "<Right>" = [ "" "i" ];
-        }
-        ```
-      '';
-
-      disabledFiletypes = helpers.mkNullOrOption (with types; listOf str) ''
-        `hardtime.nvim` is disabled under these filetypes.
-
-        default:
-        ```nix
-        ["qf" "netrw" "NvimTree" "lazy" "mason"]
-        ```
-      '';
+      disabledFiletypes = helpers.defaultNullOpts.mkListOf types.str [
+        "qf"
+        "netrw"
+        "NvimTree"
+        "lazy"
+        "mason"
+      ] "`hardtime.nvim` is disabled under these filetypes.";
 
       hints =
         helpers.mkNullOrOption

--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -109,9 +109,9 @@ in
       Closes any tmux windows harpoon that harpoon creates when you close Neovim.
     '';
 
-    excludedFiletypes = helpers.defaultNullOpts.mkNullable (
-      with types; listOf str
-    ) ''["harpoon"]'' "Filetypes that you want to prevent from adding to the harpoon list menu.";
+    excludedFiletypes = helpers.defaultNullOpts.mkListOf types.str [ "harpoon" ] ''
+      Filetypes that you want to prevent from adding to the harpoon list menu.
+    '';
 
     markBranch = helpers.defaultNullOpts.mkBool false ''
       Set marks specific to each git branch inside git repository.
@@ -144,9 +144,16 @@ in
         Menu window height
       '';
 
-      borderChars = helpers.defaultNullOpts.mkNullable (
-        with types; listOf str
-      ) ''["─" "│" "─" "│" "╭" "╮" "╯" "╰"]'' "Border characters";
+      borderChars = helpers.defaultNullOpts.mkListOf types.str [
+        "─"
+        "│"
+        "─"
+        "│"
+        "╭"
+        "╮"
+        "╯"
+        "╰"
+      ] "Border characters";
     };
   };
 

--- a/plugins/utils/hop.nix
+++ b/plugins/utils/hop.nix
@@ -243,7 +243,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       should be good if you have enough keys in `|hop-config-keys|`).
     '';
 
-    excluded_filetypes = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    excluded_filetypes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Skip hinting windows with the excluded filetypes.
       Those windows to check filetypes are collected only when you enable `multi_windows` or
       execute `MW`-commands.
@@ -251,7 +251,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       for editing.
     '';
 
-    match_mappings = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    match_mappings = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       This option allows you to specify the match mappings to use when applying the hint.
       If you set a non-empty `match_mappings`, the hint will be used as a key to look up the
       pattern to search for.

--- a/plugins/utils/hydra/hydra-config-opts.nix
+++ b/plugins/utils/hydra/hydra-config-opts.nix
@@ -61,7 +61,7 @@ with lib;
     Called after every hydra head.
   '';
 
-  timeout = helpers.defaultNullOpts.mkNullable (with types; either bool ints.unsigned) "false" ''
+  timeout = helpers.defaultNullOpts.mkNullable (with types; either bool ints.unsigned) false ''
     Timeout after which the hydra is automatically disabled.
     Calling any head will refresh the timeout
     - `true`: timeout set to value of `timeoutlen` (`:h timeoutlen`)
@@ -162,13 +162,11 @@ with lib;
       };
     in
     helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) hintConfigType)
-      ''
-        {
-          show_name = true;
-          position = "bottom";
-          offset = 0;
-        }
-      ''
+      {
+        show_name = true;
+        position = "bottom";
+        offset = 0;
+      }
       ''
         Configure the hint.
         Set to `false` to disable.

--- a/plugins/utils/illuminate.nix
+++ b/plugins/utils/illuminate.nix
@@ -9,34 +9,41 @@ with lib;
 let
   cfg = config.plugins.illuminate;
 
-  mkListStr = helpers.defaultNullOpts.mkNullable (types.listOf types.str);
+  mkListStr = helpers.defaultNullOpts.mkListOf types.str;
 
   commonOptions = with helpers.defaultNullOpts; {
-    providers = mkListStr ''["lsp" "treesitter" "regex"]'' ''
-      Provider used to get references in the buffer, ordered by priority.
-    '';
+    providers =
+      mkListStr
+        [
+          "lsp"
+          "treesitter"
+          "regex"
+        ]
+        ''
+          Provider used to get references in the buffer, ordered by priority.
+        '';
 
     delay = mkInt 100 ''
       Delay in milliseconds.
     '';
 
-    modesDenylist = mkListStr "[]" ''
+    modesDenylist = mkListStr [ ] ''
       Modes to not illuminate, this overrides `modes_allowlist`.
       See `:help mode()` for possible values.
     '';
 
-    modesAllowlist = mkListStr "[]" ''
+    modesAllowlist = mkListStr [ ] ''
       Modes to illuminate, this is overridden by `modes_denylist`.
       See `:help mode()` for possible values.
     '';
 
-    providersRegexSyntaxDenylist = mkListStr "[]" ''
+    providersRegexSyntaxDenylist = mkListStr [ ] ''
       Syntax to not illuminate, this overrides `providers_regex_syntax_allowlist`.
       Only applies to the 'regex' provider.
       Use `:echo synIDattr(synIDtrans(synID(line('.'), col('.'), 1)), 'name')`.
     '';
 
-    providersRegexSyntaxAllowlist = mkListStr "[]" ''
+    providersRegexSyntaxAllowlist = mkListStr [ ] ''
       Syntax to illuminate, this is overridden by `providers_regex_syntax_denylist`.
       Only applies to the 'regex' provider.
       Use `:echo synIDattr(synIDtrans(synID(line('.'), col('.'), 1)), 'name')`.
@@ -57,11 +64,17 @@ let
   };
 
   filetypeOptions = {
-    filetypesDenylist = mkListStr ''["dirvish" "fugitive"]'' ''
-      Filetypes to not illuminate, this overrides `filetypes_allowlist`.
-    '';
+    filetypesDenylist =
+      mkListStr
+        [
+          "dirvish"
+          "fugitive"
+        ]
+        ''
+          Filetypes to not illuminate, this overrides `filetypes_allowlist`.
+        '';
 
-    filetypesAllowlist = mkListStr "[]" ''
+    filetypesAllowlist = mkListStr [ ] ''
       Filetypes to illuminate, this is overridden by `filetypes_denylist`.
     '';
   };
@@ -77,14 +90,7 @@ in
       package = mkPluginPackageOption "vim-illuminate" pkgs.vimPlugins.vim-illuminate;
 
       filetypeOverrides =
-        helpers.defaultNullOpts.mkNullable
-          (
-            with types;
-            attrsOf (submodule {
-              options = commonOptions;
-            })
-          )
-          "{}"
+        helpers.defaultNullOpts.mkAttrsOf (types.submodule { options = commonOptions; }) { }
           ''
             Filetype specific overrides.
             The keys are strings to represent the filetype.

--- a/plugins/utils/indent-blankline.nix
+++ b/plugins/utils/indent-blankline.nix
@@ -212,7 +212,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       '';
 
       include = {
-        node_type = helpers.defaultNullOpts.mkAttrsOf (with types; listOf str) "{}" ''
+        node_type = helpers.defaultNullOpts.mkAttrsOf (with types; listOf str) { } ''
           Map of language to a list of node types which can be used as scope.
 
           - Use `*` as the language to act as a wildcard for all languages.
@@ -221,19 +221,20 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       };
 
       exclude = {
-        language = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+        language = helpers.defaultNullOpts.mkListOf types.str [ ] ''
           List of treesitter languages for which scope is disabled.
         '';
 
         node_type =
           helpers.defaultNullOpts.mkAttrsOf (with types; (listOf str))
-            ''
-              {
-                "*" = ["source_file" "program"];
-                lua = ["chunk"];
-                python = ["module"];
-              }
-            ''
+            {
+              "*" = [
+                "source_file"
+                "program"
+              ];
+              lua = [ "chunk" ];
+              python = [ "module" ];
+            }
             ''
               Map of language to a list of node types which should not be used as scope.
 
@@ -243,28 +244,24 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     };
 
     exclude = {
-      filetypes = helpers.defaultNullOpts.mkListOf types.str ''
-        [
-          "lspinfo"
-          "packer"
-          "checkhealth"
-          "help"
-          "man"
-          "gitcommit"
-          "TelescopePrompt"
-          "TelescopeResults"
-          "\'\'"
-        ]
-      '' "List of filetypes for which indent-blankline is disabled.";
+      filetypes = helpers.defaultNullOpts.mkListOf types.str [
+        "lspinfo"
+        "packer"
+        "checkhealth"
+        "help"
+        "man"
+        "gitcommit"
+        "TelescopePrompt"
+        "TelescopeResults"
+        "''"
+      ] "List of filetypes for which indent-blankline is disabled.";
 
-      buftypes = helpers.defaultNullOpts.mkListOf types.str ''
-        [
-          "terminal"
-          "nofile"
-          "quickfix"
-          "prompt"
-        ]
-      '' "List of buftypes for which indent-blankline is disabled.";
+      buftypes = helpers.defaultNullOpts.mkListOf types.str [
+        "terminal"
+        "nofile"
+        "quickfix"
+        "prompt"
+      ] "List of buftypes for which indent-blankline is disabled.";
     };
   };
 

--- a/plugins/utils/indent-o-matic.nix
+++ b/plugins/utils/indent-o-matic.nix
@@ -15,9 +15,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       helpers.defaultNullOpts.mkInt 2048
         "Number of lines without indentation before giving up (use -1 for infinite)";
     skip_multiline = helpers.defaultNullOpts.mkBool false "Skip multi-line comments and strings (more accurate detection but less performant)";
-    standard_widths =
-      helpers.defaultNullOpts.mkListOf types.ints.unsigned ''[2 4 8]''
-        "Space indentations that should be detected";
+    standard_widths = helpers.defaultNullOpts.mkListOf types.ints.unsigned [
+      2
+      4
+      8
+    ] "Space indentations that should be detected";
   };
 
   settingsExample = {

--- a/plugins/utils/lastplace.nix
+++ b/plugins/utils/lastplace.nix
@@ -15,14 +15,18 @@ with lib;
 
     package = helpers.mkPluginPackageOption "lastplace" pkgs.vimPlugins.nvim-lastplace;
 
-    ignoreBuftype =
-      helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["quickfix" "nofix" "help"]''
-        "The list of buffer types to ignore by lastplace.";
+    ignoreBuftype = helpers.defaultNullOpts.mkListOf types.str [
+      "quickfix"
+      "nofix"
+      "help"
+    ] "The list of buffer types to ignore by lastplace.";
 
-    ignoreFiletype =
-      helpers.defaultNullOpts.mkNullable (types.listOf types.str)
-        ''["gitcommit" "gitrebase" "svn" "hgcommit"]''
-        "The list of file types to ignore by lastplace.";
+    ignoreFiletype = helpers.defaultNullOpts.mkListOf types.str [
+      "gitcommit"
+      "gitrebase"
+      "svn"
+      "hgcommit"
+    ] "The list of file types to ignore by lastplace.";
 
     openFolds = helpers.defaultNullOpts.mkBool true "Whether closed folds are automatically opened when jumping to the last edit position.";
   };

--- a/plugins/utils/leap.nix
+++ b/plugins/utils/leap.nix
@@ -43,64 +43,62 @@ in
       Whether to consider case in search patterns.
     '';
 
-    equivalenceClasses =
-      helpers.defaultNullOpts.mkNullable (with types; listOf (either str (listOf str))) ''[" \t\r\n"]''
-        ''
-          A character will match any other in its equivalence class. The sets can
-          either be defined as strings or tables.
+    equivalenceClasses = helpers.defaultNullOpts.mkListOf' {
+      type = with types; either str (listOf str);
+      description = ''
+        A character will match any other in its equivalence class. The sets can
+        either be defined as strings or tables.
 
-          Example:
-          ```nix
-            [
-              "\r\n"
-              ")]}>"
-              "([{<"
-              [ "\"" "'" "`" ]
-            ]
-          ```
+        Note: Make sure to have a set containing `\n` if you want to be able to
+        target characters at the end of the line.
 
-          Note: Make sure to have a set containing `\n` if you want to be able to
-          target characters at the end of the line.
+        Note: Non-mutual aliases are not possible in Leap, for the same reason
+        that supporting |smartcase| is not possible: we would need to show two
+        different labels, corresponding to two different futures, at the same
+        time.
+      '';
+      pluginDefault = [ " \t\r\n" ];
+      example = [
+        "\r\n"
+        ")]}>"
+        "([{<"
+        [
+          "\""
+          "'"
+          "`"
+        ]
+      ];
+    };
 
-          Note: Non-mutual aliases are not possible in Leap, for the same reason
-          that supporting |smartcase| is not possible: we would need to show two
-          different labels, corresponding to two different futures, at the same
-          time.
-        '';
+    substituteChars = helpers.defaultNullOpts.mkAttrsOf' {
+      type = types.str;
+      description = ''
+        The keys in this attrs will be substituted in labels and highlighted matches by the given
+        characters.
+        This way special (e.g. whitespace) characters can be made visible in matches, or even be
+        used as labels.
+      '';
+      pluginDefault = { };
+      example = {
+        "\r" = "¬";
+      };
+    };
 
-    substituteChars = helpers.defaultNullOpts.mkNullable (with types; attrsOf str) "{}" ''
-      The keys in this attrs will be substituted in labels and highlighted matches by the given
-      characters.
-      This way special (e.g. whitespace) characters can be made visible in matches, or even be
-      used as labels.
+    safeLabels = helpers.defaultNullOpts.mkListOf types.str (stringToCharacters "sfnut/SFNLHMUGT?Z") ''
+      When the number of matches does not exceed the number of these "safe" labels plus one, the
+      plugin jumps to the first match automatically after entering the pattern.
+      Obviously, for this purpose you should choose keys that are unlikely to be used right
+      after a jump!
 
-      Example: `{"\r" = "¬";}`
+      Setting the list to `[]` effectively disables the autojump feature.
+
+      Note: Operator-pending mode ignores this, since we need to be able to select the actual
+      target before executing the operation.
     '';
 
-    safeLabels =
-      helpers.defaultNullOpts.mkNullable (with types; listOf str)
-        ''["s" "f" "n" "u" "t" "/" "S" "F" "N" "L" "H" "M" "U" "G" "T" "?" "Z"]''
-        ''
-          When the number of matches does not exceed the number of these "safe" labels plus one, the
-          plugin jumps to the first match automatically after entering the pattern.
-          Obviously, for this purpose you should choose keys that are unlikely to be used right
-          after a jump!
-
-          Setting the list to `[]` effectively disables the autojump feature.
-
-          Note: Operator-pending mode ignores this, since we need to be able to select the actual
-          target before executing the operation.
-        '';
-
     labels =
-      helpers.defaultNullOpts.mkNullable (with types; listOf str)
-        ''
-          [
-            "s" "f" "n" "j" "k" "l" "h" "o" "d" "w" "e" "m" "b" "u" "y" "v" "r" "g" "t" "c" "x" "/"
-            "z" "S" "F" "N" "J" "K" "L" "H" "O" "D" "W" "E" "M" "B" "U" "Y" "V" "R" "G" "T" "C" "X"
-            "?" "Z"
-          ]
-        ''
+      helpers.defaultNullOpts.mkListOf types.str
+        (stringToCharacters "sfnjklhodwembuyvrgtcx/zSFNJKLHODWEMBUYVRGTCX?Z")
         ''
           Target labels to be used when there are more matches than labels in
           `|leap.opts.safe_labels|` plus one.

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -67,7 +67,7 @@ mkVimPlugin config {
       The highlight group to be used for highlighting cells.
     '';
 
-    save_path = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath('data') .. '/magma'";}'' ''
+    save_path = helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath('data') .. '/magma'"; } ''
       Where to save/load with `:MagmaSave` and `:MagmaLoad` (with no parameters).
       The generated file is placed in this directory, with the filename itself being the
       buffer's name, with `%` replaced by `%%` and `/` replaced by `%`, and postfixed with the

--- a/plugins/utils/marks.nix
+++ b/plugins/utils/marks.nix
@@ -26,7 +26,7 @@ in
           "<"
           ">"
         ])
-        "[]"
+        [ ]
         ''
           Which builtin marks to track and show. If set, these marks will also show up in the
           signcolumn and will update on `|CursorMoved|`.
@@ -76,7 +76,7 @@ in
             };
           })
         )
-        "10"
+        10
         ''
           The sign priority to be used for marks.
           Can either be a number, in which case the priority applies to all types of marks, or a
@@ -88,7 +88,7 @@ in
           - bookmark: sign priority for bookmarks
         '';
 
-    excludedFiletypes = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    excludedFiletypes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Which filetypes to ignore.
       If a buffer with this filetype is opened, then `marks.nvim` will not track any marks set in
       this buffer, and will not display any signs.
@@ -96,7 +96,7 @@ in
       "m[" will not.
     '';
 
-    excludedBuftypes = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    excludedBuftypes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Which buftypes to ignore.
       If a buffer with this buftype is opened, then `marks.nvim` will not track any marks set in
       this buffer, and will not display any signs.
@@ -138,7 +138,7 @@ in
       );
     };
 
-    mappings = helpers.defaultNullOpts.mkAttrsOf (with types; either str (enum [ false ])) "{}" ''
+    mappings = helpers.defaultNullOpts.mkAttrsOf (with types; either str (enum [ false ])) { } ''
       Custom mappings.
       Set a mapping to `false` to disable it.
     '';

--- a/plugins/utils/mkdnflow.nix
+++ b/plugins/utils/mkdnflow.nix
@@ -79,8 +79,12 @@ in
         };
 
     filetypes =
-      helpers.defaultNullOpts.mkNullable (with types; attrsOf bool)
-        "{md = true; rmd = true; markdown = true;}"
+      helpers.defaultNullOpts.mkAttrsOf types.bool
+        {
+          md = true;
+          rmd = true;
+          markdown = true;
+        }
         ''
           A matching extension will enable the plugin's functionality for a file with that
           extension.
@@ -137,7 +141,7 @@ in
               notebook (requires `perspective.root_tell` to be specified)
           '';
 
-      rootTell = helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) str) "false" ''
+      rootTell = helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) str) false ''
         - `<any file name>`: Any arbitrary filename by which the plugin can uniquely identify
           the root directory of the current notebook.
         - If `false` is used instead, the plugin will never search for a root directory, even
@@ -233,7 +237,7 @@ in
         an extension, and (b) that new links should be created without an explicit extension.
       '';
 
-      transformExplicit = helpers.defaultNullOpts.mkStrLuaFnOr (types.enum [ false ]) "false" ''
+      transformExplicit = helpers.defaultNullOpts.mkStrLuaFnOr (types.enum [ false ]) false ''
         A function that transforms the text to be inserted as the source/path of a link when a
         link is created.
         Anchor links are not currently customizable.
@@ -282,18 +286,25 @@ in
     };
 
     toDo = {
-      symbols = helpers.defaultNullOpts.mkNullable (with types; listOf str) ''[" " "-" "X"]'' ''
-        A list of symbols (each no more than one character) that represent to-do list completion
-        statuses.
-        `MkdnToggleToDo` references these when toggling the status of a to-do item.
-        Three are expected: one representing not-yet-started to-dos (default: `' '`), one
-        representing in-progress to-dos (default: `-`), and one representing complete to-dos
-        (default: `X`).
+      symbols =
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            " "
+            "-"
+            "X"
+          ]
+          ''
+            A list of symbols (each no more than one character) that represent to-do list completion
+            statuses.
+            `MkdnToggleToDo` references these when toggling the status of a to-do item.
+            Three are expected: one representing not-yet-started to-dos (default: `' '`), one
+            representing in-progress to-dos (default: `-`), and one representing complete to-dos
+            (default: `X`).
 
-        NOTE: Native Lua support for UTF-8 characters is limited, so in order to ensure all
-        functionality works as intended if you are using non-ascii to-do symbols, you'll need to
-        install the luarocks module "luautf8".
-      '';
+            NOTE: Native Lua support for UTF-8 characters is limited, so in order to ensure all
+            functionality works as intended if you are using non-ascii to-do symbols, you'll need to
+            install the luarocks module "luautf8".
+          '';
 
       updateParents = helpers.defaultNullOpts.mkBool true ''
         Whether parent to-dos' statuses should be updated based on child to-do status changes
@@ -392,152 +403,158 @@ in
     };
 
     mappings =
-      helpers.defaultNullOpts.mkNullable
+      helpers.defaultNullOpts.mkAttrsOf
         (
           with types;
-          attrsOf (
-            either (enum [ false ]) (submodule {
-              options = {
-                modes = mkOption {
-                  type = either str (listOf str);
-                  description = ''
-                    Either a string or list representing the mode(s) that the mapping should apply
-                    in.
-                  '';
-                  example = [
-                    "n"
-                    "v"
-                  ];
-                };
-
-                key = mkOption {
-                  type = str;
-                  description = "String representing the keymap.";
-                  example = "<Space>";
-                };
+          either (enum [ false ]) (submodule {
+            options = {
+              modes = mkOption {
+                type = either str (listOf str);
+                description = ''
+                  Either a string or list representing the mode(s) that the mapping should apply
+                  in.
+                '';
+                example = [
+                  "n"
+                  "v"
+                ];
               };
-            })
-          )
+
+              key = mkOption {
+                type = str;
+                description = "String representing the keymap.";
+                example = "<Space>";
+              };
+            };
+          })
         )
-        ''
-          {
-            MkdnEnter = {
-              modes = ["n" "v" "i"];
-              key = "<CR>";
-            };
-            MkdnTab = false;
-            MkdnSTab = false;
-            MkdnNextLink = {
-              modes = "n";
-              key = "<Tab>";
-            };
-            MkdnPrevLink = {
-              modes = "n";
-              key = "<S-Tab>";
-            };
-            MkdnNextHeading = {
-              modes = "n";
-              key = "]]";
-            };
-            MkdnPrevHeading = {
-              modes = "n";
-              key = "[[";
-            };
-            MkdnGoBack = {
-              modes = "n";
-              key = "<BS>";
-            };
-            MkdnGoForward = {
-              modes = "n";
-              key = "<Del>";
-            };
-            MkdnFollowLink = false; # see MkdnEnter
-            MkdnCreateLink = false; # see MkdnEnter
-            MkdnCreateLinkFromClipboard = {
-              modes = ["n" "v"];
-              key = "<leader>p";
-            }; # see MkdnEnter
-            MkdnDestroyLink = {
-              modes = "n";
-              key = "<M-CR>";
-            };
-            MkdnMoveSource = {
-              modes = "n";
-              key = "<F2>";
-            };
-            MkdnYankAnchorLink = {
-              modes = "n";
-              key = "ya";
-            };
-            MkdnYankFileAnchorLink = {
-              modes = "n";
-              key = "yfa";
-            };
-            MkdnIncreaseHeading = {
-              modes = "n";
-              key = "+";
-            };
-            MkdnDecreaseHeading = {
-              modes = "n";
-              key = "-";
-            };
-            MkdnToggleToDo = {
-              modes = ["n" "v"];
-              key = "<C-Space>";
-            };
-            MkdnNewListItem = false;
-            MkdnNewListItemBelowInsert = {
-              modes = "n";
-              key = "o";
-            };
-            MkdnNewListItemAboveInsert = {
-              modes = "n";
-              key = "O";
-            };
-            MkdnExtendList = false;
-            MkdnUpdateNumbering = {
-              modes = "n";
-              key = "<leader>nn";
-            };
-            MkdnTableNextCell = {
-              modes = "i";
-              key = "<Tab>";
-            };
-            MkdnTablePrevCell = {
-              modes = "i";
-              key = "<S-Tab>";
-            };
-            MkdnTableNextRow = false;
-            MkdnTablePrevRow = {
-              modes = "i";
-              key = "<M-CR>";
-            };
-            MkdnTableNewRowBelow = {
-              modes = "n";
-              key = "<leader>ir";
-            };
-            MkdnTableNewRowAbove = {
-              modes = "n";
-              key = "<leader>iR";
-            };
-            MkdnTableNewColAfter = {
-              modes = "n";
-              key = "<leader>ic";
-            };
-            MkdnTableNewColBefore = {
-              modes = "n";
-              key = "<leader>iC";
-            };
-            MkdnFoldSection = {
-              modes = "n";
-              key = "<leader>f";
-            };
-            MkdnUnfoldSection = {
-              modes = "n";
-              key = "<leader>F";
-            };
-          }
-        ''
+        {
+          MkdnEnter = {
+            modes = [
+              "n"
+              "v"
+              "i"
+            ];
+            key = "<CR>";
+          };
+          MkdnTab = false;
+          MkdnSTab = false;
+          MkdnNextLink = {
+            modes = "n";
+            key = "<Tab>";
+          };
+          MkdnPrevLink = {
+            modes = "n";
+            key = "<S-Tab>";
+          };
+          MkdnNextHeading = {
+            modes = "n";
+            key = "]]";
+          };
+          MkdnPrevHeading = {
+            modes = "n";
+            key = "[[";
+          };
+          MkdnGoBack = {
+            modes = "n";
+            key = "<BS>";
+          };
+          MkdnGoForward = {
+            modes = "n";
+            key = "<Del>";
+          };
+          MkdnFollowLink = false; # see MkdnEnter
+          MkdnCreateLink = false; # see MkdnEnter
+          MkdnCreateLinkFromClipboard = {
+            modes = [
+              "n"
+              "v"
+            ];
+            key = "<leader>p";
+          }; # see MkdnEnter
+          MkdnDestroyLink = {
+            modes = "n";
+            key = "<M-CR>";
+          };
+          MkdnMoveSource = {
+            modes = "n";
+            key = "<F2>";
+          };
+          MkdnYankAnchorLink = {
+            modes = "n";
+            key = "ya";
+          };
+          MkdnYankFileAnchorLink = {
+            modes = "n";
+            key = "yfa";
+          };
+          MkdnIncreaseHeading = {
+            modes = "n";
+            key = "+";
+          };
+          MkdnDecreaseHeading = {
+            modes = "n";
+            key = "-";
+          };
+          MkdnToggleToDo = {
+            modes = [
+              "n"
+              "v"
+            ];
+            key = "<C-Space>";
+          };
+          MkdnNewListItem = false;
+          MkdnNewListItemBelowInsert = {
+            modes = "n";
+            key = "o";
+          };
+          MkdnNewListItemAboveInsert = {
+            modes = "n";
+            key = "O";
+          };
+          MkdnExtendList = false;
+          MkdnUpdateNumbering = {
+            modes = "n";
+            key = "<leader>nn";
+          };
+          MkdnTableNextCell = {
+            modes = "i";
+            key = "<Tab>";
+          };
+          MkdnTablePrevCell = {
+            modes = "i";
+            key = "<S-Tab>";
+          };
+          MkdnTableNextRow = false;
+          MkdnTablePrevRow = {
+            modes = "i";
+            key = "<M-CR>";
+          };
+          MkdnTableNewRowBelow = {
+            modes = "n";
+            key = "<leader>ir";
+          };
+          MkdnTableNewRowAbove = {
+            modes = "n";
+            key = "<leader>iR";
+          };
+          MkdnTableNewColAfter = {
+            modes = "n";
+            key = "<leader>ic";
+          };
+          MkdnTableNewColBefore = {
+            modes = "n";
+            key = "<leader>iC";
+          };
+          MkdnFoldSection = {
+            modes = "n";
+            key = "<leader>f";
+          };
+          MkdnUnfoldSection = {
+            modes = "n";
+            key = "<leader>F";
+          };
+        }
         ''
           An attrs declaring the key mappings.
           The keys should be the name of a commands defined in

--- a/plugins/utils/molten.nix
+++ b/plugins/utils/molten.nix
@@ -63,7 +63,7 @@ mkVimPlugin config {
       cell.
     '';
 
-    cover_lines_starting_with = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    cover_lines_starting_with = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       When `cover_empty_lines` is `true`, also covers lines starting with these strings.
     '';
 
@@ -108,7 +108,12 @@ mkVimPlugin config {
       it's open.
     '';
 
-    output_win_border = helpers.defaultNullOpts.mkBorder ''["" "━" "" ""]'' "output window" "";
+    output_win_border = helpers.defaultNullOpts.mkBorder [
+      ""
+      "━"
+      ""
+      ""
+    ] "output window" "";
 
     output_win_cover_gutter = helpers.defaultNullOpts.mkBool true ''
       Should the output window cover the gutter (numbers and sign col), or not.
@@ -138,7 +143,9 @@ mkVimPlugin config {
           Value passed to the style option in `:h nvim_open_win()`.
         '';
 
-    save_path = helpers.defaultNullOpts.mkStr ''{__raw = "vim.fn.stdpath('data')..'/molten'";}'' "Where to save/load data with `:MoltenSave` and `:MoltenLoad`.";
+    save_path = helpers.defaultNullOpts.mkStr {
+      __raw = "vim.fn.stdpath('data')..'/molten'";
+    } "Where to save/load data with `:MoltenSave` and `:MoltenLoad`.";
 
     tick_rate = helpers.defaultNullOpts.mkUnsignedInt 500 ''
       How often (in ms) we poll the kernel for updates.

--- a/plugins/utils/multicursors.nix
+++ b/plugins/utils/multicursors.nix
@@ -161,7 +161,7 @@ in
           ]
           (
             mode:
-            helpers.defaultNullOpts.mkNullable (with types; either bool str) "false" ''
+            helpers.defaultNullOpts.mkNullable (with types; either bool str) false ''
               Hints for ${mode} mode.
 
               Accepted values:

--- a/plugins/utils/navbuddy.nix
+++ b/plugins/utils/navbuddy.nix
@@ -33,7 +33,7 @@ in
             width = mkPercentageOpt 100 "The width size (in %).";
           };
         })
-      ) "60" "The size of the window.";
+      ) 60 "The size of the window.";
 
       position = helpers.defaultNullOpts.mkNullable (
         with types;
@@ -44,7 +44,7 @@ in
             width = mkPercentageOpt 100 "The width size (in %).";
           };
         })
-      ) "50" "The position of the window.";
+      ) 50 "The position of the window.";
 
       scrolloff = helpers.mkNullOrOption types.int ''
         scrolloff value within navbuddy window
@@ -76,13 +76,12 @@ in
           '';
 
           preview =
-            helpers.defaultNullOpts.mkEnum
+            helpers.defaultNullOpts.mkEnumFirstDefault
               [
                 "leaf"
                 "always"
                 "never"
               ]
-              "leaf"
               ''
                 Right section can show previews too.
                       Options: "leaf", "always" or "never"
@@ -149,50 +148,48 @@ in
     };
 
     mappings =
-      helpers.defaultNullOpts.mkNullable (with types; attrsOf (either str helpers.nixvimTypes.rawLua))
-        ''
-          {
-            "<esc>" = "close";
-            "q" = "close";
-            "j" = "next_sibling";
-            "k" = "previous_sibling";
+      helpers.defaultNullOpts.mkAttrsOf types.str
+        {
+          "<esc>" = "close";
+          "q" = "close";
+          "j" = "next_sibling";
+          "k" = "previous_sibling";
 
-            "h" = "parent";
-            "l" = "children";
-            "0" = "root";
+          "h" = "parent";
+          "l" = "children";
+          "0" = "root";
 
-            "v" = "visual_name";
-            "V" = "visual_scope";
+          "v" = "visual_name";
+          "V" = "visual_scope";
 
-            "y" = "yank_name";
-            "Y" = "yank_scope";
+          "y" = "yank_name";
+          "Y" = "yank_scope";
 
-            "i" = "insert_name";
-            "I" = "insert_scope";
+          "i" = "insert_name";
+          "I" = "insert_scope";
 
-            "a" = "append_name";
-            "A" = "append_scope";
+          "a" = "append_name";
+          "A" = "append_scope";
 
-            "r" = "rename";
+          "r" = "rename";
 
-            "d" = "delete";
+          "d" = "delete";
 
-            "f" = "fold_create";
-            "F" = "fold_delete";
+          "f" = "fold_create";
+          "F" = "fold_delete";
 
-            "c" = "comment";
+          "c" = "comment";
 
-            "<enter>" = "select";
-            "o" = "select";
-            "J" = "move_down";
-            "K" = "move_up";
+          "<enter>" = "select";
+          "o" = "select";
+          "J" = "move_down";
+          "K" = "move_up";
 
-            "s" = "toggle_preview";
+          "s" = "toggle_preview";
 
-            "<C-v>" = "vsplit";
-            "<C-s>" = "hsplit";
-          }
-        ''
+          "<C-v>" = "vsplit";
+          "<C-s>" = "hsplit";
+        }
         ''
            Actions to be triggered for specified keybindings. It can take either action name i.e `toggle_preview`
           Or it can a `rawLua`.
@@ -214,14 +211,13 @@ in
       highlight = helpers.defaultNullOpts.mkBool true "Highlight the currently focused node";
 
       reorient =
-        helpers.defaultNullOpts.mkEnum
+        helpers.defaultNullOpts.mkEnumFirstDefault
           [
             "smart"
             "top"
             "mid"
             "none"
           ]
-          "smart"
           ''
             Right section can show previews too.
             Options: "leaf", "always" or "never"

--- a/plugins/utils/neocord.nix
+++ b/plugins/utils/neocord.nix
@@ -29,12 +29,11 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     '';
 
     main_image =
-      helpers.defaultNullOpts.mkEnum
+      helpers.defaultNullOpts.mkEnumFirstDefault
         [
           "language"
           "logo"
         ]
-        "language"
         ''
           Main image display (either "language" or "logo")
         '';
@@ -65,25 +64,23 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Displays the current line number instead of the current project.
     '';
 
-    blacklist = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    blacklist = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       A list of strings or Lua patterns that disable Rich Presence if the
       current file name, path, or workspace matches.
     '';
 
     buttons =
-      helpers.defaultNullOpts.mkNullable
+      helpers.defaultNullOpts.mkListOf
         (
           with types;
-          either helpers.nixvimTypes.rawLua (
-            listOf (submodule {
-              options = {
-                label = helpers.mkNullOrOption str "";
-                url = helpers.mkNullOrOption str "";
-              };
-            })
-          )
+          submodule {
+            options = {
+              label = helpers.mkNullOrStr "";
+              url = helpers.mkNullOrStr "";
+            };
+          }
         )
-        "[]"
+        [ ]
         ''
           Button configurations which will always appear in Rich Presence.
           Can be a list of attribute sets, each with the following attributes:

--- a/plugins/utils/neogen.nix
+++ b/plugins/utils/neogen.nix
@@ -67,44 +67,44 @@ in
       If true, enables placeholders when inserting annotation
     '';
 
-    languages = helpers.defaultNullOpts.mkNullable types.attrs "see upstream documentation" ''
-      Configuration for languages.
+    languages = helpers.defaultNullOpts.mkAttrsOf' {
+      # No plugin default (see upstream)
+      type = types.anything;
+      description = ''
+        Configuration for languages.
 
-      `template.annotation_convention` (default: check the language default configurations):
-        Change the annotation convention to use with the language.
+        `template.annotation_convention` (default: check the language default configurations):
+          Change the annotation convention to use with the language.
 
-      `template.use_default_comment` (default: true):
-        Prepend any template line with the default comment for the filetype
+        `template.use_default_comment` (default: true):
+          Prepend any template line with the default comment for the filetype
 
-      `template.position` (fun(node: userdata, type: string):(number,number)?):
-        Provide an absolute position for the annotation.
-        If return values are nil, use default position
+        `template.position` (fun(node: userdata, type: string):(number,number)?):
+          Provide an absolute position for the annotation.
+          If return values are nil, use default position
 
-      `template.append`:
-        If you want to customize the position of the annotation.
+        `template.append`:
+          If you want to customize the position of the annotation.
 
-      `template.append.child_name`:
-        What child node to use for appending the annotation.
+        `template.append.child_name`:
+          What child node to use for appending the annotation.
 
-      `template.append.position` (before/after):
-        Relative positioning with `child_name`.
+        `template.append.position` (before/after):
+          Relative positioning with `child_name`.
 
-      `template.<convention_name>` (replace <convention_name> with an annotation convention):
-        Template for an annotation convention.
-        To know more about how to create your own template, go here:
-        https://github.com/danymat/neogen/blob/main/docs/adding-languages.md#default-generator
-
-      Example:
-      ```nix
-        {
-          csharp = {
-            template = {
-              annotation_convention = "...";
-            };
+        `template.<convention_name>` (replace <convention_name> with an annotation convention):
+          Template for an annotation convention.
+          To know more about how to create your own template, go here:
+          https://github.com/danymat/neogen/blob/main/docs/adding-languages.md#default-generator
+      '';
+      example = {
+        csharp = {
+          template = {
+            annotation_convention = "...";
           };
-        }
-      ```
-    '';
+        };
+      };
+    };
 
     snippetEngine = helpers.mkNullOrOption types.str ''
       Use a snippet engine to generate annotations.

--- a/plugins/utils/neorg.nix
+++ b/plugins/utils/neorg.nix
@@ -80,7 +80,7 @@ with lib;
           }
         ) modes;
 
-        floatPrecision = helpers.defaultNullOpts.mkNullable types.float "0.01" ''
+        floatPrecision = helpers.defaultNullOpts.mkNullable types.float 1.0e-2 ''
           Can limit the number of decimals displayed for floats
         '';
       };

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -70,13 +70,10 @@ in
       Function called when a new window is closed.
     '';
 
-    render = helpers.defaultNullOpts.mkNullable (
-      with types;
-      either (enum [
-        "default"
-        "minimal"
-      ]) helpers.nixvimTypes.rawLua
-    ) "default" "Function to render a notification buffer or a built-in renderer name.";
+    render = helpers.defaultNullOpts.mkEnumFirstDefault [
+      "default"
+      "minimal"
+    ] "Function to render a notification buffer or a built-in renderer name.";
 
     minimumWidth = helpers.defaultNullOpts.mkUnsignedInt 50 ''
       Minimum width for notification windows.

--- a/plugins/utils/nvim-autopairs.nix
+++ b/plugins/utils/nvim-autopairs.nix
@@ -53,9 +53,10 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     ];
 
   settingsOptions = {
-    disable_filetype =
-      helpers.defaultNullOpts.mkListOf types.str ''["TelescopePrompt" "spectre_panel"]''
-        "Disabled filetypes.";
+    disable_filetype = helpers.defaultNullOpts.mkListOf types.str [
+      "TelescopePrompt"
+      "spectre_panel"
+    ] "Disabled filetypes.";
 
     disable_in_macro = helpers.defaultNullOpts.mkBool false ''
       Disable when recording or executing a macro.
@@ -101,19 +102,17 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Use treesitter to check for a pair.
     '';
 
-    ts_config = helpers.defaultNullOpts.mkAttrsOf types.anything ''
-      {
-        lua = [
-          "string"
-          "source"
-          "string_content"
-        ];
-        javascript = [
-          "string"
-          "template_string"
-        ];
-      }
-    '' "Configuration for TreeSitter.";
+    ts_config = helpers.defaultNullOpts.mkAttrsOf types.anything {
+      lua = [
+        "string"
+        "source"
+        "string_content"
+      ];
+      javascript = [
+        "string"
+        "template_string"
+      ];
+    } "Configuration for TreeSitter.";
 
     map_cr = helpers.defaultNullOpts.mkBool true ''
       Map the `<CR>` key to confirm the completion.
@@ -136,9 +135,18 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         The key to trigger fast_wrap.
       '';
 
-      chars = helpers.defaultNullOpts.mkListOf types.str ''["{" "[" "(" "\"" "'"]'' ''
-        Characters for which to enable fast wrap.
-      '';
+      chars =
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "{"
+            "["
+            "("
+            "\""
+            "'"
+          ]
+          ''
+            Characters for which to enable fast wrap.
+          '';
 
       pattern = helpers.defaultNullOpts.mkLua ''[=[[%'%"%>%]%)%}%,%`]]=]'' ''
         The pattern to match against.

--- a/plugins/utils/nvim-bqf.nix
+++ b/plugins/utils/nvim-bqf.nix
@@ -38,8 +38,18 @@ in
       '';
 
       borderChars =
-        helpers.defaultNullOpts.mkNullable (types.listOf types.str)
-          "[ \"│\" \"│\" \"─\" \"─\" \"╭\" \"╮\" \"╰\" \"╯\" \"█\" ]"
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "│"
+            "│"
+            "─"
+            "─"
+            "╭"
+            "╮"
+            "╰"
+            "╯"
+            "█"
+          ]
           ''
             Border and scroll bar chars, they respectively represent:
               vline, vline, hline, hline, ulcorner, urcorner, blcorner, brcorner, sbar
@@ -111,9 +121,10 @@ in
           '';
         };
 
-        extraOpts =
-          helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[ \"--bind\" \"ctrl-o:toggle-all\" ]"
-            "Extra options for fzf.";
+        extraOpts = helpers.defaultNullOpts.mkListOf types.str [
+          "--bind"
+          "ctrl-o:toggle-all"
+        ] "Extra options for fzf.";
       };
     };
   };

--- a/plugins/utils/obsidian/default.nix
+++ b/plugins/utils/obsidian/default.nix
@@ -229,7 +229,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               }
             )
           )
-          "[]"
+          [ ]
           ''
             A list of vault names and paths.
             Each path should be the path to the vault root.

--- a/plugins/utils/obsidian/options.nix
+++ b/plugins/utils/obsidian/options.nix
@@ -32,7 +32,7 @@ with lib;
 
     substitutions = helpers.defaultNullOpts.mkAttrsOf (
       with helpers.nixvimTypes; either str rawLua
-    ) "{}" "A map for custom variables, the key should be the variable and the value a function.";
+    ) { } "A map for custom variables, the key should be the variable and the value a function.";
   };
 
   new_notes_location =
@@ -203,11 +203,14 @@ with lib;
   '';
 
   completion = {
-    nvim_cmp = helpers.mkNullOrOption types.bool ''
-      Set to false to disable completion.
-
-      Default: `true` if `nvim-cmp` is enabled (`plugins.cmp.enable`).
-    '';
+    # FIXME should this accept raw types?
+    nvim_cmp = helpers.mkNullOrOption' {
+      type = types.bool;
+      description = ''
+        Set to false to disable completion.
+      '';
+      defaultText = literalMD "`true` if `plugins.cmp.enable` is enabled (otherwise `null`).";
+    };
 
     min_chars = helpers.defaultNullOpts.mkUnsignedInt 2 ''
       Trigger completion at this many chars.
@@ -233,23 +236,21 @@ with lib;
           };
         })
       )
-      ''
-        {
-          gf = {
-            action = "require('obsidian').util.gf_passthrough";
-            opts = {
-              noremap = false;
-              expr = true;
-              buffer = true;
-            };
+      {
+        gf = {
+          action = "require('obsidian').util.gf_passthrough";
+          opts = {
+            noremap = false;
+            expr = true;
+            buffer = true;
           };
+        };
 
-          "<leader>ch" = {
-            action = "require('obsidian').util.toggle_checkbox";
-            opts.buffer = true;
-          };
-        }
-      ''
+        "<leader>ch" = {
+          action = "require('obsidian').util.toggle_checkbox";
+          opts.buffer = true;
+        };
+      }
       ''
         Configure key mappings.
       '';
@@ -268,12 +269,10 @@ with lib;
 
     note_mappings =
       helpers.defaultNullOpts.mkAttrsOf types.str
-        ''
-          {
-            new = "<C-x>";
-            insert_link = "<C-l>";
-          }
-        ''
+        {
+          new = "<C-x>";
+          insert_link = "<C-l>";
+        }
         ''
           Optional, configure note mappings for the picker. These are the defaults.
           Not all pickers support all mappings.
@@ -281,12 +280,10 @@ with lib;
 
     tag_mappings =
       helpers.defaultNullOpts.mkAttrsOf types.str
-        ''
-          {
-            tag_note = "<C-x>";
-            insert_tag = "<C-l>";
-          }
-        ''
+        {
+          tag_note = "<C-x>";
+          insert_tag = "<C-l>";
+        }
         ''
           Optional, configure tag mappings for the picker. These are the defaults.
           Not all pickers support all mappings.
@@ -369,10 +366,10 @@ with lib;
     '';
 
     checkboxes =
-      helpers.defaultNullOpts.mkNullable
+      helpers.defaultNullOpts.mkAttrsOf
         (
           with types;
-          attrsOf (submodule {
+          submodule {
             options = {
               char = mkOption {
                 type = with helpers.nixvimTypes; maybeRaw str;
@@ -384,28 +381,26 @@ with lib;
                 description = "The name of the highlight group to use for this checkbox.";
               };
             };
-          })
-        )
-        ''
-          {
-            " " = {
-              char = "󰄱";
-              hl_group = "ObsidianTodo";
-            };
-            "x" = {
-              char = "";
-              hl_group = "ObsidianDone";
-            };
-            ">" = {
-              char = "";
-              hl_group = "ObsidianRightArrow";
-            };
-            "~" = {
-              char = "󰰱";
-              hl_group = "ObsidianTilde";
-            };
           }
-        ''
+        )
+        {
+          " " = {
+            char = "󰄱";
+            hl_group = "ObsidianTodo";
+          };
+          "x" = {
+            char = "";
+            hl_group = "ObsidianDone";
+          };
+          ">" = {
+            char = "";
+            hl_group = "ObsidianRightArrow";
+          };
+          "~" = {
+            char = "󰰱";
+            hl_group = "ObsidianTilde";
+          };
+        }
         ''
           Define how various check-boxes are displayed.
           You can also add more custom ones...
@@ -452,40 +447,38 @@ with lib;
       '';
     };
 
-    hl_groups = helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; attrsOf highlight) ''
-      {
-        ObsidianTodo = {
-          bold = true;
-          fg = "#f78c6c";
-        };
-        ObsidianDone = {
-          bold = true;
-          fg = "#89ddff";
-        };
-        ObsidianRightArrow = {
-          bold = true;
-          fg = "#f78c6c";
-        };
-        ObsidianTilde = {
-          bold = true;
-          fg = "#ff5370";
-        };
-        ObsidianRefText = {
-          underline = true;
-          fg = "#c792ea";
-        };
-        ObsidianExtLinkIcon = {
-          fg = "#c792ea";
-        };
-        ObsidianTag = {
-          italic = true;
-          fg = "#89ddff";
-        };
-        ObsidianHighlightText = {
-          bg = "#75662e";
-        };
-      }
-    '' "Highlight group definitions.";
+    hl_groups = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight {
+      ObsidianTodo = {
+        bold = true;
+        fg = "#f78c6c";
+      };
+      ObsidianDone = {
+        bold = true;
+        fg = "#89ddff";
+      };
+      ObsidianRightArrow = {
+        bold = true;
+        fg = "#f78c6c";
+      };
+      ObsidianTilde = {
+        bold = true;
+        fg = "#ff5370";
+      };
+      ObsidianRefText = {
+        underline = true;
+        fg = "#c792ea";
+      };
+      ObsidianExtLinkIcon = {
+        fg = "#c792ea";
+      };
+      ObsidianTag = {
+        italic = true;
+        fg = "#89ddff";
+      };
+      ObsidianHighlightText = {
+        bg = "#75662e";
+      };
+    } "Highlight group definitions.";
   };
 
   attachments = {

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -277,7 +277,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       '';
 
       cleanup_delay_ms =
-        helpers.defaultNullOpts.mkNullable (with types; either types.ints.unsigned (enum [ false ])) "2000"
+        helpers.defaultNullOpts.mkNullable (with types; either types.ints.unsigned (enum [ false ])) 2000
           ''
             Oil will automatically delete hidden buffers after this delay.
             You can set the delay to false to disable cleanup entirely.
@@ -317,26 +317,24 @@ helpers.neovim-plugin.mkNeovimPlugin config {
               (enum [ false ])
             ]
           )
-          ''
-            {
-              "g?" = "actions.show_help";
-              "<CR>" = "actions.select";
-              "<C-s>" = "actions.select_vsplit";
-              "<C-h>" = "actions.select_split";
-              "<C-t>" = "actions.select_tab";
-              "<C-p>" = "actions.preview";
-              "<C-c>" = "actions.close";
-              "<C-l>" = "actions.refresh";
-              "-" = "actions.parent";
-              "_" = "actions.open_cwd";
-              "`" = "actions.cd";
-              "~" = "actions.tcd";
-              "gs" = "actions.change_sort";
-              "gx" = "actions.open_external";
-              "g." = "actions.toggle_hidden";
-              "g\\" = "actions.toggle_trash";
-            }
-          ''
+          {
+            "g?" = "actions.show_help";
+            "<CR>" = "actions.select";
+            "<C-s>" = "actions.select_vsplit";
+            "<C-h>" = "actions.select_split";
+            "<C-t>" = "actions.select_tab";
+            "<C-p>" = "actions.preview";
+            "<C-c>" = "actions.close";
+            "<C-l>" = "actions.refresh";
+            "-" = "actions.parent";
+            "_" = "actions.open_cwd";
+            "`" = "actions.cd";
+            "~" = "actions.tcd";
+            "gs" = "actions.change_sort";
+            "gx" = "actions.open_external";
+            "g." = "actions.toggle_hidden";
+            "g\\" = "actions.toggle_trash";
+          }
           ''
             Keymaps in oil buffer.
             Can be any value that `vim.keymap.set` accepts OR a table of keymap options with a
@@ -347,7 +345,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             See `:help oil-actions` for a list of all available actions.
           '';
 
-      keymaps_help = helpers.defaultNullOpts.mkAttrsOf types.anything ''{border = "rounded";}'' ''
+      keymaps_help = helpers.defaultNullOpts.mkAttrsOf types.anything { border = "rounded"; } ''
         Configuration for the floating keymaps help window.
       '';
 
@@ -379,12 +377,16 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
         sort =
           helpers.defaultNullOpts.mkListOf (with types; listOf str)
-            ''
+            [
               [
-                ["type" "asc"]
-                ["name" "asc"]
+                "type"
+                "asc"
               ]
-            ''
+              [
+                "name"
+                "asc"
+              ]
+            ]
             ''
               Sort order can be "asc" or "desc".
               See `:help oil-columns` to see which columns are sortable.
@@ -418,33 +420,45 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       };
 
       preview = {
-        max_width = helpers.defaultNullOpts.mkNullable dimensionType "0.9" ''
+        max_width = helpers.defaultNullOpts.mkNullable dimensionType 0.9 ''
           Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
           Can be a single value or a list of mixed integer/float types.
           `max_width = [100 0.8]` means "the lesser of 100 columns or 80% of total".
         '';
 
-        min_width = helpers.defaultNullOpts.mkNullable dimensionType "[40 0.4]" ''
-          Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
-          Can be a single value or a list of mixed integer/float types.
-          `min_width = [40 0.4]` means "the greater of 40 columns or 40% of total".
-        '';
+        min_width =
+          helpers.defaultNullOpts.mkNullable dimensionType
+            [
+              40
+              0.4
+            ]
+            ''
+              Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
+              Can be a single value or a list of mixed integer/float types.
+              `min_width = [40 0.4]` means "the greater of 40 columns or 40% of total".
+            '';
 
         width = helpers.mkNullOrOption (
           with types; either int (numbers.between 0.0 1.0)
         ) "Optionally define an integer/float for the exact width of the preview window.";
 
-        max_height = helpers.defaultNullOpts.mkNullable dimensionType "0.9" ''
+        max_height = helpers.defaultNullOpts.mkNullable dimensionType 0.9 ''
           Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
           Can be a single value or a list of mixed integer/float types.
           `max_height = [80 0.9]` means "the lesser of 80 columns or 90% of total".
         '';
 
-        min_height = helpers.defaultNullOpts.mkNullable dimensionType "[5 0.1]" ''
-          Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
-          Can be a single value or a list of mixed integer/float types.
-          `min_height = [5 0.1]` means "the greater of 5 columns or 10% of total".
-        '';
+        min_height =
+          helpers.defaultNullOpts.mkNullable dimensionType
+            [
+              5
+              0.1
+            ]
+            ''
+              Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
+              Can be a single value or a list of mixed integer/float types.
+              `min_height = [5 0.1]` means "the greater of 5 columns or 10% of total".
+            '';
 
         height = helpers.mkNullOrOption (
           with types; either int (numbers.between 0.0 1.0)
@@ -462,33 +476,45 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       };
 
       progress = {
-        max_width = helpers.defaultNullOpts.mkNullable dimensionType "0.9" ''
+        max_width = helpers.defaultNullOpts.mkNullable dimensionType 0.9 ''
           Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
           Can be a single value or a list of mixed integer/float types.
           `max_width = [100 0.8]` means "the lesser of 100 columns or 80% of total".
         '';
 
-        min_width = helpers.defaultNullOpts.mkNullable dimensionType "[40 0.4]" ''
-          Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
-          Can be a single value or a list of mixed integer/float types.
-          `min_width = [40 0.4]` means "the greater of 40 columns or 40% of total".
-        '';
+        min_width =
+          helpers.defaultNullOpts.mkNullable dimensionType
+            [
+              40
+              0.4
+            ]
+            ''
+              Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
+              Can be a single value or a list of mixed integer/float types.
+              `min_width = [40 0.4]` means "the greater of 40 columns or 40% of total".
+            '';
 
         width = helpers.mkNullOrOption (
           with types; either int (numbers.between 0.0 1.0)
         ) "Optionally define an integer/float for the exact width of the preview window.";
 
-        max_height = helpers.defaultNullOpts.mkNullable dimensionType "0.9" ''
+        max_height = helpers.defaultNullOpts.mkNullable dimensionType 0.9 ''
           Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
           Can be a single value or a list of mixed integer/float types.
           `max_height = [80 0.9]` means "the lesser of 80 columns or 90% of total".
         '';
 
-        min_height = helpers.defaultNullOpts.mkNullable dimensionType "[5 0.1]" ''
-          Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
-          Can be a single value or a list of mixed integer/float types.
-          `min_height = [5 0.1]` means "the greater of 5 columns or 10% of total".
-        '';
+        min_height =
+          helpers.defaultNullOpts.mkNullable dimensionType
+            [
+              5
+              0.1
+            ]
+            ''
+              Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%).
+              Can be a single value or a list of mixed integer/float types.
+              `min_height = [5 0.1]` means "the greater of 5 columns or 10% of total".
+            '';
 
         height = helpers.mkNullOrOption (
           with types; either int (numbers.between 0.0 1.0)

--- a/plugins/utils/ollama.nix
+++ b/plugins/utils/ollama.nix
@@ -178,7 +178,7 @@ in
         The command to use to start the ollama server.
       '';
 
-      args = helpers.defaultNullOpts.mkListOf types.str ''["serve"]'' ''
+      args = helpers.defaultNullOpts.mkListOf types.str [ "serve" ] ''
         The arguments to pass to the serve command.
       '';
 
@@ -186,9 +186,15 @@ in
         The command to use to stop the ollama server.
       '';
 
-      stopArgs = helpers.defaultNullOpts.mkListOf types.str ''["-SIGTERM" "ollama"]'' ''
-        The arguments to pass to the stop command.
-      '';
+      stopArgs =
+        helpers.defaultNullOpts.mkListOf types.str
+          [
+            "-SIGTERM"
+            "ollama"
+          ]
+          ''
+            The arguments to pass to the stop command.
+          '';
     };
   };
 

--- a/plugins/utils/persistence.nix
+++ b/plugins/utils/persistence.nix
@@ -12,10 +12,9 @@ with lib;
 
     package = helpers.mkPluginPackageOption "persistence.nvim" pkgs.vimPlugins.persistence-nvim;
 
-    dir =
-      helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-        ''vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/")''
-        "directory where session files are saved";
+    dir = helpers.defaultNullOpts.mkStr {
+      __raw = ''vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/")'';
+    } "directory where session files are saved";
 
     options =
       let
@@ -38,9 +37,13 @@ with lib;
           "winsize"
         ];
       in
-      helpers.defaultNullOpts.mkNullable (
-        with types; listOf (enum sessionOpts)
-      ) ''["buffers" "curdir" "tabpages" "winsize" "skiprtp"]'' "sessionoptions used for saving";
+      helpers.defaultNullOpts.mkListOf (types.enum sessionOpts) [
+        "buffers"
+        "curdir"
+        "tabpages"
+        "winsize"
+        "skiprtp"
+      ] "sessionoptions used for saving";
 
     preSave = helpers.defaultNullOpts.mkLuaFn "nil" "a function to call before saving the session";
 

--- a/plugins/utils/presence-nvim.nix
+++ b/plugins/utils/presence-nvim.nix
@@ -27,12 +27,11 @@ in
       '';
 
       mainImage =
-        helpers.defaultNullOpts.mkEnum
+        helpers.defaultNullOpts.mkEnumFirstDefault
           [
             "neovim"
             "file"
           ]
-          "neovim"
           ''
             Main image display.
           '';
@@ -63,24 +62,20 @@ in
         Displays the current line number instead of the current project.
       '';
 
-      blacklist = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" ''
+      blacklist = helpers.defaultNullOpts.mkListOf types.str [ ] ''
         A list of strings or Lua patterns that disable Rich Presence if the
         current file name, path, or workspace matches.
       '';
 
       buttons =
-        helpers.defaultNullOpts.mkNullable
-          (types.either helpers.nixvimTypes.rawLua (
-            types.listOf (
-              types.submodule {
-                options = {
-                  label = helpers.mkNullOrOption types.str "";
-                  url = helpers.mkNullOrOption types.str "";
-                };
-              }
-            )
-          ))
-          "[]"
+        helpers.defaultNullOpts.mkListOf
+          (types.submodule {
+            options = {
+              label = helpers.mkNullOrOption types.str "";
+              url = helpers.mkNullOrOption types.str "";
+            };
+          })
+          [ ]
           ''
             Button configurations which will always appear in Rich Presence.
 

--- a/plugins/utils/project-nvim.nix
+++ b/plugins/utils/project-nvim.nix
@@ -38,7 +38,11 @@ in
     '';
 
     detectionMethods =
-      helpers.defaultNullOpts.mkNullable (with types; listOf str) ''["lsp" "pattern"]''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "lsp"
+          "pattern"
+        ]
         ''
           Methods of detecting the root directory.
           **"lsp"** uses the native neovim lsp, while **"pattern"** uses vim-rooter like glob pattern
@@ -48,19 +52,27 @@ in
         '';
 
     patterns =
-      helpers.defaultNullOpts.mkNullable (with types; listOf str)
-        ''[".git" "_darcs" ".hg" ".bzr" ".svn" "Makefile" "package.json"]''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          ".git"
+          "_darcs"
+          ".hg"
+          ".bzr"
+          ".svn"
+          "Makefile"
+          "package.json"
+        ]
         ''
           All the patterns used to detect root dir, when **"pattern"** is in `detectionMethods`.
         '';
 
-    ignoreLsp = helpers.defaultNullOpts.mkNullable (
-      with types; listOf str
-    ) "[]" "Table of lsp clients to ignore by name.";
+    ignoreLsp =
+      helpers.defaultNullOpts.mkListOf types.str [ ]
+        "Table of lsp clients to ignore by name.";
 
-    excludeDirs = helpers.defaultNullOpts.mkNullable (
-      with types; listOf str
-    ) "[]" "Don't calculate root dir on specific directories.";
+    excludeDirs =
+      helpers.defaultNullOpts.mkListOf types.str [ ]
+        "Don't calculate root dir on specific directories.";
 
     showHidden = helpers.defaultNullOpts.mkBool false "Show hidden files in telescope.";
 
@@ -79,14 +91,11 @@ in
           What scope to change the directory.
         '';
 
-    dataPath =
-      helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-        ''{__raw = "vim.fn.stdpath('data')";}''
-        "Path where project.nvim will store the project history for use in telescope.";
+    dataPath = helpers.defaultNullOpts.mkStr {
+      __raw = "vim.fn.stdpath('data')";
+    } "Path where project.nvim will store the project history for use in telescope.";
 
-    enableTelescope = mkEnableOption ''
-      When set to true, enabled project-nvim telescope integration.
-    '';
+    enableTelescope = mkEnableOption "project-nvim telescope integration";
   };
 
   config = mkIf cfg.enable {

--- a/plugins/utils/refactoring.nix
+++ b/plugins/utils/refactoring.nix
@@ -43,17 +43,15 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   settingsOptions = with helpers.nixvimTypes; {
     prompt_func_return_type =
       helpers.defaultNullOpts.mkAttrsOf bool
-        ''
-          {
-            go = false;
-            java = false;
-            cpp = false;
-            c = false;
-            h = false;
-            hpp = false;
-            cxx = false;
-          }
-        ''
+        {
+          go = false;
+          java = false;
+          cpp = false;
+          c = false;
+          h = false;
+          hpp = false;
+          cxx = false;
+        }
         ''
           For certain languages like Golang, types are required for functions that return an object(s).
           Unfortunately, for some functions there is no way to automatically find their type. In those instances,
@@ -74,17 +72,15 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
     prompt_func_param_type =
       helpers.defaultNullOpts.mkAttrsOf bool
-        ''
-          {
-            go = false;
-            java = false;
-            cpp = false;
-            c = false;
-            h = false;
-            hpp = false;
-            cxx = false;
-          }
-        ''
+        {
+          go = false;
+          java = false;
+          cpp = false;
+          c = false;
+          h = false;
+          hpp = false;
+          cxx = false;
+        }
         ''
           For certain languages like Golang, types are required for functions parameters.
           Unfortunately, for some parameters there is no way to automatically find their type. In those instances,
@@ -102,7 +98,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             }
         '';
 
-    printf_statements = helpers.defaultNullOpts.mkAttrsOf (listOf (maybeRaw str)) "{ }" ''
+    printf_statements = helpers.defaultNullOpts.mkAttrsOf (listOf (maybeRaw str)) { } ''
       In any custom printf statement, it is possible to optionally add a **max of one `%s` pattern**, which is where the debug path will go.
       For an example custom printf statement, go to [this folder][folder], select your language, and click on `multiple-statements/printf.config`.
 
@@ -121,7 +117,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       [folder]: https://github.com/ThePrimeagen/refactoring.nvim/blob/master/lua/refactoring/tests/debug/printf
     '';
 
-    print_var_statements = helpers.defaultNullOpts.mkAttrsOf (listOf (maybeRaw str)) "{ }" ''
+    print_var_statements = helpers.defaultNullOpts.mkAttrsOf (listOf (maybeRaw str)) { } ''
       In any custom print var statement, it is possible to optionally add a **max of two `%s` patterns**, which is where the debug path and
       the actual variable reference will go, respectively. To add a literal `"%s"` to the string, escape the sequence like this: `%%s`.
       For an example custom print var statement, go to [this folder][folder], select your language, and view `multiple-statements/print_var.config`.
@@ -141,7 +137,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       [folder]: https://github.com/ThePrimeagen/refactoring.nvim/blob/master/lua/refactoring/tests/debug/print_var
     '';
 
-    extract_var_statements = helpers.defaultNullOpts.mkAttrsOf str "{ }" ''
+    extract_var_statements = helpers.defaultNullOpts.mkAttrsOf str { } ''
       When performing an `extract_var` refactor operation, you can custom how the new variable would be declared by setting configuration
       like the below example.
 

--- a/plugins/utils/rest.nix
+++ b/plugins/utils/rest.nix
@@ -287,18 +287,16 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             Whether to enable statistics or not.
           '';
 
-          stats = helpers.defaultNullOpts.mkListOf (with types; attrsOf str) ''
-            [
-              {
-                __unkeyed = "total_time";
-                title = "Time taken:";
-              }
-              {
-                __unkeyed = "size_download_t";
-                title = "Download size:";
-              }
-            ]
-          '' "See https://curl.se/libcurl/c/curl_easy_getinfo.html.";
+          stats = helpers.defaultNullOpts.mkListOf (with types; attrsOf str) [
+            {
+              __unkeyed = "total_time";
+              title = "Time taken:";
+            }
+            {
+              __unkeyed = "size_download_t";
+              title = "Download size:";
+            }
+          ] "See https://curl.se/libcurl/c/curl_easy_getinfo.html.";
         };
 
         formatters = {
@@ -306,29 +304,27 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             JSON formatter.
           '';
 
-          html = helpers.defaultNullOpts.mkStr ''
-            {
-              __raw = \'\'
-                function(body)
-                  if vim.fn.executable("tidy") == 0 then
-                    return body, { found = false, name = "tidy" }
-                  end
-                  local fmt_body = vim.fn.system({
-                    "tidy",
-                    "-i",
-                    "-q",
-                    "--tidy-mark",      "no",
-                    "--show-body-only", "auto",
-                    "--show-errors",    "0",
-                    "--show-warnings",  "0",
-                    "-",
-                  }, body):gsub("\n$", "")
-
-                  return fmt_body, { found = true, name = "tidy" }
+          html = helpers.defaultNullOpts.mkStr {
+            __raw = ''
+              function(body)
+                if vim.fn.executable("tidy") == 0 then
+                  return body, { found = false, name = "tidy" }
                 end
-              \'\';
-            }
-          '' "HTML formatter.";
+                local fmt_body = vim.fn.system({
+                  "tidy",
+                  "-i",
+                  "-q",
+                  "--tidy-mark",      "no",
+                  "--show-body-only", "auto",
+                  "--show-errors",    "0",
+                  "--show-warnings",  "0",
+                  "-",
+                }, body):gsub("\n$", "")
+
+                return fmt_body, { found = true, name = "tidy" }
+              end
+            '';
+          } "HTML formatter.";
         };
       };
 
@@ -359,20 +355,18 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
     keybinds =
       helpers.defaultNullOpts.mkListOf (with types; listOf str)
-        ''
+        [
           [
-            [
-              "<localleader>rr"
-              "<cmd>Rest run<cr>"
-              "Run request under the cursor"
-            ]
-            [
-              "<localleader>rl"
-              "<cmd>Rest run last<cr>"
-              "Re-run latest request"
-            ]
+            "<localleader>rr"
+            "<cmd>Rest run<cr>"
+            "Run request under the cursor"
           ]
-        ''
+          [
+            "<localleader>rl"
+            "<cmd>Rest run last<cr>"
+            "Re-run latest request"
+          ]
+        ]
         ''
           Declare some keybindings.
           Format: list of 3 strings lists: key, action and description.

--- a/plugins/utils/spectre.nix
+++ b/plugins/utils/spectre.nix
@@ -36,7 +36,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
                   description = "Executable to run.";
                 };
 
-                args = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+                args = helpers.defaultNullOpts.mkListOf types.str [ ] ''
                   List of arguments to provide to the engine.
                 '';
 
@@ -58,7 +58,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
                       The description for this option.
                     '';
                   };
-                }) "{}" "The options for this engine.";
+                }) { } "The options for this engine.";
               };
             })
           )
@@ -93,17 +93,15 @@ helpers.neovim-plugin.mkNeovimPlugin config {
 
       line_sep = helpers.defaultNullOpts.mkStr "└──────────────────────────────────────────────────────" "Line separator.";
 
-      highlight = helpers.defaultNullOpts.mkAttrsOf types.str ''
-        {
-          headers = "SpectreHeader";
-          ui = "SpectreBody";
-          filename = "SpectreFile";
-          filedirectory = "SpectreDir";
-          search = "SpectreSearch";
-          border = "SpectreBorder";
-          replace = "SpectreReplace";
-        }
-      '' "Highlight groups.";
+      highlight = helpers.defaultNullOpts.mkAttrsOf types.str {
+        headers = "SpectreHeader";
+        ui = "SpectreBody";
+        filename = "SpectreFile";
+        filedirectory = "SpectreDir";
+        search = "SpectreSearch";
+        border = "SpectreBorder";
+        replace = "SpectreReplace";
+      } "Highlight groups.";
 
       mapping =
         helpers.mkNullOrOption
@@ -144,7 +142,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             Which find engine to use. Pick one from the `find_engine` list.
           '';
 
-          options = helpers.defaultNullOpts.mkListOf types.str ''["ignore-case"]'' ''
+          options = helpers.defaultNullOpts.mkListOf types.str [ "ignore-case" ] ''
             Options to use for this engine.
           '';
         };
@@ -154,7 +152,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
             Which find engine to use. Pick one from the `replace_engine` list.
           '';
 
-          options = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+          options = helpers.defaultNullOpts.mkListOf types.str [ ] ''
             Options to use for this engine.
           '';
         };

--- a/plugins/utils/startify/options.nix
+++ b/plugins/utils/startify/options.nix
@@ -74,7 +74,7 @@ with lib;
           attrs
         ]
       )
-      "[]"
+      [ ]
       ''
         A list of files or directories to bookmark.
         The list can contain two kinds of types.
@@ -91,7 +91,7 @@ with lib;
           (listOf str)
         ]
       )
-      "[]"
+      [ ]
       ''
         A list of commands to execute on selection.
         Leading colons are optional.
@@ -132,7 +132,7 @@ with lib;
     NOTE: This option is affected by `session_delete_buffers`.
   '';
 
-  session_before_save = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+  session_before_save = helpers.defaultNullOpts.mkListOf types.str [ ] ''
     This is a list of commands to be executed before saving a session.
 
     Example: `["silent! tabdo NERDTreeClose"]`
@@ -181,7 +181,7 @@ with lib;
     Affects `change_to_dir` and `change_to_vcs_root`.
   '';
 
-  skiplist = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+  skiplist = helpers.defaultNullOpts.mkListOf types.str [ ] ''
     A list of Vim regular expressions that is used to filter recently used files.
     See `|pattern.txt|` for what patterns can be used.
 
@@ -227,7 +227,7 @@ with lib;
     The number of spaces used for left padding.
   '';
 
-  skiplist_server = helpers.defaultNullOpts.mkListOf (with helpers.nixvimTypes; maybeRaw str) "[]" ''
+  skiplist_server = helpers.defaultNullOpts.mkListOf (with helpers.nixvimTypes; maybeRaw str) [ ] ''
     Do not create the startify buffer, if this is a Vim server instance with a name contained in
     this list.
 
@@ -255,7 +255,7 @@ with lib;
     - don't filter through the bookmark list
   '';
 
-  session_remove_lines = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+  session_remove_lines = helpers.defaultNullOpts.mkListOf types.str [ ] ''
     Lines matching any of the patterns in this list, will be removed from the session file.
 
     Example:
@@ -272,7 +272,7 @@ with lib;
     probably get problems when trying to load it.
   '';
 
-  session_savevars = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+  session_savevars = helpers.defaultNullOpts.mkListOf types.str [ ] ''
     Include a list of variables in here which you would like Startify to save into the session file
     in addition to what Vim normally saves into the session file.
 
@@ -286,7 +286,7 @@ with lib;
     ```
   '';
 
-  session_savecmds = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+  session_savecmds = helpers.defaultNullOpts.mkListOf types.str [ ] ''
     Include a list of cmdline commands which Vim will run upon loading the session.
 
     Example:
@@ -307,59 +307,69 @@ with lib;
     alphabetically.
   '';
 
-  custom_indices =
-    helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; maybeRaw (listOf str)) "[]"
-      ''
-        Use any list of strings as indices instead of increasing numbers. If there are more startify
-        entries than actual items in the custom list, the remaining entries will be filled using the
-        default numbering scheme starting from 0.
+  custom_indices = helpers.defaultNullOpts.mkListOf' {
+    type = types.str;
+    pluginDefault = [ ];
+    description = ''
+      Use any list of strings as indices instead of increasing numbers. If there are more startify
+      entries than actual items in the custom list, the remaining entries will be filled using the
+      default numbering scheme starting from 0.
 
-        Thus you can create your own indexing scheme that fits your keyboard layout.
-        You don't want to leave the home row, do you?!
+      Thus you can create your own indexing scheme that fits your keyboard layout.
+      You don't want to leave the home row, do you?!
+    '';
+    example = [
+      "f"
+      "g"
+      "h"
+    ];
+  };
 
-        Example:
-        ```nix
-          ["f" "g" "h"]
-        ```
-      '';
+  custom_header = helpers.defaultNullOpts.mkListOf' {
+    type = types.str;
+    description = ''
+      Define your own header.
 
-  custom_header =
-    helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (listOf (maybeRaw str)))
-      ''
-        Define your own header.
+      This option takes a `list of strings`, whereas each string will be put on its own line.
+      If it is a simple `string`, it should evaluate to a list of strings.
+    '';
+    example = [
+      ""
+      "     ███╗   ██╗██╗██╗  ██╗██╗   ██╗██╗███╗   ███╗"
+      "     ████╗  ██║██║╚██╗██╔╝██║   ██║██║████╗ ████║"
+      "     ██╔██╗ ██║██║ ╚███╔╝ ██║   ██║██║██╔████╔██║"
+      "     ██║╚██╗██║██║ ██╔██╗ ╚██╗ ██╔╝██║██║╚██╔╝██║"
+      "     ██║ ╚████║██║██╔╝ ██╗ ╚████╔╝ ██║██║ ╚═╝ ██║"
+      "     ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝  ╚═══╝  ╚═╝╚═╝     ╚═╝"
+    ];
+  };
 
-        This option takes a `list of strings`, whereas each string will be put on its own line.
-        If it is a simple `string`, it should evaluate to a list of strings.
+  custom_header_quotes = helpers.defaultNullOpts.mkListOf' {
+    type = with types; listOf str;
+    pluginDefault = [ ];
+    description = ''
+      If you don't set `custom_header`, the internal cowsay implementation with
+      predefined random quotes will be used.
 
-        Example:
-        ```nix
-          [
-            ""
-            "     ███╗   ██╗██╗██╗  ██╗██╗   ██╗██╗███╗   ███╗"
-            "     ████╗  ██║██║╚██╗██╔╝██║   ██║██║████╗ ████║"
-            "     ██╔██╗ ██║██║ ╚███╔╝ ██║   ██║██║██╔████╔██║"
-            "     ██║╚██╗██║██║ ██╔██╗ ╚██╗ ██╔╝██║██║╚██╔╝██║"
-            "     ██║ ╚████║██║██╔╝ ██╗ ╚████╔╝ ██║██║ ╚═╝ ██║"
-            "     ╚═╝  ╚═══╝╚═╝╚═╝  ╚═╝  ╚═══╝  ╚═╝╚═╝     ╚═╝"
-          ]
-        ```
-      '';
-
-  custom_header_quotes = helpers.defaultNullOpts.mkListOf (with types; listOf str) "[]" ''
-    Example:
-    ```nix
+      To use your own quotes, set this option to a list of quotes. Each quote is
+      either another list or a `|Funcref|` (see `|expr-lambda|`) that returns a list.
+    '';
+    example = [
+      [ "quote #1" ]
       [
-        ["quote #1"]
-        ["quote #2" "using" "three lines"]
+        "quote #2"
+        "using"
+        "three lines"
       ]
-    ```
-  '';
+    ];
+  };
 
-  custom_footer =
-    helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (listOf (maybeRaw str)))
-      ''
-        Same as the custom header, but shown at the bottom of the startify buffer.
-      '';
+  custom_footer = helpers.defaultNullOpts.mkListOf' {
+    type = types.str;
+    description = ''
+      Same as the custom header, but shown at the bottom of the startify buffer.
+    '';
+  };
 
   disable_at_vimenter = helpers.defaultNullOpts.mkBool false ''
     Don't run Startify at Vim startup.

--- a/plugins/utils/startup.nix
+++ b/plugins/utils/startup.nix
@@ -65,7 +65,7 @@ in
               '';
 
               margin =
-                helpers.defaultNullOpts.mkNullable (with types; either (numbers.between 0.0 1.0) ints.positive) "5"
+                helpers.defaultNullOpts.mkNullable (with types; either (numbers.between 0.0 1.0) ints.positive) 5
                   ''
                     The margin for left or right alignment.
                     - if < 1 fraction of screen width
@@ -179,8 +179,7 @@ in
       '';
 
       cursorColumn =
-        helpers.defaultNullOpts.mkNullable (with types; either (numbers.between 0.0 1.0) ints.positive)
-          "0.5"
+        helpers.defaultNullOpts.mkNullable (with types; either (numbers.between 0.0 1.0) ints.positive) 0.5
           ''
             - if < 1, fraction of screen width
             - if > 1 numbers of column
@@ -198,7 +197,7 @@ in
         Disable status-, buffer- and tablines.
       '';
 
-      paddings = helpers.defaultNullOpts.mkNullable (with types; listOf ints.unsigned) "[]" ''
+      paddings = helpers.defaultNullOpts.mkListOf types.ints.unsigned [ ] ''
         Amount of empty lines before each section (must be equal to amount of sections).
       '';
     };

--- a/plugins/utils/toggleterm.nix
+++ b/plugins/utils/toggleterm.nix
@@ -81,7 +81,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   ];
 
   settingsOptions = {
-    size = helpers.defaultNullOpts.mkStrLuaFnOr types.number "12" ''
+    size = helpers.defaultNullOpts.mkStrLuaFnOr types.number 12 ''
       Size of the terminal.
       `size` can be a number or a function.
 
@@ -149,7 +149,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Hide the number column in toggleterm buffers.
     '';
 
-    shade_filetypes = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    shade_filetypes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Shade filetypes.
     '';
 
@@ -158,17 +158,15 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       opened.
     '';
 
-    highlights = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight ''
-      {
-        NormalFloat.link = "Normal";
-        FloatBorder.link = "Normal";
-        StatusLine.gui = "NONE";
-        StatusLineNC = {
-          cterm = "italic";
-          gui = "NONE";
-        };
-      }
-    '' "Highlights which map a highlight group name to an attrs of it's values.";
+    highlights = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight {
+      NormalFloat.link = "Normal";
+      FloatBorder.link = "Normal";
+      StatusLine.gui = "NONE";
+      StatusLineNC = {
+        cterm = "italic";
+        gui = "NONE";
+      };
+    } "Highlights which map a highlight group name to an attrs of it's values.";
 
     shade_terminals = helpers.defaultNullOpts.mkBool true ''
       NOTE: This option takes priority over highlights specified so if you specify Normal
@@ -212,7 +210,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Close the terminal window when the process exits.
     '';
 
-    shell = helpers.defaultNullOpts.mkStr ''{__raw = "vim.o.shell";}'' ''
+    shell = helpers.defaultNullOpts.mkStr { __raw = "vim.o.shell"; } ''
       Change the default shell.
     '';
 

--- a/plugins/utils/trim.nix
+++ b/plugins/utils/trim.nix
@@ -14,7 +14,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   maintainers = [ maintainers.GaetanLepage ];
 
   settingsOptions = {
-    ft_blocklist = helpers.defaultNullOpts.mkListOf types.str "[]" ''
+    ft_blocklist = helpers.defaultNullOpts.mkListOf types.str [ ] ''
       Filetypes to exclude.
     '';
 

--- a/plugins/utils/vim-matchup.nix
+++ b/plugins/utils/vim-matchup.nix
@@ -15,7 +15,7 @@ with lib;
     treesitterIntegration = {
       enable = mkEnableOption "treesitter integration";
       disable =
-        helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]"
+        helpers.defaultNullOpts.mkListOf types.str [ ]
           "Languages for each to disable this module";
 
       disableVirtualText = helpers.defaultNullOpts.mkBool false ''
@@ -66,7 +66,7 @@ with lib;
             This is intended to prevent flickering while scrolling with j and k.
           '';
         };
-      }) ''{method = "status";}'' "Dictionary controlling the behavior with off-screen matches.";
+      }) { method = "status"; } "Dictionary controlling the behavior with off-screen matches.";
 
       stopline = helpers.defaultNullOpts.mkInt 400 ''
         The number of lines to search in either direction while highlighting matches.
@@ -123,9 +123,10 @@ with lib;
     textObj = {
       enable = helpers.defaultNullOpts.mkBool true "Controls text objects";
 
-      linewiseOperators =
-        helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["d" "y"]''
-          "Modify the set of operators which may operate line-wise";
+      linewiseOperators = helpers.defaultNullOpts.mkListOf types.str [
+        "d"
+        "y"
+      ] "Modify the set of operators which may operate line-wise";
     };
 
     enableSurround = helpers.defaultNullOpts.mkBool false "To enable the delete surrounding (ds%) and change surrounding (cs%) maps";
@@ -138,13 +139,12 @@ with lib;
     '';
 
     delimNoSkips =
-      helpers.defaultNullOpts.mkNullable
-        (types.enum [
+      helpers.defaultNullOpts.mkEnumFirstDefault
+        [
           0
           1
           2
-        ])
-        "0"
+        ]
         ''
           To disable matching within strings and comments:
           - 0: matching is enabled within strings and comments

--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -42,12 +42,12 @@ with lib;
       };
     };
 
-    operators = helpers.defaultNullOpts.mkNullable (types.attrsOf types.str) ''{gc = "Comments";}'' ''
+    operators = helpers.defaultNullOpts.mkAttrsOf types.str { gc = "Comments"; } ''
       add operators that will trigger motion and text object completion
       to enable all native operators, set the preset / operators plugin above
     '';
 
-    keyLabels = helpers.defaultNullOpts.mkNullable (types.attrsOf types.str) ''{}'' ''
+    keyLabels = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
       override the label used to display some keys. It doesn't effect WK in any other way.
     '';
 
@@ -92,15 +92,21 @@ with lib;
           "bottom"
           "top"
         ] "";
-        margin =
-          helpers.defaultNullOpts.mkNullable spacingOptions ''{top = 1; right = 0; bottom = 1; left = 0;}''
-            "extra window margin";
-        padding =
-          helpers.defaultNullOpts.mkNullable spacingOptions ''{top = 1; right = 2; bottom = 1; left = 2;}''
-            "extra window padding";
+        margin = helpers.defaultNullOpts.mkNullable spacingOptions {
+          top = 1;
+          right = 0;
+          bottom = 1;
+          left = 0;
+        } "extra window margin";
+        padding = helpers.defaultNullOpts.mkNullable spacingOptions {
+          top = 1;
+          right = 2;
+          bottom = 1;
+          left = 2;
+        } "extra window padding";
         winblend = helpers.defaultNullOpts.mkNullable (types.ints.between 0
           100
-        ) "0" "0 for fully opaque and 100 for fully transparent";
+        ) 0 "0 for fully opaque and 100 for fully transparent";
       };
 
     layout =
@@ -137,38 +143,60 @@ with lib;
 
     ignoreMissing = helpers.defaultNullOpts.mkBool false "enable this to hide mappings for which you didn't specify a label";
 
-    hidden = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''
-      ["<silent>" "<cmd>" "<Cmd>" "<CR>" "^:" "^ " "^call " "^lua "]
-    '' "hide mapping boilerplate";
+    hidden = helpers.defaultNullOpts.mkListOf types.str [
+      "<silent>"
+      "<cmd>"
+      "<Cmd>"
+      "<CR>"
+      "^:"
+      "^ "
+      "^call "
+      "^lua "
+    ] "hide mapping boilerplate";
 
     showHelp = helpers.defaultNullOpts.mkBool true "show a help message in the command line for using WhichKey";
 
     showKeys = helpers.defaultNullOpts.mkBool true "show the currently pressed key and its label as a message in the command line";
 
-    triggers = helpers.defaultNullOpts.mkNullable (types.either (types.enum [ "auto" ]) (
-      types.listOf types.str
-    )) ''"auto"'' "automatically setup triggers, or specify a list manually";
+    triggers = helpers.defaultNullOpts.mkNullable (
+      with types; either (enum [ "auto" ]) (listOf str)
+    ) "auto" "automatically setup triggers, or specify a list manually";
 
     triggersNoWait =
-      helpers.defaultNullOpts.mkNullable (types.listOf types.str)
-        ''["`" "'" "g`" "g'" "\"" "<c-r>" "z="]''
+      helpers.defaultNullOpts.mkListOf types.str
+        [
+          "`"
+          "'"
+          "g`"
+          "g'"
+          "\""
+          "<c-r>"
+          "z="
+        ]
         ''
           list of triggers, where WhichKey should not wait for timeoutlen and show immediately
         '';
 
     triggersBlackList =
-      helpers.defaultNullOpts.mkNullable (types.attrsOf (types.listOf types.str))
-        ''{ i = ["j" "k"]; v = ["j" "k"]}}''
+      helpers.defaultNullOpts.mkAttrsOf (types.listOf types.str)
+        {
+          i = [
+            "j"
+            "k"
+          ];
+          v = [
+            "j"
+            "k"
+          ];
+        }
         ''
           list of mode / prefixes that should never be hooked by WhichKey
           this is mostly relevant for keymaps that start with a native binding
         '';
 
     disable = {
-      buftypes =
-        helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]"
-          "Disabled by default for Telescope";
-      filetypes = helpers.defaultNullOpts.mkNullable (types.listOf types.str) "[]" "";
+      buftypes = helpers.defaultNullOpts.mkListOf types.str [ ] "Disabled by default for Telescope";
+      filetypes = helpers.defaultNullOpts.mkListOf types.str [ ] "";
     };
   };
 

--- a/plugins/utils/wilder.nix
+++ b/plugins/utils/wilder.nix
@@ -76,20 +76,17 @@ in
     '';
 
     modes =
-      helpers.defaultNullOpts.mkNullable
-        (
-          with types;
-          listOf (enum [
-            "/"
-            "?"
-            ":"
-          ])
-        )
-        ''["/" "?"]''
-        ''
-          List of modes which wilderw will be active in.
-          Possible elements: '/', '?' and ':'
-        '';
+      helpers.defaultNullOpts.mkListOf
+        (types.enum [
+          "/"
+          "?"
+          ":"
+        ])
+        [
+          "/"
+          "?"
+        ]
+        "List of modes that wilder will be active in.";
 
     wildcharm =
       helpers.defaultNullOpts.mkNullable (with types; either str (enum [ false ])) "&wildchar"

--- a/plugins/utils/yanky.nix
+++ b/plugins/utils/yanky.nix
@@ -45,9 +45,9 @@ in
             You can change the storage path using `ring.storagePath` option.
           '';
 
-      storagePath = helpers.defaultNullOpts.mkNullable (
-        with types; either str helpers.nixvimTypes.rawLua
-      ) ''{__raw = "vim.fn.stdpath('data') .. '/databases/yanky.db'";}'' "Only for sqlite storage.";
+      storagePath = helpers.defaultNullOpts.mkStr {
+        __raw = "vim.fn.stdpath('data') .. '/databases/yanky.db'";
+      } "Only for sqlite storage.";
 
       syncWithNumberedRegisters = helpers.defaultNullOpts.mkBool true ''
         History can also be synchronized with numbered registers.
@@ -68,7 +68,7 @@ in
             cursor or content changed.
           '';
 
-      ignoreRegisters = helpers.defaultNullOpts.mkNullable (with types; listOf str) ''["_"]'' ''
+      ignoreRegisters = helpers.defaultNullOpts.mkListOf types.str [ "_" ] ''
         Define registers to be ignored.
         By default the black hole register is ignored.
       '';

--- a/plugins/utils/zk.nix
+++ b/plugins/utils/zk.nix
@@ -25,15 +25,18 @@ with lib;
 
     lsp = {
       config = helpers.neovim-plugin.extraOptionsOptions // {
-        cmd = helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["zk" "lsp"]'' "";
+        cmd = helpers.defaultNullOpts.mkListOf types.str [
+          "zk"
+          "lsp"
+        ] "";
         name = helpers.defaultNullOpts.mkStr "zk" "";
       };
 
       autoAttach = {
         enabled = helpers.defaultNullOpts.mkBool true "automatically attach buffers in a zk notebook";
-        filetypes =
-          helpers.defaultNullOpts.mkNullable (types.listOf types.str) ''["markdown"]''
-            "matching the given filetypes";
+        filetypes = helpers.defaultNullOpts.mkListOf types.str [
+          "markdown"
+        ] "matching the given filetypes";
       };
     };
   };


### PR DESCRIPTION
Superseding #1665, this is a subset of the changes there. I've kept this in a separate branch so that there is a record of the other changes that may be nice to have.

I've filtered the diff for changes that directly relate to stringified plugin-defaults and the diff has more than halved in the process. It's still a mammoth diff though; 127 files and around 2k additions _and_ removals...

That said I wasn't able to completely separate the core change from _all_ of the tangential changes, though most of them should be fairly obvious.

The changes are spread over 15 commits, though this was just to allow me to use git bisect to find some issues. I thing they should be squashed into one or two commits before merging.

Merging https://github.com/nix-community/nixvim/pull/1670 first may also (slightly) simplify the diff, at least within `lib/options`.

#### Not covered in this PR:
- Remove `mkDesc` (that's in https://github.com/nix-community/nixvim/pull/1670)
- Remove manually inserted "Plugin default"s (big job)
- Move manually inserted "Examble"s (also pretty big)
- Switch most `mkNullable` uses to `mkNullableWIthRaw`
- Validating _any_ of the touched options are still up to date
- 100% ensuring all stringified defaults are gone.
  It's a very manual process to verify whether each default should or should not be a string.
- Replacing `\'\'` with `'''` where appropriate
- Anything I flagged with a TODO or FIXME

#### Blocked by:
- [x] #1670
- [x] #1710
- [x] #1711
- [x] #1716
- [ ] #1714
