### PR TITLE
plugins/lazy.nvim: Import Statements & Adding user-specified packages to `lazyPath`

### DIFF
--- a/tests/test-sources/plugins/pluginmanagers/lazy.nix
+++ b/tests/test-sources/plugins/pluginmanagers/lazy.nix
@@ -65,6 +65,45 @@
           ];
         }
 
+        # Plugins can add an additional package to the lazy path
+        {
+          pkg = LazyVim;
+          packages = catppuccin-nvim;
+        }
+
+        # Plugins can add several additional packages to the lazy path
+        {
+          pkg = LazyVim;
+          packages = [
+            bufferline-nvim
+            catppuccin-nvim
+            cmp-buffer
+          ];
+        }
+
+        # Plugins can add an additional package to the lazy path, and import a
+        # plugin module
+        {
+          pkg = LazyVim;
+          packages = catppuccin-nvim;
+          import = "lazyvim.plugins";
+        }
+
+        # Plugins can add several additional packages to the lazy path, and
+        # import several plugin modules
+        {
+          pkg = LazyVim;
+          packages = [
+            bufferline-nvim
+            catppuccin-nvim
+            cmp-buffer
+          ];
+          import = [
+            "lazyvim.plugins"
+            "lazyvim.plugins.extras.coding.copilot"
+          ];
+        }
+
         # Plugins can have dependencies on other plugins
         {
           pkg = completion-nvim;


### PR DESCRIPTION
When using the lazy nvim plugin manager I couldn't find any way to add `import` statements to import additional plugin modules in any given spec without having to resort to just using lua in `extraConfigLua` (See: [Importing Specs, `config` & `opts`](https://lazy.folke.io/usage/structuring#%EF%B8%8F-importing-specs-config--opts)).

This PR adds 2 features:
* Import Statements
* Allow user-specified packages to be made available in the `lazyPath` 

> I'm still pretty new to Nix and I'd appreciate any suggestions or comments on this PR

## Import Statements
### Importing a single plugin module
A single plugin module can be imported like this
```Nix
{
  plugins = {
    lazy = {
      enable = true;
      plugins = with pkgs.vimPlugins; [
        {
          pkg = <some-package>;
          import = "<some-plugin-module>";
        }
      ];
    };
  };
}
```
The lua equivalent for this would look something like this:
```lua
require("lazy").setup({
  spec = {
    { dir = "<path-to-pkg-in-nix-store>", import = "<some-plugin-module>" },
  }
})
```

### Importing multiple plugin modules
```
Several plugin modules can be imported like this
```Nix
{
  plugins = {
    lazy = {
      enable = true;
      plugins = with pkgs.vimPlugins; [
        {
          pkg = <some-package>;
          import = [
            "<some-plugin-module>"
            "<another-plugin-module>"
          ];
        }
      ];
    };
  };
}
```
The lua equivalent for this would look something like this:
```lua
require("lazy").setup({
  spec = {
    { dir = "<path-to-pkg-in-nix-store>", import = "<some-plugin-module>" },
    { import = "<another-plugin-module>" },
  }
})
```

## Allow user-specified packages to be made available in the `lazyPath` 
Some plugin modules will look for packages/plugins in the `lazyPath`. This was an issue I encountered when trying to set up LazyVim with nixvim. Adding nix packages to the `lazyPath` can be done now from any plugin spec.

>Maybe using the name `packages` isn't good for this, but I couldn't think of anything better at the time and I'm open to suggestions.

Single package to add to `lazyPath` example:
```Nix
{
  plugins = {
    lazy = {
      enable = true;
      plugins = with pkgs.vimPlugins; [
        {
          pkg = <some-package>;
          packages = [
            "<some-package-to-be-added-to-lazy-path>"
            "<another-package-to-be-added-to-lazy-path>"
          ];
        }
      ];
    };
  };
}
```

Multiple packages to be added to `lazyPath` example:
```Nix
{
  plugins = {
    lazy = {
      enable = true;
      plugins = with pkgs.vimPlugins; [
        {
          pkg = <some-package>;
          packages = [
            "<some-package-to-be-added-to-lazy-path>"
            "<another-package-to-be-added-to-lazy-path>"
          ];
        }
      ];
    };
  };
}
```

### Aside Example: Setting up LazyVim with this PR's changes

Just as an aside I thought it might help or be cool to see how LazyVim can be setup using these changes as a practical example. 

> The `flake.lock` and `flake.nix` for this can be found here https://gist.github.com/tashrifsanil/613a8c127c1a80f3949501590f622feb 

**flake.nix**
```Nix
{
  description = "Setup LazyVim using NixVim";

  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
  inputs.nixvim.url = "github:tashrifsanil/nixvim/lazy-plugin-manager-enhancements";
  inputs.nixvim.inputs.nixpkgs.follows = "nixpkgs";
  inputs.nixvim.inputs.flake-parts.follows = "flake-parts";
  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
  inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";

  outputs =
    {
      self,
      nixpkgs,
      nixvim,
      flake-parts,
    }@inputs:
    flake-parts.lib.mkFlake { inherit inputs; } {
      systems = [
        "aarch64-darwin"
        "aarch64-linux"
        "x86_64-darwin"
        "x86_64-linux"
      ];

      perSystem =
        {
          pkgs,
          lib,
          system,
          ...
        }:
        let
          miniNvimModules =
            with pkgs.vimPlugins;
            [ mini-nvim ]
            ++
              lib.map
                (miniModule: {
                  name = "${miniModule}";
                  pkg = mini-nvim;
                })
                [
                  "mini.ai"
                  "mini.icons"
                  "mini.move"
                  "mini.pairs"
                  "mini.splitjoin"
                  "mini.trailspace"
                ];

          lazyVimPlugins =
            with pkgs.vimPlugins;
            [
              bufferline-nvim
              catppuccin-nvim
              cmp-buffer
              cmp-nvim-lsp
              cmp-path
              conform-nvim
              dashboard-nvim
              dressing-nvim
              flash-nvim
              friendly-snippets
              gitsigns-nvim
              indent-blankline-nvim
              lazydev-nvim
              lualine-nvim
              #luvit-meta
              mason-lspconfig-nvim
              mason-nvim
              mini-nvim
              neo-tree-nvim
              noice-nvim
              nui-nvim
              nvim-autopairs
              nvim-cmp
              nvim-lint
              nvim-lspconfig
              nvim-notify
              nvim-snippets
              nvim-spectre
              nvim-treesitter
              nvim-treesitter-textobjects
              nvim-ts-autotag
              persistence-nvim
              plenary-nvim
              telescope-fzf-native-nvim
              telescope-nvim
              todo-comments-nvim
              trouble-nvim
              ts-comments-nvim
              which-key-nvim
              tokyonight-nvim
            ]
            ++ miniNvimModules;

          config = {
            extraPackages = with pkgs; [
              # LazyVim
              lua-language-server
              stylua
              # Telescope
              ripgrep
            ];

            plugins = {
              lazy = {
                enable = true;
                plugins = with pkgs.vimPlugins; [
                  {
                    pkg = LazyVim;
                    import = "lazyvim.plugins";
                    packages = lazyVimPlugins;
                  }
                  {
                    pkg = nvim-treesitter;
                    opts = {
                      highlight = {
                        enable = true;
                      };
                      ensure_installed = [
                        "vim"
                        "regex"
                        "lua"
                        "bash"
                        "markdown"
                        "markdown_inline"
                      ];
                      parser_install_dir.__raw = "vim.fs.joinpath(vim.fn.stdpath('data'), 'site')";
                    };
                  }
                  {
                    pkg = telescope-fzf-native-nvim;
                    enabled = true;
                  }
                  {
                    pkg = mason-nvim;
                    enabled = false;
                  }
                  {
                    pkg = mason-lspconfig-nvim;
                    enabled = false;
                  }
                ];
              };
            };

          };
          nixvim' = nixvim.legacyPackages."${system}";
          nvim = nixvim'.makeNixvim config;
        in
        {
          packages = {
            inherit nvim;
            default = nvim;
          };
        };
    };
}
```