### PR TITLE
modules: refactor `extraFiles`

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -27,6 +27,8 @@
 
         extend = import ../tests/extend.nix { inherit pkgs makeNixvimWithModule; };
 
+        extra-files = import ../tests/extra-files.nix { inherit pkgs makeNixvimWithModule; };
+
         enable-except-in-tests = import ../tests/enable-except-in-tests.nix {
           inherit pkgs makeNixvimWithModule;
           inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -12,6 +12,7 @@
     ./diagnostics.nix
     ./doc.nix
     ./editorconfig.nix
+    ./files.nix
     ./filetype.nix
     ./highlights.nix
     ./keymaps.nix

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  helpers,
+  pkgs,
+  ...
+}:
+let
+  fileType = lib.types.submodule (
+    {
+      name,
+      config,
+      options,
+      ...
+    }:
+    {
+      options = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Whether this file should be generated.
+            This option allows specific files to be disabled.
+          '';
+        };
+
+        target = lib.mkOption {
+          type = lib.types.str;
+          defaultText = lib.literalMD "the attribute name";
+          description = ''
+            Name of symlink, relative to nvim config.
+          '';
+        };
+
+        text = lib.mkOption {
+          type = with lib.types; nullOr lines;
+          default = null;
+          description = "Text of the file.";
+        };
+
+        source = lib.mkOption {
+          type = lib.types.path;
+          description = "Path of the source file.";
+        };
+      };
+
+      config =
+        let
+          derivationName = "nvim-" + lib.replaceStrings [ "/" ] [ "-" ] name;
+        in
+        {
+          target = lib.mkDefault name;
+          source = lib.mkIf (config.text != null) (
+            # mkDerivedConfig uses the option's priority, and calls our function with the option's value.
+            # This means our `source` definition has the same priority as `text`.
+            lib.mkDerivedConfig options.text (pkgs.writeText derivationName)
+          );
+        };
+    }
+  );
+
+  # TODO: Added 2024-07-07, remove after 24.11
+  # Before we had a fileType, we used types.str.
+  coercedFileType = helpers.transitionType lib.types.str (text: { inherit text; }) fileType;
+in
+{
+  options = {
+    extraFiles = lib.mkOption {
+      type = lib.types.attrsOf coercedFileType;
+      description = "Extra files to add to the runtime path";
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "ftplugin/nix.lua".text = '''
+            vim.opt.tabstop = 2
+            vim.opt.shiftwidth = 2
+            vim.opt.expandtab = true
+          ''';
+        }
+      '';
+    };
+  };
+}

--- a/modules/output.nix
+++ b/modules/output.nix
@@ -95,12 +95,6 @@ in
       description = "Extra lua packages to include with neovim";
       default = _: [ ];
     };
-
-    extraFiles = mkOption {
-      type = types.attrsOf types.str;
-      description = "Extra files to add to the runtime path";
-      default = { };
-    };
   };
 
   config =

--- a/modules/top-level/files/submodule.nix
+++ b/modules/top-level/files/submodule.nix
@@ -14,9 +14,14 @@
       internal = true;
     };
   };
-  config = {
-    path = name;
-    type = lib.mkDefault (if lib.hasSuffix ".vim" name then "vim" else "lua");
-    plugin = pkgs.writeTextDir config.path config.content;
-  };
+  config =
+    let
+      derivationName = "nvim-" + lib.replaceStrings [ "/" ] [ "-" ] name;
+    in
+    {
+      path = lib.mkDefault name;
+      type = lib.mkDefault (if lib.hasSuffix ".vim" name then "vim" else "lua");
+      # No need to use mkDerivedConfig; this option is readOnly.
+      plugin = pkgs.writeText derivationName config.content;
+    };
 }

--- a/modules/top-level/files/submodule.nix
+++ b/modules/top-level/files/submodule.nix
@@ -2,7 +2,7 @@
   name,
   config,
   lib,
