### PR TITLE
plugins/which-key: deprecate v2 registrations

### DIFF
--- a/tests/test-sources/plugins/utils/which-key.nix
+++ b/tests/test-sources/plugins/utils/which-key.nix
@@ -8,46 +8,57 @@
       enable = true;
 
       # Testing for registrations
-      registrations."f" = {
-        prefix = "<leader>";
-        mode = [
-          "n"
-          "v"
-          "i"
-          "t"
-          "c"
-          "x"
-          "s"
-          "o"
-        ];
-        name = "Group Test";
-        f = "Label Test";
-        "1" = [
+      settings.spec =
+        let
+          mode = [
+            "n"
+            "v"
+            "i"
+            "t"
+            "c"
+            "x"
+            "s"
+            "o"
+          ];
+        in
+        [
           {
-            __raw = ''
+            __unkeyed-1 = "<leader>f";
+            group = "Group Test";
+            inherit mode;
+          }
+          {
+            __unkeyed-1 = "<leader>ff";
+            desc = "Label Test";
+            inherit mode;
+          }
+          {
+            __unkeyed-1 = "<leader>f1";
+            __unkeyed-2.__raw = ''
               function()
-                print("Raw Lua Code and List KeyMapping Test")
+                print("Raw Lua KeyMapping Test")
               end
             '';
+            desc = "Raw Lua KeyMapping Test";
+            inherit mode;
           }
-          "Raw Lua Code and List KeyMapping Test"
+          {
+            __unkeyed-1 = "<leader>foo";
+            desc = "Label Test 2";
+            inherit mode;
+          }
+          {
+            __unkeyed-1 = "<leader>f<tab>";
+            group = "Group in Group Test";
+            inherit mode;
+          }
+          {
+            __unkeyed-1 = "<leader>f<tab>f";
+            __unkeyed-2 = "<cmd>echo 'Vim cmd KeyMapping Test'<cr>";
+            desc = "Vim cmd KeyMapping Test";
+            inherit mode;
+          }
         ];
-        "oo" = "Label Test 2";
-        "<tab>" = {
-          name = "Group in Group Test";
-          f = [
-            {
-              __raw = ''
-                function()
-                  vim.cmd("echo 'Raw Lua Code and List KeyMapping Test 2'")
-                end
-              '';
-            }
-
-            "Raw Lua Code and List KeyMapping Test 2"
-          ];
-        };
-      };
 
       plugins = {
         marks = true;


### PR DESCRIPTION
These have been replaced in v3 with a new spec.

This is an **interim** solution until we have time to fully migrate which-key to rfc42 freeform settings.

I've done this because the warning shown when starting vim is kinda obnixious and without this the only way to avoid it is to remove all registrations.

As we will (hopefully) migrate which-key to `settings` options soon, I've named the new option `settings.spec` so that we do not need to "rename" it again.

This PR **does not** actually add a freeform settings option.

The old option (`registrations`) is deprecated, when defined it will print:
```
trace: evaluation warning: nixvim (plugins.which-key):
The option definition `plugins.which-key.registrations' in `<unknown-file>' has been deprecated in which-key v3; please remove it.
You should use `plugins.which-key.settings.spec' instead.

Note: the spec format has changed in which-key v3
See: https://github.com/folke/which-key.nvim?tab=readme-ov-file#%EF%B8%8F-mappings
```

(I haven't added a deprecation notice to the `apply`, so reading the option will not print warnings)

After this warning has been in place for a while, we can upgrade to a `mkRemovedOptionModule` assertion.

~~Marked as a draft since the test cases still need to be updated.~~

Fixes #1901
See https://github.com/nix-community/nixvim/pull/1927#issuecomment-2250725447
