### PR TITLE
docs: use pkgsDoc to build helpers

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,4 +1,4 @@
-{ helpers, pkgs }:
+{ getHelpers, pkgs }:
 let
   # Extend nixpkg's lib, so that we can handle recursive leaf types such as `either`
   lib = pkgs.lib.extend (
@@ -31,6 +31,8 @@ let
   pkgsDoc = pkgs // {
     inherit lib;
   };
+
+  helpers = getHelpers pkgsDoc false;
 
   nixvimPath = toString ./..;
 

--- a/flake-modules/packages.nix
+++ b/flake-modules/packages.nix
@@ -1,14 +1,10 @@
+{ getHelpers, ... }:
 {
   perSystem =
-    {
-      pkgsUnfree,
-      config,
-      helpers,
-      ...
-    }:
+    { pkgsUnfree, config, ... }:
     {
       packages = import ../docs {
-        inherit helpers;
+        inherit getHelpers;
         # Building the docs evaluates each plugin's default package, some of which are unfree
         pkgs = pkgsUnfree;
       };


### PR DESCRIPTION
`getHelpers` is defined here: https://github.com/nix-community/nixvim/blob/main/flake-modules/helpers.nix (asside: I'm not a fan of having this defined in a flake module)

I was hoping this would be a fix for #1618, but that doesn't seem to be the case.
