### PR TITLE
plugins/treesitter: fix parser_install_dir default

### DIFF
--- a/tests/test-sources/plugins/languages/treesitter/treesitter.nix
+++ b/tests/test-sources/plugins/languages/treesitter/treesitter.nix
@@ -8,7 +8,9 @@
         auto_install = false;
         ensure_installed = [ ];
         ignore_install = [ ];
-        parser_install_dir = null;
+        # NOTE: This is our default, not the plugin's
+        parser_install_dir.__raw = "vim.fs.joinpath(vim.fn.stdpath('data'), 'site')";
+
         sync_install = false;
 
         highlight = {


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/1849

We default to null for settingsOptions to respect plugin defaults. The nvim-treesitter plugin also has a null default for parser_install_dir, but the fallback of package path isn't a writeable directory on NixOS. This provides a sane default for NixOS users. 