### PR TITLE
modules/performance: add byteCompileLua option

### DIFF
--- a/flake-modules/wrappers.nix
+++ b/flake-modules/wrappers.nix
@@ -15,6 +15,13 @@
               inherit (inputs) home-manager;
               nixvim = self;
             }).activationPackage;
+          home-manager-extra-files-byte-compiling =
+            import ../tests/modules/hm-extra-files-byte-compiling.nix
+              {
+                inherit pkgs;
+                inherit (inputs) home-manager;
+                nixvim = self;
+              };
         }
         // pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
           nixos-module =

--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -26,4 +26,26 @@
         --indent-width 4 \
         "$out"
     '';
+
+  /*
+    Write a byte compiled lua file to the nix store.
+
+    # Type
+
+    ```
+    writeByteCompiledLua :: String -> String -> Derivation
+    ```
+
+    # Arguments
+
+    - [name] The name of the derivation
+    - [text] The content of the lua file
+  */
+  writeByteCompiledLua =
+    name: text:
+    pkgs.runCommandLocal name { inherit text; } ''
+      echo -n "$text" > "$out"
+
+      ${lib.getExe' pkgs.luajit "luajit"} -bd -- "$out" "$out"
+    '';
 }

--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -1,5 +1,5 @@
 { lib, pkgs }:
-{
+rec {
   /*
     Write a lua file to the nix store, formatted using stylua.
 
@@ -48,4 +48,88 @@
 
       ${lib.getExe' pkgs.luajit "luajit"} -bd -- "$out" "$out"
     '';
+
+  /*
+    Get a source lua file and write a byte compiled copy of it
+    to the nix store.
+
+    # Type
+
+    ```
+    byteCompileLuaFile :: String -> String -> Derivation
+    ```
+
+    # Arguments
+
+    - [name] The name of the derivation
+    - [src] The path to the source lua file
+  */
+  byteCompileLuaFile =
+    name: src:
+    pkgs.runCommandLocal name { inherit src; } ''
+      ${lib.getExe' pkgs.luajit "luajit"} -bd -- "$src" "$out"
+    '';
+
+  # Setup hook to byte compile all lua files in the output directory.
+  # Invalid lua files are ignored.
+  byteCompileLuaHook = pkgs.makeSetupHook { name = "byte-compile-lua-hook"; } (
+    let
+      luajit = lib.getExe' pkgs.luajit "luajit";
+    in
+    pkgs.writeText "byte-compile-lua-hook.sh" # bash
+      ''
+        byteCompileLuaPostFixup() {
+            # Target is a single file
+            if [[ -f $out ]]; then
+                if [[ $out = *.lua ]]; then
+                    tmp=$(mktemp)
+                    ${luajit} -bd -- "$out" "$tmp"
+                    mv "$tmp" "$out"
+                fi
+                return
+            fi
+
+            # Target is a directory
+            while IFS= read -r -d "" file; do
+                tmp=$(mktemp -u "$file.XXXX")
+                # Ignore invalid lua files
+                if ${luajit} -bd -- "$file" "$tmp"; then
+                    mv "$tmp" "$file"
+                else
+                    echo "WARNING: Ignoring byte compiling error for '$file' lua file" >&2
+                fi
+            done < <(find "$out" -type f,l -name "*.lua" -print0)
+        }
+
+        postFixupHooks+=(byteCompileLuaPostFixup)
+      ''
+  );
+
+  /*
+    Returns an overridden derivation with all lua files byte compiled.
+
+    # Type
+
+    ```
+    byteCompileLuaDrv :: Derivation -> Derivation
+    ```
+
+    # Arguments
+
+    - [drv] Input derivation
+  */
+  byteCompileLuaDrv =
+    drv:
+    drv.overrideAttrs (
+      prev:
+      {
+        nativeBuildInputs = prev.nativeBuildInputs or [ ] ++ [ byteCompileLuaHook ];
+      }
+      // lib.optionalAttrs (prev ? buildCommand) {
+        buildCommand = ''
+          ${prev.buildCommand}
+          runHook postFixup
+        '';
+      }
+    );
 }

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -12,6 +12,12 @@ in
         default = true;
         example = false;
       };
+      configs = lib.mkOption {
+        description = "Whether to byte compile lua configuration files.";
+        type = types.bool;
+        default = true;
+        example = false;
+      };
     };
 
     combinePlugins = {

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -21,6 +21,9 @@ in
       plugins = lib.mkEnableOption "plugins" // {
         description = "Whether to byte compile lua plugins.";
       };
