### PR TITLE
plugins/gitsigns: remove deprecated options

### DIFF
--- a/lib/deprecation.nix
+++ b/lib/deprecation.nix
@@ -1,0 +1,49 @@
+{ lib, ... }:
+with lib;
+rec {
+  # Get a (sub)option by walking the path,
+  # checking for submodules along the way
+  getOptionRecursive =
+    opt: prefix: optionPath:
+    if optionPath == [ ] then
+      opt
+    else if isOption opt then
+      getOptionRecursive (opt.type.getSubOptions prefix) prefix optionPath
+    else
+      let
+        name = head optionPath;
+        opt' = getAttr name opt;
+        prefix' = prefix ++ [ name ];
+        optionPath' = drop 1 optionPath;
+      in
+      getOptionRecursive opt' prefix' optionPath';
+
+  # Like mkRemovedOptionModule, but has support for nested sub-options
+  # and uses warnings instead of assertions.
+  mkDeprecatedSubOptionModule =
+    optionPath: replacementInstructions:
+    { options, ... }:
+    {
+      options = setAttrByPath optionPath (mkOption {
+        # When (e.g.) `mkAttrs` is used on a submodule, this option will be evaluated.
+        # Therefore we have to apply _something_ (null) when there's no definition.
+        apply =
+          v:
+          let
+            # Avoid "option used but not defined" errors
+            res = builtins.tryEval v;
+          in
+          if res.success then res.value else null;
+        visible = false;
+      });
+      config.warnings =
+        let
+          opt = getOptionRecursive options [ ] optionPath;
+        in
+        optional opt.isDefined ''
+          The option definition `${showOption optionPath}' in ${showFiles opt.files} is deprecated.
+          ${replacementInstructions}
+        '';
+    };
+
+}

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -9,6 +9,7 @@ let
   nixvimTypes = import ./types.nix { inherit lib nixvimOptions; };
   nixvimUtils = import ./utils.nix { inherit lib nixvimTypes _nixvimTests; };
   nixvimOptions = import ./options.nix { inherit lib nixvimTypes nixvimUtils; };
+  nixvimDeprecation = import ./deprecation.nix { inherit lib; };
   inherit (import ./to-lua.nix { inherit lib; }) toLuaObject;
 in
 {
@@ -30,3 +31,4 @@ in
 // nixvimUtils
 // nixvimOptions
 // nixvimBuilders
+// nixvimDeprecation

--- a/plugins/git/gitsigns/default.nix
+++ b/plugins/git/gitsigns/default.nix
@@ -19,22 +19,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     [
       "signs"
       "add"
-      "hl"
-    ]
-    [
-      "signs"
-      "add"
       "text"
-    ]
-    [
-      "signs"
-      "add"
-      "numhl"
-    ]
-    [
-      "signs"
-      "add"
-      "linehl"
     ]
     [
       "signs"
@@ -44,22 +29,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     [
       "signs"
       "change"
-      "hl"
-    ]
-    [
-      "signs"
-      "change"
       "text"
-    ]
-    [
-      "signs"
-      "change"
-      "numhl"
-    ]
-    [
-      "signs"
-      "change"
-      "linehl"
     ]
     [
       "signs"
@@ -69,22 +39,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     [
       "signs"
       "topdelete"
-      "hl"
-    ]
-    [
-      "signs"
-      "topdelete"
       "text"
-    ]
-    [
-      "signs"
-      "topdelete"
-      "numhl"
-    ]
-    [
-      "signs"
-      "topdelete"
-      "linehl"
     ]
     [
       "signs"
@@ -94,22 +49,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     [
       "signs"
       "changedelete"
-      "hl"
-    ]
-    [
-      "signs"
-      "changedelete"
       "text"
-    ]
-    [
-      "signs"
-      "changedelete"
-      "numhl"
-    ]
-    [
-      "signs"
-      "changedelete"
-      "linehl"
     ]
     [
       "signs"
@@ -119,22 +59,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     [
       "signs"
       "untracked"
-      "hl"
-    ]
-    [
-      "signs"
-      "untracked"
       "text"
-    ]
-    [
-      "signs"
-      "untracked"
-      "numhl"
-    ]
-    [
-      "signs"
-      "untracked"
-      "linehl"
     ]
     [
       "signs"
@@ -195,10 +120,6 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       "virtTextPriority"
     ]
     "trouble"
-    [
-      "yadm"
-      "enable"
-    ]
     "wordDiff"
     "debugMode"
   ];
@@ -209,8 +130,41 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         "gitsigns"
       ];
       settingsPath = basePluginPaths ++ [ "settings" ];
+
+      highlights = {
+        add = "Add";
+        change = "Change";
+        delete = "Delete";
+        topdelete = "Topdelete";
+        changedelete = "Changedelete";
+        untracked = "Untracked";
+      };
+
+      subHighlights = {
+        hl = "";
+        linehl = "Ln";
+        numhl = "Nr";
+      };
+
+      highlightRemovals = flatten (
+        mapAttrsToList (
+          opt: hlg:
+          mapAttrsToList (subOpt: subHlg: {
+            optionPath = settingsPath ++ [
+              "signs"
+              opt
+              subOpt
+            ];
+            hlg = "GitSigns${hlg}${subHlg}";
+          }) subHighlights
+        ) highlights
+      );
     in
-    [
+    (map (
+      { optionPath, hlg }:
+      helpers.mkDeprecatedSubOptionModule optionPath "Please define the `${hlg}` highlight group instead."
+    ) highlightRemovals)
+    ++ [
       (mkRenamedOptionModule (
         basePluginPaths
         ++ [
@@ -278,6 +232,13 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           "nonCommitted"
         ]
       ) (settingsPath ++ [ "current_line_blame_formatter_nc" ]))
+      (helpers.mkDeprecatedSubOptionModule (
+        settingsPath
+        ++ [
+          "yadm"
+          "enable"
+        ]
+      ) "yadm support was removed upstream.")
     ];
 
   extraOptions = {

--- a/plugins/git/gitsigns/options.nix
+++ b/plugins/git/gitsigns/options.nix
@@ -3,26 +3,9 @@ with lib;
 {
   signs =
     let
-      # TODO (2024-06-24): find a way to properly remove the `hl`, `numhl` and `linehl` options
-      # https://github.com/lewis6991/gitsigns.nvim/issues/453#issuecomment-2178736570
       signOptions = defaults: {
-        hl = helpers.defaultNullOpts.mkStr defaults.hl ''
-          **DEPRECATED**
-          Specifies the highlight group to use for the sign.
-        '';
-
         text = helpers.defaultNullOpts.mkStr defaults.text ''
           Specifies the character to use for the sign.
-        '';
-
-        numhl = helpers.defaultNullOpts.mkStr defaults.numhl ''
-          **DEPRECATED**
-          Specifies the highlight group to use for the number column.
-        '';
-
-        linehl = helpers.defaultNullOpts.mkStr defaults.linehl ''
-          **DEPRECATED**
-          Specifies the highlight group to use for the line.
         '';
 
         show_count = helpers.defaultNullOpts.mkBool false ''
@@ -421,15 +404,6 @@ with lib;
 
     Default: `pcall(require, 'trouble')`
   '';
-
-  yadm = {
-    # TODO (2024-06-24): find a way to properly remove this option
-    # https://github.com/lewis6991/gitsigns.nvim/issues/453#issuecomment-2178743878
-    enable = helpers.defaultNullOpts.mkBool false ''
-      **DEPRECATED**
-      Enable YADM support.
-    '';
-  };
 
   word_diff = helpers.defaultNullOpts.mkBool false ''
     Highlight intra-line word differences in the buffer.


### PR DESCRIPTION
- **lib/deprecation: init with mkRemovedSubmoduleOptionModule**
- **plugins/gitsigns: remove deprecated options**

Added a clone of `mkRemovedOptionModule` that supports nested sub-options. This is exactly the same, except is uses our custom `getOptionRecursive` instead of `getAttrFromPath`.

Like `mkRemovedOptionModule`, this is an assertion. Maybe a warning would make sense instead, seeing as `settings` is a freeform type?

I've tested the functions a little in the repl and by checking out the old test file (before the options were removed from the test).

Should we have some lib-tests? If so do you have any suggestions for test-cases?
