### PR TITLE
docs: Add an option search to our documentation

### DIFF
--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -21,3 +21,4 @@
 ---
 
 [Contributing](./CONTRIBUTING.md)
+[NixVim Options Search](./search/index.html)

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -6,6 +6,7 @@
   nixosOptionsDoc,
   transformOptions,
   hmOptions,
+  search,
 }:
 with lib;
 let
@@ -268,5 +269,7 @@ pkgs.stdenv.mkDerivation {
     ${prepareMD}
     mdbook build
     cp -r ./book/* $dest
+    mkdir -p $dest/search
+    cp -r ${search}/* $dest/search
   '';
 }

--- a/flake-modules/dev/devshell.nix
+++ b/flake-modules/dev/devshell.nix
@@ -81,10 +81,9 @@
 
                 echo -e "\n=> Documentation successfully built ('$doc_derivation')"
 
-                port=8000
-                echo -e "\n=> Now open your browser and navigate to 'localhost:$port'\n"
+                echo -e "\n=> You can then open your browser to view the doc\n"
 
-                ${pkgs.lib.getExe pkgs.python3} -m http.server -d "$doc_derivation"/share/doc
+                (cd "$doc_derivation"/share/doc && ${pkgs.lib.getExe pkgs.python3} ${./server.py})
               '';
             }
             {

--- a/flake-modules/dev/server.py
+++ b/flake-modules/dev/server.py
@@ -1,0 +1,16 @@
+import http.server
+
+PORT = 8000
+
+
+class UncachedHTTPHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+
+with http.server.HTTPServer(("", PORT), UncachedHTTPHandler) as httpd:
+    print(f"Serving documentation at http://localhost:{PORT}")
+    httpd.serve_forever()

--- a/flake-modules/packages.nix
+++ b/flake-modules/packages.nix
@@ -1,10 +1,16 @@
 {
   perSystem =
-    { pkgsUnfree, config, ... }:
+    {
+      pkgsUnfree,
+      config,
+      inputs',
+      ...
+    }:
     {
       packages = import ../docs {
         # Building the docs evaluates each plugin's default package, some of which are unfree
         pkgs = pkgsUnfree;
+        inherit (inputs') nuschtosSearch;
       };
 
       # Test that all packages build fine when running `nix flake check`.

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,10 @@
   "nodes": {
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "nuschtosSearch",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -60,11 +63,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -177,6 +180,27 @@
         "type": "github"
       }
     },
+    "nuschtosSearch": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721332622,
+        "narHash": "sha256-04AOrnpZIz15AXXlVWKRmZwbFgI/pjC8AaQ+T6VlFMc=",
+        "owner": "NuschtOS",
+        "repo": "search",
+        "rev": "b5990bce952c39824169dad255ff39c8abe4ca21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NuschtOS",
+        "repo": "search",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devshell": "devshell",
@@ -186,6 +210,7 @@
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
+        "nuschtosSearch": "nuschtosSearch",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,11 @@
       ```
     */
 
+    nuschtosSearch = {
+      url = "github:NuschtOS/search";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -45,6 +50,7 @@
     devshell = {
       url = "github:numtide/devshell";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "nuschtosSearch/flake-utils";
     };
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
This option search is availaible in the `/search/` sub path.
It's provided by [NuschtOS/search](https://github.com/NuschtOS/search).