### PR TITLE
lib/lua: more readable tables

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -10,10 +10,10 @@ let
   nixvimUtils = import ./utils.nix { inherit lib nixvimTypes _nixvimTests; };
   nixvimOptions = import ./options.nix { inherit lib nixvimTypes nixvimUtils; };
   nixvimDeprecation = import ./deprecation.nix { inherit lib; };
-  inherit (import ./to-lua.nix { inherit lib; }) toLuaObject;
 in
-{
+rec {
   maintainers = import ./maintainers.nix;
+  lua = import ./to-lua.nix { inherit lib; };
   keymaps = import ./keymap-helpers.nix { inherit lib nixvimOptions nixvimTypes; };
   autocmd = import ./autocmd-helpers.nix { inherit lib nixvimOptions nixvimTypes; };
   neovim-plugin = import ./neovim-plugin.nix {
@@ -26,7 +26,7 @@ in
   };
   vim-plugin = import ./vim-plugin.nix { inherit lib nixvimOptions nixvimUtils; };
   inherit nixvimTypes;
-  inherit toLuaObject;
+  inherit (lua) toLuaObject;
 }
 // nixvimUtils
 // nixvimOptions

--- a/lib/to-lua.nix
+++ b/lib/to-lua.nix
@@ -43,7 +43,7 @@ rec {
         "{ }"
       else
         "{"
-        + (concatStringsSep "," (
+        + (concatStringsSep ", " (
           mapAttrsToList (
             n: v:
             let
@@ -63,7 +63,7 @@ rec {
         ))
         + "}"
     else if builtins.isList args then
-      "{" + concatMapStringsSep "," toLuaObject args + "}"
+      "{" + concatMapStringsSep ", " toLuaObject args + "}"
     else if builtins.isString args then
       # This should be enough!
       builtins.toJSON args

--- a/lib/to-lua.nix
+++ b/lib/to-lua.nix
@@ -1,6 +1,37 @@
 { lib }:
 with lib;
 rec {
+  # Whether the string is a reserved keyword in lua
+  isKeyword =
+    s:
+    elem s [
+      "and"
+      "break"
+      "do"
+      "else"
+      "elseif"
+      "end"
+      "false"
+      "for"
+      "function"
+      "if"
+      "in"
+      "local"
+      "nil"
+      "not"
+      "or"
+      "repeat"
+      "return"
+      "then"
+      "true"
+      "until"
+      "while"
+    ];
+
+  # Valid lua identifiers are not reserved keywords, do not start with a digit,
+  # and contain only letters, digits, and underscores.
+  isIdentifier = s: !(isKeyword s) && (match "[A-Za-z_][0-9A-Za-z_]*" s) == [ ];
+
   # Black functional magic that converts a bunch of different Nix types to their
   # lua equivalents!
   toLuaObject =

--- a/lib/to-lua.nix
+++ b/lib/to-lua.nix
@@ -47,16 +47,18 @@ rec {
           mapAttrsToList (
             n: v:
             let
+              keyString =
+                if n == "__emptyString" then
+                  "['']"
+                else if hasPrefix "__rawKey__" n then
+                  "[${removePrefix "__rawKey__" n}]"
+                else if isIdentifier n then
+                  n
+                else
+                  "[${toLuaObject n}]";
               valueString = toLuaObject v;
             in
-            if hasPrefix "__unkeyed" n then
-              valueString
-            else if hasPrefix "__rawKey__" n then
-              ''[${removePrefix "__rawKey__" n}] = '' + valueString
-            else if n == "__emptyString" then
-              "[''] = " + valueString
-            else
-              "[${toLuaObject n}] = " + valueString
+            if hasPrefix "__unkeyed" n then valueString else "${keyString} = ${valueString}"
           ) (filterAttrs (n: v: v != null && (toLuaObject v != "{}")) args)
         ))
         + "}"

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -55,7 +55,7 @@ let
           3
         ];
       };
-      expected = ''{["foo"] = "bar",["qux"] = {1,2,3}}'';
+      expected = ''{foo = "bar",qux = {1,2,3}}'';
     };
 
     testToLuaObjectRawLua = {
@@ -68,7 +68,7 @@ let
         "__unkeyed...." = "foo";
         bar = "baz";
       };
-      expected = ''{"foo",["bar"] = "baz"}'';
+      expected = ''{"foo",bar = "baz"}'';
     };
 
     testToLuaObjectNestedAttrs = {
@@ -81,7 +81,7 @@ let
           };
         };
       };
-      expected = ''{["a"] = {["b"] = 1,["c"] = 2,["d"] = {["e"] = 3}}}'';
+      expected = ''{a = {b = 1,c = 2,d = {e = 3}}}'';
     };
 
     testToLuaObjectNestedList = {
@@ -109,7 +109,7 @@ let
         d = false;
         e = null;
       };
-      expected = ''{["a"] = 1.000000,["b"] = 2,["c"] = true,["d"] = false}'';
+      expected = ''{a = 1.000000,b = 2,c = true,d = false}'';
     };
 
     testToLuaObjectNilPrim = {
@@ -150,7 +150,17 @@ let
           g = helpers.emptyTable;
         };
       };
