### PR TITLE
plugins/none-ls: switch to mkNeovimPlugin

### DIFF
--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -2,287 +2,154 @@
   lib,
   helpers,
   config,
+  options,
   pkgs,
   ...
 }:
 with lib;
-let
-  cfg = config.plugins.none-ls;
-in
-{
-  imports = [
-    ./servers.nix
-    (mkRenamedOptionModule
-      [
-        "plugins"
-        "null-ls"
-      ]
-      [
-        "plugins"
-        "none-ls"
-      ]
-    )
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "none-ls";
+  originalName = "none-ls.nvim";
+  luaName = "null-ls";
+  defaultPackage = pkgs.vimPlugins.none-ls-nvim;
+
+  maintainers = [ maintainers.MattSturgeon ];
+
+  # TODO: introduced 2024-06-18, remove after 24.11
+  deprecateExtraOptions = true;
+  optionsRenamedToSettings = [
+    "border"
+    "cmd"
+    "debounce"
+    "debug"
+    "defaultTimeout"
+    "diagnosticConfig"
+    "diagnosticsFormat"
+    "fallbackSeverity"
+    "logLevel"
+    "notifyFormat"
+    "onAttach"
+    "onInit"
+    "onExit"
+    "rootDir"
+    "shouldAttach"
+    "tempDir"
+    "updateInInsert"
   ];
 
-  options.plugins.none-ls = helpers.neovim-plugin.extraOptionsOptions // {
-    enable = mkEnableOption "none-ls";
-
-    package = mkOption {
-      type = types.package;
-      default = pkgs.vimPlugins.none-ls-nvim;
-      description = "Plugin to use for none-ls";
-    };
-
-    enableLspFormat = mkOption {
-      type = types.bool;
-      default = config.plugins.lsp-format.enable;
-      description = ''
-        Automatically enable the `lsp-format` plugin and configure `none-ls` accordingly.
-      '';
-      example = true;
-    };
-
-    border = helpers.defaultNullOpts.mkBorder null "`:NullLsInfo` UI window." ''
-      Uses `NullLsInfoBorder` highlight group (see [Highlight Groups](#highlight-groups)).
-    '';
-
-    cmd = helpers.defaultNullOpts.mkListOf types.str [ "nvim" ] ''
-      Defines the command used to start the null-ls server. If you do not have an
-      `nvim` binary available on your `$PATH`, you should change this to an absolute
-      path to the binary.
-    '';
-
-    debounce = helpers.defaultNullOpts.mkInt 250 ''
-      The `debounce` setting controls the amount of time between the last change to a buffer and the
-      next `textDocument/didChange` notification.
-      These notifications cause null-ls to generate diagnostics, so this setting indirectly controls
-      the rate of diagnostic generation (affected by `update_in_insert`, described below).
-
-      Lowering `debounce` will result in quicker diagnostic refreshes at the cost of running
-      diagnostic sources more frequently, which can affect performance.
-      The default value should be enough to provide near-instantaneous feedback from most sources
-      without unnecessary resource usage.
-    '';
-
-    debug = helpers.defaultNullOpts.mkBool false ''
-      Displays all possible log messages and writes them to the null-ls log, which you
-      can view with the command `:NullLsLog`. This option can slow down Neovim, so
-      it's strongly recommended to disable it for normal use.
-
-      `debug = true` is the same as setting `logLevel` to `"trace"`.
-    '';
-
-    defaultTimeout = helpers.defaultNullOpts.mkInt 5000 ''
-      Sets the amount of time (in milliseconds) after which built-in sources will time out.
-      Note that built-in sources can define their own timeout period and that users can override the
-      timeout period on a per-source basis, too (see [BUILTIN_CONFIG.md](BUILTIN_CONFIG.md)).
-
-      Specifying a timeout with a value less than zero will prevent commands from timing out.
-    '';
-
-    diagnosticConfig = helpers.defaultNullOpts.mkNullable types.attrs null ''
-      Specifies diagnostic display options for null-ls sources, as described in
-      `:help vim.diagnostic.config()`.
-      (null-ls uses separate namespaces for each source, so server-wide configuration will not work
-      as expected.)
-
-      You can also configure `diagnostic_config` per built-in by using the `with` method, described
-      in BUILTIN_CONFIG.md.
-    '';
-
-    diagnosticsFormat = helpers.defaultNullOpts.mkStr "#{m}" ''
-      Sets the default format used for diagnostics. The plugin will replace the following special
-      components with the relevant diagnostic information:
-
-      - `#{m}`: message
-      - `#{s}`: source name (defaults to `null-ls` if not specified)
-      - `#{c}`: code (if available)
-
-      For example, setting `diagnostics_format` to the following:
-
-      ```lua
-      diagnostics_format = "[#{c}] #{m} (#{s})"
-      ```
-
-      Formats diagnostics as follows:
-
-      ```txt
-      [2148] Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. (shellcheck)
-      ```
-
-      You can also configure `diagnostics_format` per built-in by using the `with`
-      method, described in [BUILTIN_CONFIG](BUILTIN_CONFIG.md).
-    '';
-
-    fallbackSeverity = helpers.defaultNullOpts.mkSeverity "error" ''
-      Defines the severity used when a diagnostic source does not explicitly define a severity.
-      See `:help diagnostic-severity` for available values.
-    '';
-
-    logLevel =
-      helpers.defaultNullOpts.mkEnum
-        [
-          "off"
-          "error"
-          "warn"
-          "info"
-          "debug"
-          "trace"
-        ]
-        "warn"
-        ''
-          Enables or disables logging to file.
-
-          Plugin logs messages on several logging levels to following destinations:
-
-          - file, can be inspected by `:NullLsLog`.
-          - neovim's notification area.
-        '';
-
-    notifyFormat = helpers.defaultNullOpts.mkStr "[null-ls] %s" ''
-      Sets the default format for `vim.notify()` messages.
-      Can be used to customize 3rd party notification plugins like
-      [nvim-notify](https://github.com/rcarriga/nvim-notify).
-    '';
-
-    onAttach = helpers.defaultNullOpts.mkStr null ''
-      Defines an `on_attach` callback to run whenever null-ls attaches to a buffer.
-      If you have a common `on_attach` you're using for LSP servers, you can reuse that here, use a
-      custom callback for null-ls, or leave this undefined.
-    '';
-
-    onInit = helpers.defaultNullOpts.mkLuaFn null ''
-      Defines an `on_init` callback to run when null-ls initializes. From here, you
-      can make changes to the client (the first argument) or `initialize_result` (the
-      second argument, which as of now is not used).
-    '';
-
-    onExit = helpers.defaultNullOpts.mkLuaFn null ''
-      Defines an `on_exit` callback to run when the null-ls client exits.
-    '';
-
-    rootDir = helpers.defaultNullOpts.mkLuaFn null ''
-      Determines the root of the null-ls server. On startup, null-ls will call
-      `root_dir` with the full path to the first file that null-ls attaches to.
-
-      ```lua
-      local root_dir = function(fname)
-          return fname:match("my-project") and "my-project-root"
-      end
-      ```
-
-      If `root_dir` returns `nil`, the root will resolve to the current working
-      directory.
-    '';
-
-    shouldAttach = helpers.defaultNullOpts.mkLuaFn null ''
-      A user-defined function that controls whether to enable null-ls for a given
-      buffer. Receives `bufnr` as its first argument.
-
-      To cut down potentially expensive calls, null-ls will call `should_attach` after
-      its own internal checks pass, so it's not guaranteed to run on each new buffer.
-
-      ```lua
-      require("null-ls.nvim").setup({
-          should_attach = function(bufnr)
-              return not vim.api.nvim_buf_get_name(bufnr):match("^git://")
-          end,
-      })
-      ```
-    '';
-
-    tempDir = helpers.defaultNullOpts.mkStr null ''
-      Defines the directory used to create temporary files for sources that rely on them (a
-      workaround used for command-based sources that do not support `stdio`).
-
-      To maximize compatibility, null-ls defaults to creating temp files in the same directory as
-      the parent file.
-      If this is causing issues, you can set it to `/tmp` (or another appropriate directory) here.
-      Otherwise, there is no need to change this setting.
-
-      **Note**: some null-ls built-in sources expect temp files to exist within a project for
-      context and so will not work if this option changes.
-
-      You can also configure `temp_dir` per built-in by using the `with` method, described in
-      BUILTIN_CONFIG.md.
-    '';
-
-    updateInInsert = helpers.defaultNullOpts.mkBool false ''
-      Controls whether diagnostic sources run in insert mode.
-      If set to `false`, diagnostic sources will run upon exiting insert mode, which greatly
-      improves performance but can create a slight delay before diagnostics show up.
-      Set this to `true` if you don't experience performance issues with your sources.
-
-      Note that by default, Neovim will not display updated diagnostics in insert mode.
-      Together with the option above, you need to pass `update_in_insert = true` to
-      `vim.diagnostic.config` for diagnostics to work as expected.
-      See `:help vim.diagnostic.config` for more info.
-    '';
-
-    sourcesItems = helpers.mkNullOrOption (
-      with types; listOf (attrsOf str)
-    ) "The list of sources to enable, should be strings of lua code. Don't use this directly";
-  };
-
-  config = mkIf cfg.enable {
-    warnings = optional (cfg.enableLspFormat && (cfg.onAttach != null)) ''
-      You have enabled the lsp-format integration with none-ls.
-      However, you have provided a custom value to `plugins.none-ls.onAttach`.
-
-      -> The `enableLspFormat` option will thus not be able to add the `require('lsp-format').on_attach` snippet to `none-ls`.
-    '';
-
-    assertions = [
-      {
-        assertion = cfg.enableLspFormat -> config.plugins.lsp-format.enable;
-        message = ''
-          Nixvim: You have enabled the `lsp-format` integration with none-ls.
-          However, you have not enabled the `lsp-format` plugin itself (`plugins.lsp-format.enable = true`).
-        '';
-      }
+  imports =
+    let
+      namespace = "plugins";
+      oldPluginPath = [
+        namespace
+        "null-ls"
+      ];
+      basePluginPath = [
+        namespace
+        "none-ls"
+      ];
+      settingsPath = basePluginPath ++ [ "settings" ];
+    in
+    [
+      ./servers.nix
+      (mkRenamedOptionModule oldPluginPath basePluginPath)
+      (mkRenamedOptionModule (basePluginPath ++ [ "sourcesItems" ]) (settingsPath ++ [ "sources" ]))
     ];
 
-    extraPlugins = [ cfg.package ];
+  settingsExample = {
+    diagnostics_format = "[#{c}] #{m} (#{s})";
+    on_attach = ''
+      function(client, bufnr)
+        -- Integrate lsp-format with none-ls
+        require('lsp-format').on_attach(client, bufnr)
+      end
+    '';
+    on_exit = ''
+      function()
+        print("Goodbye, cruel world!")
+      end
+    '';
+    on_init = ''
+      function(client, initialize_result)
+        print("Hello, world!")
+      end
+    '';
+    root_dir = ''
+      function(fname)
+        return fname:match("my-project") and "my-project-root"
+      end
+    '';
+    root_dir_async = ''
+      function(fname, cb)
+        cb(fname:match("my-project") and "my-project-root")
+      end
+    '';
+    should_attach = ''
+      function(bufnr)
+        return not vim.api.nvim_buf_get_name(bufnr):match("^git://")
+      end
+    '';
+    temp_dir = "/tmp";
+    update_in_insert = false;
+  };
 
-    extraConfigLua =
-      let
-        onAttach' =
-          if (cfg.onAttach == null) && cfg.enableLspFormat then
-            ''
-              require('lsp-format').on_attach
-            ''
-          else
-            cfg.onAttach;
+  settingsOptions = import ./settings.nix { inherit helpers; };
 
-        setupOptions =
-          with cfg;
-          {
-            inherit
-              border
-              cmd
-              debounce
-              debug
-              ;
-            default_timeout = defaultTimeout;
-            diagnostic_config = diagnosticConfig;
-            diagnostics_format = diagnosticsFormat;
-            fallback_severity = fallbackSeverity;
-            log_level = logLevel;
-            notify_format = notifyFormat;
-            on_attach = helpers.mkRaw onAttach';
-            on_init = onInit;
-            on_exit = onExit;
-            root_dir = rootDir;
-            should_attach = shouldAttach;
-            temp_dir = tempDir;
-            update_in_insert = updateInInsert;
+  extraOptions = {
+    enableLspFormat = mkOption {
+      type = types.bool;
+      # TODO: consider default = false and enabling lsp-format automatically instead?
+      default = config.plugins.lsp-format.enable;
+      defaultText = literalExpression "plugins.lsp-format.enable";
+      example = false;
+      description = ''
+        Automatically configure `none-ls` to use the `lsp-format` plugin.
 
-            sources = sourcesItems;
-          }
-          // cfg.extraOptions;
-      in
-      ''
+        Enabled automatically when `plugins.lsp-format` is enabled.
+        Set `false` to disable that behavior.
+      '';
+    };
+  };
+
+  callSetup = false;
+  extraConfig =
+    cfg:
+    let
+      # Set a custom on_attach when enableLspFormat is enabled
+      # FIXME: Using `mkIf (...) (mkDefault "...")` would be better,
+      # but that'd make it difficult to implement the "has no effect" warning.
+      setupOptions =
+        cfg.settings
+        // optionalAttrs (cfg.enableLspFormat && cfg.settings.on_attach == null) {
+          on_attach.__raw = ''
+            require('lsp-format').on_attach
+          '';
+        };
+    in
+    {
+      warnings = optional (cfg.enableLspFormat && cfg.settings.on_attach != null) ''
+        You have enabled the lsp-format integration with none-ls.
+        However, you have provided a custom value to `plugins.none-ls.settings.on_attach`.
+        This means the `enableLspFormat` option will have no effect.
+        Final value is:
+        ${generators.toPretty { } cfg.settings.on_attach}
+      '';
+
+      assertions = [
+        {
+          assertion = cfg.enableLspFormat -> config.plugins.lsp-format.enable;
+          message = ''
+            Nixvim: You have enabled the lsp-format integration with none-ls.
+            However, you have not enabled `plugins.lsp-format` itself.
+            Note: `plugins.none-ls.enableLspFormat` is enabled by default when `plugins.lsp-format` is enabled.
+            `plugins.none-ls.enableLspFormat` definitions: ${lib.options.showDefs options.plugins.none-ls.enableLspFormat.definitionsWithLocations}
+          '';
+        }
+      ];
+
+      # We only do this here because of enableLspFormat
+      extraConfigLua = ''
         require("null-ls").setup(${helpers.toLuaObject setupOptions})
       '';
-  };
+    };
 }

--- a/plugins/none-ls/servers.nix
+++ b/plugins/none-ls/servers.nix
@@ -317,16 +317,18 @@ in
           -> [${concatStringsSep ", " uselesslyDeclaredToolNames}]
         '');
 
-      plugins.none-ls.sourcesItems = builtins.map (
-        source:
-        let
-          sourceItem = "${source.sourceType}.${source.sourceName}";
-          withArgs = if source.withArgs == null then sourceItem else "${sourceItem}.with(${source.withArgs})";
-        in
-        helpers.mkRaw ''
-          require("null-ls").builtins.${withArgs}
-        ''
-      ) enabledSources;
+      plugins.none-ls.settings.sources = mkIf (enabledSources != [ ]) (
+        map (
+          {
+            sourceType,
+            sourceName,
+            withArgs,
+            ...
+          }:
+          "require('null-ls').builtins.${sourceType}.${sourceName}"
+          + optionalString (withArgs != null) ".with(${withArgs})"
+        ) enabledSources
+      );
       plugins.gitsigns.enable = mkIf gitsignsEnabled true;
       extraPackages = map (source: source.package or null) enabledSources;
     };

--- a/plugins/none-ls/settings.nix
+++ b/plugins/none-ls/settings.nix
@@ -1,0 +1,255 @@
+{ helpers }:
+let
+  types = helpers.nixvimTypes;
+  applyListOfLua = x: map (v: if builtins.isString v then helpers.mkRaw v else v) x;
+in
+{
+  border = helpers.defaultNullOpts.mkNullable' {
+    type =
+      with types;
+      oneOf [
+        attrs
+        str
+        rawLua
+      ];
+    pluginDefault = null;
+    description = ''
+      Defines the border to use for the `:NullLsInfo` UI window.
+      Uses `NullLsInfoBorder` highlight group (see [Highlight Groups]).
+      Accepts same border values as `nvim_open_win()`.
+      See `:help nvim_open_win()` for more info.
+
+      [Highlight Groups]: https://github.com/nvimtools/none-ls.nvim/blob/main/doc/CONFIG.md#highlight-groups
+    '';
+  };
+
+  cmd = helpers.defaultNullOpts.mkListOf types.str [ "nvim" ] ''
+    Defines the command used to start the null-ls server.
+    If you do not have an `nvim` binary available on your `$PATH`,
+    you should change this to an absolute path to the binary.
+  '';
+
+  debounce = helpers.defaultNullOpts.mkUnsignedInt 250 ''
+    The `debounce` setting controls the amount of time between the last change to a
+    buffer and the next `textDocument/didChange` notification. These notifications
+    cause null-ls to generate diagnostics, so this setting indirectly controls the
+    rate of diagnostic generation (affected by `update_in_insert`, described below).
+
+    Lowering `debounce` will result in quicker diagnostic refreshes at the cost of running
+    diagnostic sources more frequently, which can affect performance.
+    The default value should be enough to provide near-instantaneous feedback from most sources
+    without unnecessary resource usage.
+  '';
+
+  debug = helpers.defaultNullOpts.mkBool false ''
+    Displays all possible log messages and writes them to the null-ls log, which you
+    can view with the command `:NullLsLog`. This option can slow down Neovim, so
+    it's strongly recommended to disable it for normal use.
+
+    `debug = true` is the same as setting `log_level` to `"trace"`.
+  '';
+
+  default_timeout = helpers.defaultNullOpts.mkUnsignedInt 5000 ''
+    Sets the amount of time (in milliseconds) after which built-in sources will time out.
+    Note that built-in sources can define their own timeout period and that users can override the
+    timeout period on a per-source basis, too
+    (see [BUILTIN_CONFIG.md](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md)).
+
+    Specifying a timeout with a value less than zero will prevent commands from timing out.
+  '';
+
+  diagnostic_config = helpers.defaultNullOpts.mkNullable' {
+    type =
+      with types;
+      oneOf [
+        attrs
+        str
+        rawLua
+      ];
+    pluginDefault = { };
+    description = ''
+      Specifies diagnostic display options for null-ls sources, as described in
+      `:help vim.diagnostic.config()`.
+      (null-ls uses separate namespaces for each source,
+      so server-wide configuration will not work as expected.)
+
+      You can also configure `diagnostic_config` per built-in by using the `with` method, described
+      in [BUILTIN_CONFIG](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md).
+    '';
+  };
+
+  diagnostics_format = helpers.defaultNullOpts.mkStr "#{m}" ''
+    Sets the default format used for diagnostics. The plugin will replace the following special
+    components with the relevant diagnostic information:
+
+    - `#{m}`: message
+    - `#{s}`: source name (defaults to `null-ls` if not specified)
+    - `#{c}`: code (if available)
+
+    For example, setting `diagnostics_format` to the following:
+
+    ```lua
+      diagnostics_format = "[#{c}] #{m} (#{s})"
+    ```
+
+    Formats diagnostics as follows:
+
+    ```txt
+      [2148] Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. (shellcheck)
+    ```
+
+      You can also configure `diagnostics_format` per built-in by using the `with`
+      method, described in [BUILTIN_CONFIG](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md).
+  '';
+
+  fallback_severity =
+    helpers.defaultNullOpts.mkUnsignedInt { __raw = "vim.diagnostic.severity.ERROR"; }
+      ''
+        Defines the severity used when a diagnostic source does not explicitly define a severity.
+        See `:help diagnostic-severity` for available values.
+      '';
+
+  log_level =
+    helpers.defaultNullOpts.mkEnum
+      [
+        "off"
+        "error"
+        "warn"
+        "info"
+        "debug"
+        "trace"
+      ]
+      "warn"
+      ''
+        Enables or disables logging to file.
+
+        Plugin logs messages on several logging levels to following destinations:
+        - file, can be inspected by `:NullLsLog`.
+        - neovim's notification area.
+      '';
+
+  notify_format = helpers.defaultNullOpts.mkStr "[null-ls] %s" ''
+    Sets the default format for `vim.notify()` messages.
+    Can be used to customize 3rd party notification plugins like
+    [nvim-notify](https://github.com/rcarriga/nvim-notify).
+  '';
+
+  on_attach = helpers.defaultNullOpts.mkLuaFn null ''
+    Defines an `on_attach` callback to run whenever null-ls attaches to a buffer.
+    If you have a common `on_attach` you're using for LSP servers, you can reuse that here,
+    use a custom callback for null-ls, or leave this undefined.
+  '';
+
+  on_init = helpers.defaultNullOpts.mkLuaFn null ''
+    Defines an `on_init` callback to run when null-ls initializes.
+    From here, you can make changes to the client (the first argument)
+    or `initialize_result` (the second argument, which as of now is not used).
+  '';
+
+  on_exit = helpers.defaultNullOpts.mkLuaFn null ''
+    Defines an `on_exit` callback to run when the null-ls client exits.
+  '';
+
+  root_dir = helpers.defaultNullOpts.mkLuaFn' {
+    pluginDefault = "require('null-ls.utils').root_pattern('.null-ls-root', 'Makefile', '.git')";
+    description = ''
+      Determines the root of the null-ls server. On startup, null-ls will call
+      `root_dir` with the full path to the first file that null-ls attaches to.
+
+      If `root_dir` returns `nil`, the root will resolve to the current working directory.
+    '';
+    example = ''
+      function(fname)
+        return fname:match("my-project") and "my-project-root"
+      end
+    '';
+  };
+
+  root_dir_async = helpers.defaultNullOpts.mkLuaFn' {
+    pluginDefault = null;
+    description = ''
+      Like `root_dir` but also accepts a callback parameter allowing it to be
+      asynchronous. Overwrites `root_dir` when present.
+
+      For a utility that asynchronously finds a matching file, see `utils.root_pattern_async`.
+    '';
+    example = ''
+      function(fname, cb)
+        cb(fname:match("my-project") and "my-project-root")
+      end
+    '';
+  };
+
+  should_attach = helpers.defaultNullOpts.mkLuaFn' {
+    pluginDefault = null;
+    description = ''
+      A user-defined function that controls whether to enable null-ls for a given
+      buffer. Receives `bufnr` as its first argument.
+
+      To cut down potentially expensive calls, null-ls will call `should_attach` after
+      its own internal checks pass, so it's not guaranteed to run on each new buffer.
+    '';
+    example = ''
+      function(bufnr)
+        return not vim.api.nvim_buf_get_name(bufnr):match("^git://")
+      end
+    '';
+  };
+
+  # Not using mkListOf because I want `strLua` instead of `rawLua`
+  sources = helpers.defaultNullOpts.mkNullable' {
+    # TODO: support custom & third-party sources.
+    # Need a "source" submodule type:
+    # https://github.com/nvimtools/none-ls.nvim/blob/main/doc/MAIN.md#sources
+    type = with types; listOf strLua;
+    apply = x: if x == null then null else applyListOfLua x;
+    pluginDefault = null;
+    description = ''
+      The list of sources to enable, should be strings of lua code. Don't use this directly.
+
+      You should use `plugins.none-ls.sources.*.enable` instead.
+
+      **Upstream's description:**
+
+      Defines a list of sources for null-ls to register.
+      Users can add built-in sources (see [BUILTINS]) or custom sources (see [MAIN]).
+
+      If you've installed an integration that provides its own sources and aren't
+      interested in built-in sources, you don't have to define any sources here. The
+      integration will register them independently.
+
+      [BUILTINS]: https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTINS.md
+      [MAIN]: https://github.com/nvimtools/none-ls.nvim/blob/main/doc/MAIN.md
+    '';
+    # Hide this option until we decide how to handle non-builtin sources:
+    visible = false;
+  };
+
+  temp_dir = helpers.defaultNullOpts.mkStr null ''
+    Defines the directory used to create temporary files for sources that rely on
+    them (a workaround used for command-based sources that do not support `stdio`).
+
+    To maximize compatibility, null-ls defaults to creating temp files in the same
+    directory as the parent file. If this is causing issues, you can set it to
+    `/tmp` (or another appropriate directory) here. Otherwise, there is no need to
+    change this setting.
+
+    **Note**: some null-ls built-in sources expect temp files to exist within a
+    project for context and so will not work if this option changes.
+
+    You can also configure `temp_dir` per built-in by using the `with` method,
+    described in [BUILTIN_CONFIG](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md).
+  '';
+
+  update_in_insert = helpers.defaultNullOpts.mkBool false ''
+    Controls whether diagnostic sources run in insert mode. If set to `false`,
+    diagnostic sources will run upon exiting insert mode, which greatly improves
+    performance but can create a slight delay before diagnostics show up. Set this
+    to `true` if you don't experience performance issues with your sources.
+
+    Note that by default, Neovim will not display updated diagnostics in insert
+    mode. Together with the option above, you need to pass `update_in_insert = true`
+    to `vim.diagnostic.config` for diagnostics to work as expected. See
+    `:help vim.diagnostic.config` for more info.
+  '';
+}

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -21,34 +21,89 @@
       lsp-format.enable = true;
       none-ls = {
         enable = true;
-        enableLspFormat = true;
+        # This is implied:
+        # enableLspFormat = true;
       };
     };
   };
 
