### PR TITLE
modules/output: Remove the initContent option

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -61,13 +61,6 @@ with lib;
       visible = false;
     };
 
-    initContent = mkOption {
-      type = types.str;
-      description = "The content of the `init.lua` file.";
-      readOnly = true;
-      visible = false;
-    };
-
     printInitPackage = mkOption {
       type = types.package;
       description = "A tool to show the content of the generated `init.lua` file.";
@@ -142,7 +135,6 @@ with lib;
     {
       type = lib.mkForce "lua";
       finalPackage = wrappedNeovim;
-      initContent = readFile init;
       initPath = "${init}";
 
       printInitPackage = pkgs.writeShellApplication {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -18,7 +18,7 @@ let
   shared = import ./_shared.nix helpers args;
   cfg = config.programs.nixvim;
   files = shared.configFiles // {
-    "nvim/init.lua".text = cfg.initContent;
+    "nvim/init.lua".source = cfg.initPath;
   };
 in
 {

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -19,7 +19,7 @@ let
   shared = import ./_shared.nix helpers args;
   cfg = config.programs.nixvim;
   files = shared.configFiles // {
-    "nvim/sysinit.lua".text = cfg.initContent;
+    "nvim/sysinit.lua".source = cfg.initPath;
   };
 in
 {


### PR DESCRIPTION
This (internal) option introduces IFD, and can be substituted internally with the `initPath` option easily.
If the content is required somewhere users can use readFile on the initPath, though it will result in an IFD in their project.