### PR TITLE
modules/performance: add an option to combine plugins to a single plugin pack

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -19,6 +19,7 @@
     ./lua-loader.nix
     ./opts.nix
     ./output.nix
+    ./performance.nix
     ./plugins.nix
   ];
 }

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -56,6 +56,8 @@ in
       "/after"
       # ftdetect
       "/ftdetect"
+      # plenary.nvim
+      "/data/plenary/filetypes"
     ];
   };
 }

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -1,0 +1,54 @@
+{ lib, ... }:
+let
+  inherit (lib) types;
+in
+{
+  options.performance = {
+    combinePlugins = {
+      enable = lib.mkEnableOption "combinePlugins" // {
+        description = ''
+          Whether to enable EXPERIMENTAL option to combine all plugins
+          into a single plugin pack. It can significantly reduce startup time,
+          but all your plugins must have unique filenames and doc tags.
+          Any collision will result in a build failure.
+          Only standard neovim runtime directories are linked to the combined plugin.
+          If some of your plugins contain important files outside of standard
+          directories, add these paths to `pathsToLink` option.
+        '';
+      };
+      pathsToLink = lib.mkOption {
+        type = with types; listOf str;
+        default = [ ];
+        example = [ "/data" ];
+        description = "List of paths to link into a combined plugin pack.";
+      };
+    };
+  };
+
+  config.performance = {
+    # Set option value with default priority so that values are appended by default
+    combinePlugins.pathsToLink = [
+      # :h rtp
+      "/autoload"
+      "/colors"
+      "/compiler"
+      "/doc"
+      "/ftplugin"
+      "/indent"
+      "/keymap"
+      "/lang"
+      "/lua"
+      "/pack"
+      "/parser"
+      "/plugin"
+      "/queries"
+      "/rplugin"
+      "/spell"
+      "/syntax"
+      "/tutor"
+      "/after"
+      # ftdetect
+      "/ftdetect"
+    ];
+  };
+}

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -10,7 +10,8 @@ in
           Whether to enable EXPERIMENTAL option to combine all plugins
           into a single plugin pack. It can significantly reduce startup time,
           but all your plugins must have unique filenames and doc tags.
-          Any collision will result in a build failure.
+          Any collision will result in a build failure. To avoid collisions
+          you can add your plugin to the `standalonePlugins` option.
           Only standard neovim runtime directories are linked to the combined plugin.
           If some of your plugins contain important files outside of standard
           directories, add these paths to `pathsToLink` option.
@@ -21,6 +22,12 @@ in
         default = [ ];
         example = [ "/data" ];
         description = "List of paths to link into a combined plugin pack.";
+      };
+      standalonePlugins = lib.mkOption {
+        type = with types; listOf (either str package);
+        default = [ ];
+        example = [ "nvim-treesitter" ];
+        description = "List of plugins (names or packages) to exclude from plugin pack.";
       };
     };
   };

--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -93,5 +93,8 @@ in
           ]
         ) extraFiles}
       '';
+
+      # Never combine user files with the rest of the plugins
+      performance.combinePlugins.standalonePlugins = [ config.filesPlugin ];
     };
 }

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -5,7 +5,10 @@
   helpers,
   ...
 }:
-with lib;
+let
+  inherit (lib) types mkOption;
+  inherit (lib) optional optionalString optionalAttrs;
+in
 {
   options = {
     viAlias = mkOption {
@@ -97,7 +100,7 @@ with lib;
         # Necessary to make sure the runtime path is set properly in NixOS 22.05,
         # or more generally before the commit:
         # cda1f8ae468 - neovim: pass packpath via the wrapper
-        // optionalAttrs (functionArgs pkgs.neovimUtils.makeNeovimConfig ? configure) {
+        // optionalAttrs (lib.functionArgs pkgs.neovimUtils.makeNeovimConfig ? configure) {
           configure.packages = {
             nixvim = {
               start = map (x: x.plugin) normalizedPlugins;
@@ -115,7 +118,9 @@ with lib;
       init = helpers.writeLua "init.lua" customRC;
 
       extraWrapperArgs = builtins.concatStringsSep " " (
-        (optional (config.extraPackages != [ ]) ''--prefix PATH : "${makeBinPath config.extraPackages}"'')
+        (optional (
+          config.extraPackages != [ ]
+        ) ''--prefix PATH : "${lib.makeBinPath config.extraPackages}"'')
         ++ (optional config.wrapRc ''--add-flags -u --add-flags "${init}"'')
       );
 

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -95,6 +95,13 @@ in
         })
       ) allPlugins;
 
+      # Python3 dependencies from all plugins
+      python3Dependencies =
+        let
+          deps = map (p: p.python3Dependencies or (_: [ ])) allPluginsOverrided;
+        in
+        ps: builtins.concatMap (f: f ps) deps;
+
       # Combine all plugins into a single pack
       pluginPack = pkgs.vimUtils.toVimPlugin (
         pkgs.buildEnv {
@@ -106,6 +113,9 @@ in
             find $out -type d -empty -delete
             runHook preFixup
           '';
+          passthru = {
+            inherit python3Dependencies;
+          };
         }
       );
 

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -328,5 +328,10 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       foldmethod = mkDefault "expr";
       foldexpr = mkDefault "nvim_treesitter#foldexpr()";
     };
+
+    # Since https://github.com/NixOS/nixpkgs/pull/321550 upstream queries are added
+    # to grammar plugins. Exclude nvim-treesitter itself from combining to avoid
+    # collisions with grammar's queries
+    performance.combinePlugins.standalonePlugins = [ cfg.package ];
   };
 }

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -112,6 +112,9 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         require('telescope').load_extension(extension)
       end
     '';
