### PR TITLE
wrappers: make `_shared` return a module

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,4 +1,6 @@
-{ getHelpers, pkgs }:
+{
+  pkgs ? import <nixpkgs> { config.enableUnfree = true; },
+}:
 let
   # Extend nixpkg's lib, so that we can handle recursive leaf types such as `either`
   lib = pkgs.lib.extend (
@@ -32,7 +34,10 @@ let
     inherit lib;
   };
 
-  helpers = getHelpers pkgsDoc false;
+  helpers = import ../lib/helpers.nix {
+    inherit lib;
+    pkgs = pkgsDoc;
+  };
 
   nixvimPath = toString ./..;
 

--- a/docs/user-guide/helpers.md
+++ b/docs/user-guide/helpers.md
@@ -1,16 +1,24 @@
 # Helpers
 
-Regardless of the way NixVim is used (as a home-manager module, a nixos module, or as a standalone module),
-helpers can be included in the same way.
-
-You can simply use:
+If Nixvim is built using the standalone method, you can access our `helpers` as a module arg:
 
 ```nix
+{ helpers, ... }:
 {
-    helpers,
-    ...
-}: {
-    # Your config
+  # Your config
+}
+```
+
+If Nixvim is being used as as a home-manager module, a nixos module, or as a dawwin module,
+helpers can be accessed via the `config.nixvim.helpers` option:
+
+```nix
+{ config, ... }:
+let
+  inherit (config.nixvim) helpers;
+in
+{
+  # Your config
 }
 ```
 

--- a/flake-modules/helpers.nix
+++ b/flake-modules/helpers.nix
@@ -1,15 +1,7 @@
-{ getHelpers, ... }:
 {
-  _module.args.getHelpers =
-    pkgs: _nixvimTests:
-    import ../lib/helpers.nix {
-      inherit pkgs _nixvimTests;
-      inherit (pkgs) lib;
-    };
-
   perSystem =
-    { pkgs, config, ... }:
+    { pkgs, ... }:
     {
-      _module.args.helpers = getHelpers pkgs false;
+      _module.args.helpers = import ../lib/helpers.nix { inherit pkgs; };
     };
 }

