### PR TITLE
wrappers: make `helpers` available via `lib` option

### DIFF
--- a/docs/user-guide/helpers.md
+++ b/docs/user-guide/helpers.md
@@ -10,12 +10,12 @@ If Nixvim is built using the standalone method, you can access our `helpers` as 
 ```
 
 If Nixvim is being used as as a home-manager module, a nixos module, or as a dawwin module,
-helpers can be accessed via the `config.nixvim.helpers` option:
+helpers can be accessed via the `config.lib` option:
 
 ```nix
 { config, ... }:
 let
-  inherit (config.nixvim) helpers;
+  helpers = config.lib.nixvim;
 in
 {
   # Your config

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -29,20 +29,24 @@ let
   extraFiles = lib.filter (file: file.enable) (lib.attrValues cfg.extraFiles);
 in
 {
-  options = {
-    nixvim.helpers = mkOption {
-      type = mkOptionType {
-        name = "helpers";
-        description = "Helpers that can be used when writing nixvim configs";
-        check = isAttrs;
-      };
-      description = "Use this option to access the helpers";
-    };
-  };
+  # TODO: Added 2024-07-24; remove after 24.11
+  imports = [
+    (lib.mkRenamedOptionModule
+      [
+        "nixvim"
+        "helpers"
+      ]
+      [
+        "lib"
+        "nixvim"
+      ]
+    )
+  ];
 
   config = mkMerge [
     # Make our lib available to the host modules
-    { nixvim.helpers = lib.mkDefault (import ../lib/helpers.nix { inherit pkgs lib; }); }
+    # TODO: import top-level ../lib
+    { lib.nixvim = lib.mkDefault (import ../lib/helpers.nix { inherit pkgs lib; }); }
     # Propagate extraFiles to the host modules
     (optionalAttrs (filesOpt != null) (
       mkIf (!cfg.wrapRc) (


### PR DESCRIPTION
[NixOS](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/misc/lib.nix?rgh-link-date=2024-07-08T17%3A09%3A50Z), [HM](https://github.com/nix-community/home-manager/blob/master/modules/misc/lib.nix), & [Darwin](https://github.com/LnL7/nix-darwin/blob/master/modules/misc/lib.nix) provide a `lib` option.

This option exists because the nixpkgs `lib` cannot be modified within an evaluating module system. Therefore it exists as an alternative place where functions and other attrs can be defined, used & shared by modules.

> [!NOTE]
> The [`lib` _option_](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/misc/lib.nix) is **completely unrelated** to the `lib` specialArg [added by `evalModules`](https://github.com/NixOS/nixpkgs/blob/97f336bc91e53b59371ed405c22936a62740d4fe/lib/modules.nix#L245).
> It doesn't contain any nixpkgs `lib` functions, (and vice versa)

> [!WARNING]
> As it is defined via `config` and `options`, functions in the `lib` option _cannot_ be used to define module `imports`.

#### Migration

Previously we used a custom option to do the same thing, therefore we can just use a `mkRenamedModuleOption` alias. If the old name is evaluated it prints:

The old option is renamed, if it is accessed it will print:
```
trace: Obsolete option `nixvim.helpers' is used. It was renamed to `lib.nixvim'.
```

This was originally part of #1831, but is now part of a larger work to cleanup and refactor our custom lib.
