### PR TITLE
plugins/lsp fix: incorrect function call

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -212,7 +212,7 @@ in
       plugins.lsp.onAttach = mkIf cfg.inlayHints ''
         -- LSP Inlay Hints {{{
         if client.server_capabilities.inlayHintProvider and vim.lsp.inlay_hint then
-          vim.lsp.inlay_hint.enable(bufnr, true)
+          vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
         end
         -- }}}
       '';


### PR DESCRIPTION
The new lsp inlay hint option in Nixvim (#1655) wasn't enabling inlay hints, and was producing the following error message (apologies for the poor screenshot, the message dissapears quickly with Noice)

![image](https://github.com/nix-community/nixvim/assets/66882633/e96ef0c0-ffed-450b-8a5d-42a106582414)

The error is caused by an incorrect function call to [`vim.lsp.inlay_hint.enable`](https://github.com/neovim/neovim/blob/72155121006bca884e154e935640054f2e090367/runtime/lua/vim/lsp/inlay_hint.lua#L408). I wasn't sure what to put for the filter parameter (maybe that should be it's own option?), so I just left it as an empty table for the time being. 