### PR TITLE
plugins/lsp-lines: switch to mkNeovimPlugin

### DIFF
--- a/tests/test-sources/plugins/lsp/lsp-lines.nix
+++ b/tests/test-sources/plugins/lsp/lsp-lines.nix
@@ -2,4 +2,13 @@
   empty = {
     plugins.lsp-lines.enable = true;
   };
+
+  example = {
+    plugins.lsp-lines.enable = true;
+
+    diagnostics.virtual_lines = {
+      only_current_line = true;
+      highlight_whole_line = false;
+    };
+  };
 }


### PR DESCRIPTION
~~It is a neovim plugin, but it has no setup options so use mkVimPlugin.~~

The plugin recommends several defaults and examples for `vim.diagnostic.config`, some of which we've historically set. This PR makes that a little more configurable, closes #1703.

IMO we could probably handle this better by having a `diagnostics` module (similar to `opts`, `keymaps`, etc); a freeform submodule option that gets passed directly to `vim.diagnostic.config()`. Any thoughts on this approach?

If we had a diagnostics module, would we deprecate the `extraOptions` here, or would we just `lib.mkDefault` what we need to and document other examples?
