### PR TITLE
Remove aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you want to use it standalone, you can use the `makeNixvim` function:
 ```nix
 { pkgs, nixvim, ... }: {
   environment.systemModules = [
-    (nixvim.legacyPackages."${pkgs.system}".makeNixvim {
+    (nixvim.legacyPackages."${pkgs.stdenv.hostPlatform.system}".makeNixvim {
       colorschemes.gruvbox.enable = true;
     })
   ];

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -49,7 +49,7 @@ in
       environment.systemPackages = [
         cfg.finalPackage
         cfg.printInitPackage
-      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.system}.man-docs);
+      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs);
     }
     { inherit (cfg) warnings assertions; }
   ]);

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -46,7 +46,7 @@ in
       home.packages = [
         cfg.finalPackage
         cfg.printInitPackage
-      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.system}.man-docs);
+      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs);
     }
     (mkIf (!cfg.wrapRc) { xdg.configFile = files; })
     {

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -55,7 +55,7 @@ in
       environment.systemPackages = [
         cfg.finalPackage
         cfg.printInitPackage
-      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.system}.man-docs);
+      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs);
     }
     (mkIf (!cfg.wrapRc) {
       environment.etc = files;

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -52,7 +52,7 @@ let
       paths = [
         config.finalPackage
         config.printInitPackage
-      ] ++ pkgs.lib.optional config.enableMan self.packages.${pkgs.system}.man-docs;
+      ] ++ pkgs.lib.optional config.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
       meta.mainProgram = "nvim";
     })
     // {


### PR DESCRIPTION
Otherwise the following error is generated when building my config


```
       … while evaluating definitions from `/nix/store/ds9973rzhbwq1mk4lznqwrm9x44qp9qy-source/flake.nix#nixosModules.nixvim':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'system' missing
       at /nix/store/ds9973rzhbwq1mk4lznqwrm9x44qp9qy-source/wrappers/nixos.nix:58:56:
           57|         cfg.printInitPackage
           58|       ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.system}.man-docs);
             |                                                        ^
           59|     }
       Did you mean one of mystem, systemc, systemd, syntex or systemfd?
```