### PR TITLE
modules/context: init

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -58,7 +58,10 @@ let
       ) opt.declarations;
     };
 
-  modules = [ ../modules/top-level ];
+  modules = [
+    ../modules/top-level
+    { isDocs = true; }
+  ];
 
   hmOptions = builtins.removeAttrs (lib.evalModules {
     modules = [ (import ../wrappers/modules/hm.nix { inherit lib; }) ];
@@ -73,7 +76,6 @@ rec {
           specialArgs = {
             inherit helpers;
             defaultPkgs = pkgsDoc;
-            isDocs = true;
           };
         })
         options

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -14,7 +14,6 @@ let
     specialArgs = {
       inherit helpers;
       defaultPkgs = pkgs;
-      isDocs = true;
     };
   };
 

--- a/modules/misc/context.nix
+++ b/modules/misc/context.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+{
+  options = {
+    isDocs = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether modules are being evaluated to build documentation.
+      '';
+      internal = true;
+      visible = false;
+    };
+  };
+}

--- a/modules/misc/default.nix
+++ b/modules/misc/default.nix
@@ -6,6 +6,7 @@ let
 in
 {
   imports = [
+    ./context.nix
     ./nixpkgs.nix
     ./nixvim-info.nix
     (nixosModules + "/misc/assertions.nix")

--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -3,12 +3,10 @@
   config,
   lib,
   helpers,
-  specialArgs,
   ...
 }:
 let
   inherit (lib) types;
-  isDocs = specialArgs.isDocs or false;
 
   fileModuleType = types.submoduleWith {
     shorthandOnlyDefinesConfig = true;
@@ -17,7 +15,7 @@ let
       defaultPkgs = pkgs;
     };
     # Don't include the modules in the docs, as that'd be redundant
-    modules = lib.optionals (!isDocs) [
+    modules = lib.optionals (!config.isDocs) [
       ../../.
       ./submodule.nix
     ];


### PR DESCRIPTION
### Summary
Added `isTopLevel` and `isDocs` internal options. This replaces `specialArgs.isDocs` that was added in #1807.

### specialArgs vs options
We should only use `specialArgs` when absolutely necessary, a module or `_module.args` is preferred, but those aren't available until `config` is evaluated so they can't be used for `imports`.

The main problem with `specialArgs` is it makes our modules less portable, but it also means the arg can't be overridden with `mkForce` (etc).

Luckily that shouldn't be an issue for these context flags.

### What is `isTopLevel` even for??
The `isTopLevel` option is currently unused; I can drop it from this PR if preferred.

It is _intended_ to allow `files` or `extraFiles` to have a different _type_ when at the top-level, since we can't have a submodule option that recursively includes itself in its modules.
