### PR TITLE
modules/lsp/servers/vls: do not add filetype extension if not enabled

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -591,7 +591,9 @@ let
           example = false;
         };
       };
-      extraConfig = cfg: { filetype.extension = mkIf cfg.autoSetFiletype { v = "vlang"; }; };
+      extraConfig = cfg: {
+        filetype.extension = mkIf (cfg.enable && cfg.autoSetFiletype) { v = "vlang"; };
+      };
     }
     {
       name = "vuels";

--- a/tests/test-sources/plugins/lsp/language-servers/vls.nix
+++ b/tests/test-sources/plugins/lsp/language-servers/vls.nix
@@ -1,0 +1,29 @@
+{
+  default = {
+    plugins.lsp = {
+      enable = true;
+      servers.vls.enable = true;
+    };
+
+    extraConfigLuaPost = ''
+      -- V files are recognized by default
+      assert(vim.filetype.match({ filename = "test.v" }) == "vlang", "V filetype is not recognized")
+    '';
+  };
+
+  extra-options = {
+    plugins.lsp = {
+      enable = true;
+
+      servers.vls = {
+        enable = true;
+        autoSetFiletype = true;
+      };
+    };
+
+    extraConfigLuaPost = ''
+      -- autoSetFiletype
+      assert(vim.filetype.match({ filename = "test.v" }) == "vlang", "V filetype is not recognized")
+    '';
+  };
+}


### PR DESCRIPTION
Option `plugins.lsp.servers.vls.autoSetFiletype` adds filetype extension by default, even when `plugins.lsp.servers.vls.enable = false`. I think this is not intended behavior.

My main goal is to make `files` submodules to produce empty configs by default. When I do

```nix
files."ftplugin/nix.lua".localOpts.shiftwidth = 2;
```

I expect `ftplugin/nix.lua` to have only this option, and nothing else.