### PR TITLE
tests/plugins/utils/spectre: enable tests on Darwin

### DIFF
--- a/tests/test-sources/plugins/utils/spectre.nix
+++ b/tests/test-sources/plugins/utils/spectre.nix
@@ -1,16 +1,12 @@
 { pkgs, ... }:
-let
-  # Fails on darwin with: `module 'plenary.job' not found`
-  enable = !pkgs.stdenv.isDarwin;
-in
 {
   empty = {
-    plugins.spectre.enable = enable;
+    plugins.spectre.enable = true;
   };
 
   package-options-manual = {
     plugins.spectre = {
-      inherit enable;
+      enable = true;
 
       findPackage = pkgs.ripgrep;
       replacePackage = pkgs.gnused;
@@ -19,7 +15,7 @@ in
 
   package-options-from-settings = {
     plugins.spectre = {
-      inherit enable;
+      enable = true;
 
       settings.default = {
         find.cmd = "rg";
@@ -30,7 +26,7 @@ in
 
   example = {
     plugins.spectre = {
-      inherit enable;
+      enable = true;
 
       settings = {
         live_update = true;
@@ -87,7 +83,7 @@ in
 
   defaults = {
     plugins.spectre = {
-      inherit enable;
+      enable = true;
 
       settings = {
         filetype = "spectre_panel";


### PR DESCRIPTION
The `module 'plenary.job' not found` issue has been resolved and tests can be executed on Darwin.

Tests should be updated for Darwin to handle the missing sed warning (`ERROR: You need to install gnu sed 'brew install gnu-sed'`) as soon as #1952 is resolved. (e.g. [this failure](https://buildbot.nix-community.org/#/builders/495/builds/44/steps/1/logs/stdio))