### PR TITLE
modules/output: cleanup + refactoring

### DIFF
--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -5,6 +5,9 @@
 }:
 with lib;
 {
+  # Whether a string contains something other than whitespace
+  hasContent = str: (builtins.match "[[:space:]]*" str) == null;
+
   listToUnkeyedAttrs =
     list:
     builtins.listToAttrs (lib.lists.imap0 (idx: lib.nameValuePair "__unkeyed-${toString idx}") list);

--- a/modules/output.nix
+++ b/modules/output.nix
@@ -93,15 +93,15 @@ in
     content = mkOption {
       type = types.str;
       description = "The content of the config file";
-      readOnly = true;
       visible = false;
+      # FIXME: can't be readOnly because we override it in top-level modules
     };
 
     finalConfig = mkOption {
       type = types.package;
       description = "The config file written as a derivation";
+      readOnly = true;
       internal = true;
-      # FIXME: can't be readOnly because we override it in top-level modules
     };
 
     extraLuaPackages = mkOption {

--- a/modules/output.nix
+++ b/modules/output.nix
@@ -91,10 +91,10 @@ in
     };
 
     content = mkOption {
-      type = types.str;
+      type = types.lines;
       description = "The content of the config file";
       visible = false;
-      # FIXME: can't be readOnly because we override it in top-level modules
+      # FIXME: can't be readOnly because we prefix it in top-level modules
     };
 
     finalConfig = mkOption {

--- a/modules/output.nix
+++ b/modules/output.nix
@@ -82,6 +82,7 @@ in
       default = if lib.hasSuffix ".vim" config.target then "vim" else "lua";
       defaultText = lib.literalMD ''`"lua"` unless `config.target` ends with `".vim"`'';
       description = "Whether the generated file is a vim or a lua file";
+      readOnly = true;
     };
 
     target = mkOption {

--- a/modules/output.nix
+++ b/modules/output.nix
@@ -78,9 +78,10 @@ in
       description = "Whether the generated file is a vim or a lua file";
     };
 
-    path = mkOption {
+    target = mkOption {
       type = types.str;
       description = "Path of the file relative to the config directory";
+      default = "init.lua";
     };
 
     content = mkOption {
@@ -96,6 +97,8 @@ in
       default = _: [ ];
     };
   };
+
+  imports = [ (lib.mkRenamedOptionModule [ "path" ] [ "target" ]) ];
 
   config =
     let

--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -64,7 +64,7 @@ in
       extraFiles = lib.mkDerivedConfig options.files (
         lib.mapAttrs' (
           _: file: {
-            name = file.path;
+            name = file.target;
             value.source = file.plugin;
           }
         )

--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -65,7 +65,7 @@ in
         lib.mapAttrs' (
           _: file: {
             name = file.target;
-            value.source = file.plugin;
+            value.source = file.finalConfig;
           }
         )
       );

