### PR TITLE
plugins/leap: allow __empty for safeLabels option

### DIFF
--- a/plugins/utils/leap.nix
+++ b/plugins/utils/leap.nix
@@ -84,17 +84,20 @@ in
       };
     };
 
-    safeLabels = helpers.defaultNullOpts.mkListOf types.str (stringToCharacters "sfnut/SFNLHMUGT?Z") ''
-      When the number of matches does not exceed the number of these "safe" labels plus one, the
-      plugin jumps to the first match automatically after entering the pattern.
-      Obviously, for this purpose you should choose keys that are unlikely to be used right
-      after a jump!
+    safeLabels =
+      helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; maybeRaw (listOf str))
+        (stringToCharacters "sfnut/SFNLHMUGT?Z")
+        ''
+          When the number of matches does not exceed the number of these "safe" labels plus one, the
+          plugin jumps to the first match automatically after entering the pattern.
+          Obviously, for this purpose you should choose keys that are unlikely to be used right
+          after a jump!
 
-      Setting the list to `[]` effectively disables the autojump feature.
+          Setting the list to `[]` effectively disables the autojump feature.
 
-      Note: Operator-pending mode ignores this, since we need to be able to select the actual
-      target before executing the operation.
-    '';
+          Note: Operator-pending mode ignores this, since we need to be able to select the actual
+          target before executing the operation.
+        '';
 
     labels =
       helpers.defaultNullOpts.mkListOf types.str

--- a/tests/test-sources/plugins/utils/leap.nix
+++ b/tests/test-sources/plugins/utils/leap.nix
@@ -3,6 +3,15 @@
     plugins.leap.enable = true;
   };
 
+  # https://github.com/nix-community/nixvim/issues/1698
+  autojump-disabled = {
+    plugins.leap = {
+      enable = true;
+
+      safeLabels.__empty = null;
+    };
+  };
+
   example = {
     plugins.leap = {
       enable = true;


### PR DESCRIPTION
Fixes #1698.

I have added an item to the notepad to not forget about considering the fundamental problem.
-> Should `mkListOf` options be typed `maybeRaw (listOf ...)` ?