### PR TITLE
Simplify flakes instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,7 @@ system. To enable flakes, add this to `/etc/nixos/configuration.nix`
 { pkgs, lib, ... }:
 {
   nix = {
-    package = pkgs.nixFlakes;
-    extraOptions = lib.optionalString (config.nix.package == pkgs.nixFlakes)
-      "experimental-features = nix-command flakes";
+    settings.experimental-features = [ "nix-command" "flakes" ];
   };
 }
 ```


### PR DESCRIPTION
nixFlakes is an alias to just nix.stable for a good while and all currently supported nixos releases have it.