### PR TITLE
plugins/none-ls/sources: structured "with" settings

### DIFF
--- a/plugins/none-ls/_mk-source-plugin.nix
+++ b/plugins/none-ls/_mk-source-plugin.nix
@@ -18,9 +18,26 @@ in
   options.plugins.none-ls.sources.${sourceType}.${sourceName} =
     {
       enable = lib.mkEnableOption "the ${sourceName} ${sourceType} source for none-ls";
-      withArgs = helpers.mkNullOrOption helpers.nixvimTypes.strLua ''
-        Raw Lua code passed as an argument to the source's `with` method.
-      '';
+      # Support strLua for compatibility with the old withArgs option
+      settings = helpers.defaultNullOpts.mkStrLuaOr' {
+        type = with lib.types; attrsOf anything;
+        description = ''
+          Options provided to the `require('null-ls').builtins.${sourceType}.${sourceName}.with` function.
+
+          See upstream's [`BUILTIN_CONFIG`] documentation.
+
+          [`BUILTIN_CONFIG`]: https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md
+        '';
+        example = {
+          extra_filetypes = [ "toml" ];
+          disabled_filetypes = [ "lua" ];
+          extra_args = [
+            "-i"
+            "2"
+            "-ci"
+          ];
+        };
+      };
     }
     # Only declare a package option if a package is required
     // lib.optionalAttrs (packaged ? ${sourceName}) {
@@ -42,11 +59,24 @@ in
       );
     };
 
+  # TODO: Added 2024-07-16; remove after 24.11
+  imports =
+    let
+      basePath = [
+        "plugins"
+        "none-ls"
+        "sources"
+        sourceType
+        sourceName
+      ];
+    in
+    [ (lib.mkRenamedOptionModule (basePath ++ [ "withArgs" ]) (basePath ++ [ "settings" ])) ];
+
   config = lib.mkIf (cfg.enable && cfg'.enable) {
     plugins.none-ls.settings.sources = lib.mkDefault [
       (
         "require('null-ls').builtins.${sourceType}.${sourceName}"
-        + lib.optionalString (cfg'.withArgs != null) ".with(${cfg'.withArgs})"
+        + lib.optionalString (cfg'.settings != null) ".with(${helpers.toLuaObject cfg'.settings})"
       )
     ];
 


### PR DESCRIPTION
Either strLua, or a structured `attrsOf anything`.

I resisted the urge to make this a submodule with options, but maybe it'd make sense to link the upstream documentation.