+      nvimRuntime = lib.mkEnableOption "nvimRuntime" // {
+        description = "Whether to byte compile lua files in Nvim runtime.";
+      };
     };
 
     combinePlugins = {

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -18,6 +18,9 @@ in
         default = true;
         example = false;
       };
+      plugins = lib.mkEnableOption "plugins" // {
+        description = "Whether to byte compile lua plugins.";
+      };
     };
 
     combinePlugins = {

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -4,6 +4,16 @@ let
 in
 {
   options.performance = {
+    byteCompileLua = {
+      enable = lib.mkEnableOption "byte compiling of lua files";
+      initLua = lib.mkOption {
+        description = "Whether to byte compile init.lua.";
+        type = types.bool;
+        default = true;
+        example = false;
+      };
+    };
+
     combinePlugins = {
       enable = lib.mkEnableOption "combinePlugins" // {
         description = ''

--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -84,11 +84,11 @@ in
 
         mkdir -p "$out"
         ${lib.concatMapStringsSep "\n" (
-          { target, source, ... }:
+          { target, finalSource, ... }:
           lib.escapeShellArgs [
             "makeEntry"
             # Force local source paths to be added to the store
-            "${source}"
+            "${finalSource}"
             target
           ]
         ) extraFiles}

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -206,7 +206,17 @@ in
         config.content
       ];
 
-      init = helpers.writeLua "init.lua" customRC;
+      textInit = helpers.writeLua "init.lua" customRC;
+      byteCompiledInit = helpers.writeByteCompiledLua "init.lua" customRC;
+      init =
+        if
+          config.type == "lua"
+          && config.performance.byteCompileLua.enable
+          && config.performance.byteCompileLua.initLua
+        then
+          byteCompiledInit
+        else
+          textInit;
 
       extraWrapperArgs = builtins.concatStringsSep " " (
         (optional (
@@ -232,7 +242,7 @@ in
         name = "nixvim-print-init";
         runtimeInputs = [ pkgs.bat ];
         text = ''
-          bat --language=lua "${init}"
+          bat --language=lua "${textInit}"
         '';
       };
 

--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -14,7 +14,7 @@ let
       file = "${root}/${relativePath}/${name}";
     in
     if type == "regular" then
-      [
+      lib.optional (lib.hasSuffix ".nix" name) [
         {
           namespace = namespace ++ [ (lib.strings.removeSuffix ".nix" name) ];
           cases = import file;

--- a/tests/modules/hm-extra-files-byte-compiling.nix
+++ b/tests/modules/hm-extra-files-byte-compiling.nix
@@ -1,0 +1,104 @@
+{
+  nixvim,
+  pkgs,
+  home-manager,
+}:
+let
+  config = {
+    home = {
+      username = "nixvim";
+      homeDirectory = "/invalid/dir";
+      stateVersion = "24.05";
+    };
+
+    programs.nixvim = {
+      enable = true;
+
+      performance.byteCompileLua.enable = true;
+
+      extraFiles = {
+        "extra-files/test1.lua".text = "vim.opt.tabstop = 2";
+        "extra-files/test2.lua".source = builtins.toFile "file_source.lua" "vim.opt.tabstop = 2";
+        "extra-files/test3.lua".source = pkgs.writeText "test3.lua" "vim.opt.tabstop = 2";
+        "extra-files/test.vim".text = "set tabstop=2";
+        "extra-files/test.json".text = builtins.toJSON { a = 1; };
+      };
+
+      files = {
+        "files/test.lua".opts.tabstop = 2;
+        "files/test.vim".opts.tabstop = 2;
+      };
+    };
+  };
+
+  homeFilesByteCompilingEnabled =
+    (home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+
+      modules = [
+        nixvim.homeManagerModules.nixvim
+        config
+        { programs.nixvim.performance.byteCompileLua.configs = true; }
+      ];
+    }).config.home-files;
+
+  homeFilesByteCompilingDisabled =
+    (home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+
+      modules = [
+        nixvim.homeManagerModules.nixvim
+        config
+        { programs.nixvim.performance.byteCompileLua.configs = false; }
+      ];
+    }).config.home-files;
+in
+pkgs.runCommand "home-manager-extra-files-byte-compiling" { } ''
+  is_binary() {
+      ! grep -qI . "$1"
+  }
+  test_byte_compiled() {
+      if ! is_binary "$home_files/.config/nvim/$1"; then
+          echo "File $1 is expected to be byte compiled, but it's not"
+          exit 1
+      fi
+  }
+  test_not_byte_compiled() {
+      if is_binary "$home_files/.config/nvim/$1"; then
+          echo "File $1 is not expected to be byte compiled, but it is"
+          exit 1
+      fi
+  }
+
+  # Test directory with extraFiles byte compiling enabled
+  home_files="${homeFilesByteCompilingEnabled}"
+
+  echo "Testing home-files with extraFiles byte compiling enabled"
+
+  # extraFiles
+  test_byte_compiled extra-files/test1.lua
+  test_byte_compiled extra-files/test2.lua
+  test_byte_compiled extra-files/test3.lua
+  test_not_byte_compiled extra-files/test.vim
+  test_not_byte_compiled extra-files/test.json
+  # files
+  test_byte_compiled files/test.lua
+  test_not_byte_compiled files/test.vim
+
+  # Test directory with extraFiles byte compiling disabled
+  home_files="${homeFilesByteCompilingDisabled}"
+
+  echo "Testing home-files with extraFiles byte compiling disabled"
+
+  # extraFiles
+  test_not_byte_compiled extra-files/test1.lua
+  test_not_byte_compiled extra-files/test2.lua
+  test_not_byte_compiled extra-files/test3.lua
+  test_not_byte_compiled extra-files/test.vim
+  test_not_byte_compiled extra-files/test.json
+  # files
+  test_not_byte_compiled files/test.lua
+  test_not_byte_compiled files/test.vim
+
+  touch $out
+''

--- a/tests/test-sources/modules/performance/byte-compile-lua.nix
+++ b/tests/test-sources/modules/performance/byte-compile-lua.nix
@@ -1,0 +1,139 @@
+{ pkgs, helpers, ... }:
+let
+  isByteCompiledFun = ''
+    local function is_byte_compiled(filename)
+      local f = assert(io.open(filename, "rb"))
+      local data = assert(f:read("*a"))
+      -- Assume that file is binary if it contains null bytes
+      for i = 1, #data do
+        if data:byte(i) == 0 then
+          return true
+        end
+      end
+      return false
+    end
+
+    local function test_rtp_file(name, is_compiled)
+      local file = assert(vim.api.nvim_get_runtime_file(name, false)[1], "file " .. name .. " not found in runtime")
+      if is_compiled then
+        assert(is_byte_compiled(file), name .. " is expected to be byte compiled, but it's not")
+      else
+        assert(not is_byte_compiled(file), name .. " is not expected to be byte compiled, but it is")
+      end
+    end
+  '';
+in
+{
+  default.module =
+    { config, ... }:
+    {
+      performance.byteCompileLua.enable = true;
+
+      extraFiles = {
+        "plugin/file_text.lua".text = "vim.opt.tabstop = 2";
+        "plugin/file_source.lua".source = helpers.writeLua "file_source.lua" "vim.opt.tabstop = 2";
+        "plugin/test.vim".text = "set tabstop=2";
+        "plugin/test.json".text = builtins.toJSON { a = 1; };
+      };
+
+      files = {
+        "plugin/file.lua" = {
+          opts.tabstop = 2;
+        };
+        "plugin/file.vim" = {
+          opts.tabstop = 2;
+        };
+      };
+
+      extraPlugins = [ pkgs.vimPlugins.nvim-lspconfig ];
+
+      extraConfigLua = ''
+        -- The test will search for this string in nixvim-print-init output: VALIDATING_STRING.
+        -- Since this is the comment, it won't appear in byte compiled file.
+      '';
+
+      # Using plugin for the test code to avoid infinite recursion
+      extraFiles."plugin/test.lua".text = ''
+        ${isByteCompiledFun}
+
+        -- vimrc is byte compiled
+        local init = vim.env.MYVIMRC or vim.fn.getscriptinfo({name = "init.lua"})[1].name
+        assert(is_byte_compiled(init), "MYVIMRC is expected to be byte compiled, but it's not")
+
+        -- nixvim-print-init prints text
+        local init_content = vim.fn.system("${config.printInitPackage}/bin/nixvim-print-init")
+        assert(init_content:find("VALIDATING_STRING"), "nixvim-print-init's output is byte compiled")
+
+        -- extraFiles
+        test_rtp_file("plugin/file_text.lua", false)
+        test_rtp_file("plugin/file_source.lua", false)
+        test_rtp_file("plugin/test.vim", false)
+        test_rtp_file("plugin/test.json", false)
+
+        -- files
+        test_rtp_file("plugin/file.lua", false)
+        test_rtp_file("plugin/file.vim", false)
+
+        -- Plugins and neovim runtime aren't byte compiled by default
+        test_rtp_file("lua/vim/lsp.lua", false)
+        test_rtp_file("lua/lspconfig.lua", false)
+      '';
+
+    };
+
+  disabled.module =
+    { config, ... }:
+    {
+      performance.byteCompileLua.enable = false;
+
+      extraFiles."plugin/test1.lua".text = "vim.opt.tabstop = 2";
+
+      files."plugin/test2.lua".opts.tabstop = 2;
+
+      extraPlugins = [ pkgs.vimPlugins.nvim-lspconfig ];
+
+      extraConfigLua = ''
+        -- The test will search for this string in nixvim-print-init output: VALIDATING_STRING.
+        -- Since this is the comment, it won't appear in byte compiled file.
+      '';
+
+      # Using plugin for the test code to avoid infinite recursion
+      extraFiles."plugin/test.lua".text = ''
+        ${isByteCompiledFun}
+
+        -- vimrc
+        local init = vim.env.MYVIMRC or vim.fn.getscriptinfo({name = "init.lua"})[1].name
+        assert(not is_byte_compiled(init), "MYVIMRC is not expected to be byte compiled, but it is")
+
+        -- nixvim-print-init prints text
+        local init_content = vim.fn.system("${config.printInitPackage}/bin/nixvim-print-init")
+        assert(init_content:find("VALIDATING_STRING"), "nixvim-print-init's output is byte compiled")
+
+        -- Nothing is byte compiled
+        -- extraFiles
+        test_rtp_file("plugin/test1.lua", false)
+        -- files
+        test_rtp_file("plugin/test2.lua", false)
+        -- Plugins
+        test_rtp_file("lua/lspconfig.lua", false)
+        -- Neovim runtime
+        test_rtp_file("lua/vim/lsp.lua", false)
+      '';
+
+    };
+
+  init-lua-disabled = {
+    performance.byteCompileLua = {
+      enable = true;
+      initLua = false;
+    };
+
+    extraConfigLuaPost = ''
+      ${isByteCompiledFun}
+
+      -- vimrc is not byte compiled
+      local init = vim.env.MYVIMRC or vim.fn.getscriptinfo({name = "init.lua"})[1].name
+      assert(not is_byte_compiled(init), "MYVIMRC is not expected to be byte compiled, but it is")
+    '';
+  };
+}

--- a/tests/test-sources/modules/performance/byte-compile-lua.nix
+++ b/tests/test-sources/modules/performance/byte-compile-lua.nix
@@ -182,6 +182,40 @@ in
       test_rtp_file("plugin/test2.lua", false)
     '';
   };
+
+  nvim-runtime = {
+    performance.byteCompileLua = {
+      enable = true;
+      nvimRuntime = true;
+    };
+
+    extraPlugins = [
+      # Python 3 dependencies
+      (pkgs.vimPlugins.nvim-lspconfig.overrideAttrs { passthru.python3Dependencies = ps: [ ps.pyyaml ]; })
+    ];
+
+    extraConfigLuaPost = ''
+      ${isByteCompiledFun}
+
+      -- vim namespace is working
+      vim.opt.tabstop = 2
+      vim.api.nvim_get_runtime_file("init.lua", false)
+      vim.lsp.get_clients()
+      vim.treesitter.language.get_filetypes("nix")
+      vim.iter({})
+
+      test_rtp_file("lua/vim/lsp.lua", true)
+      test_rtp_file("lua/vim/iter.lua", true)
+      test_rtp_file("lua/vim/treesitter/query.lua", true)
+      test_rtp_file("lua/vim/lsp/buf.lua", true)
+      test_rtp_file("plugin/editorconfig.lua", true)
+      test_rtp_file("plugin/tutor.vim", false)
+      test_rtp_file("ftplugin/vim.vim", false)
+
+      -- Python3 packages are importable
+      vim.cmd.py3("import yaml")
+    '';
+  };
 }
 //
   # Two equal tests, one with combinePlugins.enable = true

--- a/tests/test-sources/modules/performance/files/file.lua
+++ b/tests/test-sources/modules/performance/files/file.lua
@@ -1,0 +1,1 @@
+vim.opt.tabstop = 2

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -53,11 +53,11 @@ in
         setAttrByPath filesOpt (
           listToAttrs (
             map (
-              { target, source, ... }:
+              { target, finalSource, ... }:
               {
                 name = filesPrefix + target;
                 value = {
-                  inherit source;
+                  source = finalSource;
                 };
               }
             ) extraFiles


### PR DESCRIPTION
This PR implements a second item from [this comment](https://github.com/nix-community/nixvim/issues/421#issuecomment-1646834969).

It can be merged only on top of #1886.

It introduces an option `performance.byteCompileLua`, that, when enabled, byte compiles lua files. It can be configured what to compile. By default it's user configs. But also plugins and neovim itself can be compiled.