### PR TITLE
tests/test-derivation: allow tests to be modules

### DIFF
--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -75,9 +75,10 @@ If using the home-manager module, see [Home Manager Usage](./modules/hm.md) for 
 ### Standalone usage
 
 When using nixvim as a standalone derivation you can use the following functions, located in `<nixvim>.legacyPackages.${system}`:
-- `makeNixvim`: This function takes an attribute set of options values as arguments
+- `makeNixvim`: A simplified version of `makeNixvimWithModule` for when you only need to specify `module` and the other options can be left as the defaults.
+  This function's only argument is a nixvim module, e.g. `{ extraConfigLua = "print('hi')"; }`
 - `makeNixvimWithModule`: This function takes an attribute set of the form: `{pkgs, extraSpecialArgs, module}`.
-  The only required argument is `module`, being a NixOS module. This gives access to the `imports`, `options`, `config` variables, and using functions like `{config, ...}: { ... }`.
+  The only required argument is `module`, being a nixvim module. This gives access to the `imports`, `options`, `config` variables, and using functions like `{config, ...}: { ... }`.
 
 There are also some helper functions in `<nixvim>.lib.${system}` like:
 - `check.mkTestDerivationFromNixvimModule`, taking the same arguments as `makeNixvimWithModule` and generates a check derivation.

--- a/flake-modules/legacy-packages.nix
+++ b/flake-modules/legacy-packages.nix
@@ -9,13 +9,7 @@
     {
       legacyPackages = rec {
         inherit makeNixvimWithModule;
-        makeNixvim =
-          configuration:
-          makeNixvimWithModule {
-            module = {
-              config = configuration;
-            };
-          };
+        makeNixvim = module: makeNixvimWithModule { inherit module; };
       };
     };
 }

--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -3,25 +3,21 @@
   perSystem =
     {
       pkgs,
-      config,
+      pkgsUnfree,
       system,
       helpers,
-      makeNixvimWithModuleUnfree,
       makeNixvimWithModule,
       ...
     }:
     {
       checks = {
         tests = import ../tests {
-          inherit pkgs helpers makeNixvimWithModule;
-          inherit (pkgs) lib;
-          makeNixvim =
-            configuration:
-            makeNixvimWithModuleUnfree {
-              module = {
-                config = configuration;
-              };
-            };
+          inherit
+            pkgs
+            pkgsUnfree
+            helpers
+            makeNixvimWithModule
+            ;
         };
 
         extra-args-tests = import ../tests/extra-args.nix {

--- a/flake-modules/wrappers.nix
+++ b/flake-modules/wrappers.nix
@@ -14,18 +14,10 @@ let
 in
 {
   perSystem =
-    {
-      system,
-      pkgs,
-      pkgsUnfree,
-      config,
-      ...
-    }:
+    { system, pkgs, ... }:
     {
       _module.args = {
         makeNixvimWithModule = import ../wrappers/standalone.nix pkgs wrapperArgs;
-
-        makeNixvimWithModuleUnfree = import ../wrappers/standalone.nix pkgsUnfree wrapperArgs;
       };
 
       checks =

--- a/tests/test-derivation.nix
+++ b/tests/test-derivation.nix
@@ -1,8 +1,4 @@
-{
-  pkgs,
-  makeNixvim,
-  makeNixvimWithModule,
-}:
+{ pkgs, makeNixvimWithModule, ... }:
 let
   # Create a nix derivation from a nixvim executable.
   # The build phase simply consists in running the provided nvim binary.
@@ -46,12 +42,15 @@ let
       '';
     };
 
+  # Create a nix derivation from a nixvim configuration.
+  # The build phase simply consists in running neovim with the given configuration.
   mkTestDerivationFromNixvimModule =
     {
       name ? "nixvim-check",
-      pkgs,
+      pkgs ? pkgs,
       module,
       extraSpecialArgs ? { },
+      dontRun ? false,
     }:
     let
       nvim = makeNixvimWithModule {
@@ -59,21 +58,8 @@ let
         _nixvimTests = true;
       };
     in
-    mkTestDerivationFromNvim { inherit name nvim; };
-
-  # Create a nix derivation from a nixvim configuration.
-  # The build phase simply consists in running neovim with the given configuration.
-  mkTestDerivation =
-    name: config:
-    let
-      testAttributes = if builtins.hasAttr "tests" config then config.tests else { dontRun = false; };
-      nvim = makeNixvim (pkgs.lib.attrsets.filterAttrs (n: _: n != "tests") config);
-    in
-    mkTestDerivationFromNvim {
-      inherit name nvim;
-      inherit (testAttributes) dontRun;
-    };
+    mkTestDerivationFromNvim { inherit name nvim dontRun; };
 in
 {
-  inherit mkTestDerivation mkTestDerivationFromNvim mkTestDerivationFromNixvimModule;
+  inherit mkTestDerivationFromNvim mkTestDerivationFromNixvimModule;
 }


### PR DESCRIPTION
## tests/test-derivation: allow tests to be modules
This ended up being a bigger cleanup/refactor than expected, as I encountered a lot of cruft and redundancy.

The core motivation of these changes is to allow for more complex tests, that need access to module args such as `options` or `config`. In particular #1776.

I've removed a few functions, which may look scary at first, however I've checked for any places where they may have been exposed publicly and they appear to be 100% internal.

## flake/legacyPackages: simplify `makeNixvim`, making it more powerful
While working in this area I was question why `makeNixvim` is deliberately restrictive in only accepting a config attrset.
I guess this made sense when we had a name conflict with `options`, but now that that's resolved I see no reason why _any_ module form shouldn't be accepted and passed directly through to `makeNixvimWithModule`.

Incidentally, this makes me want to find a better name for `makeNixvimWithModule`, maybe `makeNixvim'`? Regardless, out of scope for this PR.
