### PR TITLE
plugins/auto-save: switch to mkNeovimPlugin + update options

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -67,4 +67,10 @@
     githubId = 67534814;
     name = "Ben";
   };
+  braindefender = {
+    email = "braindefender@gmail.com";
+    github = "braindefender";
+    githubId = 4646110;
+    name = "Nikita Shirokov";
+  };
 }

--- a/tests/test-sources/plugins/utils/auto-save.nix
+++ b/tests/test-sources/plugins/utils/auto-save.nix
@@ -3,47 +3,61 @@
     plugins.auto-save.enable = true;
   };
 
+  example = {
+    plugins.auto-save = {
+      enable = true;
+
+      settings = {
+        condition = ''
+          function(buf)
+            local fn = vim.fn
+            local utils = require("auto-save.utils.data")
+
+            if utils.not_in(fn.getbufvar(buf, "&filetype"), {'oil'}) then
+              return true
+            end
+            return false
+          end
+        '';
+        write_all_buffers = true;
+        debounce_delay = 1000;
+      };
+    };
+  };
+
   defaults = {
     plugins.auto-save = {
       enable = true;
 
-      keymaps = {
-        silent = true;
-        toggle = "<leader>s";
-      };
-      enableAutoSave = true;
-      executionMessage = {
-        message.__raw = ''
-          function()
-            return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
-          end
-        '';
-        dim = 0.18;
-        cleaningInterval = 1250;
-      };
-      triggerEvents = [
-        "InsertLeave"
-        "TextChanged"
-      ];
-      condition = ''
-        function(buf)
-          local fn = vim.fn
-          local utils = require("auto-save.utils.data")
-
-          if fn.getbufvar(buf, "&modifiable") == 1 and utils.not_in(fn.getbufvar(buf, "&filetype"), {}) then
-            return true -- met condition(s), can save
-          end
-          return false -- can't save
-        end
-      '';
-      writeAllBuffers = false;
-      debounceDelay = 135;
-      callbacks = {
-        enabling = null;
-        disabling = null;
-        beforeAssertingSave = null;
-        beforeSaving = null;
-        afterSaving = null;
+      settings = {
+        enabled = true;
+        execution_message = {
+          enabled = true;
+          dim = 0.18;
+          cleaning_interval = 1250;
+          message.__raw = ''
+            function()
+              return ("AutoSave: saved at " .. vim.fn.strftime("%H:%M:%S"))
+            end
+          '';
+        };
+        trigger_events = {
+          immediate_save = [
+            "BufLeave"
+            "FocusLost"
+          ];
+          defer_save = [
+            "InsertLeave"
+            "TextChanged"
+          ];
+          cancel_defered_save = [ "InsertEnter" ];
+        };
+        condition = null;
+        write_all_buffers = false;
+        noautocmd = false;
+        lockmarks = false;
+        debounce_delay = 1000;
+        debug = false;
       };
     };
   };

--- a/typos.toml
+++ b/typos.toml
@@ -5,6 +5,7 @@ darcula = "darcula"       # base16-list
 Parm = "Parm"             # clangd-extensions
 Definitons = "Definitons" # TODO: ./plugins/languages/treesitter/treesitter-refactor.nix
 deffered = "deffered"     # TODO: ./plugins/utils/vim-matchup.nix
+defered = "defered"       # ./plugins/utils/auto-save.nix
 Highligt = "Highligt"     # TODO: ./plugins/utils/neogen.nix
 Annote = "Annote"         # TODO: ./plugins/lsp/fidget.nix
 ket = "ket"               # ./plugins/utils/sandwich.nix


### PR DESCRIPTION
This PR switches the plugin to `mkNeovimPlugin` and updates plugin options according to [okuuva/auto-save.nvim](https://github.com/okuuva/auto-save.nvim?tab=readme-ov-file#%EF%B8%8F-configuration) configuration options.