### PR TITLE
tests: add check for nixpkgs maintainers

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -44,6 +44,8 @@
           inherit pkgs helpers;
           inherit (pkgs) lib;
         };
+
+        maintainers = import ../tests/maintainers.nix { inherit pkgs; };
       };
     };
 }

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -12,14 +12,6 @@
     githubId = 1176328;
     name = "Alison Jenkins";
   };
-  MattSturgeon = {
-    email = "matt@sturgeon.me.uk";
-    matrix = "@mattsturg:matrix.org";
-    github = "MattSturgeon";
-    githubId = 5046562;
-    name = "Matt Sturgeon";
-    keys = [ { fingerprint = "7082 22EA 1808 E39A 83AC  8B18 4F91 844C ED1A 8299"; } ];
-  };
   DanielLaing = {
     email = "daniel@daniellaing.com";
     matrix = "@bodleum:matrix.org";

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -11,7 +11,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   originalName = "dashboard-nvim";
   defaultPackage = pkgs.vimPlugins.dashboard-nvim;
 
-  maintainers = [ helpers.maintainers.MattSturgeon ];
+  maintainers = [ maintainers.MattSturgeon ];
 
   # TODO introduced 2024-05-30: remove 2024-09-01
   imports =

--- a/plugins/utils/refactoring.nix
+++ b/plugins/utils/refactoring.nix
@@ -11,7 +11,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   originalName = "refactoring.nvim";
   defaultPackage = pkgs.vimPlugins.refactoring-nvim;
 
-  maintainers = [ helpers.maintainers.MattSturgeon ];
+  maintainers = [ maintainers.MattSturgeon ];
 
   # TODO: introduced 2024-05-24, remove on 2024-08-24
   optionsRenamedToSettings = [

--- a/plugins/utils/tmux-navigator.nix
+++ b/plugins/utils/tmux-navigator.nix
@@ -12,7 +12,7 @@ helpers.vim-plugin.mkVimPlugin config {
   defaultPackage = pkgs.vimPlugins.vim-tmux-navigator;
   globalPrefix = "tmux_navigator_";
 
-  maintainers = [ helpers.maintainers.MattSturgeon ];
+  maintainers = [ maintainers.MattSturgeon ];
 
   description = ''
     When combined with a set of tmux key bindings, the plugin will allow you to navigate seamlessly between vim splits and tmux panes using a consistent set of hotkeys.

--- a/tests/maintainers.nix
+++ b/tests/maintainers.nix
@@ -1,0 +1,21 @@
+{
+  pkgs ? import <nixpkgs> { },
+  lib ? pkgs.lib,
+}:
+let
+  inherit (lib) attrNames filter length;
+  nixvimList = import ../lib/maintainers.nix;
+  nixpkgsList = lib.maintainers;
+  duplicates = filter (name: nixpkgsList ? ${name}) (attrNames nixvimList);
+  count = length duplicates;
+in
+pkgs.runCommand "maintainers-test" { inherit count duplicates; } ''
+  if [ $count -gt 0 ]; then
+    echo "$count nixvim maintainers are also nixpkgs maintainers:"
+    for name in $duplicates; do
+      echo "- $name"
+    done
+    exit 1
+  fi
+  touch $out
+''


### PR DESCRIPTION
Would it make sense for this to be a custom CI workflow instead of a flake check?
I'm wondering if there's an out-of-sync nixpkgs lock scenario where it being a check could cause issues.

If we can't think of any, then this is fine and we can deal with issues as they come up.
