### PR TITLE
plugins/none-ls: more compatible `gdtoolkit` fix

### DIFF
--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -121,8 +121,11 @@ let
     erb_format = pkgs.rubyPackages.erb-formatter;
     fish_indent = pkgs.fish;
     format_r = pkgs.R;
-    gdformat = pkgs.gdtoolkit_4;
-    gdlint = pkgs.gdtoolkit_4;
+    # TODO: Added 2024-06-13; remove 2024-09-13
+    # Nixpkgs renamed to _3 & _4 without maintaining an alias
+    # Out of sync lock files could be using either attr name...
+    gdformat = pkgs.gdtoolkit_4 or pkgs.gdtoolkit;
+    gdlint = pkgs.gdtoolkit_4 or pkgs.gdtoolkit;
     gitsigns = pkgs.git;
     gleam_format = pkgs.gleam;
     glslc = pkgs.shaderc;


### PR DESCRIPTION
Nixpkgs renamed to gdtoolkit_3 & _4 without maintaining an alias!
Out of sync lock files could be using either attr name...

I needed this change with my lock file (updated saturday) and the nixvim input overridden to one of my PR feature branches.

Updating my lock file or removing `follows` would fix the issue, of course, but I figured I'd propose a more compatible workaround here.

Ideally, nixpkgs would've kept an alias for the old name (with a trace warning).
