### PR TITLE
modules/output: fix extraLuaPackages

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -85,6 +85,7 @@ with lib;
         {
           inherit (config)
             extraPython3Packages
+            extraLuaPackages
             viAlias
             vimAlias
             withRuby

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -1,0 +1,7 @@
+{
+  extraLuaPackages = {
+    extraLuaPackages = ps: [ ps.jsregexp ];
+    # Make sure jsregexp is in LUA_PATH
+    extraConfigLua = ''require("jsregexp")'';
+  };
+}


### PR DESCRIPTION
It seams `extraLuaPackages` doesn't work or am I missing something?

This PR ensures `extraLuaPackages` are made available on the runtimepath.