-  default = {
+  defaults = {
+    plugins.none-ls = {
+      enable = true;
+
+      settings = {
+        border = null;
+        cmd = [ "nvim" ];
+        debounce = 250;
+        debug = false;
+        default_timeout = 5000;
+        diagnostic_config = { };
+        diagnostics_format = "#{m}";
+        fallback_severity.__raw = "vim.diagnostic.severity.ERROR";
+        log_level = "warn";
+        notify_format = "[null-ls] %s";
+        on_attach = null;
+        on_init = null;
+        on_exit = null;
+        root_dir = "require('null-ls.utils').root_pattern('.null-ls-root', 'Makefile', '.git')";
+        root_dir_async = null;
+        should_attach = null;
+        sources = null;
+        temp_dir = null;
+        update_in_insert = false;
+      };
+    };
+  };
+
+  example = {
+    plugins.none-ls = {
+      enable = true;
+
+      settings = {
+        diagnostics_format = "[#{c}] #{m} (#{s})";
+        on_attach = ''
+          function(client, bufnr)
+            -- Integrate lsp-format with none-ls
+            -- Disabled because plugins.lsp-format is not enabled
+            -- require('lsp-format').on_attach(client, bufnr)
+          end
+        '';
+        on_exit = ''
+          function()
+            print("Goodbye, cruel world!")
+          end
+        '';
+        on_init = ''
+          function(client, initialize_result)
+            print("Hello, world!")
+          end
+        '';
+        root_dir = ''
+          function(fname)
+            return fname:match("my-project") and "my-project-root"
+          end
+        '';
+        root_dir_async = ''
+          function(fname, cb)
+            cb(fname:match("my-project") and "my-project-root")
+          end
+        '';
+        should_attach = ''
+          function(bufnr)
+            return not vim.api.nvim_buf_get_name(bufnr):match("^git://")
+          end
+        '';
+        temp_dir = "/tmp";
+        update_in_insert = false;
+      };
+    };
+  };
+
+  with-sources = {
     plugins.none-ls = {
       # sandbox-exec: pattern serialization length 159032 exceeds maximum (65535)
       enable = !pkgs.stdenv.isDarwin;
 
-      enableLspFormat = false;
-      border = null;
-      cmd = [ "nvim" ];
-      debounce = 250;
-      debug = false;
-      defaultTimeout = 5000;
-      diagnosticConfig = null;
-      diagnosticsFormat = "#{m}";
-      fallbackSeverity = "error";
-      logLevel = "warn";
-      notifyFormat = "[null-ls] %s";
-      onAttach = null;
-      onInit = null;
-      onExit = null;
-      rootDir = null;
-      shouldAttach = null;
-      tempDir = null;
-      updateInInsert = false;
       sources =
         let
           options = nonels-sources-options.options.plugins.none-ls.sources;


### PR DESCRIPTION
Part one refactoring none-ls (#1705): switch the top-level plugin options to use mkNeovimPlugin and rfc42-style settings.

### lsp-format

This PR maintains the existing option `enableLspFormat`, a legacy option that sets none-ls's `on_attach` to `require('lsp-format').on_attach`. There are some issues with this option, but removing or refactoring it is not a focus for this initial PR.

I did update the option description though: fixes #1690.

### `with()` args

The various sources have a `withArgs` option (`plugins.none-ls.sources.*.*.withArgs`), which is a lua-string type. Switching this to rfc42-style settings would be nice, but is not in scope for this PR. ([Upstream docs](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md#configuration), [experimental draft PR](https://github.com/nix-community/nixvim/pull/1724)).

### Non-builtin sources

The `settings.sources` option (previously `sourcesItems`) can list builtin sources, along with custom sources and "third-party" sources. We're currently only considering builtin sources (as listed in `builtins.json`). Properly supporting other sources is not in scope for this PR.