-  pkgs,
+  helpers,
   ...
 }:
 {
@@ -22,6 +22,6 @@
       path = lib.mkDefault name;
       type = lib.mkDefault (if lib.hasSuffix ".vim" name then "vim" else "lua");
       # No need to use mkDerivedConfig; this option is readOnly.
-      plugin = pkgs.writeText derivationName config.content;
+      plugin = helpers.writeLua derivationName config.content;
     };
 }

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -178,7 +178,7 @@ in
         '');
 
       extraFiles = mkIf cfg.nixvimInjections {
-        "queries/nix/injections.scm" = ''
+        "queries/nix/injections.scm".text = ''
           ;; extends
 
           (binding

--- a/tests/extra-files.nix
+++ b/tests/extra-files.nix
@@ -1,0 +1,32 @@
+{ makeNixvimWithModule, pkgs }:
+let
+  extraFiles = {
+    "one".text = "one";
+    "two".text = "two";
+    "nested/in/dirs/file.txt".text = "nested";
+    "this/file/test.nix".source = ./extra-files.nix;
+  };
+  build = makeNixvimWithModule {
+    module = {
+      inherit extraFiles;
+    };
+  };
+in
+pkgs.runCommand "extra-files-test"
+  {
+    root = build.config.filesPlugin;
+    files = builtins.attrNames extraFiles;
+  }
+  ''
+    for file in $files; do
+      path="$root"/"$file"
+      if [[ -f "$path" ]]; then
+        echo "File $path exists"
+      else
+        echo "File $path is missing"
+        exit 1
+      fi
+    done
+
+    touch $out
+  ''

--- a/tests/test-sources/modules/extra-files.nix
+++ b/tests/test-sources/modules/extra-files.nix
@@ -1,7 +1,13 @@
 {
   query = {
     extraFiles = {
-      "queries/lua/injections.scm" = ''
+      "testing/test-case.nix".source = ./extra-files.nix;
+      "testing/123.txt".text = ''
+        One
+        Two
+        Three
+      '';
+      "queries/lua/injections.scm".text = ''
         ;; extends
       '';
     };

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,23 +1,37 @@
 helpers:
 { lib, config, ... }:
 let
-  inherit (lib) mkOption mkOptionType;
+  inherit (lib)
+    isAttrs
+    listToAttrs
+    map
+    mkOption
+    mkOptionType
+    ;
   cfg = config.programs.nixvim;
+  extraFiles = lib.filter (file: file.enable) (lib.attrValues cfg.extraFiles);
 in
 {
   helpers = mkOption {
     type = mkOptionType {
       name = "helpers";
       description = "Helpers that can be used when writing nixvim configs";
-      check = builtins.isAttrs;
+      check = isAttrs;
     };
     description = "Use this option to access the helpers";
     default = helpers;
   };
 
-  configFiles =
-    (lib.mapAttrs' (_: file: lib.nameValuePair "nvim/${file.path}" { text = file.content; }) cfg.files)
-    // (lib.mapAttrs' (
-      path: content: lib.nameValuePair "nvim/${path}" { text = content; }
-    ) cfg.extraFiles);
+  # extraFiles, but nested under "nvim/" for use in etc/xdg config
+  configFiles = listToAttrs (
+    map (
+      { target, source, ... }:
+      {
+        name = "nvim/" + target;
+        value = {
+          inherit source;
+        };
+      }
+    ) extraFiles
+  );
 }


### PR DESCRIPTION
### Summary
Refactored `extraFiles` to use a file-type submodule.

This submodule has the following options:
- `source`: the file path to use
- `text`: (optional) text to write and (potentially) override `source`
- `target`: (default attr name) where the file should be installed
- `enable` (default true) can be used to disable a file added by another module

Users should now assign text to a `text` attribute, however they could also assign a file path to a `source` attribute instead.

### Type coercion
The type conversion is a non-breaking change, as I was able to deprecate the old type using coercion.

I've introduced a tweaked version of `types.coerceTo` (`helpers.transitionType`) that a) only shows the new type's description and b) prints a warning when the old type is used in a definition.

### Tests
I've added an additional check derivation that tests extra files exist in the correct location within `config.filesPlugin`.

### Breaking changes
The `files` option's submodule has an (internal) `plugin` option, which is a derivation containing the resulting file.

Previously this was built using `pkgs.writeTextDir` (i.e. the file was nested in its dir path), however now the file is written directly to the derivation location, using `pkgs.writeText`.

This is done so that `files` can be easily added directly to `extraFiles`, another step towards #1794.

### text vs sources
This means we now pass all files to hm/nixos as filepath "sources" instead of text. This enabled me to use `helpers.writeLua` to format submodule files like we do with `initPath`.

### The future
#### init in extraFiles?
It'd be nice if we could say "everything is in `extraFiles`" (maybe we'd look to rename it at some point?)

To that end, I think it should be a goal to also include `init.lua` in `extraFiles` instead of handling it separately. IDK if there's any complications to this idea though?

#### Print extraFiles
Even if that's not practical, I'd still like to make a way for nixvim-print-init to be able to print extra files too.

#### Nested extraFiles
I believe that currently `extraFiles` nested in a `files` submodule have no effect, i.e. they do not propagate to the top-level `extraFiles`. I haven't tested this though.