### PR TITLE
docs: render maintainers with github links

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -77,7 +77,7 @@ let
         if info ? file && info ? description && info ? url then
           "# ${lib.last path}\n\n"
           + (lib.optionalString (info.description != null) "${info.description}\n\n")
-          + (lib.optionalString (info.url != null) "**Url:** [${info.url}](${info.url})\n\n")
+          + (lib.optionalString (info.url != null) "**URL:** [${info.url}](${info.url})\n\n")
           + (lib.optionalString (
             maintainers != [ ]
           ) "**Maintainers:** ${lib.concatStringsSep ", " maintainersNames}\n\n")

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -70,7 +70,8 @@ let
         let
           info = optionalAttrs (hasAttrByPath path nixvimInfo) (getAttrFromPath path nixvimInfo);
           maintainers = lib.unique (options.config.meta.maintainers.${info.file} or [ ]);
-          maintainersNames = builtins.map (m: m.name) maintainers;
+          maintainersNames = builtins.map maintToMD maintainers;
+          maintToMD = m: if m ? github then "[${m.name}](https://github.com/${m.github})" else m.name;
         in
         # Make sure this path has a valid info attrset
         if info ? file && info ? description && info ? url then


### PR DESCRIPTION
If a maintainer has their github defined, render their name as a link to their github profile:

![Screenshot from 2024-06-13 05-50-17_cropped](https://github.com/nix-community/nixvim/assets/5046562/5f249c52-386b-4776-b07e-e4ccd6cf1b67)


I snuck in a second commit "capitalize URL" because it is so tiny it'd be a waste of time to review it separately.
