### PR TITLE
lib/neovim-plugin: more configurable settings

### DIFF
--- a/plugins/completion/cmp/sources/cmp-git.nix
+++ b/plugins/completion/cmp/sources/cmp-git.nix
@@ -15,8 +15,8 @@ let
     '';
 in
 {
-  options.plugins.cmp-git.settings = helpers.neovim-plugin.mkSettingsOption {
-    pluginName = "cmp_git";
+  options.plugins.cmp-git.settings = helpers.mkSettingsOption {
+    description = "Options provided to the `require('cmp_git').setup` function.";
     options = {
       filetypes = helpers.defaultNullOpts.mkListOf types.str [
         "gitcommit"


### PR DESCRIPTION
### Motivation
Sometimes we use `mkVimPlugin` for neovim plugins just because we want to avoid creating the `settings` option. This isn't ideal at the best of times, but makes even less sense when we still need to call `setup` anyway.

### Implementation
Allow callers to explicitly set `settingsOptions = null` to disable creating the `settings` option.
It still defaults to `{ }`, so existing plugins are not affected.

`toLuaObject cfg.settings` is now an optional string.

### Descriptions

I've incorporated changes from #1676 that felt more suited to this PR than that one.

Namely:
- Allow overriding the settings description
- Allow overriding the `setup` function name (used in config & description)