### PR TITLE
plugins/which-key: fix registrations type

### DIFF
--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -13,12 +13,15 @@ with lib;
     package = helpers.mkPluginPackageOption "which-key-nvim" pkgs.vimPlugins.which-key-nvim;
 
     registrations = mkOption {
-      type = with types; attrsOf anything;
-      default = { };
+      type = with types; anything;
+      default = [ ];
       description = "Manually register the description of mappings.";
-      example = {
-        "<leader>p" = "Find git files with telescope";
-      };
+      example = [
+        [
+          "<leader>p"
+          { desc = "Find git files with telescope"; }
+        ]
+      ];
     };
 
     plugins = {


### PR DESCRIPTION
Every time I open nvim, it gives me this message
![image](https://github.com/user-attachments/assets/4c30473a-b752-484a-be71-61f4a0950e2d)

And in `:checkhealth which-key` I see this:

```lua
Checking for issues with your mappings ~
- WARNING You're using an old version of the which-key spec.
  Your mappings will work, but it's recommended to update them to the new version.
  Please check the docs and suggested spec below for more info.
  Mappings: >
  {
    ["<leader>c"] = { name = "[C]ode" },
    ["<leader>d"] = { name = "[D]ocument" },
    ["<leader>r"] = { name = "[R]ename" },
    ["<leader>s"] = { name = "[S]earch" },
    ["<leader>w"] = { name = "[W]orkspace" }
  }
  
  -- Suggested Spec:
  {
    { "<leader>c", group = "[C]ode" },
    { "<leader>d", group = "[D]ocument" },
    { "<leader>r", group = "[R]ename" },
    { "<leader>s", group = "[S]earch" },
    { "<leader>w", group = "[W]orkspace" },
  }
```

Translated to nix syntax it is:

```nix
[
  [ "<leader>c" { group = "[C]ode"; } ]
  [ "<leader>d" { group = "[D]ocument"; } ]
  [ "<leader>r" { group = "[R]ename"; } ]
  [ "<leader>s" { group = "[S]earch"; } ]
  [ "<leader>w" { group = "[W]orkspace"; } ]
]
```

Fixes #1901 