### PR TITLE
modules/keymaps: improve `lua` deprecation

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -43,82 +43,58 @@ with lib;
     };
   };
 
-  config =
-    let
-      # TODO remove `normalizeMapping` once `lua` option is gone
-      normalizeMapping = keyMapping: {
-        inherit (keyMapping) mode key options;
-
-        action =
-          if keyMapping.lua != null && keyMapping.lua then
-            helpers.mkRaw keyMapping.action
-          else
-            keyMapping.action;
-      };
-    in
-    {
-      # Deprecate `lua` keymap option
-      # TODO upgrade to an assertion (removal notice) in 24.11
-      # TODO remove entirely in 25.05?
-      warnings =
-        let
-          luaDefs = pipe options.keymaps.definitionsWithLocations [
-            (map (def: {
-              inherit (def) file;
-              value = filter (v: (v.lua or null) != null) def.value;
-            }))
-            (filter (def: def.value != [ ]))
-            (map (
-              def:
-              let
-                count = length def.value;
-                plural = count > 1;
-              in
-              ''
-                Found ${toString count} use${optionalString plural "s"} in ${def.file}:
-                ${generators.toPretty { } def.value}
-              ''
-            ))
+  config = {
+    # Deprecate `lua` keymap option
+    # TODO upgrade to an assertion (removal notice) in 24.11
+    # TODO remove entirely in 25.05?
+    warnings =
+      let
+        foldLuaDefs = foldr (keymap: defs: defs ++ keymap.luaDefs) [ ];
+        luaDefs = filterAttrs (_: v: v != [ ]) {
+          keymaps = foldLuaDefs config.keymaps;
+          keymapsOnEvents = pipe config.keymapsOnEvents [
+            attrValues
+            flatten
+            foldLuaDefs
           ];
-        in
-        optional (luaDefs != [ ]) ''
-          Nixvim (keymaps): the `lua` keymap option is deprecated.
+        };
+      in
+      mapAttrsToList (opt: defs: ''
+        Nixvim (${opt}): the `lua` option is deprecated and will be removed in 24.11.
+        You should use a "raw" `action` instead:
+        e.g. `action.__raw = "<lua code>"` or `action = helpers.mkRaw "<lua code>"`.
+        Definitions: ${lib.options.showDefs defs}
+      '') luaDefs;
 
-          This option will be removed in 24.11. You should use a "raw" `action` instead;
-          e.g. `action.__raw = "<lua code>"` or `action = helpers.mkRaw "<lua code>"`.
-
-          ${concatStringsSep "\n" luaDefs}
-        '';
-
-      extraConfigLua = optionalString (config.keymaps != [ ]) ''
-        -- Set up keybinds {{{
-        do
-          local __nixvim_binds = ${helpers.toLuaObject (map normalizeMapping config.keymaps)}
-          for i, map in ipairs(__nixvim_binds) do
-            vim.keymap.set(map.mode, map.key, map.action, map.options)
-          end
+    extraConfigLua = optionalString (config.keymaps != [ ]) ''
+      -- Set up keybinds {{{
+      do
+        local __nixvim_binds = ${helpers.toLuaObject config.keymaps}
+        for i, map in ipairs(__nixvim_binds) do
+          vim.keymap.set(map.mode, map.key, map.action, map.options)
         end
-        -- }}}
-      '';
+      end
+      -- }}}
+    '';
 
-      autoGroups = mapAttrs' (
-        event: mappings: nameValuePair "nixvim_binds_${event}" { clear = true; }
-      ) config.keymapsOnEvents;
+    autoGroups = mapAttrs' (
+      event: mappings: nameValuePair "nixvim_binds_${event}" { clear = true; }
+    ) config.keymapsOnEvents;
 
-      autoCmd = mapAttrsToList (event: mappings: {
-        inherit event;
-        group = "nixvim_binds_${event}";
-        callback = helpers.mkRaw ''
-          function()
-            do
-              local __nixvim_binds = ${helpers.toLuaObject (map normalizeMapping mappings)}
-              for i, map in ipairs(__nixvim_binds) do
-                vim.keymap.set(map.mode, map.key, map.action, map.options)
-              end
+    autoCmd = mapAttrsToList (event: mappings: {
+      inherit event;
+      group = "nixvim_binds_${event}";
+      callback = helpers.mkRaw ''
+        function()
+          do
+            local __nixvim_binds = ${helpers.toLuaObject mappings}
+            for i, map in ipairs(__nixvim_binds) do
+              vim.keymap.set(map.mode, map.key, map.action, map.options)
             end
           end
-        '';
-        desc = "Load keymaps for ${event}";
-      }) config.keymapsOnEvents;
-    };
+        end
+      '';
+      desc = "Load keymaps for ${event}";
+    }) config.keymapsOnEvents;
+  };
 }


### PR DESCRIPTION
### Summary
- Take advantage of the module system in the keymap submodule
- Use `showDefs` to better print the actual definitions and locations
  (e.g. improves how `_type="override"` is shown)
- Removed `normalizeMapping` (inlined into `action`'s `apply` function)
- Also show warning for `keymapsOnEvent`

### Testing
When adding the following test case:

```nix
{
  keymaps = [
    {
      key = ",";
      action = "function() print('lua true') end";
      lua = true;
    }
    {
      key = ".";
      action = "function() print('lua false') end";
      lua = false;
    }
    {
      key = ".";
      action = "function() print('lua mkDefault true') end";
      lua = pkgs.lib.mkDefault true;
    }
    {
      key = ".";
      action.__raw = "function() print('raw lua') end";
    }
  ];
}
```

The following warning is printed:
```
trace: warning: Nixvim (keymaps): the `lua` option is deprecated and will be removed in 24.11.
You should use a "raw" `action` instead:
e.g. `action.__raw = "<lua code>"` or `action = helpers.mkRaw "<lua code>"`.
Definitions:
- In `<unknown-file>': true
- In `<unknown-file>': false
- In `<unknown-file>': true
```

Note:
- `mkDefault true` correctly prints as `true` thanks to using `showDefs` rather than `toPretty`.
  - **EDIT:** This happens because overrides are resolved in the `luaDefs` submodule config _not_ because `showDefs` strips them. So this is actually unintended behavior!
- `<unknown-file>` is shown because I used a test case, this would normally be an actual file path.

### Extra submodule option
To access `options.lua.definitionsWithLocations` from outside the submodule, I created a `luaDefs` option. This probably isn't the correct approach, but IDK how to correctly access the `lua` sub-option from outside a list of submodule.
