### PR TITLE
lib/helpers: build recursively

### DIFF
--- a/lib/autocmd-helpers.nix
+++ b/lib/autocmd-helpers.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  nixvimOptions,
-  nixvimTypes,
-}:
+{ lib, helpers }:
 with lib;
 rec {
   autoGroupOption = types.submodule {
@@ -16,34 +12,34 @@ rec {
   };
 
   autoCmdOptions = {
-    event = nixvimOptions.mkNullOrOption (with types; either str (listOf str)) ''
+    event = helpers.mkNullOrOption (with types; either str (listOf str)) ''
       The event or events to register this autocommand.
     '';
 
-    group = nixvimOptions.mkNullOrOption (with types; either str int) ''
+    group = helpers.mkNullOrOption (with types; either str int) ''
       The autocommand group name or id to match against.
     '';
 
-    pattern = nixvimOptions.mkNullOrOption (with types; either str (listOf str)) ''
+    pattern = helpers.mkNullOrOption (with types; either str (listOf str)) ''
       Pattern or patterns to match literally against.
     '';
 
-    buffer = nixvimOptions.mkNullOrOption types.int ''
+    buffer = helpers.mkNullOrOption types.int ''
       Buffer number for buffer local autocommands |autocmd-buflocal|.
       Cannot be used with `pattern`.
     '';
 
     # Introduced early October 2023.
     # TODO remove in early December 2023.
-    description = nixvimOptions.mkNullOrOption types.str ''
+    description = helpers.mkNullOrOption types.str ''
       DEPRECATED, please use `desc`.
     '';
 
-    desc = nixvimOptions.mkNullOrOption types.str ''
+    desc = helpers.mkNullOrOption types.str ''
       A textual description of this autocommand.
     '';
 
-    callback = nixvimOptions.mkNullOrOption (with types; either str nixvimTypes.rawLua) ''
+    callback = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
       A function or a string.
       - if a string, the name of a Vimscript function to call when this autocommand is triggered.
       - Otherwise, a Lua function which is called when this autocommand is triggered.
@@ -67,13 +63,13 @@ rec {
         }
     '';
 
-    command = nixvimOptions.defaultNullOpts.mkStr "" ''
+    command = helpers.defaultNullOpts.mkStr "" ''
       Vim command to execute on event. Cannot be used with `callback`.
     '';
 
-    once = nixvimOptions.defaultNullOpts.mkBool false "Run the autocommand only once.";
+    once = helpers.defaultNullOpts.mkBool false "Run the autocommand only once.";
 
-    nested = nixvimOptions.defaultNullOpts.mkBool false "Run nested autocommands.";
+    nested = helpers.defaultNullOpts.mkBool false "Run nested autocommands.";
   };
 
   autoCmdOption = types.submodule { options = autoCmdOptions; };

--- a/lib/deprecation.nix
+++ b/lib/deprecation.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 with lib;
 rec {
   # Get a (sub)option by walking the path,

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -5,30 +5,21 @@
   ...
 }:
 let
-  nixvimBuilders = import ./builders.nix { inherit lib pkgs; };
-  nixvimTypes = import ./types.nix { inherit lib nixvimOptions; };
-  nixvimUtils = import ./utils.nix { inherit lib nixvimTypes _nixvimTests; };
-  nixvimOptions = import ./options.nix { inherit lib nixvimTypes nixvimUtils; };
-  nixvimDeprecation = import ./deprecation.nix { inherit lib; };
+  # Build helpers recursively
+  helpers =
+    {
+      autocmd = import ./autocmd-helpers.nix { inherit lib helpers; };
+      keymaps = import ./keymap-helpers.nix { inherit lib helpers; };
+      lua = import ./to-lua.nix { inherit lib; };
+      toLuaObject = helpers.lua.toLua;
+      maintainers = import ./maintainers.nix;
+      neovim-plugin = import ./neovim-plugin.nix { inherit lib helpers; };
+      nixvimTypes = import ./types.nix { inherit lib helpers; };
+      vim-plugin = import ./vim-plugin.nix { inherit lib helpers; };
+    }
+    // import ./builders.nix { inherit lib pkgs; }
+    // import ./deprecation.nix { inherit lib; }
+    // import ./options.nix { inherit lib helpers; }
+    // import ./utils.nix { inherit lib helpers _nixvimTests; };
 in
-rec {
-  maintainers = import ./maintainers.nix;
-  lua = import ./to-lua.nix { inherit lib; };
-  keymaps = import ./keymap-helpers.nix { inherit lib nixvimOptions nixvimTypes; };
-  autocmd = import ./autocmd-helpers.nix { inherit lib nixvimOptions nixvimTypes; };
-  neovim-plugin = import ./neovim-plugin.nix {
-    inherit
-      lib
-      nixvimOptions
-      nixvimUtils
-      toLuaObject
-      ;
-  };
-  vim-plugin = import ./vim-plugin.nix { inherit lib nixvimOptions nixvimUtils; };
-  inherit nixvimTypes;
-  toLuaObject = lua.toLua;
-}
-// nixvimUtils
-// nixvimOptions
-// nixvimBuilders
-// nixvimDeprecation
+helpers

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -5,21 +5,24 @@
   ...
 }:
 let
+  # Used when importing parts of helpers
+  call = lib.callPackageWith { inherit pkgs lib helpers; };
+
   # Build helpers recursively
   helpers =
     {
-      autocmd = import ./autocmd-helpers.nix { inherit lib helpers; };
-      keymaps = import ./keymap-helpers.nix { inherit lib helpers; };
-      lua = import ./to-lua.nix { inherit lib; };
+      autocmd = call ./autocmd-helpers.nix { };
+      keymaps = call ./keymap-helpers.nix { };
+      lua = call ./to-lua.nix { };
       toLuaObject = helpers.lua.toLua;
       maintainers = import ./maintainers.nix;
-      neovim-plugin = import ./neovim-plugin.nix { inherit lib helpers; };
-      nixvimTypes = import ./types.nix { inherit lib helpers; };
-      vim-plugin = import ./vim-plugin.nix { inherit lib helpers; };
+      neovim-plugin = call ./neovim-plugin.nix { };
+      nixvimTypes = call ./types.nix { };
+      vim-plugin = call ./vim-plugin.nix { };
     }
-    // import ./builders.nix { inherit lib pkgs; }
-    // import ./deprecation.nix { inherit lib; }
-    // import ./options.nix { inherit lib helpers; }
-    // import ./utils.nix { inherit lib helpers _nixvimTests; };
+    // call ./builders.nix { }
+    // call ./deprecation.nix { }
+    // call ./options.nix { }
+    // call ./utils.nix { inherit _nixvimTests; };
 in
 helpers

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -1,29 +1,25 @@
-{
-  lib,
-  nixvimOptions,
-  nixvimTypes,
-}:
+{ lib, helpers }:
 with lib;
 rec {
   # These are the configuration options that change the behavior of each mapping.
   mapConfigOptions = {
-    silent = nixvimOptions.defaultNullOpts.mkBool false "Whether this mapping should be silent. Equivalent to adding `<silent>` to a map.";
+    silent = helpers.defaultNullOpts.mkBool false "Whether this mapping should be silent. Equivalent to adding `<silent>` to a map.";
 
-    nowait = nixvimOptions.defaultNullOpts.mkBool false "Whether to wait for extra input on ambiguous mappings. Equivalent to adding `<nowait>` to a map.";
+    nowait = helpers.defaultNullOpts.mkBool false "Whether to wait for extra input on ambiguous mappings. Equivalent to adding `<nowait>` to a map.";
 
-    script = nixvimOptions.defaultNullOpts.mkBool false "Equivalent to adding `<script>` to a map.";
+    script = helpers.defaultNullOpts.mkBool false "Equivalent to adding `<script>` to a map.";
 
-    expr = nixvimOptions.defaultNullOpts.mkBool false "Means that the action is actually an expression. Equivalent to adding `<expr>` to a map.";
+    expr = helpers.defaultNullOpts.mkBool false "Means that the action is actually an expression. Equivalent to adding `<expr>` to a map.";
 
-    unique = nixvimOptions.defaultNullOpts.mkBool false "Whether to fail if the map is already defined. Equivalent to adding `<unique>` to a map.";
+    unique = helpers.defaultNullOpts.mkBool false "Whether to fail if the map is already defined. Equivalent to adding `<unique>` to a map.";
 
-    noremap = nixvimOptions.defaultNullOpts.mkBool true "Whether to use the `noremap` variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
+    noremap = helpers.defaultNullOpts.mkBool true "Whether to use the `noremap` variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
 
-    remap = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping recursive. Inverses `noremap`.";
+    remap = helpers.defaultNullOpts.mkBool false "Make the mapping recursive. Inverses `noremap`.";
 
-    desc = nixvimOptions.mkNullOrOption types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
+    desc = helpers.mkNullOrOption types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
 
-    buffer = nixvimOptions.defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
+    buffer = helpers.defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
   };
 
   modes = {
@@ -107,7 +103,7 @@ rec {
           // (optionalAttrs (isAttrs action || action) {
             action = mkOption (
               {
-                type = nixvimTypes.maybeRaw str;
+                type = helpers.nixvimTypes.maybeRaw str;
                 description = "The action to execute.";
               }
               // (optionalAttrs (isAttrs action) action)

--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  nixvimOptions,
-  toLuaObject,
-  nixvimUtils,
-}:
+{ lib, helpers }:
 with lib;
 {
   # TODO: DEPRECATED: use the `settings` option instead
@@ -81,7 +76,7 @@ with lib;
           let
             optionPath = if isString option then [ option ] else option; # option is already a path (i.e. a list)
 
-            optionPathSnakeCase = map nixvimUtils.toSnakeCase optionPath;
+            optionPathSnakeCase = map helpers.toSnakeCase optionPath;
           in
           mkRenamedOptionModule (basePluginPath ++ optionPath) (settingsPath ++ optionPathSnakeCase)
         ) optionsRenamedToSettings);
@@ -90,10 +85,10 @@ with lib;
         {
           enable = mkEnableOption originalName;
 
-          package = nixvimOptions.mkPluginPackageOption originalName defaultPackage;
+          package = helpers.mkPluginPackageOption originalName defaultPackage;
         }
         // optionalAttrs hasSettings {
-          settings = nixvimOptions.mkSettingsOption {
+          settings = helpers.mkSettingsOption {
             description = settingsDescription;
             options = settingsOptions;
             example = settingsExample;
@@ -113,7 +108,7 @@ with lib;
           }
           (optionalAttrs callSetup {
             ${extraConfigNamespace} = ''
-              require('${luaName}')${setup}(${optionalString (cfg ? settings) (toLuaObject cfg.settings)})
+              require('${luaName}')${setup}(${optionalString (cfg ? settings) (helpers.toLuaObject cfg.settings)})
             '';
           })
           (optionalAttrs (isColorscheme && (colorscheme != null)) { colorscheme = mkDefault colorscheme; })

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -1,10 +1,6 @@
-{
-  lib,
-  nixvimTypes,
-  nixvimUtils,
-}:
+{ lib, helpers }:
 with lib;
-with nixvimUtils;
+with helpers;
 let
   # Render a plugin default string
   pluginDefaultText =
@@ -85,7 +81,7 @@ rec {
     );
   mkCompositeOption = description: options: mkCompositeOption' { inherit description options; };
 
-  mkNullOrStr' = args: mkNullOrOption' (args // { type = with nixvimTypes; maybeRaw str; });
+  mkNullOrStr' = args: mkNullOrOption' (args // { type = with helpers.nixvimTypes; maybeRaw str; });
   mkNullOrStr = description: mkNullOrStr' { inherit description; };
 
   mkNullOrLua' =
@@ -93,7 +89,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = nixvimTypes.strLua;
+        type = helpers.nixvimTypes.strLua;
         apply = mkRaw;
       }
     );
@@ -104,7 +100,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = nixvimTypes.strLuaFn;
+        type = helpers.nixvimTypes.strLuaFn;
         apply = mkRaw;
       }
     );
@@ -115,7 +111,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = with nixvimTypes; either strLua type;
+        type = with helpers.nixvimTypes; either strLua type;
         apply = v: if isString v then mkRaw v else v;
       }
     );