--- a/flake-modules/packages.nix
+++ b/flake-modules/packages.nix
@@ -1,10 +1,8 @@
-{ getHelpers, ... }:
 {
   perSystem =
     { pkgsUnfree, config, ... }:
     {
       packages = import ../docs {
-        inherit getHelpers;
         # Building the docs evaluates each plugin's default package, some of which are unfree
         pkgs = pkgsUnfree;
       };

--- a/flake-modules/wrappers.nix
+++ b/flake-modules/wrappers.nix
@@ -1,21 +1,10 @@
-{
-  inputs,
-  getHelpers,
-  self,
-  ...
-}:
-let
-  wrapperArgs = {
-    inherit self;
-    inherit getHelpers;
-  };
-in
+{ inputs, self, ... }:
 {
   perSystem =
     { system, pkgs, ... }:
     {
       _module.args = {
-        makeNixvimWithModule = import ../wrappers/standalone.nix pkgs wrapperArgs;
+        makeNixvimWithModule = import ../wrappers/standalone.nix pkgs self;
       };
 
       checks =
@@ -47,15 +36,15 @@ in
 
   flake = {
     nixosModules = {
-      nixvim = import ../wrappers/nixos.nix wrapperArgs;
+      nixvim = import ../wrappers/nixos.nix self;
       default = self.nixosModules.nixvim;
     };
     homeManagerModules = {
-      nixvim = import ../wrappers/hm.nix wrapperArgs;
+      nixvim = import ../wrappers/hm.nix self;
       default = self.homeManagerModules.nixvim;
     };
     nixDarwinModules = {
-      nixvim = import ../wrappers/darwin.nix wrapperArgs;
+      nixvim = import ../wrappers/darwin.nix self;
       default = self.nixDarwinModules.nixvim;
     };
   };

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -1,7 +1,7 @@
 {
-  lib,
   pkgs,
-  _nixvimTests,
+  lib ? pkgs.lib,
+  _nixvimTests ? false,
   ...
 }:
 let

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,6 +1,4 @@
 {
-  # Our helpers
-  helpers,
   # Option path where extraFiles should go
   filesOpt ? null,
   # Filepath prefix to apply to extraFiles
@@ -9,7 +7,12 @@
   # Is prefixed with `filesPrefix`
   initName ? "init.lua",
 }:
-{ lib, config, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 let
   inherit (lib)
     isAttrs
@@ -39,7 +42,7 @@ in
 
   config = mkMerge [
     # Make our lib available to the host modules
-    { nixvim.helpers = lib.mkDefault helpers; }
+    { nixvim.helpers = lib.mkDefault (import ../lib/helpers.nix { inherit pkgs lib; }); }
     # Propagate extraFiles to the host modules
     (optionalAttrs (filesOpt != null) (
       mkIf (!cfg.wrapRc) (

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,37 +1,65 @@
-helpers:
+{
+  # Our helpers
+  helpers,
+  # Option path where extraFiles should go
+  filesOpt ? null,
+  # Filepath prefix to apply to extraFiles
+  filesPrefix ? "nvim/",
+  # Filepath to use when adding `cfg.initPath` to `filesOpt`
+  # Is prefixed with `filesPrefix`
+  initName ? "init.lua",
+}:
 { lib, config, ... }:
 let
   inherit (lib)
     isAttrs
     listToAttrs
     map
+    mkIf
+    mkMerge
     mkOption
     mkOptionType
+    optionalAttrs
+    setAttrByPath
     ;
   cfg = config.programs.nixvim;
   extraFiles = lib.filter (file: file.enable) (lib.attrValues cfg.extraFiles);
 in
 {
-  helpers = mkOption {
-    type = mkOptionType {
-      name = "helpers";
-      description = "Helpers that can be used when writing nixvim configs";
-      check = isAttrs;
+  options = {
+    nixvim.helpers = mkOption {
+      type = mkOptionType {
+        name = "helpers";
+        description = "Helpers that can be used when writing nixvim configs";
+        check = isAttrs;
+      };
+      description = "Use this option to access the helpers";
     };
-    description = "Use this option to access the helpers";
-    default = helpers;
   };
 
-  # extraFiles, but nested under "nvim/" for use in etc/xdg config
-  configFiles = listToAttrs (
-    map (
-      { target, source, ... }:
-      {
-        name = "nvim/" + target;
-        value = {
-          inherit source;
-        };
-      }
-    ) extraFiles
-  );
+  config = mkMerge [
+    # Make our lib available to the host modules
+    { nixvim.helpers = lib.mkDefault helpers; }
+    # Propagate extraFiles to the host modules
+    (optionalAttrs (filesOpt != null) (
+      mkIf (!cfg.wrapRc) (
+        setAttrByPath filesOpt (
+          listToAttrs (
+            map (
+              { target, source, ... }:
+              {
+                name = filesPrefix + target;
+                value = {
+                  inherit source;
+                };
+              }
+            ) extraFiles
+          )
+          // {
+            ${filesPrefix + initName}.source = cfg.initPath;
+          }
+        )
+      )
+    ))
+  ];
 }

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -1,4 +1,4 @@
-{ self, getHelpers }:
+self:
 {
   pkgs,
   config,
@@ -15,7 +15,6 @@ let
     mkIf
     types
     ;
-  helpers = getHelpers pkgs false;
   cfg = config.programs.nixvim;
 in
 {
@@ -27,7 +26,7 @@ in
         specialArgs = {
           darwinConfig = config;
           defaultPkgs = pkgs;
-          inherit helpers;
+          inherit (config.nixvim) helpers;
         };
         modules = [
           ./modules/darwin.nix
@@ -37,7 +36,7 @@ in
     };
   };
 
-  imports = [ (import ./_shared.nix { inherit helpers; }) ];
+  imports = [ (import ./_shared.nix { }) ];
 
   config = mkIf cfg.enable (mkMerge [
     {

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -16,7 +16,6 @@ let
     types
     ;
   helpers = getHelpers pkgs false;
-  shared = import ./_shared.nix helpers args;
   cfg = config.programs.nixvim;
 in
 {
@@ -36,8 +35,9 @@ in
         ];
       };
     };
-    nixvim.helpers = shared.helpers;
   };
+
+  imports = [ (import ./_shared.nix { inherit helpers; }) ];
 
   config = mkIf cfg.enable (mkMerge [
     {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -1,4 +1,4 @@
-{ self, getHelpers }:
+self:
 {
   pkgs,
   config,
@@ -14,7 +14,6 @@ let
     mkIf
     types
     ;
-  helpers = getHelpers pkgs false;
   cfg = config.programs.nixvim;
 in
 {
@@ -26,7 +25,7 @@ in
         specialArgs = {
           hmConfig = config;
           defaultPkgs = pkgs;
-          inherit helpers;
+          inherit (config.nixvim) helpers;
         };
         modules = [
           ./modules/hm.nix
@@ -38,7 +37,6 @@ in
 
   imports = [
     (import ./_shared.nix {
-      inherit helpers;
       filesOpt = [
         "xdg"
         "configFile"

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -15,11 +15,7 @@ let
     types
     ;
   helpers = getHelpers pkgs false;
-  shared = import ./_shared.nix helpers args;
   cfg = config.programs.nixvim;
-  files = shared.configFiles // {
-    "nvim/init.lua".source = cfg.initPath;
-  };
 in
 {
   options = {
@@ -38,8 +34,17 @@ in
         ];
       };
     };
-    nixvim.helpers = shared.helpers;
   };
+
+  imports = [
+    (import ./_shared.nix {
+      inherit helpers;
+      filesOpt = [
+        "xdg"
+        "configFile"
+      ];
+    })
+  ];
 
   config = mkIf cfg.enable (mkMerge [
     {
@@ -48,7 +53,6 @@ in
         cfg.printInitPackage
       ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs);
     }
-    (mkIf (!cfg.wrapRc) { xdg.configFile = files; })
     {
       inherit (cfg) warnings assertions;
       home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -1,4 +1,4 @@
-{ self, getHelpers }:
+self:
 {
   pkgs,
   config,
@@ -15,7 +15,6 @@ let
     mkIf
     types
     ;
-  helpers = getHelpers pkgs false;
   cfg = config.programs.nixvim;
 in
 {
@@ -27,7 +26,7 @@ in
         specialArgs = {
           nixosConfig = config;
           defaultPkgs = pkgs;
-          inherit helpers;
+          inherit (config.nixvim) helpers;
         };
         modules = [
           ./modules/nixos.nix
@@ -39,7 +38,6 @@ in
 
   imports = [
     (import ./_shared.nix {
-      inherit helpers;
       filesOpt = [
         "environment"
         "etc"

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -1,5 +1,4 @@
-default_pkgs:
-{ self, getHelpers }:
+default_pkgs: self:
 {
   pkgs ? default_pkgs,
   extraSpecialArgs ? { },
@@ -9,7 +8,7 @@ default_pkgs:
 let
   inherit (pkgs) lib;
 
-  helpers = getHelpers pkgs _nixvimTests;
+  helpers = import ../lib/helpers.nix { inherit pkgs lib _nixvimTests; };
 
   handleAssertions =
     config:


### PR DESCRIPTION
## Make `_shared.nix` return a module
We can consolidate some duplication by propagating config files directly in a shared module, we just need to know the option name and the name of the init file.

## Make `helpers` available via `lib` option
**NOTE: this change has been dropped from this PR!**

<details><summary>Details</summary>
<p>

Currently we make helpers available via `config.nixvim.helpers`, however NixOS, nix-darwin and home-manager all provide a `config.lib` option (type `attrsOf attrs`).

This `lib` option is intended to be used by modules to define their custom functions in a global scope. It is **unrelated** to the `lib` available via module args.

I've used `mkRenameOptionModule` to rename `nixvim.helpers` to `lib.nixvim`. This prints a warning when `config.nixvim.helpers` is evaluated:
```
trace: Obsolete option `nixvim.helpers' is used. It was renamed to `lib.nixvim'.
```

</p>
</details> 

I've also updated the docs. Previously they said that `helpers` is available as a module arg in all wrappers, however this was only true for the standalone build. Fixes #1220.

Maybe we should fix the nixos-24.05 docs too.

## Bootstrap "helpers" directly
In order to simplify the wrappers some more, and reduce the number of arguments needed to be passed in, we can bootstrap `helpers` directly from `../lib/helpers.nix` instead of using a `getHelpers` function passed in from the flake.

We do this in the shared module returned by `_shared.nix`.

## Remove `getHelpers` function
It was now only used by the docs, so we may as well remove it.