### PR TITLE
github/update: remove broken team-reviewers

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -92,8 +92,6 @@ jobs:
           add-paths: "!**"
           branch: update/${{ github.ref_name }}
           delete-branch: true
-          team-reviewers: |
-            nix-community/nixvim
           title: |
             [${{ github.ref_name }}] Update flake.lock & generated files
           body: |


### PR DESCRIPTION
> Unable to request reviewers.
> If requesting team reviewers a 'repo' scoped PAT is required.

I missed this when testing on my fork, as I had to disable team-reviews there because it was a fork.

(I stopped buildbot as this is a yaml only change)