### PR TITLE
plugins/toggleterm: allow lua functions in `float_opts` keys which support them

### DIFF
--- a/plugins/utils/toggleterm.nix
+++ b/plugins/utils/toggleterm.nix
@@ -228,13 +228,27 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         The 'curved' border is a custom border type not natively supported but implemented in this plugin.
       '';
 
-      width = helpers.mkNullOrOption types.ints.unsigned "";
+      width = helpers.defaultNullOpts.mkStrLuaFnOr types.ints.unsigned null ''
+        Width of the floating terminal. Like `size`, `width` can be a number or
+        function which is passed the current terminal.
+      '';
 
-      height = helpers.mkNullOrOption types.ints.unsigned "";
+      height = helpers.defaultNullOpts.mkStrLuaFnOr types.ints.unsigned null ''
+        Height of the floating terminal. Like `size`, `height` can be a number
+        or function which is passed the current terminal.
+      '';
 
-      row = helpers.mkNullOrOption types.ints.unsigned "";
+      row = helpers.defaultNullOpts.mkStrLuaFnOr types.ints.unsigned null ''
+        Start row of the floating terminal. Defaults to the center of the
+        screen. Like `size`, `row` can be a number or function which is passed
+        the current terminal.
+      '';
 
-      col = helpers.mkNullOrOption types.ints.unsigned "";
+      col = helpers.defaultNullOpts.mkStrLuaFnOr types.ints.unsigned null ''
+        Start column of the floating terminal. Defaults to the center of the
+        screen. Like `size`, `col` can be a number or function which is passed
+        the current terminal.
+      '';
 
       winblend = helpers.defaultNullOpts.mkUnsignedInt 0 "";
 

--- a/tests/test-sources/plugins/utils/toggleterm.nix
+++ b/tests/test-sources/plugins/utils/toggleterm.nix
@@ -60,7 +60,11 @@
         auto_scroll = false;
         float_opts = {
           border = "double";
-          width = 30;
+          width = ''
+            function()
+              return math.ceil(vim.o.columns * 0.8)
+            end
+          '';
           height = 30;
           winblend = 5;
           zindex = 20;


### PR DESCRIPTION
Updates the option schema for the `toggleterm` plugin to allow lua functions as values for the `float_opts` options `width`, `height`, `row`, and `col`. These properties are described as being either a number or lua function [in the plugin documentation](https://github.com/akinsho/toggleterm.nvim?tab=readme-ov-file#setup).