### PR TITLE
lib/neovim-plugin: Add lazyLoad option to plugins

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -44,6 +44,7 @@ let
       defaultNullOpts
       mkCompositeOption
       mkCompositeOption'
+      mkLazyLoadOption
       mkNullOrLua
       mkNullOrLua'
       mkNullOrLuaFn

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -372,11 +372,6 @@ rec {
       originalName,
       lazyLoadDefaults ? { },
     }:
-    let
-      pluginDefault = {
-        enable = false;
-      } // lazyLoadDefaults;
-    in
     mkOption {
       description = ''
         Lazy-load settings for ${originalName}.
@@ -393,65 +388,71 @@ rec {
         submodule {
           options = with defaultNullOpts; {
 
-            enable = mkOption {
-              type = bool;
-              default = pluginDefault.enable;
-              description = ''
-                Enable lazy-loading for ${originalName}
-              '';
-            };
+            enable = mkEnableOption ''
+              lazy-loading for ${originalName}
+            '';
 
             # Spec loading:
-            enabled = mkStrLuaFnOr bool pluginDefault.enabledInSpec or null ''
+            enabled = mkStrLuaFnOr bool (lazyLoadDefaults.enabledInSpec or null) ''
               When false, or if the function returns false, then ${originalName} will not be included in the spec.
+
               Equivalence: lz.n => enabled; lazy.nvim => enabled
             '';
 
-            priority = mkNullable number pluginDefault.priority or null ''
+            priority = mkNullable number (lazyLoadDefaults.priority or null) ''
               Only useful for start plugins (not lazy-loaded) to force loading certain plugins first.
+
               Equivalence: lz.n => priority; lazy.nvim => priority
             '';
 
             # Spec setup
             # Actions
-            beforeAll = mkLuaFn pluginDefault.beforeAll or null ''
+            beforeAll = mkLuaFn (lazyLoadDefaults.beforeAll or null) ''
               Always executed before any plugins are loaded.
+
               Equivalence: lz.n => beforeAll; lazy.nvim => init
             '';
 
-            before = mkLuaFn pluginDefault.before or null ''
+            before = mkLuaFn (lazyLoadDefaults.before or null) ''
               Executed before ${originalName} is loaded.
+
               Equivalence: lz.n => before; lazy.nvim => None
             '';
 
-            after = mkLuaFn pluginDefault.after or null ''
+            after = mkLuaFn (lazyLoadDefaults.after or null) ''
               Executed after ${originalName} is loaded.
+
               Equivalence: lz.n => after; lazy.nvim => config
             '';
 
             # Triggers
-            event = mkNullable triggerType pluginDefault.event or null ''
+            event = mkNullable triggerType (lazyLoadDefaults.event or null) ''
               Lazy-load on event. Events can be specified as `BufEnter` or with a pattern like `BufEnter *.lua`
+
               Equivalence: lz.n => event; lazy.nvim => event
             '';
 
-            cmd = mkNullable triggerType pluginDefault.cmd or null ''
+            cmd = mkNullable triggerType (lazyLoadDefaults.cmd or null) ''
               Lazy-load on command.
+
               Equivalence: lz.n => cmd; lazy.nvim => cmd
             '';
 
-            ft = mkNullable triggerType pluginDefault.ft or null ''
+            ft = mkNullable triggerType (lazyLoadDefaults.ft or null) ''
               Lazy-load on filetype.
+
               Equivalence: lz.n => ft; lazy.nvim => ft
             '';
 
-            keys = mkNullable (listOf helpers.keymaps.mapOptionSubmodule) pluginDefault.keys or null ''
+            keys = mkNullable (listOf helpers.keymaps.mapOptionSubmodule) (lazyLoadDefaults.keys or null) ''
               Lazy-load on key mapping. Use the same format as `config.keymaps`.
+
               Equivalence: lz.n => keys; lazy.nvim => keys
             '';
 
-            colorscheme = mkNullable triggerType pluginDefault.colorscheme or null ''
+            colorscheme = mkNullable triggerType (lazyLoadDefaults.colorscheme or null) ''
               Lazy-load on colorscheme.
+
               Equivalence: lz.n => colorscheme; lazy.nvim => None
             '';
 
@@ -468,6 +469,6 @@ rec {
             };
           };
         };
-      default = pluginDefault;
+      default = lazyLoadDefaults;
     };
 }

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -366,4 +366,108 @@ rec {
         else
           example;
     };
