### PR TITLE
plugins/treesitter: Update nixvim queries

### DIFF
--- a/plugins/languages/treesitter/injections.scm
+++ b/plugins/languages/treesitter/injections.scm
@@ -11,7 +11,20 @@
       ((string_fragment) @injection.content
         (#set! injection.language "lua")))
   ]
-  (#match? @_path "(^extraConfigLua(Pre|Post)?)$"))
+  (#match? @_path "(^(extraConfigLua(Pre|Post)?|__raw))$"))
+
+(apply_expression
+  function: (_) @_func
+  argument: [
+    (string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "lua")))
+    (indented_string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "lua")))
+  ]
+  (#match? @_func "(^|\\.)mkRaw$")
+  (#set! injection.combined))
 
 (binding
   attrpath: (attrpath

--- a/plugins/languages/treesitter/injections.scm
+++ b/plugins/languages/treesitter/injections.scm
@@ -1,17 +1,27 @@
 ;; extends
 
 (binding
-  attrpath: (attrpath (identifier) @_path)
+  attrpath: (attrpath
+    (identifier) @_path)
   expression: [
-    (string_expression (string_fragment) @lua)
-    (indented_string_expression (string_fragment) @lua)
+    (string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "lua")))
+    (indented_string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "lua")))
   ]
-  (#match? @_path "^extraConfigLua(Pre|Post)?$"))
+  (#match? @_path "(^extraConfigLua(Pre|Post)?)$"))
 
 (binding
-  attrpath: (attrpath (identifier) @_path)
+  attrpath: (attrpath
+    (identifier) @_path)
   expression: [
-    (string_expression (string_fragment) @vim)
-    (indented_string_expression (string_fragment) @vim)
+    (string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "vim")))
+    (indented_string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "vim")))
   ]
-  (#match? @_path "^extraConfigVim(Pre|Post)?$"))
+  (#match? @_path "(^extraConfigVim(Pre|Post)?)$"))


### PR DESCRIPTION
This PR fixes the existing nixvim queries to work with neovim 0.10. It also adds support for `lua` injections in `helpers.mkRaw` or `__raw` strings.