+
+    # planets picker requires files in data/memes/planets
+    performance.combinePlugins.pathsToLink = [ "/data/memes/planets" ];
   };
 
   settingsOptions = {

--- a/plugins/telescope/extensions/fzf-native.nix
+++ b/plugins/telescope/extensions/fzf-native.nix
@@ -52,4 +52,9 @@
       override_file_sorter = false;
       case_mode = "ignore_case";
     };
+
+    extraConfig = cfg: {
+      # Native library is in build/libfzf.so
+      performance.combinePlugins.pathsToLink = [ "/build" ];
+    };
   }

--- a/plugins/telescope/extensions/fzy-native.nix
+++ b/plugins/telescope/extensions/fzy-native.nix
@@ -38,4 +38,9 @@
       override_file_sorter = true;
       override_generic_sorter = false;
     };
+
+    extraConfig = cfg: {
+      # fzy-native itself is in deps directory
+      performance.combinePlugins.pathsToLink = [ "/deps/fzy-lua-native" ];
+    };
   }

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -1,0 +1,105 @@
+{ pkgs, ... }:
+{
+  # Test basic functionality
+  default.module =
+    { config, ... }:
+    {
+      performance.combinePlugins.enable = true;
+      extraPlugins = with pkgs.vimPlugins; [
+        nvim-lspconfig
+        nvim-treesitter
+      ];
+      extraConfigLuaPost = ''
+        -- Plugins are loadable
+        require("lspconfig")
+        require("nvim-treesitter")
+
+        -- No separate plugin entries in nvim_list_runtime_paths
+        assert(not vim.iter(vim.api.nvim_list_runtime_paths()):any(function(entry)
+          return entry:find("treesitter") or entry:find("lspconfig")
+        end), "separate plugins are found in runtime")
+
+        -- Help tags are generated
+        assert(vim.fn.getcompletion("lspconfig", "help")[1], "no help tags for nvim-lspconfig")
+        assert(vim.fn.getcompletion("nvim-treesitter", "help")[1], "no help tags for nvim-treesitter")
+      '';
+      assertions = [
+        {
+          assertion = builtins.length config.finalPackage.packpathDirs.myNeovimPackages.start == 1;
+          message = "More than one plugin is defined in packpathDirs, expected one plugin pack.";
+        }
+      ];
+    };
+
+  # Test disabled option
+  disabled.module =
+    { config, ... }:
+    {
+      performance.combinePlugins.enable = false;
+      extraPlugins = with pkgs.vimPlugins; [
+        nvim-lspconfig
+        nvim-treesitter
+      ];
+      assertions = [
+        {
+          assertion = builtins.length config.finalPackage.packpathDirs.myNeovimPackages.start >= 2;
+          message = "Only one plugin is defined in packpathDirs, expected at least two.";
+        }
+      ];
+    };
+
+  # Test that plugin dependencies are handled
+  dependencies.module =
+    { config, ... }:
+    {
+      performance.combinePlugins.enable = true;
+      extraPlugins = with pkgs.vimPlugins; [
+        # Depends on nvim-cmp
+        cmp-dictionary
+        # Depends on telescope-nvim which itself depends on plenary-nvim
+        telescope-undo-nvim
+      ];
+      extraConfigLuaPost = ''
+        -- Plugins and its dependencies are loadable
+        require("cmp_dictionary")
+        require("cmp")
+        require("telescope-undo")
+        require("telescope")
+        require("plenary")
+      '';
+      assertions = [
+        {
+          assertion = builtins.length config.finalPackage.packpathDirs.myNeovimPackages.start == 1;
+          message = "More than one plugin is defined in packpathDirs.";
+        }
+      ];
+    };
+
+  # Test that pathsToLink option works
+  paths-to-link.module =
+    { config, ... }:
+    {
+      performance.combinePlugins = {
+        enable = true;
+        # fzf native library is in build directory
+        pathsToLink = [ "/build" ];
+      };
+      extraPlugins = [ pkgs.vimPlugins.telescope-fzf-native-nvim ];
+      extraConfigLuaPost = ''
+        -- Native library is in runtimepath
+        assert(
+          vim.api.nvim_get_runtime_file("build/libfzf.so", false)[1],
+          "build/libfzf.so is not found in runtimepath"
+        )
+
+        -- Native library is loadable
+        require("fzf_lib")
+      '';
+      assertions = [
+        {
+          assertion = builtins.length config.finalPackage.packpathDirs.myNeovimPackages.start == 1;
+          message = "More than one plugin is defined in packpathDirs.";
+        }
+      ];
+    };
+}

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -102,4 +102,31 @@
         }
       ];
     };
