### PR TITLE
plugins/lsp/nextls: init

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -311,6 +311,15 @@ let
       description = "metals for Scala";
     }
     {
+      name = "nextls";
+      description = "The language server for Elixir that just works.";
+      package = pkgs.next-ls;
+      cmd = cfg: [
+        "nextls"
+        "--stdio"
+      ];
+    }
+    {
       name = "nginx-language-server";
       description = "nginx-language-server for `nginx.conf`";
       serverName = "nginx_language_server";

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -154,6 +154,7 @@
             lua-ls.enable = true;
             marksman.enable = true;
             metals.enable = true;
+            nextls.enable = true;
             nginx-language-server.enable = true;
             nickel-ls.enable = true;
             nil-ls.enable = true;


### PR DESCRIPTION
Adds `nextls` the language server for Elixir that just works.