### PR TITLE
docs/mdbook: only show sub-options of visible options

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -42,13 +42,9 @@ let
   isVisible =
     opts:
     if isOption opts then
-      attrByPath [ "visible" ] true opts
+      opts.visible or true
     else if opts.isOption then
-      attrByPath [
-        "index"
-        "options"
-        "visible"
-      ] true opts
+      opts.index.options.visible or true
     else
       let
         filterFunc = filterAttrs (_: v: if isAttrs v then isVisible v else true);

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -37,7 +37,8 @@ let
 
   removeWhitespace = builtins.replaceStrings [ " " ] [ "" ];
 
-  getSubOptions = opts: path: removeUnwanted (opts.type.getSubOptions path);
+  getSubOptions =
+    opts: path: optionalAttrs (isVisible opts) (removeUnwanted (opts.type.getSubOptions path));
 
   isVisible =
     opts:


### PR DESCRIPTION
This prevents non-visible aliases for submodules (e.g. `settings`) from appearing in the docs.

<details><summary>Screenshot comparison</summary>
<p>

| Current | This PR |
|--------|--------|
| ![image](https://github.com/nix-community/nixvim/assets/5046562/8896b724-06e0-4bf4-85a8-34230d187a8b) | ![image](https://github.com/nix-community/nixvim/assets/5046562/a225878c-6248-4e0b-a695-e0a1b8ff5e54) | 

</p>
</details>

I also included an additional commit cleaning up the `isVisible` function a little. This shouldn't change its behaviour at all.