-      expected = ''{["c"] = { },["d"] = {["g"] = { }}}'';
+      expected = ''{c = { },d = {g = { }}}'';
+    };
+
+    testToLuaObjectQuotedKeys = {
+      expr = helpers.toLuaObject {
+        "1_a" = "a";
+        _b = "b";
+        c = "c";
+        d-d = "d";
+      };
+      expected = ''{["1_a"] = "a",_b = "b",c = "c",["d-d"] = "d"}'';
     };
 
     testIsLuaKeyword = {

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -6,6 +6,45 @@
   helpers,
 }:
 let
+  luaNames = {
+    # Keywords in lua 5.1
+    keywords = [
+      "and"
+      "break"
+      "do"
+      "else"
+      "elseif"
+      "end"
+      "false"
+      "for"
+      "function"
+      "if"
+      "in"
+      "local"
+      "nil"
+      "not"
+      "or"
+      "repeat"
+      "return"
+      "then"
+      "true"
+      "until"
+      "while"
+    ];
+    identifiers = [
+      "validIdentifier"
+      "valid_identifier"
+      "_also_valid_"
+      "_weirdNameFMT"
+    ];
+    other = [
+      "1_starts_with_digit"
+      "01234"
+      "12340"
+      "kebab-case"
+    ];
+  };
+
   results = pkgs.lib.runTests {
     testToLuaObject = {
       expr = helpers.toLuaObject {
@@ -112,6 +151,51 @@ let
         };
       };
       expected = ''{["c"] = { },["d"] = {["g"] = { }}}'';
+    };
+
+    testIsLuaKeyword = {
+      expr = builtins.mapAttrs (_: builtins.filter helpers.lua.isKeyword) luaNames;
+      expected = {
+        keywords = [
+          "and"
+          "break"
+          "do"
+          "else"
+          "elseif"
+          "end"
+          "false"
+          "for"
+          "function"
+          "if"
+          "in"
+          "local"
+          "nil"
+          "not"
+          "or"
+          "repeat"
+          "return"
+          "then"
+          "true"
+          "until"
+          "while"
+        ];
+        identifiers = [ ];
+        other = [ ];
+      };
+    };
+
+    testIsLuaIdentifier = {
+      expr = builtins.mapAttrs (_: builtins.filter helpers.lua.isIdentifier) luaNames;
+      expected = {
+        keywords = [ ];
+        identifiers = [
+          "validIdentifier"
+          "valid_identifier"
+          "_also_valid_"
+          "_weirdNameFMT"
+        ];
+        other = [ ];
+      };
     };
 
     testUpperFirstChar = {

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -55,7 +55,7 @@ let
           3
         ];
       };
-      expected = ''{foo = "bar",qux = {1,2,3}}'';
+      expected = ''{foo = "bar", qux = {1, 2, 3}}'';
     };
 
     testToLuaObjectRawLua = {
@@ -68,7 +68,7 @@ let
         "__unkeyed...." = "foo";
         bar = "baz";
       };
-      expected = ''{"foo",bar = "baz"}'';
+      expected = ''{"foo", bar = "baz"}'';
     };
 
     testToLuaObjectNestedAttrs = {
@@ -81,7 +81,7 @@ let
           };
         };
       };
-      expected = ''{a = {b = 1,c = 2,d = {e = 3}}}'';
+      expected = ''{a = {b = 1, c = 2, d = {e = 3}}}'';
     };
 
     testToLuaObjectNestedList = {
@@ -98,7 +98,7 @@ let
         ]
         7
       ];
-      expected = "{1,2,{3,4,{5,6}},7}";
+      expected = "{1, 2, {3, 4, {5, 6}}, 7}";
     };
 
     testToLuaObjectNonStringPrims = {
@@ -109,7 +109,7 @@ let
         d = false;
         e = null;
       };
-      expected = ''{a = 1.000000,b = 2,c = true,d = false}'';
+      expected = ''{a = 1.000000, b = 2, c = true, d = false}'';
     };
 
     testToLuaObjectNilPrim = {
@@ -150,7 +150,7 @@ let
           g = helpers.emptyTable;
         };
       };
-      expected = ''{c = { },d = {g = { }}}'';
+      expected = ''{c = { }, d = {g = { }}}'';
     };
 
     testToLuaObjectQuotedKeys = {
@@ -160,7 +160,7 @@ let
         c = "c";
         d-d = "d";
       };
-      expected = ''{["1_a"] = "a",_b = "b",c = "c",["d-d"] = "d"}'';
+      expected = ''{["1_a"] = "a", _b = "b", c = "c", ["d-d"] = "d"}'';
     };
 
     testIsLuaKeyword = {


### PR DESCRIPTION
- **lib/lua: add `isKeyword` and `isIdentifier`**
- **lib/lua: only quote table keys when needed**
- **lib/lua: pad table `,` with a space**


## Identifiers
Valid identifiers as [defined in the lua manual](https://www.lua.org/manual/5.1/manual.html#2.1) do not need to be quoted in lua tables, so we can make most tables less verbose and more readable by checking if the key is a valid identifier.

## Separators
The table separators are more readable when padded with whitespace.

## Future work
I think toLuaObject could be improved by taking some inspiration from generators.toPretty.

In particular, we could add optional support for multiline output and the empty attr values filter could be more efficient by not calling toLuaObject recursively in its condition.
