### PR TITLE
[nixos-24.05] github/update: sync with main

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,16 +1,28 @@
 name: update
 on:
-  workflow_dispatch: # allows manual triggering
+  # Runs every Saturday at noon
+  schedule:
+    - cron: "0 12 * * SAT"
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+
+# Allow one concurrent update per branch
+concurrency:
+  group: "update-${{ github.ref_name }}"
+  cancel-in-progress: true
+
+# Allow running workflows, pushing and creating PRs
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
 
 jobs:
-  lockfile:
+  update:
     name: Update the flake inputs
     runs-on: ubuntu-latest
     timeout-minutes: 40
-
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -45,10 +57,9 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:
+          add-paths: "!**"
           branch: update/${{ github.ref_name }}
           delete-branch: true
-          team-reviewers: |
-            nix-community/nixvim
           title: |
             [${{ github.ref_name }}] Update flake.lock
           body: |


### PR DESCRIPTION
Sync update workflow with `main` again, following #1863 and #1869

(buildbot is having issues, but I probably would've cancelled a yaml only change from building anyway)