### PR TITLE
plugins/lsp/jdtls: add Eclipse JDT language server for Java

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -239,6 +239,12 @@ let
       cmd = cfg: [ "${cfg.package}/bin/java-language-server" ];
     }
     {
+      name = "jdt-language-server";
+      description = "Eclipse JDT Language Server for Java";
+      serverName = "jdtls";
+      cmd = cfg: [ (lib.getExe cfg.package) ];
+    }
+    {
       name = "jsonls";
       description = "jsonls for JSON";
       package = pkgs.vscode-langservers-extracted;

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -142,6 +142,7 @@
             html.enable = true;
             htmx.enable = true;
             java-language-server.enable = true;
+            jdt-language-server.enable = true;
             jsonls.enable = true;
             jsonnet-ls.enable = true;
             julials.enable = true;


### PR DESCRIPTION
This adds the Eclipse JDT language server for Java. The existing Java LSP, "Java Language Server" was not suiting my use case. JDT seems to work better for me, so this adds that functionality to the list of LSPs.