### PR TITLE
plugins/coverage: Add loadLcov keymap.

### DIFF
--- a/plugins/utils/coverage.nix
+++ b/plugins/utils/coverage.nix
@@ -50,6 +50,13 @@ let
       command = "Summary";
       description = "Displays a coverage summary report in a floating window.";
     };
+    loadLcov = {
+      command = "LoadLcov";
+      description = ''
+        Loads a coverage report from an lcov file but does not display the coverage signs.
+        Uses the lcov file configuration option.
+      '';
+    };
   };
 in
 {

--- a/tests/test-sources/plugins/utils/coverage.nix
+++ b/tests/test-sources/plugins/utils/coverage.nix
@@ -16,6 +16,7 @@
         toggle = "<leader>e";
         clear = "<leader>f";
         summary = "<leader>g";
+        loadLcov = "<leader>h";
       };
 
       autoReload = false;


### PR DESCRIPTION
Adds option for setting a keymap to the [CoverageLoadLcov](https://github.com/andythigpen/nvim-coverage/blob/aa4b4400588e2259e87e372b1e4e90ae13cf5a39/doc/nvim-coverage.txt#L275) command.