### PR TITLE
lib: make lua types + `mkRaw` helper more accommodating

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -7,7 +7,7 @@
 let
   nixvimBuilders = import ./builders.nix { inherit lib pkgs; };
   nixvimTypes = import ./types.nix { inherit lib nixvimOptions; };
-  nixvimUtils = import ./utils.nix { inherit lib _nixvimTests; };
+  nixvimUtils = import ./utils.nix { inherit lib nixvimTypes _nixvimTests; };
   nixvimOptions = import ./options.nix { inherit lib nixvimTypes nixvimUtils; };
   inherit (import ./to-lua.nix { inherit lib; }) toLuaObject;
 in

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -14,7 +14,7 @@ let
     };
 in
 rec {
-  isRawType = v: lib.isAttrs v && lib.hasAttr "__raw" v && lib.isString v.__raw;
+  isRawType = v: v ? __raw && isString v.__raw;
 
   rawLua = mkOptionType {
     name = "rawLua";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -9,12 +9,13 @@ let
       name = "str";
       inherit description;
       descriptionClass = "noun";
-      check = lib.isString;
+      check = v: isString v || isRawType v;
       merge = lib.options.mergeEqualOption;
     };
+  isRawType = v: v ? __raw && isString v.__raw;
 in
 rec {
-  isRawType = v: v ? __raw && isString v.__raw;
+  inherit isRawType;
 
   rawLua = mkOptionType {
     name = "rawLua";

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -1,4 +1,8 @@
-{ lib, _nixvimTests }:
+{
+  lib,
+  nixvimTypes,
+  _nixvimTests,
+}:
 with lib;
 {
   listToUnkeyedAttrs =
@@ -98,7 +102,16 @@ with lib;
 
   ifNonNull' = x: y: if (x == null) then null else y;
 
-  mkRaw = r: if (isString r && (r != "")) then { __raw = r; } else null;
+  mkRaw =
+    r:
+    if r == null || r == "" then
+      null
+    else if isString r then
+      { __raw = r; }
+    else if nixvimTypes.isRawType r then
+      r
+    else
+      throw "mkRaw: invalid input: ${generators.toPretty { multiline = false; } r}";
 
   wrapDo = string: ''
     do


### PR DESCRIPTION
Motivated by needing to migrate some existing options from maybeRaw types to strLua types, this PR refactors the types and mkRaw to accommodate that use case, plus others.

To be specific:
- strLua types now also accept rawLua
- mkRaw will "pass through" rawLua untouched
- mkRaw now `throw`s when passed a non-null, non-string, non-raw value
  - previously _any_ invalid value resulted in `null`
