### PR TITLE
lib/neovim-plugin: allow disabling `installPackage`

### DIFF
--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -47,6 +47,7 @@ with lib;
       extraPlugins ? [ ],
       extraPackages ? [ ],
       callSetup ? true,
+      installPackage ? true,
     }:
     let
       namespace = if isColorscheme then "colorschemes" else "plugins";
@@ -107,7 +108,7 @@ with lib;
         in
         mkIf cfg.enable (mkMerge [
           {
-            extraPlugins = [ cfg.package ] ++ extraPlugins;
+            extraPlugins = (optional installPackage cfg.package) ++ extraPlugins;
             inherit extraPackages;
 
             ${extraConfigNamespace} = optionalString callSetup ''


### PR DESCRIPTION
Some plugins may wish to handle package installation themselves, so make installing `cfg.package` optional.

I used a "real" branch instead of `mkIf` because we don't know _why_ the plugin doesn't want us to install it - it's possible `cfg.package` shouldn't be evaluated.

This is needed for #1801

@GaetanLepage sorry to step on your toes again re: the the mkPlugin refactor!