@@ -126,7 +122,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = with nixvimTypes; either strLuaFn type;
+        type = with helpers.nixvimTypes; either strLuaFn type;
         apply = v: if isString v then mkRaw v else v;
       }
     );
@@ -155,7 +151,7 @@ rec {
         mkNullable' { inherit type pluginDefault description; };
 
       mkNullableWithRaw' =
-        { type, ... }@args: mkNullable' (args // { type = nixvimTypes.maybeRaw type; });
+        { type, ... }@args: mkNullable' (args // { type = helpers.nixvimTypes.maybeRaw type; });
       mkNullableWithRaw =
         type: pluginDefault: description:
         mkNullableWithRaw' { inherit type pluginDefault description; };
@@ -191,17 +187,19 @@ rec {
       mkStr' = args: mkNullableWithRaw' (args // { type = types.str; });
       mkStr = pluginDefault: description: mkStr' { inherit pluginDefault description; };
 
-      mkAttributeSet' = args: mkNullable' (args // { type = nixvimTypes.attrs; });
+      mkAttributeSet' = args: mkNullable' (args // { type = helpers.nixvimTypes.attrs; });
       mkAttributeSet = pluginDefault: description: mkAttributeSet' { inherit pluginDefault description; };
 
       mkListOf' =
-        { type, ... }@args: mkNullable' (args // { type = with nixvimTypes; listOf (maybeRaw type); });
+        { type, ... }@args:
+        mkNullable' (args // { type = with helpers.nixvimTypes; listOf (maybeRaw type); });
       mkListOf =
         type: pluginDefault: description:
         mkListOf' { inherit type pluginDefault description; };
 
       mkAttrsOf' =
-        { type, ... }@args: mkNullable' (args // { type = with nixvimTypes; attrsOf (maybeRaw type); });
+        { type, ... }@args:
+        mkNullable' (args // { type = with helpers.nixvimTypes; attrsOf (maybeRaw type); });
       mkAttrsOf =
         type: pluginDefault: description:
         mkAttrsOf' { inherit type pluginDefault description; };
@@ -242,7 +240,7 @@ rec {
         mkNullableWithRaw' (
           (filterAttrs (n: v: n != "name") args)
           // {
-            type = nixvimTypes.border;
+            type = helpers.nixvimTypes.border;
             description = concatStringsSep "\n" (
               (optional (description != "") description)
               ++ [
@@ -281,7 +279,7 @@ rec {
         mkNullOrOption' (
           args
           // {
-            type = with nixvimTypes; either ints.unsigned logLevel;
+            type = with helpers.nixvimTypes; either ints.unsigned logLevel;
             apply = mapNullable (
               value: if isInt value then value else mkRaw "vim.log.levels.${strings.toUpper value}"
             );
@@ -297,7 +295,7 @@ rec {
         mkNullable' (
           args
           // {
-            type = nixvimTypes.highlight;
+            type = helpers.nixvimTypes.highlight;
             inherit description;
           }
         );

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,4 +1,4 @@
-{ lib, helpers, ... }:
+{ lib, helpers }:
 with lib;
 with helpers;
 with lib.types;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,6 +1,6 @@
-{ lib, nixvimOptions, ... }:
+{ lib, helpers, ... }:
 with lib;
-with nixvimOptions;
+with helpers;
 with lib.types;
 let
   strLikeType =

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  nixvimTypes,
+  helpers,
   _nixvimTests,
 }:
 with lib;
@@ -115,7 +115,7 @@ rec {
       null
     else if isString r then
       { __raw = r; }
-    else if nixvimTypes.isRawType r then
+    else if helpers.nixvimTypes.isRawType r then
       r
     else
       throw "mkRaw: invalid input: ${generators.toPretty { multiline = false; } r}";

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  nixvimOptions,
-  nixvimUtils,
-}:
+{ lib, helpers }:
 with lib;
 {
   mkVimPlugin =
@@ -43,12 +39,12 @@ with lib;
         if defaultPackage == null then
           { }
         else
-          { package = nixvimOptions.mkPluginPackageOption name defaultPackage; };
+          { package = helpers.mkPluginPackageOption name defaultPackage; };
 
       createSettingsOption = (isString globalPrefix) && (globalPrefix != "");
 
       settingsOption = optionalAttrs createSettingsOption {
-        settings = nixvimOptions.mkSettingsOption {
+        settings = helpers.mkSettingsOption {
           options = settingsOptions;
           example = settingsExample;
           description = ''
@@ -95,7 +91,7 @@ with lib;
           let
             optionPath = if isString option then [ option ] else option; # option is already a path (i.e. a list)
 
-            optionPathSnakeCase = map nixvimUtils.toSnakeCase optionPath;
+            optionPathSnakeCase = map helpers.toSnakeCase optionPath;
           in
           mkRenamedOptionModule (basePluginPath ++ optionPath) (settingsPath ++ optionPathSnakeCase)
         ) optionsRenamedToSettings);


### PR DESCRIPTION
This ended up being a fairly small change, but the result is much cleaner.

Instead of naming each part of `helpers` and passing those sections to the other parts that need them, we can build `helpers` in a let-block and pass `helpers` itself to parts of `helpers` while building `helpers`.

I also made use of `callPackageWith autoArgs` to clean up some of the repetitive boilerplate.
