### PR TITLE
fix: update intellitab treesitter config to fix deprecation

### DIFF
--- a/plugins/utils/intellitab.nix
+++ b/plugins/utils/intellitab.nix
@@ -29,7 +29,7 @@ in
       }
     ];
     plugins.treesitter = {
-      indent = true;
+      settings.indent.enable = true;
     };
   };
 }


### PR DESCRIPTION
```
trace: warning: hrmny profile: The option `plugins.treesitter.indent' defined in `/nix/store/i14h4i6hra9b046ywr8p4n53mk7481wd-source/plugins/utils/intellitab.nix' has been renamed to `plugins.treesitter.settings.indent.enable'.
```