### PR TITLE
treewide: add global iconsEnabled option

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -15,6 +15,7 @@
     ./files.nix
     ./filetype.nix
     ./highlights.nix
+    ./icons.nix
     ./keymaps.nix
     ./lua-loader.nix
     ./opts.nix

--- a/modules/icons.nix
+++ b/modules/icons.nix
@@ -1,0 +1,8 @@
+{ lib, ... }:
+{
+  options.iconsEnabled = lib.mkOption {
+    type = lib.types.bool;
+    description = "Toggle icon support. Installs nvim-web-devicons.";
+    default = true;
+  };
+}

--- a/plugins/git/diffview.nix
+++ b/plugins/git/diffview.nix
@@ -107,7 +107,7 @@ in
       useIcons = mkOption {
         type = types.bool;
         description = "Requires nvim-web-devicons";
-        default = true;
+        default = config.iconsEnabled;
       };
 
       showHelpHints = mkBool true ''

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -111,7 +111,7 @@ in
       iconsEnabled = mkOption {
         type = types.bool;
         description = "Whether to enable/disable icons for all components.";
-        default = true;
+        default = config.iconsEnabled;
       };
 
       theme = helpers.defaultNullOpts.mkNullable (

--- a/plugins/utils/alpha.nix
+++ b/plugins/utils/alpha.nix
@@ -58,7 +58,7 @@ in
       iconsEnabled = mkOption {
         type = types.bool;
         description = "Toggle icon support. Installs nvim-web-devicons.";
-        default = true;
+        default = config.iconsEnabled;
       };
 
       theme = mkOption {

--- a/plugins/utils/fzf-lua.nix
+++ b/plugins/utils/fzf-lua.nix
@@ -50,7 +50,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     iconsEnabled = mkOption {
       type = types.bool;
       description = "Toggle icon support. Installs nvim-web-devicons.";
-      default = true;
+      default = config.iconsEnabled;
     };
 
     profile = helpers.defaultNullOpts.mkEnumFirstDefault [

--- a/tests/test-sources/modules/icons.nix
+++ b/tests/test-sources/modules/icons.nix
@@ -1,0 +1,42 @@
+{
+  default.module =
+    { config, ... }:
+    {
+      plugins.lualine.enable = true;
+
+      assertions = [
+        {
+          assertion = config.plugins.lualine.iconsEnabled;
+          message = "Expected lualine to default to icons enabled.";
+        }
+      ];
+    };
+
+  enabled.module =
+    { config, ... }:
+    {
+      iconsEnabled = true;
+      plugins.lualine.enable = true;
+
+      assertions = [
+        {
+          assertion = config.plugins.lualine.iconsEnabled;
+          message = "Expected lualine iconsEnabled to be true when globally enabled.";
+        }
+      ];
+    };
+
+  disabled.module =
+    { config, ... }:
+    {
+      iconsEnabled = false;
+      plugins.lualine.enable = true;
+
+      assertions = [
+        {
+          assertion = !config.plugins.lualine.iconsEnabled;
+          message = "Expected lualine iconsEnabled to be false when globally disabled.";
+        }
+      ];
+    };
+}


### PR DESCRIPTION
While I really like Nerd Fonts, it would be great if there was a single global way to disable them for environments where Nerd Fonts won't be used. A number of plugins already provide individual `iconsEnabled` options while others handle icons flags in more ad-hoc way. It would be great to standardize on the `iconsEnabled` name and provide a top level global value they would default to.

Ideally disabling `iconsEnabled` prevents `pkgs.vimPlugins.nvim-web-devicon` from being installed at all. Though there's still some follow-up work that could be done to improve the per plugin handling of their own `iconsEnabled` options.

Open to naming this option whatever is preferred by the maintainers, but `iconsEnabled` seemed most used already.