### PR TITLE
flake/dev/formatting: run ruff format in isolated mode

### DIFF
--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -49,6 +49,7 @@
             "**.svg"
             "**/man/*.5"
           ];
+          formatter.ruff-format.options = [ "--isolated" ];
         };
       };
     }


### PR DESCRIPTION
This prevents ruff to look for personal config files when running `nix fmt`.