### PR TITLE
modules/diagnostic: init

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -4,6 +4,7 @@
     ./clipboard.nix
     ./colorscheme.nix
     ./commands.nix
+    ./diagnostic.nix
     ./doc.nix
     ./editorconfig.nix
     ./filetype.nix

--- a/modules/diagnostic.nix
+++ b/modules/diagnostic.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  helpers,
+  config,
+  ...
+}:
+with lib;
+{
+  options = {
+    diagnostics = mkOption {
+      type = with types; attrsOf anything;
+      default = { };
+      description = "The configuration diagnostic options, provided to `vim.diagnostic.config`.";
+      example = {
+        virtual_text = false;
+        virtual_lines.only_current_line = true;
+      };
+    };
+  };
+
+  config = {
+    extraConfigLuaPre = optionalString (config.diagnostics != { }) ''
+      vim.diagnostic.config(${helpers.toLuaObject config.diagnostics})
+    '';
+  };
+}


### PR DESCRIPTION
[`:h vim.diagnostic.config()`](https://neovim.io/doc/user/diagnostic.html#vim.diagnostic.config())

> Configuration can be specified globally, per-namespace, or ephemerally

Maybe we should offer a way to set config per-namespace? Uses the second parameter:
> `{namespace}` `(integer?)` Update the options for the given namespace. When omitted, update the global diagnostic options.