### PR TITLE
plugins/surround: stop using alias

### DIFF
--- a/plugins/utils/surround.nix
+++ b/plugins/utils/surround.nix
@@ -8,7 +8,7 @@
 helpers.vim-plugin.mkVimPlugin config {
   name = "surround";
   originalName = "surround.vim";
-  defaultPackage = pkgs.vimPlugins.surround;
+  defaultPackage = pkgs.vimPlugins.vim-surround;
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }


### PR DESCRIPTION
This alias exists already in 23.11, so it should be safe to backport.

https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/applications/editors/vim/plugins/aliases.nix