### PR TITLE
lib/lua: workaround `builtins.match` alias issue

### DIFF
--- a/lib/to-lua.nix
+++ b/lib/to-lua.nix
@@ -30,7 +30,7 @@ rec {
 
   # Valid lua identifiers are not reserved keywords, do not start with a digit,
   # and contain only letters, digits, and underscores.
-  isIdentifier = s: !(isKeyword s) && (match "[A-Za-z_][0-9A-Za-z_]*" s) == [ ];
+  isIdentifier = s: !(isKeyword s) && (builtins.match "[A-Za-z_][0-9A-Za-z_]*" s) == [ ];
 
   # toLua' with default options, aliased as toLuaObject at the top-level
   toLua = toLua' { };


### PR DESCRIPTION
A user has reported (https://github.com/nix-community/nixvim/pull/1760#issuecomment-2192066615) that `with lib` isn't bringing `match` into scope on in their flake. Odd, but we can fix by explicitly using `builtins.match`
