### PR TITLE
plugins/treesitter: fix folding

### DIFF
--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -319,9 +319,9 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       cfg.treesitterPackage
     ];
 
-    opts = mkIf cfg.folding (mkDefault {
-      foldmethod = "expr";
-      foldexpr = "nvim_treesitter#foldexpr()";
-    });
+    opts = mkIf cfg.folding {
+      foldmethod = mkDefault "expr";
+      foldexpr = mkDefault "nvim_treesitter#foldexpr()";
+    };
   };
 }


### PR DESCRIPTION
opts getting wiped out by setting entire set as default instead of each attribute