### PR TITLE
plugins/flash: switch to mkNeovimPlugin

### DIFF
--- a/tests/test-sources/plugins/utils/flash.nix
+++ b/tests/test-sources/plugins/utils/flash.nix
@@ -8,205 +8,195 @@
     plugins.flash = {
       enable = true;
 
-      labels = "asdfghjklqwertyuiopzxcvbnm";
-      search = {
-        multiWindow = true;
-        forward = true;
-        wrap = true;
-        mode = "exact";
-        incremental = false;
-        exclude = [
-          "notify"
-          "cmp_menu"
-          "noice"
-          "flash_prompt"
-          {
-            __raw = ''
+      settings = {
+        labels = "asdfghjklqwertyuiopzxcvbnm";
+        search = {
+          multi_window = true;
+          forward = true;
+          wrap = true;
+          mode = "exact";
+          incremental = false;
+          exclude = [
+            "notify"
+            "cmp_menu"
+            "noice"
+            "flash_prompt"
+            (helpers.mkRaw ''
               function(win)
                 -- exclude non-focusable windows
                 return not vim.api.nvim_win_get_config(win).focusable
               end
-            '';
-          }
-        ];
-        trigger = "";
-        maxLength = false;
-      };
-      jump = {
-        jumplist = true;
-        pos = "start";
-        history = false;
-        register = false;
-        nohlsearch = false;
-        autojump = false;
-        inclusive = null;
-        offset = null;
-      };
-      label = {
-        uppercase = true;
-        exclude = "";
-        current = true;
-        after = true;
-        before = false;
-        style = "overlay";
-        reuse = "lowercase";
-        distance = true;
-        minPatternLength = 0;
-        rainbow = {
-          enabled = false;
-          shade = 5;
-        };
-        format = ''
-          function(opts)
-            return { { opts.match.label, opts.hl_group } }
-          end
-        '';
-      };
-      highlight = {
-        backdrop = true;
-        matches = true;
-        priority = 5000;
-        groups = {
-          match = "FlashMatch";
-          current = "FlashCurrent";
-          backdrop = "FlashBackdrop";
-          label = "FlashLabel";
-        };
-      };
-      action = null;
-      pattern = "";
-      continue = false;
-      config = null;
-      prompt = {
-        enabled = true;
-        prefix = [
-          [
-            "⚡"
-            "FlashPromptIcon"
-          ]
-        ];
-        winConfig = {
-          relative = "editor";
-          width = 1;
-          height = 1;
-          row = -1;
-          col = 0;
-          zindex = 1000;
-        };
-      };
-      remoteOp = {
-        restore = false;
-        motion = false;
-      };
-      modes = {
-        search = {
-          enabled = true;
-          highlight = {
-            backdrop = false;
-          };
-          jump = {
-            history = true;
-            register = true;
-            nohlsearch = true;
-          };
-          search.automatic = true;
-        };
-        char = {
-          enabled = true;
-          config = ''
-            function(opts)
-              -- autohide flash when in operator-pending mode
-              opts.autohide = vim.fn.mode(true):find("no") and vim.v.operator == "y"
-
-              -- disable jump labels when not enabled, when using a count,
-              -- or when recording/executing registers
-              opts.jump_labels = opts.jump_labels
-                and vim.v.count == 0
-                and vim.fn.reg_executing() == ""
-                and vim.fn.reg_recording() == ""
-
-              -- Show jump labels only in operator-pending mode
-              -- opts.jump_labels = vim.v.count == 0 and vim.fn.mode(true):find("o")
-            end
-          '';
-          autohide = false;
-          jumpLabels = false;
-          multiLine = true;
-          label = {
-            exclude = "hjkliardc";
-          };
-          keys = helpers.listToUnkeyedAttrs [
-            "f"
-            "F"
-            "t"
-            "T"
-            ";"
-            ","
+            '')
           ];
-          charActions = ''
-            function(motion)
-              return {
-                [";"] = "next", -- set to `right` to always go right
-                [","] = "prev", -- set to `left` to always go left
-                -- clever-f style
-                [motion:lower()] = "next",
-                [motion:upper()] = "prev",
-                -- jump2d style: same case goes next, opposite case goes prev
-                -- [motion] = "next",
-                -- [motion:match("%l") and motion:upper() or motion:lower()] = "prev",
-              }
+          trigger = "";
+          max_length = false;
+        };
+        jump = {
+          jumplist = true;
+          pos = "start";
+          history = false;
+          register = false;
+          nohlsearch = false;
+          autojump = false;
+          inclusive = null;
+          offset = null;
+        };
+        label = {
+          uppercase = true;
+          exclude = "";
+          current = true;
+          after = true;
+          before = false;
+          style = "overlay";
+          reuse = "lowercase";
+          distance = true;
+          min_pattern_length = 0;
+          rainbow = {
+            enabled = false;
+            shade = 5;
+          };
+          format = ''
+            function(opts)
+              return { { opts.match.label, opts.hl_group } }
             end
           '';
-          search = {
-            wrap = false;
-          };
-          highlight = {
-            backdrop = true;
-          };
-          jump = {
-            register = false;
+        };
+        highlight = {
+          backdrop = true;
+          matches = true;
+          priority = 5000;
+          groups = {
+            match = "FlashMatch";
+            current = "FlashCurrent";
+            backdrop = "FlashBackdrop";
+            label = "FlashLabel";
           };
         };
-        treesitter = {
-          labels = "abcdefghijklmnopqrstuvwxyz";
-          jump = {
-            pos = "range";
-          };
-          search = {
-            incremental = false;
-          };
-          label = {
-            before = true;
-            after = true;
-            style = "inline";
-          };
-          highlight = {
-            backdrop = false;
-            matches = false;
-          };
-        };
-        treesitterSearch = {
-          jump = {
-            pos = "range";
-          };
-          search = {
-            multiWindow = true;
-            wrap = true;
-            incremental = false;
-          };
-          remoteOp = {
-            restore = true;
-          };
-          label = {
-            before = true;
-            after = true;
-            style = "inline";
+        action = null;
+        pattern = "";
+        continue = false;
+        config = null;
+        prompt = {
+          enabled = true;
+          prefix = [
+            [
+              "⚡"
+              "FlashPromptIcon"
+            ]
+          ];
+          win_config = {
+            relative = "editor";
+            width = 1;
+            height = 1;
+            row = -1;
+            col = 0;
+            zindex = 1000;
           };
         };
-        remote = {
-          remoteOp = {
-            restore = true;
-            motion = true;
+        remote_op = {
+          restore = false;
+          motion = false;
+        };
+        modes = {
+          search = {
+            enabled = false;
+            highlight = {
+              backdrop = false;
+            };
+            jump = {
+              history = true;
+              register = true;
+              nohlsearch = true;
+            };
+            search = {
+              forward.__raw = "vim.fn.getcmdtype() == '/'";
+              mode = "search";
+              incremental.__raw = "vim.go.incsearch";
+            };
+          };
+          char = {
+            enabled = true;
+            config = ''
+              function(opts)
+                -- autohide flash when in operator-pending mode
+                opts.autohide = opts.autohide or (vim.fn.mode(true):find("no") and vim.v.operator == "y")
+
+                -- disable jump labels when not enabled, when using a count,
+                -- or when recording/executing registers
+                opts.jump_labels = opts.jump_labels
+                  and vim.v.count == 0
+                  and vim.fn.reg_executing() == ""
+                  and vim.fn.reg_recording() == ""
+
+                -- Show jump labels only in operator-pending mode
+                -- opts.jump_labels = vim.v.count == 0 and vim.fn.mode(true):find("o")
+              end
+            '';
+            autohide = false;
+            jump_labels = false;
+            multi_line = true;
+            label = {
+              exclude = "hjkliardc";
+            };
+            keys = {
+              __unkeyed-0 = "f";
+              __unkeyed-1 = "F";
+              __unkeyed-2 = "t";
+              __unkeyed-3 = "T";
+              __unkeyed-4 = ";";
+              __unkeyed-5 = ",";
+            };
+            char_actions = ''
+              function(motion)
+                return {
+                  [";"] = "next", -- set to `right` to always go right
+                  [","] = "prev", -- set to `left` to always go left
+                  -- clever-f style
+                  [motion:lower()] = "next",
+                  [motion:upper()] = "prev",
+                  -- jump2d style: same case goes next, opposite case goes prev
+                  -- [motion] = "next",
+                  -- [motion:match("%l") and motion:upper() or motion:lower()] = "prev",
+                }
+              end
+            '';
+            search.wrap = false;
+            highlight.backdrop = true;
+            jump.register = false;
+          };
+          treesitter = {
+            labels = "abcdefghijklmnopqrstuvwxyz";
+            jump.pos = "range";
+            search.incremental = false;
+            label = {
+              before = true;
+              after = true;
+              style = "inline";
+            };
+            highlight = {
+              backdrop = false;
+              matches = false;
+            };
+          };
+          treesitter_search = {
+            jump.pos = "range";
+            search = {
+              multi_window = true;
+              wrap = true;
+              incremental = false;
+            };
+            remote_op.restore = true;
+            label = {
+              before = true;
+              after = true;
+              style = "inline";
+            };
+          };
+          remote = {
+            remote_op = {
+              restore = true;
+              motion = true;
+            };
           };
         };
       };


### PR DESCRIPTION
Prompted by changes in #1674, I've gone ahead and updated https://github.com/folke/flash.nvim to use mkNeovimPlugin and rfc42 settings.

The "modes" use the same options as top-level settings, so I've maintained a similar system to the existing implementation where `mkModeOption` combines all the common settings with any extras.

Rather than documenting mode-specific defaults in the option itself, I pass the defaults through to the sub-options themselves. This makes the docs slightly more accurate.

The `search.automatic` option is removed. If my interpretation of upstream's docs is correct it was never needed?