### PR TITLE
plugin/rustaceanvim: Handle rust-analyzer settings rename

### DIFF
--- a/plugins/languages/rust/rustaceanvim/default.nix
+++ b/plugins/languages/rust/rustaceanvim/default.nix
@@ -34,7 +34,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         "nightly"
         "rust-analyzer"
       ];
-      settings = {
+      default_settings = {
         rust-analyzer = {
           inlayHints = {
             lifetimeElisionHints = {
@@ -58,7 +58,23 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       '';
     in
     mkMerge [
-      { extraPackages = [ cfg.rustAnalyzerPackage ]; }
+      {
+        extraPackages = [ cfg.rustAnalyzerPackage ];
+        # TODO: remove after 24.11
+        warnings =
+          optional
+            (hasAttrByPath [
+              "settings"
+              "server"
+              "settings"
+            ] cfg)
+            ''
+              The `plugins.rustaceanvim.settings.server.settings' option has been renamed to `plugins.rustaceanvim.settings.server.default_settings'.
+
+              Note that if you supplied an attrset and not a function you need to set this attr set in:
+                `plugins.rustaceanvim.settings.server.default_settings.rust-analyzer'.
+            '';
+      }
       # If nvim-lspconfig is enabled:
       (mkIf config.plugins.lsp.enable {
         # Use the same `on_attach` callback as for the other LSP servers

--- a/plugins/languages/rust/rustaceanvim/settings-options.nix
+++ b/plugins/languages/rust/rustaceanvim/settings-options.nix
@@ -254,10 +254,10 @@ with lib;
       ```
     '';
 
-    settings =
+    default_settings =
       helpers.mkNullOrStrLuaFnOr
         (types.submodule {
-          options = import ../../../lsp/language-servers/rust-analyzer-config.nix lib helpers;
+          options.rust-analyzer = import ../../../lsp/language-servers/rust-analyzer-config.nix lib helpers;
           freeformType = with types; attrsOf anything;
         })
         ''

--- a/tests/test-sources/plugins/languages/rust/rustaceanvim.nix
+++ b/tests/test-sources/plugins/languages/rust/rustaceanvim.nix
@@ -143,7 +143,7 @@
     plugins.rustaceanvim = {
       enable = true;
 
-      settings.server.settings = {
+      settings.server.default_settings.rust-analyzer = {
         linkedProjects = [ "foo/bar/hello" ];
         numThreads = 42;
         joinLines.joinElseIf = true;


### PR DESCRIPTION
There is not much more than we can do than print a warning, due to the complication of using submodules.
We may want to have a more generic framework to handle removal/renaming of options.

Fixes #1847 