+
+  # Test that plugin python3 dependencies are handled
+  python-dependencies.module =
+    { config, ... }:
+    {
+      performance.combinePlugins.enable = true;
+      extraPlugins = with pkgs.vimPlugins; [
+        # No python3 dependencies
+        plenary-nvim
+        # Duplicate python3 dependencies
+        (nvim-lspconfig.overrideAttrs { passthru.python3Dependencies = ps: [ ps.pyyaml ]; })
+        (nvim-treesitter.overrideAttrs { passthru.python3Dependencies = ps: [ ps.pyyaml ]; })
+        # Another python3 dependency
+        (nvim-cmp.overrideAttrs { passthru.python3Dependencies = ps: [ ps.requests ]; })
+      ];
+      extraConfigLuaPost = ''
+        -- Python modules are importable
+        vim.cmd.py3("import yaml")
+        vim.cmd.py3("import requests")
+      '';
+      assertions = [
+        {
+          assertion = builtins.length config.finalPackage.packpathDirs.myNeovimPackages.start == 1;
+          message = "More than one plugin is defined in packpathDirs.";
+        }
+      ];
+    };
 }

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -374,4 +374,14 @@ in
         }
       ];
     };
+
+  # Test if plenary.filetype is working
+  plenary-nvim = {
+    performance.combinePlugins.enable = true;
+    extraPlugins = [ pkgs.vimPlugins.plenary-nvim ];
+    extraConfigLuaPost = ''
+      -- Plenary filetype detection is usable
+      assert(require("plenary.filetype").detect(".bashrc") == "sh", "plenary.filetype is not working")
+    '';
+  };
 }

--- a/tests/test-sources/plugins/languages/treesitter/combine-plugins.nix
+++ b/tests/test-sources/plugins/languages/treesitter/combine-plugins.nix
@@ -1,0 +1,37 @@
+{ pkgs, ... }:
+{
+  combine-plugins = {
+    performance.combinePlugins.enable = true;
+
+    plugins.treesitter = {
+      enable = true;
+
+      # Exclude nixvim injections for test to pass
+      nixvimInjections = false;
+    };
+
+    extraConfigLuaPost = ''
+      -- Ensure that queries from nvim-treesitter are first in rtp
+      local queries_path = "${pkgs.vimPlugins.nvim-treesitter}/queries"
+      for name, type in vim.fs.dir(queries_path, {depth = 10}) do
+        if type == "file" then
+          -- Resolve all symlinks and compare nvim-treesitter's path with
+          -- whatever we've got from runtime
+          local nvim_treesitter_path = assert(vim.uv.fs_realpath(vim.fs.joinpath(queries_path, name)))
+          local rtp_path = assert(
+            vim.uv.fs_realpath(vim.api.nvim_get_runtime_file("queries/" .. name, false)[1]),
+            name .. " not found in runtime"
+          )
+          assert(
+            nvim_treesitter_path == rtp_path,
+            string.format(
+              "%s from rtp (%s) is not the same as from nvim-treesitter (%s)",
+              name,
+              rtp_path, nvim_treesitter_path
+            )
+          )
+        end
+      end
+    '';
+  };
+}