--- a/modules/top-level/files/submodule.nix
+++ b/modules/top-level/files/submodule.nix
@@ -19,7 +19,7 @@
       derivationName = "nvim-" + lib.replaceStrings [ "/" ] [ "-" ] name;
     in
     {
-      path = lib.mkDefault name;
+      target = lib.mkDefault name;
       type = lib.mkDefault (if lib.hasSuffix ".vim" name then "vim" else "lua");
       # No need to use mkDerivedConfig; this option is readOnly.
       plugin = helpers.writeLua derivationName config.content;

--- a/modules/top-level/files/submodule.nix
+++ b/modules/top-level/files/submodule.nix
@@ -1,27 +1,13 @@
+{ name, lib, ... }:
 {
-  name,
-  config,
-  lib,
-  helpers,
-  ...
-}:
-{
-  options = {
-    plugin = lib.mkOption {
-      type = lib.types.package;
-      description = "A derivation with the content of the file in it";
-      readOnly = true;
-      internal = true;
-    };
+  imports = [
+    (lib.mkRenamedOptionModule [
+      "plugin"
+      "finalConfig"
+    ])
+  ];
+
+  config = {
+    target = lib.mkDefault name;
   };
-  config =
-    let
-      derivationName = "nvim-" + lib.replaceStrings [ "/" ] [ "-" ] name;
-    in
-    {
-      target = lib.mkDefault name;
-      type = lib.mkDefault (if lib.hasSuffix ".vim" name then "vim" else "lua");
-      # No need to use mkDerivedConfig; this option is readOnly.
-      plugin = helpers.writeLua derivationName config.content;
-    };
 }

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -87,17 +87,19 @@ with lib;
         (optional (config.extraPackages != [ ]) ''--prefix PATH : "${makeBinPath config.extraPackages}"'')
         ++ (optional config.wrapRc ''--add-flags -u --add-flags "${config.finalConfig}"'')
       );
+
+      configPrefix =
+        if config.type == "lua" then
+          ''
+            vim.cmd([[
+              ${neovimConfig.neovimRcContent}
+            ]])
+          ''
+        else
+          neovimConfig.neovimRcContent;
     in
     {
-      type = lib.mkForce "lua";
-
-      content = lib.mkIf (helpers.hasContent neovimConfig.neovimRcContent) (
-        lib.mkBefore ''
-          vim.cmd([[
-            ${neovimConfig.neovimRcContent}
-          ]])
-        ''
-      );
+      content = lib.mkIf (helpers.hasContent neovimConfig.neovimRcContent) (lib.mkBefore configPrefix);
 
       finalPackage = pkgs.wrapNeovimUnstable config.package (
         neovimConfig

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -2,6 +2,7 @@
   pkgs,
   config,
   lib,
+  helpers,
   ...
 }:
 with lib;
@@ -69,8 +70,6 @@ with lib;
 
   config =
     let
-      hasContent = str: (builtins.match "[[:space:]]*" str) == null;
-
       neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
         inherit (config)
           extraPython3Packages
@@ -92,7 +91,7 @@ with lib;
     {
       type = lib.mkForce "lua";
 
-      content = lib.mkIf (hasContent neovimConfig.neovimRcContent) (
+      content = lib.mkIf (helpers.hasContent neovimConfig.neovimRcContent) (
         lib.mkBefore ''
           vim.cmd([[
             ${neovimConfig.neovimRcContent}

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -92,22 +92,12 @@ with lib;
     {
       type = lib.mkForce "lua";
 
-      content = lib.mkForce (
-        lib.concatStringsSep "\n" [
-          (optionalString (hasContent neovimConfig.neovimRcContent) ''
-            vim.cmd([[
-              ${neovimConfig.neovimRcContent}
-            ]])
-          '')
-          config.extraConfigLuaPre
-          (optionalString (hasContent config.extraConfigVim) ''
-            vim.cmd([[
-              ${config.extraConfigVim}
-            ]])
-          '')
-          config.extraConfigLua
-          config.extraConfigLuaPost
-        ]
+      content = lib.mkIf (hasContent neovimConfig.neovimRcContent) (
+        lib.mkBefore ''
+          vim.cmd([[
+            ${neovimConfig.neovimRcContent}
+          ]])
+        ''
       );
 
       finalPackage = pkgs.wrapNeovimUnstable config.package (

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -3,7 +3,7 @@
   filesOpt ? null,
   # Filepath prefix to apply to extraFiles
   filesPrefix ? "nvim/",
-  # Filepath to use when adding `cfg.initPath` to `filesOpt`
+  # Filepath to use when adding `cfg.finalConfig` to `filesOpt`
   # Is prefixed with `filesPrefix`
   initName ? "init.lua",
 }:
@@ -59,7 +59,7 @@ in
             ) extraFiles
           )
           // {
-            ${filesPrefix + initName}.source = cfg.initPath;
+            ${filesPrefix + initName}.source = cfg.finalConfig;
           }
         )
       )

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -3,9 +3,6 @@
   filesOpt ? null,
   # Filepath prefix to apply to extraFiles
   filesPrefix ? "nvim/",
-  # Filepath to use when adding `cfg.finalConfig` to `filesOpt`
-  # Is prefixed with `filesPrefix`
-  initName ? "init.lua",
 }:
 {
   pkgs,
@@ -59,7 +56,7 @@ in
             ) extraFiles
           )
           // {
-            ${filesPrefix + initName}.source = cfg.finalConfig;
+            ${filesPrefix + cfg.target}.source = cfg.finalConfig;
           }
         )
       )

--- a/wrappers/modules/nixos.nix
+++ b/wrappers/modules/nixos.nix
@@ -8,5 +8,6 @@
 
   config = {
     wrapRc = lib.mkForce true;
+    target = lib.mkDefault "sysinit.lua";
   };
 }

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -42,7 +42,6 @@ in
         "environment"
         "etc"
       ];
-      initName = "sysinit.lua";
     })
   ];
 


### PR DESCRIPTION
## Summary
General cleanup and refactoring to the output module, with the goal of streamlining and simplifying the implementation.

For example, the `files` submodule has `path` and `plugin` options that are essentially the same as `extraFiles`' `target` and the top-level's `initPath` options respectively.

As another example, the `content` option is currently read-only, meaning we cannot reflect the entire config file content there when we add `neovimConfig.neovimRcContent` to it.

Being able to do this also means the common (non top-level) modules can handle writing the config file, reducing the complexity in both the `files` submodule and the top-level output module.

As the changes in this PR are fairly broad, I also added some comments and inlined some sections of the top-level output module. IMO this makes it much easier to understand.

Generalising many of these output options allows for other changes like enabling `type="vim"` at the top-level (if users configure `target="init.vim"`)

I did make the `type` option read-only, since it didn't make sense to me for it to default to the `target`'s extension otherwise. But I'm unsure if this is a good change.

## Draft
This is a draft because it's currently difficult to test; #1878

It also feels kinda broad, maybe it could be split up into smaller PRs? This is difficult since all the changes touch the same code...

I'd still appreciate feedback on the overall direction, style, changes while we wait for buildbot to work again.

## pkgs.wrapNeovimUnstable lua support
While nixpkgs added luaRC support recently, I don't think we can take advantage of that for two reasons:
1. the wrapper function expects the string content
2. the wrapper will want to write the init file(s) itself
3. the wrapper may not order the rc sections the way we would like
4. the wrapper can't implement `wrapRc` the way we would like

## Related work
It'd be nice to make "standalone" builds less special; I think we can achieve that by adding a `standalonePackage` option, similar to `finalPackage`.

I think the "disabling env config" is somewhat unrelated to `wrapRc`, so perhaps that should have its own option?
I don't think we need `wrapRc = mkForce true` in the nixos wrapper, other than to ensure `/etc` is used instead of `~/.config`.
Removing "site" from the rtp could also conflict with treesitter (#1855).

## Changes when opening PR
- **modules/output: rename `path` -> `target`**
- **modules/output: introduce `finalConfig` option**
- **modules/output: override `content` in top-level**
- **modules/output: cleanup top-level**
- **modules/output: make `content` type `lines`**
- **lib/utils: move `hasContent` to helpers lib**
- **modules/output: only print relevant parts of config**
- **modules/output: allow lua or vim init files**
- **modules/output: make `type` option readOnly**