+
+  mkLazyLoadOption =
+    {
+      originalName,
+      lazyLoadDefaults ? { },
+    }:
+    let
+      pluginDefault = {
+        enable = false;
+      } // lazyLoadDefaults;
+    in
+    mkOption {
+      description = ''
+        Lazy-load settings for ${originalName}.
+      '';
+      type =
+        with helpers.nixvimTypes;
+        let
+          triggerType = oneOf [
+            rawLua
+            str
+            (listOf str)
+          ];
+        in
+        submodule {
+          options = with defaultNullOpts; {
+
+            enable = mkOption {
+              type = bool;
+              default = pluginDefault.enable;
+              description = ''
+                Enable lazy-loading for ${originalName}
+              '';
+            };
+
+            # Spec loading:
+            enabled = mkStrLuaFnOr bool pluginDefault.enabledInSpec or null ''
+              When false, or if the function returns false, then ${originalName} will not be included in the spec.
+              Equivalence: lz.n => enabled; lazy.nvim => enabled
+            '';
+
+            priority = mkNullable number pluginDefault.priority or null ''
+              Only useful for start plugins (not lazy-loaded) to force loading certain plugins first.
+              Equivalence: lz.n => priority; lazy.nvim => priority
+            '';
+
+            # Spec setup
+            # Actions
+            beforeAll = mkLuaFn pluginDefault.beforeAll or null ''
+              Always executed before any plugins are loaded.
+              Equivalence: lz.n => beforeAll; lazy.nvim => init
+            '';
+
+            before = mkLuaFn pluginDefault.before or null ''
+              Executed before ${originalName} is loaded.
+              Equivalence: lz.n => before; lazy.nvim => None
+            '';
+
+            after = mkLuaFn pluginDefault.after or null ''
+              Executed after ${originalName} is loaded.
+              Equivalence: lz.n => after; lazy.nvim => config
+            '';
+
+            # Triggers
+            event = mkNullable triggerType pluginDefault.event or null ''
+              Lazy-load on event. Events can be specified as `BufEnter` or with a pattern like `BufEnter *.lua`
+              Equivalence: lz.n => event; lazy.nvim => event
+            '';
+
+            cmd = mkNullable triggerType pluginDefault.cmd or null ''
+              Lazy-load on command.
+              Equivalence: lz.n => cmd; lazy.nvim => cmd
+            '';
+
+            ft = mkNullable triggerType pluginDefault.ft or null ''
+              Lazy-load on filetype.
+              Equivalence: lz.n => ft; lazy.nvim => ft
+            '';
+
+            keys = mkNullable (listOf helpers.keymaps.mapOptionSubmodule) pluginDefault.keys or null ''
+              Lazy-load on key mapping. Use the same format as `config.keymaps`.
+              Equivalence: lz.n => keys; lazy.nvim => keys
+            '';
+
+            colorscheme = mkNullable triggerType pluginDefault.colorscheme or null ''
+              Lazy-load on colorscheme.
+              Equivalence: lz.n => colorscheme; lazy.nvim => None
+            '';
+
+            extraSettings = mkSettingsOption {
+              description = ''
+                Extra settings to pass to the lazy loader backend.
+              '';
+              example = {
+                dependencies = {
+                  __unkeyed-1 = "nvim-lua/plenary.nvim";
+                  lazy = true;
+                };
+              };
+            };
+          };
+        };
+      default = pluginDefault;
+    };
 }

--- a/tests/test-derivation.nix
+++ b/tests/test-derivation.nix
@@ -38,6 +38,7 @@ let
       buildPhase = lib.optionalString (!dontRun) (
         ''
           mkdir -p .cache/nvim
+          mkdir $out
         ''
         + lib.concatStringsSep "\n" (
           builtins.map (
@@ -47,6 +48,8 @@ let
               dontRun ? false,
             }:
             lib.optionalString (!dontRun) ''
+              ln -s ${derivation} $out/${name}
+
               echo "Running test for ${name}"
 
               output=$(HOME=$(realpath .) ${lib.getExe derivation} -mn --headless "+q" 2>&1 >/dev/null)
@@ -58,11 +61,6 @@ let
           ) testList
         )
       );
-
-      # If we don't do this nix is not happy
-      installPhase = ''
-        mkdir $out
-      '';
     };
 
   # Create a nix derivation from a nixvim configuration.

--- a/tests/test-sources/modules/lazy-load.nix
+++ b/tests/test-sources/modules/lazy-load.nix
@@ -1,0 +1,39 @@
+{
+  example = {
+    plugins.lz-n.enable = true;
+    plugins = {
+      cmp = {
+        enable = true;
+        settings = {
+          sources = [ { name = "snippets"; } ];
+          mapping.__raw = "require('cmp').mapping.preset.insert()";
+        };
+      };
+
+      nvim-snippets = {
+        enable = true;
+        lazyLoad = {
+          enable = true;
+          event = "InsertEnter";
+        };
+      };
+
+      telescope = {
+        enable = true;
+        lazyLoad = {
+          enable = true;
+          cmd = "Telescope";
+        };
+      };
+    };
+
+    colorschemes.ayu = {
+      enable = true;
+      settings.mirage = true;
+      lazyLoad = {
+        enable = true;
+        event = "InsertEnter";
+      };
+    };
+  };
+}


### PR DESCRIPTION
This PR is the second split of PR #1866, it works on a solution for the issue #421.
This PR depends on PR #1874.
All suggestions from the original PR are included.

# Design description
The idea is to automatically create `lazyLoad` option for all plugins that are defined with `mkNeovimPlugin`.
`lazyLoad` is conformed by triggers (e.g. filetype, event, key, command) and actions (e.g. functions to run before/after loading the plugin). `mkNeovimPlugin` would also generate default values for some of these options (e.g. the setup).

Plugin maintainers can decide to not create the `lazyLoad` option, by setting `allowLazyLoading` to false when defining the plguin.

Plugin maintainers can provide sensible default values to `lazyLoad` when defining a plugin. For example, if defining `telescope.nvim`, set `Telescope` as a command trigger. Also defining a custom setup function if they are setting `callSetup` as false.

Finnally users can :
- Enable lazy-loading (globally or on a per-plugin basis)
- Add to these triggers (or override them with `mkForce`) on a per-plugin basis.
- Override actions on a per-plugin basis.

# Progress
- [x] Adding `mkLazyLoadOption` to generate lazyLoad options for plugins.
- [x] Conditionally enabling lazy or regular loading depending on user settings in `mkNeovimPlugin`.
- [x] Adding and implementing a lazy-loading mechanism using [lz.n](https://github.com/nvim-neorocks/lz.n).
- [ ]  Adding and implementing a lazy-loading mechanism using [lazy.nvim](https://github.com/folke/lazy.nvim).
- [ ] Assert that only one of the backends is enabled.
- [ ] Conditionally enabling lazy or regular loading depending on user settings in `mkVimPlugin`.
