### PR TITLE
lib/to-lua: handle derivations as path strings

### DIFF
--- a/lib/to-lua.nix
+++ b/lib/to-lua.nix
@@ -141,6 +141,8 @@ rec {
           value
         else if allowRawValues && value ? __raw then
           value
+        else if isDerivation value then
+          value
         else if isList value then
           let
             needsFiltering = removeNullListEntries || removeEmptyListEntries;
@@ -205,8 +207,8 @@ rec {
           builtins.toJSON v
         else if isBool v then
           boolToString v
-        else if isPath v then
-          go indent (toString v)
+        else if isPath v || isDerivation v then
+          go indent "${v}"
         else if isString v then
           # TODO: support lua's escape sequences, literal string, and content-appropriate quote style
           # See https://www.lua.org/pil/2.4.html
@@ -217,8 +219,6 @@ rec {
           "{ }"
         else if isFunction v then
           abort "nixvim(toLua): Unexpected function: " + generators.toPretty { } v
-        else if isDerivation v then
-          abort "nixvim(toLua): Unexpected derivation: " + generators.toPretty { } v
         else if isList v then
           "{" + introSpace + concatMapStringsSep ("," + introSpace) (go (indent + "  ")) v + outroSpace + "}"
         else if isAttrs v then

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -45,6 +45,8 @@ let
     ];
   };
 
+  drv = pkgs.writeText "example-derivation" "hello, world!";
+
   results = pkgs.lib.runTests {
     testToLuaObject = {
       expr = helpers.toLuaObject {
@@ -122,6 +124,23 @@ let
         foo\bar
         baz'';
       expected = ''"foo\\bar\nbaz"'';
+    };
+
+    testToLuaObjectDerivation = {
+      expr = helpers.toLuaObject drv;
+      expected = ''"${drv}"'';
+    };
+
+    testToLuaObjectDerivationNested = {
+      expr = helpers.toLuaObject {
+        a = drv;
+        b = {
+          c = drv;
+        };
+        d = [ drv ];
+        e = [ { f = drv; } ];
+      };
+      expected = ''{ a = "${drv}", b = { c = "${drv}" }, d = { "${drv}" }, e = { { f = "${drv}" } } }'';
     };
 
     testToLuaObjectFilters = {


### PR DESCRIPTION
Fixes #1888

Without the changes in `lib`, the new tests fail with inf recursion. It'd be nice if they failed gracefully, but it seems `lib.runTests` doesn't handle that.

This means there's we just get:

```
evaluating derivation 'git+file:///home/matt/nixvim.git/drv_to_lua#checks.x86_64-linux.lib-tests'error: stack overflow (possible infinite recursion)
```

Instead of a _proper_ error message listing all failures and printing the expected & resulting values

_With_ the changes in `lib/to-lua.nix` the lib-tests all pass ok.

Ping: @SuperSandro2000 