### PR TITLE
plugins/nvim-osc52: hide warnings in tests

### DIFF
--- a/tests/test-sources/plugins/utils/nvim-osc52.nix
+++ b/tests/test-sources/plugins/utils/nvim-osc52.nix
@@ -1,10 +1,16 @@
+{ pkgs, ... }:
 {
   empty = {
     plugins.nvim-osc52.enable = true;
+
+    # Hide warnings, since this plugin is deprecated
+    warnings = pkgs.lib.mkForce [ ];
   };
 
   defaults = {
     plugins.nvim-osc52 = {
+      enable = true;
+
       maxLength = 0;
       silent = false;
       trim = false;
@@ -14,5 +20,8 @@
         enable = true;
       };
     };
+
+    # Hide warnings, since this plugin is deprecated
+    warnings = pkgs.lib.mkForce [ ];
   };
 }


### PR DESCRIPTION
#1736 introduced deprecation warnings, which now print when we run the tests. ([Example](https://buildbot.nix-community.org/api/v2/logs/141658/raw_inline)).

We don't care about them in the tests, so just disable all warnings using `mkForce`. This might also hide other warnings we do care about, but I don't see a better approach?