### PR TITLE
flake: make most inputs optional

### DIFF
--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -1,13 +1,17 @@
-{ inputs, ... }:
+{ lib, inputs, ... }:
 {
   imports = [
-    inputs.git-hooks.flakeModule
     inputs.treefmt-nix.flakeModule
     ./devshell.nix
-  ];
+  ] ++ lib.optional (inputs.git-hooks ? flakeModule) inputs.git-hooks.flakeModule;
 
   perSystem =
-    { pkgs, config, ... }:
+    {
+      lib,
+      pkgs,
+      config,
+      ...
+    }:
     let
       fmt = pkgs.nixfmt-rfc-style;
     in
@@ -23,7 +27,8 @@
           statix.enable = true;
         };
       };
-
+    }
+    // lib.optionalAttrs (inputs.git-hooks ? flakeModule) {
       pre-commit = {
         settings.hooks = {
           nixfmt = {

--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -1,9 +1,9 @@
 { lib, inputs, ... }:
 {
-  imports = [
-    inputs.treefmt-nix.flakeModule
-    ./devshell.nix
-  ] ++ lib.optional (inputs.git-hooks ? flakeModule) inputs.git-hooks.flakeModule;
+  imports =
+    [ ./devshell.nix ]
+    ++ lib.optional (inputs.git-hooks ? flakeModule) inputs.git-hooks.flakeModule
+    ++ lib.optional (inputs.treefmt-nix ? flakeModule) inputs.treefmt-nix.flakeModule;
 
   perSystem =
     {
@@ -15,7 +15,7 @@
     let
       fmt = pkgs.nixfmt-rfc-style;
     in
-    {
+    lib.optionalAttrs (inputs.treefmt-nix ? flakeModule) {
       treefmt.config = {
         projectRootFile = "flake.nix";
 

--- a/flake-modules/dev/devshell.nix
+++ b/flake-modules/dev/devshell.nix
@@ -1,15 +1,16 @@
-{ inputs, ... }:
+{ lib, inputs, ... }:
 {
-  imports = [ inputs.devshell.flakeModule ];
+  imports = lib.optional (inputs.devshell ? flakeModule) inputs.devshell.flakeModule;
 
   perSystem =
     {
+      lib,
       pkgs,
       config,
       system,
       ...
     }:
-    {
+    lib.optionalAttrs (inputs.devshell ? flakeModule) {
       devshells.default = {
         devshell.startup.pre-commit.text = config.pre-commit.installationScript;
 

--- a/flake.lock
+++ b/flake.lock
@@ -35,22 +35,6 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -91,7 +75,9 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": [
+          "flake-compat"
+        ],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
       url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nixpkgs-stable.follows = "nixpkgs";
+      inputs.flake-compat.follows = "flake-compat";
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,36 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    /*
+      # NOTE: The inputs below this comment are optional
+      # You can remove them with `inputs.<input>.follows = ""`
+
+      For example:
+
+      ```
+      nixvim = {
+        url = "github:nix-community/nixvim";
+        inputs = {
+          nixpkgs.follows = "nixpkgs";
+          flake-parts.follows = "flake-parts";
+
+          devshell.follows = "";
+          flake-compat.follows = "";
+          git-hooks.follows = "";
+          home-manager.follows = "";
+          nix-darwin.follows = "";
+          treefmt-nix.follows = "";
+        };
+      };
+      ```
+    */
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -12,10 +42,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
-    };
     devshell = {
       url = "github:numtide/devshell";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Primarily based off the work done in https://github.com/nix-community/lanzaboote/pull/282

Currently most of the flake's dependencies are solely used for development (with the exception of nixpkgs of course). There isn't much reason to have these inputs pollute the flake.lock of end users, and they should be able to remove them via the `inputs.<input>.follows = ""` interface

Usually this would "just work" with lazy evaluation, but due to flake-parts and it's modules, inputs that we import `flakeModule`s from are evaluated eagerly and become required. To work around this, we can conditionally define and import these options and modules

Assuming the `nixvim` input was originally defined with the following
```nix
{
  inputs = {
    nixvim = {
      url = "github:nix-community/nixvim";
      inputs.nixpkgs.follows = "";
    };
  };
}
```

the following inputs are removed

```
• Updated input 'nixvim/devshell':
    'github:numtide/devshell/1ebbe68d57457c8cae98145410b164b5477761f4' (2024-06-03)
  → follows ''
• Removed input 'nixvim/devshell/flake-utils'
• Removed input 'nixvim/devshell/flake-utils/systems'
• Removed input 'nixvim/devshell/nixpkgs'
• Updated input 'nixvim/flake-compat':
    'https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz?narHash=sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U%3D' (2023-10-04)
  → follows ''
• Updated input 'nixvim/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/4e3583423212f9303aa1a6337f8dffb415920e4f' (2024-07-01)
• Updated input 'nixvim/git-hooks':
    'github:cachix/git-hooks.nix/0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07' (2024-06-24)
  → follows ''
• Removed input 'nixvim/git-hooks/flake-compat'
• Removed input 'nixvim/git-hooks/gitignore'
• Removed input 'nixvim/git-hooks/gitignore/nixpkgs'
• Removed input 'nixvim/git-hooks/nixpkgs'
• Removed input 'nixvim/git-hooks/nixpkgs-stable'
• Updated input 'nixvim/home-manager':
    'github:nix-community/home-manager/6b7ce96f34b324e4e104abc30d06955d216bac71' (2024-07-07)
  → follows ''
• Removed input 'nixvim/home-manager/nixpkgs'
• Updated input 'nixvim/nix-darwin':
    'github:lnl7/nix-darwin/0f89b73f41eaa1dde67b291452c181d9a75f10dd' (2024-07-07)
  → follows ''
• Removed input 'nixvim/nix-darwin/nixpkgs'
• Updated input 'nixvim/treefmt-nix':
    'github:numtide/treefmt-nix/bdb6355009562d8f9313d9460c0d3860f525bc6c' (2024-07-02)
  → follows ''
• Removed input 'nixvim/treefmt-nix/nixpkgs'
```
