### PR TITLE
plugins/lsp: add nickel-ls

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -303,6 +303,12 @@ let
       serverName = "nginx_language_server";
     }
     {
+      name = "nickel-ls";
+      description = "nls for Nickel";
+      package = pkgs.nls;
+      serverName = "nickel_ls";
+    }
+    {
       name = "nil-ls";
       description = "nil for Nix";
       package = pkgs.nil;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -153,6 +153,7 @@
             marksman.enable = true;
             metals.enable = true;
             nginx-language-server.enable = true;
+            nickel-ls.enable = true;
             nil-ls.enable = true;
             nimls.enable = true;
             nixd.enable = true;


### PR DESCRIPTION
Add `nls`, the official language server for the Nickel language.

https://github.com/tweag/nickel/
