### PR TITLE
plugins/otter: init

### DIFF
--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -71,6 +71,7 @@
     ./languages/nix.nix
     ./languages/nvim-jdtls.nix
     ./languages/openscad.nix
+    ./languages/otter.nix
     ./languages/parinfer-rust.nix
     ./languages/plantuml-syntax.nix
     ./languages/python/jupytext.nix

--- a/plugins/languages/otter.nix
+++ b/plugins/languages/otter.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  helpers,
+  config,
+  pkgs,
+  ...
+}:
+helpers.neovim-plugin.mkNeovimPlugin config {
+  name = "otter";
+  originalName = "otter.nvim";
+  defaultPackage = pkgs.vimPlugins.otter-nvim;
+
+  maintainers = [ lib.maintainers.perchun ];
+
+  settingsOptions = {
+    lsp = {
+      hover = {
+        border = helpers.defaultNullOpts.mkListOf lib.types.str [
+          "╭"
+          "─"
+          "╮"
+          "│"
+          "╯"
+          "─"
+          "╰"
+          "│"
+        ] "";
+      };
+
+      diagnostic_update_events = helpers.defaultNullOpts.mkListOf' {
+        type = lib.types.str;
+        pluginDefault = [ "BufWritePost" ];
+        description = ''
+          `:h events` that cause the diagnostics to update.
+
+          See example for less performant but more instant diagnostic updates.
+        '';
+        example = [
+          "BufWritePost"
+          "InsertLeave"
+          "TextChanged"
+        ];
+      };
+    };
+
+    buffers = {
+      set_filetype = helpers.defaultNullOpts.mkBool false ''
+        If set to true, the filetype of the otterbuffers will be set.
+        Otherwise only the autocommand of lspconfig that attaches
+        the language server will be executed without setting the filetype.
+      '';
+
+      write_to_disk = helpers.defaultNullOpts.mkBool false ''
+        Write `<path>.otter.<embedded language extension>` files
+        to disk on save of main buffer.
+        Useful for some linters that require actual files,
+        otter files are deleted on quit or main buffer close.
+      '';
+    };
+
+    strip_wrapping_quote_characters = helpers.defaultNullOpts.mkListOf lib.types.str [
+      "'"
+      "\""
+      "\`"
+    ] "";
+
+    handle_leading_whitespace = helpers.defaultNullOpts.mkBool false ''
+      Otter may not work the way you expect when entire code blocks are indented (eg. in Org files).
+      When true, otter handles these cases fully. This is a (minor) performance hit.
+    '';
+  };
+
+  extraOptions = {
+    addCmpSources = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Automatically add otter to cmp sources, as it is required for some functionality.
+      '';
+    };
+  };
+
+  extraConfig = cfg: {
+    plugins.cmp.settings.sources = lib.mkIf cfg.addCmpSources [ { name = "otter"; } ];
+  };
+}

--- a/tests/test-sources/plugins/languages/otter.nix
+++ b/tests/test-sources/plugins/languages/otter.nix
@@ -1,0 +1,39 @@
+{
+  empty = {
+    plugins.otter.enable = true;
+  };
+
+  defaults = {
+    plugins.otter = {
+      enable = true;
+
+      settings = {
+        lsp = {
+          hover = {
+            border = [
+              "╭"
+              "─"
+              "╮"
+              "│"
+              "╯"
+              "─"
+              "╰"
+              "│"
+            ];
+          };
+          diagnostic_update_events = [ "BufWritePost" ];
+        };
+        buffers = {
+          set_filetype = false;
+          write_to_disk = false;
+        };
+        strip_wrapping_quote_characters = [
+          "'"
+          "\""
+          "\`"
+        ];
+        handle_leading_whitespace = false;
+      };
+    };
+  };
+}


### PR DESCRIPTION
https://github.com/jmbuhr/otter.nvim

Unfortunately, cannot run tests for this. After 33 minutes, it exits with SIGSTOP with no error message (both times I tried)