### PR TITLE
plugins/spectre: set freeformType for engine options

### DIFF
--- a/plugins/utils/spectre.nix
+++ b/plugins/utils/spectre.nix
@@ -30,6 +30,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
           (
             with types;
             attrsOf (submodule {
+              freeformType = with types; attrsOf anything;
               options = {
                 cmd = mkOption {
                   type = types.str;


### PR DESCRIPTION
This adds the `warn` engine option to be able to silence messages when an executable is missing from the PATH. See https://github.com/nvim-pack/nvim-spectre/pull/242 for the upstream change.