### PR TITLE
Fix typo in highlights.nix

### DIFF
--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -23,7 +23,7 @@ with lib;
       default = { };
       description = "Define highlight groups to override existing highlight";
       example = ''
-        highlight = {
+        highlightOverride = {
           Comment.fg = "#ff0000";
         };
       '';


### PR DESCRIPTION
Hi. Thanks for the great project! Just submitting a small typo fix for the docs.

The example of highlightOverride didn't use the correct option name.