### PR TITLE
plugins/languages/lint: allow irregular linters

### DIFF
--- a/plugins/languages/lint.nix
+++ b/plugins/languages/lint.nix
@@ -247,7 +247,7 @@ in
                 propName: propValue:
                 optionalString (
                   propValue != null
-                ) "__lint.linters.${linter}.${propName} = ${helpers.toLuaObject propValue}"
+                ) ''__lint.linters["${linter}"]["${propName}"] = ${helpers.toLuaObject propValue}''
               ) linterConfig
             ) cfg.linters
           )
@@ -260,7 +260,7 @@ in
             let
               linterConfig' = if isString linterConfig then helpers.mkRaw linterConfig else linterConfig;
             in
-            "__lint.linters.${customLinter} = ${helpers.toLuaObject linterConfig'}"
+            ''__lint.linters["${customLinter}"] = ${helpers.toLuaObject linterConfig'}''
           ) cfg.customLinters
         )
       ));


### PR DESCRIPTION
closes  #1678 

setting `linters.markdownlint-cli.cmd` would genenrate

before:
`linters.markdownlint-cli.cmd` resulting in an error.

after:
`linters["markdownlint-cli"]["cmd"]`