### PR TITLE
plugins/treesitter: disable folding by default

### DIFF
--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -203,12 +203,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   };
 
   extraOptions = {
-    folding = mkOption {
-      type = types.bool;
-      default = true;
-      example = false;
-      description = "Whether to enable treesitter folding.";
-    };
+    folding = mkEnableOption "tree-sitter based folding";
 
     gccPackage = helpers.mkPackageOption {
       name = "gcc";


### PR DESCRIPTION
I think this got erroneously changed in #1801.

Having a fold at every function is rather annoying to work with and having to unfold many things in every file.