### PR TITLE
lib/options: migrate to `pluginDefault` arg-name

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -27,7 +27,7 @@ let
     {
       # plugin default: any value or literal expression
       pluginDefault,
-      # nix option default value, used if `nixDefaultText` is missing
+      # nix option default value, used if `defaultText` is missing
       default ? null,
       # nix option default string or literal expression
       defaultText ? (options.renderOptionValue default) // {

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -151,7 +151,7 @@ rec {
   defaultNullOpts =
     let
       # Ensures that default is null and defaultText is not set
-      convertArgs =
+      processDefaultNullArgs =
         args:
         assert
           args ? default
@@ -165,7 +165,7 @@ rec {
       # TODO: removed 2024-06-14; remove stub 2024-09-01
       mkDesc = abort "mkDesc has been removed. Use the `pluginDefault` argument or `helpers.pluginDefaultText`.";
 
-      mkNullable' = args: mkNullOrOption' (convertArgs args);
+      mkNullable' = args: mkNullOrOption' (processDefaultNullArgs args);
       mkNullable =
         type: pluginDefault: description:
         mkNullable' { inherit type pluginDefault description; };
@@ -176,20 +176,20 @@ rec {
         type: pluginDefault: description:
         mkNullableWithRaw' { inherit type pluginDefault description; };
 
-      mkStrLuaOr' = args: mkNullOrStrLuaOr' (convertArgs args);
+      mkStrLuaOr' = args: mkNullOrStrLuaOr' (processDefaultNullArgs args);
       mkStrLuaOr =
         type: pluginDefault: description:
         mkStrLuaOr' { inherit type pluginDefault description; };
 
-      mkStrLuaFnOr' = args: mkNullOrStrLuaFnOr' (convertArgs args);
+      mkStrLuaFnOr' = args: mkNullOrStrLuaFnOr' (processDefaultNullArgs args);
       mkStrLuaFnOr =
         type: pluginDefault: description:
         mkStrLuaFnOr' { inherit type pluginDefault description; };
 
-      mkLua' = args: mkNullOrLua' (convertArgs args);
+      mkLua' = args: mkNullOrLua' (processDefaultNullArgs args);
       mkLua = pluginDefault: description: mkLua' { inherit pluginDefault description; };
 
-      mkLuaFn' = args: mkNullOrLuaFn' (convertArgs args);
+      mkLuaFn' = args: mkNullOrLuaFn' (processDefaultNullArgs args);
       mkLuaFn = pluginDefault: description: mkLuaFn' { inherit pluginDefault description; };
 
       mkNum' = args: mkNullableWithRaw' (args // { type = types.number; });

--- a/plugins/lsp/language-servers/nil-ls-settings.nix
+++ b/plugins/lsp/language-servers/nil-ls-settings.nix
@@ -6,7 +6,7 @@ with lib;
   formatting = {
     command = helpers.defaultNullOpts.mkListOf' {
       type = types.str;
-      default = null;
+      pluginDefault = null;
       description = ''
         External formatting command, complete with required arguments.
 
@@ -25,7 +25,7 @@ with lib;
 
     excludedFiles = helpers.defaultNullOpts.mkListOf' {
       type = types.str;
-      default = [ ];
+      pluginDefault = [ ];
       description = ''
         Files to exclude from showing diagnostics. Useful for generated files.
 
@@ -38,13 +38,13 @@ with lib;
 
   nix = {
     binary = helpers.defaultNullOpts.mkStr' {
-      default = "nix";
+      pluginDefault = "nix";
       description = "The path to the `nix` binary.";
       example = "/run/current-system/sw/bin/nix";
     };
 
     maxMemoryMB = helpers.defaultNullOpts.mkUnsignedInt' {
-      default = 2560;
+      pluginDefault = 2560;
       example = 1024;
       description = ''
         The heap memory limit in MiB for `nix` evaluation.
@@ -72,7 +72,7 @@ with lib;
       '';
 
       nixpkgsInputName = helpers.defaultNullOpts.mkStr' {
-        default = "nixpkgs";
+        pluginDefault = "nixpkgs";
         example = "nixos";
         description = ''
           The input name of nixpkgs for NixOS options evaluation.

--- a/plugins/lsp/language-servers/nixd-settings.nix
+++ b/plugins/lsp/language-servers/nixd-settings.nix
@@ -14,7 +14,7 @@ with lib;
         See [the source](https://github.com/nix-community/nixd/blob/main/libnixf/include/nixf/Basic/DiagnosticKinds.inc)
         for available diagnostics.
       '';
-      default = [ ];
+      pluginDefault = [ ];
       example = [ "sema-escaping-with" ];
     };
   };


### PR DESCRIPTION
I was expecting this PR to be much bigger. Luckily we only use the `defaultNullOpts` prime variants in a few locations and many of those uses don't actually set a plugin default.

The non-prime variants are only affected internally, because renaming arguments does not change the function signature.

See original discussion here: https://github.com/nix-community/nixvim/pull/1667#discussion_r1632607368