### PR TITLE
dev: Move assert in derivation for generated file in the derivation definition

### DIFF
--- a/flake-modules/updates/efmls-configs.nix
+++ b/flake-modules/updates/efmls-configs.nix
@@ -58,11 +58,11 @@ let
 
   unknownTools = lib.filter (tool: !(lib.hasAttr tool packaged || lib.elem tool unpackaged)) toolList;
 in
-assert lib.assertMsg (lib.length unknownTools == 0)
-  "The following tools are neither marked as unpackaged nor as packaged: ${
-    lib.generators.toPretty { } unknownTools
-  }";
 writeText "efmls-configs-sources.nix" (
+  assert lib.assertMsg (lib.length unknownTools == 0)
+    "The following tools are neither marked as unpackaged nor as packaged: ${
+      lib.generators.toPretty { } unknownTools
+    }";
   "# WARNING: DO NOT EDIT\n"
   + "# This file is generated with packages.<system>.efmls-configs-sources, which is run automatically by CI\n"
   + (lib.generators.toPretty { } sources)

--- a/flake-modules/updates/none-ls.nix
+++ b/flake-modules/updates/none-ls.nix
@@ -21,11 +21,11 @@ let
     unpackaged ++ noPackage ++ (lib.attrNames packaged)
   );
 in
-assert lib.assertMsg (lib.length undeclaredTool == 0)
-  "Undeclared tools: ${lib.generators.toPretty { } undeclaredTool}";
-assert lib.assertMsg (lib.length uselesslyDeclaredTool == 0)
-  "Tool is not supported upstream: ${lib.generators.toPretty { } uselesslyDeclaredTool}";
 writeText "efmls-configs-sources.nix" (
+  assert lib.assertMsg (lib.length undeclaredTool == 0)
+    "Undeclared tools: ${lib.generators.toPretty { } undeclaredTool}";
+  assert lib.assertMsg (lib.length uselesslyDeclaredTool == 0)
+    "Tool is not supported upstream: ${lib.generators.toPretty { } uselesslyDeclaredTool}";
   "# WARNING: DO NOT EDIT\n"
   + "# This file is generated with packages.<system>.none-ls-builtins, which is run automatically by CI\n"
   + (lib.generators.toPretty { } builtinSourceNames)


### PR DESCRIPTION
If we access the asserts outside the derivation arguments, and inside the code that _creates_ the derivation then we observe IFD in `nix flake show`.

This commit fixes it, and allows `nix flake show` to work!

Fixes #1154