--- a/tests/test-sources/plugins/telescope/default.nix
+++ b/tests/test-sources/plugins/telescope/default.nix
@@ -17,4 +17,19 @@
       highlightTheme = "gruvbox";
     };
   };
+
+  combine-plugins.module =
+    { config, ... }:
+    {
+      plugins.telescope.enable = true;
+
+      performance.combinePlugins.enable = true;
+
+      extraConfigLuaPost = # lua
+        ''
+          -- I don't know how run telescope properly in test environment,
+          -- so just check that files exist
+          assert(vim.api.nvim_get_runtime_file("data/memes/planets/earth", false)[1], "telescope planets aren't found in runtime")
+        '';
+    };
 }

--- a/tests/test-sources/plugins/telescope/fzf-native.nix
+++ b/tests/test-sources/plugins/telescope/fzf-native.nix
@@ -22,4 +22,13 @@
       };
     };
   };
+
+  combine-plugins = {
+    plugins.telescope = {
+      enable = true;
+      extensions.fzf-native.enable = true;
+    };
+
+    performance.combinePlugins.enable = true;
+  };
 }

--- a/tests/test-sources/plugins/telescope/fzy-native.nix
+++ b/tests/test-sources/plugins/telescope/fzy-native.nix
@@ -20,4 +20,13 @@
       };
     };
   };
+
+  combine-plugins = {
+    plugins.telescope = {
+      enable = true;
+      extensions.fzy-native.enable = true;
+    };
+
+    performance.combinePlugins.enable = true;
+  };
 }


### PR DESCRIPTION
Hey. I'm the one from [this comment](https://github.com/nix-community/nixvim/issues/421#issuecomment-1646834969) in [[Feature] Lazy loading](https://github.com/nix-community/nixvim/issues/421) issue. I decided to give nixvim a try, but since I don't want to lose my performance optimizations, I implemented them in nixvim. Since my comment have got a couple of upvotes, here I am with a PR. I don't know if this would be merged, since this feature have caveats. But if it works for your config, you'll get a free performance boost (startup time and every time you `:e` a buffer). It's optional, so it shouldn't brake existing configs. I still think that this is more important than trying to lazy load everything (but for some specific cases lazy loading is also useful).

I'm planning to implement three performance options:

1) This one: combine plugins into a single pack
2) Optimize runtimepath further (basically set rtp to essential directories, removing everything else, mostly all system dirs). On my system with home-manager I have 14 useless items there. It's not yet implemented, but should be easy. For now I still have this in my config: https://github.com/stasjok/dotfiles/blob/36037f523185ba1409dd953999fda0f0db0dbd4f/nvim/init.lua#L1-L17, so I'm not in a hurry. It would depend on a feedback on this PR.
3) Byte compile every lua file. It's already implemented, will be a second PR.

To get you interested here are startuptime measurements (all measurements are taken from my config after a couple of tries with a hot disk cache):

1) No optimizations: 155 ms
2) All plugins combined: 95-100 ms
3) Everything byte compiled (including plugins and nvim runtime): 55-57 ms
4) rtp optimized: 53-55 ms (doesn't do much, to be honest)
5) For comparison, `vim.loader.enable()` without everything from the above: 115-120 ms

This PR adds a `performance.combinePlugins` option with two tunables: `pathsToLink` for choosing what paths are linked to plugin pack and `standalonePlugins` for specifying what plugins to exclude from combining. Last option is important, because for combining to work there must not be any file and doc tag collisions. Good news is if it builds, most of the time it would work correctly (except when some paths need to be added to `pathsToLink`).

Also this PR adds a couple of examples on how to fix errors in nixvim on a per plugin case (so most of the time user wouldn't need to configure anything). This is not all problematic plugins, but the ones I have in my config (to get this PR usable). Bad news came from a recent nixpkgs PR https://github.com/NixOS/nixpkgs/pull/321550. After that PR parser queries are colliding with treesitter plugins. It can be fixed in user overlay ([example](https://github.com/stasjok/dotfiles/blob/36037f523185ba1409dd953999fda0f0db0dbd4f/overlay/default.nix#L47-L61)), or like in this PR with nvim-treesitter (to exclude plugins containing a collection of queries from combining), or `meta.priority` can also be used. Because of this issue I even wanted to introduce a second layer of combined plugins, but for now a completely separate plugins would suffice. If the list of such exclusions will be too large, than it can be reevaluated.