### PR TITLE
github/mergify: init

### DIFF
--- a/.github/mergify.yaml
+++ b/.github/mergify.yaml
@@ -1,0 +1,21 @@
+# Essential reading on condition syntax:
+# https://docs.mergify.com/configuration/conditions/#testing-and-debugging-conditions
+
+# https://docs.mergify.com/merge-queue
+queue_rules:
+  - name: default
+    update_method: rebase
+    merge_method: fast-forward
+    merge_conditions:
+      - check-success = buildbot/nix-eval
+    queue_conditions:
+      - or:
+        # Allow queuing PRs that have been approved
+        - "#approved-reviews-by >= 1"
+
+        # Allow queuing flake.lock updates without approval
+        - and:
+          - "#files = 1"
+          - files = flake.lock
+          - author = GaetanLepage
+


### PR DESCRIPTION
Follow up to the slightly more extensive #1642, this PR keeps things simple and does **not** add any automation rules.

All interactions with mergify will therefore have to be done using [commands], i.e. special comments that tag @mergifyio.

## Trial evaluation
The goal of this PR is to setup an initial mergify config, allowing us to trial using mergify via its [commands].
We can then evaluate if we wish to continue using mergify, and if so whether we want to introduce additional config/rules.

## Setup
As per their [getting started](https://docs.mergify.com/getting-started/) instructions, we should:
- [ ] Log into the [Mergify dashboard](https://dashboard.mergify.com) using GitHub SSO.
- [ ] Click on [`Enable Mergify on a new account`](https://github.com/apps/mergify/installations/new)
- [ ] Select the repositories you want to give Mergify access to (nix-community/nixvim).
- [ ] You will be redirected to the [dashboard](https://dashboard.mergify.com).

## Branch protection
Like us, mergify is subject to GitHub branch protection rules.

If we later decide we want to exclusively use mergify to merge PRs, we should set _GitHub's_ branch protection to [only mergify can push](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#restrict-who-can-push-to-matching-branches).

This would be particularly useful for the flake.lock updates, as we could remove the "require approvals" rule from GitHub's branch protection and instead rely on mergify's `queue_conditions` and `merge_conditions`, which are more flexible.

As per [this discussion](https://github.com/Mergifyio/mergify/discussions/5115), we can rely on mergify to protect our branches if mergify is the only user who can push.

## How to queue a PR
Once the `queue_conditions` **and** github branch protection rules are met, you can simply comment on a PR with `@mergifyio queue`.
See the [queue command](https://docs.mergify.com/commands/queue) docs for more info.

To learn more about the PR Queue system and why it is useful, see [Introduction to Merge Queues], [Setting Up a Merge Queue] and the videos embedded on those pages.

## How to backport a PR
Use the [backport command](https://docs.mergify.com/commands/backport), `@Mergifyio backport <target-branch> [<another-target-branch>] […]`.
e.g. `@mergifyio backport nixos-24.05`.

IMO this is best done once a PR is merged, but I think mergify would also keep backport PRs in sync with the main PR if created earlier.

## Improving this workflow
In the future, once we've gotten used to mergify, we might decide to introduce some automation rules to streamline things further.

For example, instead of manually using the backport command, we could add backport labels and a [rule](https://docs.mergify.com/workflow/writing-your-first-rule) that automatically backports any PR with those labels.

[commands]: https://docs.mergify.com/commands
[Introduction to Merge Queues]: https://docs.mergify.com/merge-queue
[Setting Up a Merge Queue]: https://docs.mergify.com/merge-queue/setup
