### PR TITLE
modules/output: produce empty files by default

### DIFF
--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -110,11 +110,12 @@ with lib;
           {
             extraPlugins = (optional installPackage cfg.package) ++ extraPlugins;
             inherit extraPackages;
-
-            ${extraConfigNamespace} = optionalString callSetup ''
+          }
+          (optionalAttrs callSetup {
+            ${extraConfigNamespace} = ''
               require('${luaName}')${setup}(${optionalString (cfg ? settings) (toLuaObject cfg.settings)})
             '';
-          }
+          })
           (optionalAttrs (isColorscheme && (colorscheme != null)) { colorscheme = mkDefault colorscheme; })
           (extraConfig cfg)
         ]);

--- a/modules/autocmd.nix
+++ b/modules/autocmd.nix
@@ -42,7 +42,7 @@ with lib;
     let
       inherit (config) autoGroups autoCmd;
     in
-    mkIf (autoGroups != { } || autoCmd != { }) {
+    mkIf (autoGroups != { } || autoCmd != [ ]) {
       # Introduced early October 2023.
       # TODO remove in early December 2023.
       assertions = [

--- a/modules/diagnostics.nix
+++ b/modules/diagnostics.nix
@@ -19,7 +19,7 @@ with lib;
   };
 
   config = {
-    extraConfigLuaPre = optionalString (config.diagnostics != { }) ''
+    extraConfigLuaPre = mkIf (config.diagnostics != { }) ''
       vim.diagnostic.config(${helpers.toLuaObject config.diagnostics})
     '';
   };

--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -35,50 +35,52 @@ with lib;
     };
   };
 
-  config = {
-    extraConfigLuaPre =
-      (optionalString (config.highlight != { })
-        # lua
-        ''
-          -- Highlight groups {{
-          do
-            local highlights = ${helpers.toLuaObject config.highlight}
+  config = mkMerge [
+    {
+      extraConfigLuaPre =
+        mkIf (config.highlight != { })
+          # lua
+          ''
+            -- Highlight groups {{
+            do
+              local highlights = ${helpers.toLuaObject config.highlight}
 
-            for k,v in pairs(highlights) do
-              vim.api.nvim_set_hl(0, k, v)
+              for k,v in pairs(highlights) do
+                vim.api.nvim_set_hl(0, k, v)
+              end
             end
-          end
-          -- }}
-        ''
-      )
-      + (optionalString (config.match != { })
-        # lua
-        ''
-          -- Match groups {{
-          do
-            local match = ${helpers.toLuaObject config.match}
-
-            for k,v in pairs(match) do
-              vim.fn.matchadd(k, v)
-            end
-          end
             -- }}
-        ''
-      );
+          '';
+      extraConfigLuaPost =
+        mkIf (config.highlightOverride != { })
+          # lua
+          ''
+            -- Highlight groups {{
+            do
+              local highlights = ${helpers.toLuaObject config.highlightOverride}
 
-    extraConfigLuaPost =
-      optionalString (config.highlightOverride != { })
-        # lua
-        ''
-          -- Highlight groups {{
-          do
-            local highlights = ${helpers.toLuaObject config.highlightOverride}
-
-            for k,v in pairs(highlights) do
-              vim.api.nvim_set_hl(0, k, v)
+              for k,v in pairs(highlights) do
+                vim.api.nvim_set_hl(0, k, v)
+              end
             end
-          end
-          -- }}
-        '';
-  };
+            -- }}
+          '';
+    }
+    {
+      extraConfigLuaPre =
+        mkIf (config.match != { })
+          # lua
+          ''
+            -- Match groups {{
+            do
+              local match = ${helpers.toLuaObject config.match}
+
+              for k,v in pairs(match) do
+                vim.fn.matchadd(k, v)
+              end
+            end
+              -- }}
+          '';
+    }
+  ];
 }

--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -90,7 +90,7 @@ with lib;
           ${concatStringsSep "\n" luaDefs}
         '';
 
-      extraConfigLua = optionalString (config.keymaps != [ ]) ''
+      extraConfigLua = mkIf (config.keymaps != [ ]) ''
         -- Set up keybinds {{{
         do
           local __nixvim_binds = ${helpers.toLuaObject (map normalizeMapping config.keymaps)}

--- a/modules/opts.nix
+++ b/modules/opts.nix
@@ -55,31 +55,35 @@ in
   };
 
   config = {
-    extraConfigLuaPre = concatLines (
-      mapAttrsToList (
-        optionName:
-        {
-          prettyName,
-          luaVariableName,
-          luaApi,
-          ...
-        }:
-        let
-          varName = "nixvim_${luaVariableName}";
-          optionDefinitions = config.${optionName};
-        in
-        optionalString (optionDefinitions != { }) ''
-          -- Set up ${prettyName} {{{
-          do
-            local ${varName} = ${helpers.toLuaObject optionDefinitions}
+    extraConfigLuaPre =
+      let
+        content = helpers.concatNonEmptyLines (
+          mapAttrsToList (
+            optionName:
+            {
+              prettyName,
+              luaVariableName,
+              luaApi,
+              ...
+            }:
+            let
+              varName = "nixvim_${luaVariableName}";
+              optionDefinitions = config.${optionName};
+            in
+            optionalString (optionDefinitions != { }) ''
+              -- Set up ${prettyName} {{{
+              do
+                local ${varName} = ${helpers.toLuaObject optionDefinitions}
 
-            for k,v in pairs(${varName}) do
-              vim.${luaApi}[k] = v
-            end
-          end
-          -- }}}
-        ''
-      ) optionsAttrs
-    );
+                for k,v in pairs(${varName}) do
+                  vim.${luaApi}[k] = v
+                end
+              end
+              -- }}}
+            ''
+          ) optionsAttrs
+        );
+      in
+      mkIf (content != "") content;
   };
 }

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -107,16 +107,10 @@ with lib;
         }
       );
 
