### PR TITLE
modules/lua-loader: allow null value, do not configure by default

### DIFF
--- a/modules/lua-loader.nix
+++ b/modules/lua-loader.nix
@@ -1,30 +1,30 @@
-{ lib, config, ... }:
-with lib;
+{
+  lib,
+  config,
+  helpers,
+  ...
+}:
 let
   cfg = config.luaLoader;
 in
 {
-  options.luaLoader = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to enable/disable the experimental lua loader:
+  options.luaLoader.enable = helpers.mkNullOrOption lib.types.bool ''
+    Whether to enable/disable the experimental lua loader:
 
-        If `true`: Enables the experimental Lua module loader:
-          - overrides loadfile
-          - adds the lua loader using the byte-compilation cache
-          - adds the libs loader
-          - removes the default Neovim loader
+    If `true`: Enables the experimental Lua module loader:
+      - overrides loadfile
+      - adds the lua loader using the byte-compilation cache
+      - adds the libs loader
+      - removes the default Neovim loader
 
-        If `false`: Disables the experimental Lua module loader:
-          - removes the loaders
-          - adds the default Neovim loader
-      '';
-    };
-  };
+    If `false`: Disables the experimental Lua module loader:
+      - removes the loaders
+      - adds the default Neovim loader
 
-  config = {
+    If `null`: Nothing is configured.
+  '';
+
+  config = helpers.mkIfNonNull' cfg.enable {
     extraConfigLuaPre = if cfg.enable then "vim.loader.enable()" else "vim.loader.disable()";
   };
 }

--- a/tests/test-sources/modules/lua-loader.nix
+++ b/tests/test-sources/modules/lua-loader.nix
@@ -1,9 +1,59 @@
 {
-  enabled = {
-    luaLoader.enable = true;
-  };
+  # Test that nothing is configured by default
+  default.module =
+    { config, ... }:
+    {
+      files."files_test.lua" = { };
 
-  disabled = {
-    luaLoader.enable = false;
-  };
+      assertions = [
+        {
+          assertion = builtins.match ".*vim\.loader.*" config.content == null;
+          message = "No luaLoader configuration is expected in init.lua by default.";
+        }
+        {
+          assertion = builtins.match ".*vim\.loader.*" config.files."files_test.lua".content == null;
+          message = "No luaLoader configuration is expected in 'files' submodules.";
+        }
+      ];
+    };
+
+  # Test lua loader enabled
+  enabled.module =
+    { config, ... }:
+    {
+      luaLoader.enable = true;
+
+      files."files_test.lua" = { };
+
+      assertions = [
+        {
+          assertion = builtins.match ".*vim\.loader\.enable\(\).*" config.content != null;
+          message = "luaLoader is expected to be explicitly enabled.";
+        }
+        {
+          assertion = builtins.match ".*vim\.loader.*" config.files."files_test.lua".content == null;
+          message = "No luaLoader configuration is expected in 'files' submodules.";
+        }
+      ];
+    };
+
+  # Test lua loader disabled
+  disabled.module =
+    { config, ... }:
+    {
+      luaLoader.enable = false;
+
+      files."files_test.lua" = { };
+
+      assertions = [
+        {
+          assertion = builtins.match ".*vim\.loader\.disable\(\).*" config.content != null;
+          message = "luaLoader is expected to be explicitly disabled.";
+        }
+        {
+          assertion = builtins.match ".*vim\.loader.*" config.files."files_test.lua".content == null;
+          message = "No luaLoader configuration is expected in 'files' submodules.";
+        }
+      ];
+    };
 }


### PR DESCRIPTION
This changes `luaLoader.enable` option's type to allow null and sets its default to null.

Why? First, most important: it's not expected to have vim.loader configuration in `files` submodules. Changing default to null fixes that. Second, as I understand, the goal of this project is to not configure anything by default. I don't particularly like this extra line in `init.lua`.

My goal is to make `files` submodules to produce empty configs by default. When I do

```nix
files."ftplugin/nix.lua".localOpts.shiftwidth = 2;
```

I expect `ftplugin/nix.lua` will have only this option, and nothing else.

If somehow it's not desired, maybe a compromise can be made. Set it to `false` somewhere in the `top-level` modules, so that the default in `files` stays null.

Current behavior is completely undesired. Consider config:

```nix
luaLoader.enable = true;
files."plugin/test.lua" = {};
```

With this config `init.lua` has `vim.loader.enable()` and `plugin/test.lua` has `vim.loader.disable()`...