### PR TITLE
modules/filetype: ensure that modules does not provide empty settings

### DIFF
--- a/modules/filetype.nix
+++ b/modules/filetype.nix
@@ -6,6 +6,8 @@
 }:
 with lib;
 let
+  cfg = config.filetype;
+
   filetypeDefinition = helpers.mkNullOrOption (
     with types;
     attrsOf (oneOf [
@@ -52,7 +54,9 @@ in
         pattern = filetypeDefinition "set filetypes matching the specified pattern";
       };
 
-  config.extraConfigLua = helpers.mkIfNonNull' config.filetype ''
-    vim.filetype.add(${helpers.toLuaObject config.filetype})
-  '';
+  config.extraConfigLua =
+    lib.mkIf (cfg != null && (builtins.any (v: v != null) (builtins.attrValues cfg)))
+      ''
+        vim.filetype.add(${helpers.toLuaObject cfg})
+      '';
 }

--- a/tests/test-sources/modules/filetypes.nix
+++ b/tests/test-sources/modules/filetypes.nix
@@ -38,4 +38,21 @@
       };
     };
   };
+
+  default-empty.module =
+    { config, ... }:
+    {
+      files.test = { };
+
+      assertions = [
+        {
+          assertion = builtins.match ".*vim\.filetype\..*" config.content == null;
+          message = "No vim.filetype definitions should be present in init.lua by default.";
+        }
+        {
+          assertion = builtins.match ".*vim\.filetype\..*" config.files.test.content == null;
+          message = "No vim.filetype definitions should be present in files submodules by default.";
+        }
+      ];
+    };
 }


### PR DESCRIPTION
`helpers.mkIfNonNull'` checks only for value = null, but I noticed that when there is anywhere something like `mkIf false config.filename = {}` (like with vlang filetype currently in nixvim, see also #1907), value of `config.filetype` is not null, but has all attrs with null values. It can be debugged with `nix repl`:

```
nix-repl> c = makeNixvim {}

nix-repl> :p c.options.filetype.definitions
[ { extension = { _type = "if"; condition = false; content = { v = "vlang"; }; }; } ]

nix-repl> :p c.config.filetype
{ extension = null; filename = null; pattern = null; }
```

Notice that `condition = false`, but the value is not null.

This PR changes mkIf condition to account for that.

NOTE: Test `checks.x86_64-linux.tests.entries.modules-filetypes` will fail until #1907 is merged.