### PR TITLE
Revert "plugins/neotest/adapters/playwright: temporarily enable telescope when this adapter is used"

### DIFF
--- a/plugins/neotest/adapters.nix
+++ b/plugins/neotest/adapters.nix
@@ -48,10 +48,5 @@ let
     };
 in
 {
-  imports = (mapAttrsToList mkAdapter supportedAdapters) ++ [
-    # TODO: Remove when https://github.com/NixOS/nixpkgs/pull/319314 reaches `nixos-unstable`
-    (mkIf config.plugins.neotest.adapters.playwright.enable {
-      plugins.telescope.enable = mkDefault true;
-    })
-  ];
+  imports = mapAttrsToList mkAdapter supportedAdapters;
 }


### PR DESCRIPTION
The fix has reached `nixos-unstable`.