### PR TITLE
wrappers: use `lib.nixvim` option

### DIFF
--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -26,7 +26,7 @@ in
         specialArgs = {
           darwinConfig = config;
           defaultPkgs = pkgs;
-          inherit (config.nixvim) helpers;
+          helpers = config.lib.nixvim;
         };
         modules = [
           ./modules/darwin.nix

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -25,7 +25,7 @@ in
         specialArgs = {
           hmConfig = config;
           defaultPkgs = pkgs;
-          inherit (config.nixvim) helpers;
+          helpers = config.lib.nixvim;
         };
         modules = [
           ./modules/hm.nix

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -26,7 +26,7 @@ in
         specialArgs = {
           nixosConfig = config;
           defaultPkgs = pkgs;
-          inherit (config.nixvim) helpers;
+          helpers = config.lib.nixvim;
         };
         modules = [
           ./modules/nixos.nix


### PR DESCRIPTION
Update internal usage from the deprecated `nixvim.helpers` option to the new `lib.nixvim` option name.

See https://github.com/nix-community/nixvim/commit/216d64c158da5523d5b3db0895e1345175c21502#commitcomment-144629377
