### PR TITLE
otter: ensures no warning is shown when running tests

### DIFF
--- a/tests/test-sources/plugins/completion/cmp-all-sources.nix
+++ b/tests/test-sources/plugins/completion/cmp-all-sources.nix
@@ -20,6 +20,8 @@
                 disabledSources = [
                   # We do not provide the required HF_API_KEY environment variable.
                   "cmp_ai"
+                  # Triggers the warning complaining about treesitter highlighting being disabled
+                  "otter"
                 ] ++ optional (pkgs.stdenv.hostPlatform.system == "aarch64-linux") "cmp_tabnine";
               in
               pipe config.cmpSourcePlugins [

--- a/tests/test-sources/plugins/languages/otter.nix
+++ b/tests/test-sources/plugins/languages/otter.nix
@@ -1,38 +1,47 @@
 {
   empty = {
-    plugins.otter.enable = true;
+    plugins = {
+      otter.enable = true;
+      # Avoid the warning
+      treesitter.settings.highlight.enable = true;
+    };
   };
 
   defaults = {
-    plugins.otter = {
-      enable = true;
+    plugins = {
+      # Avoid the warning
+      treesitter.settings.highlight.enable = true;
 
-      settings = {
-        lsp = {
-          hover = {
-            border = [
-              "╭"
-              "─"
-              "╮"
-              "│"
-              "╯"
-              "─"
-              "╰"
-              "│"
-            ];
+      otter = {
+        enable = true;
+
+        settings = {
+          lsp = {
+            hover = {
+              border = [
+                "╭"
+                "─"
+                "╮"
+                "│"
+                "╯"
+                "─"
+                "╰"
+                "│"
+              ];
+            };
+            diagnostic_update_events = [ "BufWritePost" ];
           };
-          diagnostic_update_events = [ "BufWritePost" ];
+          buffers = {
+            set_filetype = false;
+            write_to_disk = false;
+          };
+          strip_wrapping_quote_characters = [
+            "'"
+            "\""
+            "\`"
+          ];
+          handle_leading_whitespace = false;
         };
-        buffers = {
-          set_filetype = false;
-          write_to_disk = false;
-        };
-        strip_wrapping_quote_characters = [
-          "'"
-          "\""
-          "\`"
-        ];
-        handle_leading_whitespace = false;
       };
     };
   };


### PR DESCRIPTION
- **tests/cmp-all-sources: disable the otter source as it triggers a warning when treesitter is missing**
- **tests/otter: add treesitter to avoid warning**
