### PR TITLE
github/mergify: set an explicit "update" account

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,6 +4,10 @@
 # https://docs.mergify.com/merge-queue
 queue_rules:
   - name: default
+    # Account used for pushing rebased updates. Default is {{author}},
+    # but that doesn't work when they haven't logged into Mergify Dashboard:
+    # https://github.com/Mergifyio/mergify/issues/5075
+    update_bot_account: GaetanLepage
     update_method: rebase
     merge_method: fast-forward
     merge_conditions:


### PR DESCRIPTION
Fixes #1793

See [our issue], [upstreams issue], and [this discussion] I had with upstream.

The core problem is also summarised nicely in [this comment] on another affected project:
> Quick summary here:
> * GitHub API doesn't allow a bot to do certain things including rebasing. So, it has to impersonate real people to work because rebasing is pretty usual:
>   * we use rebase to update a PR branch  when `master` went ahead (see Mergify config);
>   * we use Mergify queues, and those require rebases in general: the bot tries to create a "merge train" rebasing several PRs one on top of each other (Ibid.).
> * Before February 2023 Mergify would impersonate random "authorized users" (users with elevated permissions on the repo), which was annoying but working.
> * [Since February 2023 they impersonate the PR author](https://changelog.mergify.com/changelog/rebasing-pull-requests-with-a-random-user-is-deprecated) by default. The issue is, not every PR author have enough permissions for the whole thing to work. As a result we see errors like the ones reported upstream, which I referenced at the start ("Unable to update: user X is unknown").
> * Their description of the change seem to suggest that setting `update_bot_account` to a user that is logged into Mergify Dashboard (like Mikolaj or myself) should solve the issue.

## Who to set
I've marked @GaetanLepage as the "update account", so _pushing_ rebased changes will use his account.
I'm also happy to put my name there, but I think @GaetanLepage made more sense as he is the most "senior" and most active maintainer.

This _should_ be fairly invisible though, because when rebasing, mergify sets committer and author matching the original commit's.
This also only affects the push to the PR branch, `Mergify[bot]` is still used to actually _merge_ the PR into the base branch.

## The future
`update_bot_account` is a "template" type (the default is `{{author}}`). I've suggested that Mergify add a "known to mergify" filter, which would allow us to filter a list of users (e.g. `approved-reviews-by.prepend(author).append(GaetanLepage)`) and then filter that list for users that have logged into Mergify's dashboard, (then finally filtering for the `first` matching user). See [the discussion][this discussion] mentioned above.

[our issue]: https://github.com/nix-community/nixvim/issues/1793
[upstreams issue]: https://github.com/Mergifyio/mergify/issues/5075
[this discussion]: https://github.com/Mergifyio/mergify/discussions/5117
[this comment]: https://github.com/haskell/cabal/issues/8462#issuecomment-1633421241
