### PR TITLE
tests: Reduce the size of the test derivation link farm

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   fetchTests = import ./fetch-tests.nix;
-  test-derivation = import ./test-derivation.nix { inherit pkgs makeNixvimWithModule; };
+  test-derivation = import ./test-derivation.nix { inherit pkgs makeNixvimWithModule lib; };
   inherit (test-derivation) mkTestDerivationFromNixvimModule;
 
   # List of files containing configurations

--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -62,13 +62,10 @@ let
   # handled by mkTestDerivation
   handleTestFile =
     { namespace, cases }:
-    lib.attrsets.mapAttrs' (case: config: {
-      name = lib.strings.concatStringsSep "-" (namespace ++ [ case ]);
-      value = config;
-    }) cases;
-
-  # Helper function that calls `//` for each attrset of a list
-  concatMany = lib.lists.foldr lib.mergeAttrs { };
+    {
+      name = lib.strings.concatStringsSep "-" namespace;
+      cases = lib.mapAttrsToList (name: case: { inherit case name; }) cases;
+    };
 in
-# An attrset of 'test-name' -> 'test-config'
-concatMany (builtins.map handleTestFile testsListEvaluated)
+# A list of the form [ { name = "..."; modules = [ /* test cases */ ]; } ]
+builtins.map handleTestFile testsListEvaluated

--- a/tests/test-sources/plugins/completion/coq.nix
+++ b/tests/test-sources/plugins/completion/coq.nix
@@ -4,16 +4,21 @@
   };
 
   nixvim-defaults = {
-    plugins.coq-nvim = {
-      enable = true;
+    module =
+      { pkgs, ... }:
+      {
+        plugins.coq-nvim = {
+          # It seems that the plugin has issues being executed in the same derivation
+          enable = !(pkgs.stdenv.isDarwin && pkgs.stdenv.isx86_64);
 
-      settings = {
-        xdg = true;
-        auto_start = true;
-        keymap.recommended = true;
-        completion.always = true;
+          settings = {
+            xdg = true;
+            auto_start = true;
+            keymap.recommended = true;
+            completion.always = true;
+          };
+        };
       };
-    };
   };
 
   artifacts = {


### PR DESCRIPTION
This PR reduces the number of test derivations, only creating one derivation per plugin instead of one test derivation per test configuration

#1878