-      customRC =
-        let
-          hasContent = str: (builtins.match "[[:space:]]*" str) == null;
-        in
-        (optionalString (hasContent neovimConfig.neovimRcContent) ''
-          vim.cmd([[
-            ${neovimConfig.neovimRcContent}
-          ]])
-        '')
-        + config.content;
+      customRC = helpers.concatNonEmptyLines [
+        (helpers.wrapVimscriptForLua neovimConfig.neovimRcContent)
+        config.content
+      ];
 
       init = helpers.writeLua "init.lua" customRC;
 

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -140,7 +140,7 @@ with lib;
         '';
       };
 
-      extraConfigLuaPre = lib.optionalString config.wrapRc ''
+      extraConfigLuaPre = lib.mkIf config.wrapRc ''
         -- Ignore the user lua configuration
         vim.opt.runtimepath:remove(vim.fn.stdpath('config'))              -- ~/.config/nvim
         vim.opt.runtimepath:remove(vim.fn.stdpath('config') .. "/after")  -- ~/.config/nvim/after

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -4,4 +4,90 @@
     # Make sure jsregexp is in LUA_PATH
     extraConfigLua = ''require("jsregexp")'';
   };
+
+  # Test that all extraConfigs are present in output
+  all-configs.module =
+    {
+      config,
+      pkgs,
+      lib,
+      ...
+    }:
+    let
+      configs = {
+        extraConfigLuaPre = "string.format('extraConfigLuaPre1')";
+        extraConfigLua = "string.format('extraConfigLua2')";
+        extraConfigLuaPost = "string.format('extraConfigLuaPost3')";
+        extraConfigVim = "let g:var = 'extraConfigVim4'";
+      };
+      mkConfigAssertions = name: value: [
+        {
+          assertion = lib.hasInfix "extraConfigLuaPre1" value;
+          message = "Configuration file ${name} does not contain extraConfigLuaPre.";
+        }
+        {
+          assertion = lib.hasInfix "extraConfigLua2" value;
+          message = "Configuration file ${name} does not contain extraConfigLua.";
+        }
+        {
+          assertion = lib.hasInfix "extraConfigLuaPost3" value;
+          message = "Configuration file ${name} does not contain extraConfigLuaPost.";
+        }
+        {
+          assertion = lib.hasInfix "extraConfigVim4" value;
+          message = "Configuration file ${name} does not contain extraConfigVim.";
+        }
+      ];
+    in
+    configs
+    // {
+      files = {
+        "test.lua" = configs;
+        "test.vim" = configs;
+      };
+
+      # Plugin configs
+      extraPlugins = [
+        {
+          plugin = pkgs.emptyDirectory;
+          config = "let g:var = 'neovimRcContent5'";
+        }
+      ];
+
+      assertions =
+        mkConfigAssertions "init.lua" config.content
+        ++ mkConfigAssertions "test.lua" config.files."test.lua".content
+        ++ mkConfigAssertions "test.vim" config.files."test.vim".content
+        # Check the final generated init.lua too
+        ++ mkConfigAssertions "initPath" (builtins.readFile config.initPath)
+        ++ [
+          # Only init.lua contains configuration from plugin definitions
+          {
+            assertion = lib.hasInfix "neovimRcContent5" (builtins.readFile config.initPath);
+            message = "Configuration file init.lua does not contain plugin configs";
+          }
+        ];
+    };
+
+  files-default-empty.module =
+    { config, helpers, ... }:
+    {
+      files = {
+        # lua type
+        "test.lua" = { };
+        # vim type
+        "test.vim" = { };
+      };
+
+      assertions = [
+        {
+          assertion = !helpers.hasContent config.files."test.lua".content;
+          message = "Default content of test.lua file is expected to be empty.";
+        }
+        {
+          assertion = !helpers.hasContent config.files."test.vim".content;
+          message = "Default content of test.vim file is expected to be empty.";
+        }
+      ];
+    };
 }


### PR DESCRIPTION
This PR removes empty

```lua
vim.cmd([[

]])
```

block from config.

I know that this is already handled by #1889, but I've added tests to make sure that this is the behavior. Also I added the test to make sure that all extraConfigs are outputted.

This also changes various places in other modules with the intention of not setting `extraConfig*` options to empty strings (more specifically whitespace only strings).

NOTE: The tests will fail until #1906, #1907 and #1908 are merged.