### PR TITLE
[backport] docs/mdbook: only show sub-options of visible options

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -42,13 +42,9 @@ let
   isVisible =
     opts:
     if isOption opts then
-      attrByPath [ "visible" ] true opts
+      opts.visible or true
     else if opts.isOption then
-      attrByPath [
-        "index"
-        "options"
-        "visible"
-      ] true opts
+      opts.index.options.visible or true
     else
       let
         filterFunc = filterAttrs (_: v: if isAttrs v then isVisible v else true);

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -37,7 +37,8 @@ let
 
   removeWhitespace = builtins.replaceStrings [ " " ] [ "" ];
 
-  getSubOptions = opts: path: removeUnwanted (opts.type.getSubOptions path);
+  getSubOptions =
+    opts: path: optionalAttrs (isVisible opts) (removeUnwanted (opts.type.getSubOptions path));
 
   isVisible =
     opts:


### PR DESCRIPTION
Backport #1752 to 24.05
