### PR TITLE
github/update: run `update` on the respective branch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -71,10 +71,17 @@ jobs:
           nix run .#generate-files -- --commit
           new=$(git show --no-patch --format=%h)
           if [ "$old" != "$new" ]; then
-            summary=$(git show --no-patch --format=%s)
-            echo "summary=$summary" >> "$GITHUB_OUTPUT"
+            body=$(git show --no-patch --format=%b)
             echo "body<<EOF" >> "$GITHUB_OUTPUT"
-            git show --no-patch --format=%b >> "$GITHUB_OUTPUT"
+            if [ -n "$body" ]; then
+              # Multi-file changes are listed in the body
+              echo "$body" >> "$GITHUB_OUTPUT"
+            else
+              # Single-file changes are only in the summary,
+              # e.g. "generated: Updated none-ls.nix"
+              git show --no-patch --format=%s | \
+              sed -e 's/^generated:/-/' >> "$GITHUB_OUTPUT"
+            fi
             echo "EOF" >> "$GITHUB_OUTPUT"
           fi
 
@@ -96,7 +103,7 @@ jobs:
             ```
 
             ## Generate
-            ${{ steps.generate.outputs.body || steps.generate.outputs.summary || 'No changes' }}
+            ${{ steps.generate.outputs.body || 'No changes' }}
 
       - name: Print summary
         if: ${{ steps.pr.outputs.pull-request-number }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,45 +1,45 @@
 name: update
 on:
-  workflow_dispatch: # allows manual triggering
-    inputs:
-      branch:
-        description: "Branch to update"
-        type: choice
-        options:
-          - "stable & unstable"
-          - "main"
-          - "nixos-24.05"
+  # Runs every Saturday at noon
   schedule:
-    - cron: "0 12 * * SAT" # runs weekly on Saturday at noon
+    - cron: "0 12 * * SAT"
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      nixos-24.05:
+        type: boolean
+        description: Also update nixos-24.05
+
+# Allow one concurrent update per branch
+concurrency:
+  group: "update-${{ github.ref_name }}"
+  cancel-in-progress: true
+
+# Allow running workflows, pushing and creating PRs
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
 
 jobs:
-  lockfile:
-    strategy:
-      matrix:
-        # This allows to update both stable & unstable branches, but not both when triggered
-        # manually
-        branch: ["main", "nixos-24.05"]
-        selectedBranch: ["${{ inputs.branch }}"]
-        exclude:
-          - selectedBranch: main
-            branch: "nixos-24.05"
-          - selectedBranch: "nixos-24.05"
-            branch: main
-
+  update:
     name: Update the flake inputs and generate options
     runs-on: ubuntu-latest
     timeout-minutes: 40
-
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.CI_UPDATE_SSH_KEY }}
-          ref: ${{ matrix.branch }}
+
+      # NOTE: If additional "inputs" are added, copy this step
+      - name: Update nixos-24.05
+        if: inputs['nixos-24.05'] || github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run update.yml --ref nixos-24.05
 
       - name: Install Nix
         uses: cachix/install-nix-action@v26
@@ -82,13 +82,13 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: update/${{ matrix.branch }}
-          base: ${{ matrix.branch }}
+          add-paths: "!**"
+          branch: update/${{ github.ref_name }}
           delete-branch: true
           team-reviewers: |
             nix-community/nixvim
           title: |
-            [${{ matrix.branch }}] Update flake.lock & generated files
+            [${{ github.ref_name }}] Update flake.lock & generated files
           body: |
             ## Flake lockfile
             ```
@@ -112,7 +112,7 @@ jobs:
           echo "${pr} was ${operation}."
 
           # markdown summary
-          echo "## ${{ matrix.branch }}" >> $GITHUB_STEP_SUMMARY
+          echo "## ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
           echo "\`${head:0:6}\` pushed to \`${pr_branch}\`" >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY

--- a/flake-modules/updates/default.nix
+++ b/flake-modules/updates/default.nix
@@ -43,13 +43,14 @@
             cd "$generated_dir"
             git add .
 
-            # Construct a msg body from `git status`
+            # Construct a msg body from `git status -- .`
             body=$(
               git status \
                 --short \
                 --ignored=no \
                 --untracked-files=no \
                 --no-ahead-behind \
+                -- . \
               | sed \
                 -e 's/^\s*\([A-Z]\)\s*/\1 /' \
                 -e 's/^A/Added/' \
@@ -60,7 +61,7 @@
             )
 
             # Construct the commit message based on the body
-            count=$(echo "$body" | wc -l)
+            count=$(echo -n "$body" | wc -l)
             if [ "$count" -gt 1 ] || [ ''${#body} -gt 50 ]; then
               msg=$(echo -e "generated: Update\n\n$body")
             else
@@ -68,7 +69,11 @@
             fi
 
             # Commit if there are changes
-            [ "$count" -gt 0 ] && git commit -m "$msg" --no-verify
+            if [ "$count" -gt 0 ]; then
+              echo "Committing $count changes..."
+              echo "$msg"
+              git commit -m "$msg" --no-verify
+            fi
           fi
         '';
       };


### PR DESCRIPTION
### Summary

The main goal of this PR is to remove the branches matrix and instead run the update CI only for the workflow's branch. This is paired with #1862 and should fix issues where the CI fails due to branch differences such as `generate-files` being missing.

It is still possible to update both branches at once, using the "also update nixos-24.05" checkbox. When ticked (or when the workflow is `scheduled`), a conditional step will trigger the other branch's workflow using the `gh workflow run` command.

<img src="https://github.com/user-attachments/assets/f878d8ce-3aee-47eb-82e2-5cbbd9ed2f9f" width=350>

### All changes
- Run the `update.yml` workflow on the triggered branch, replace the job matrix with a conditional step that runs update on nixos-24.05.
- Added a `cancel-in-progress` concurrency group.
- Disabled committing in PR action (using negative add-paths).
- Improve summary for generated files.
- Fixed some issues with `generate-files`' `--commit` option

### Backport
Most changes that affect the stable branch were already merged in #1862, where relevant I'll backport other changes once this is merged.

### Updating more than two branches
If we ever want to update additional branches, we can do that by adding an extra _input_ and copy-pasting the conditional _"Update nixos-24.05"_ step.

<details><summary>(Old) draft PR description</summary>
<p>

Allows the `update.yml` workflow to just run on the triggered branch without needing inputs.

`call-update.yml` will use `gh workflow run` to trigger it on the correct branch.

Don't have time to test, so just pushing my initial draft for now.

</p>
</details> 
