### PR TITLE
lib/helpers: scope all subsections, but keep top-level aliases

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -9,20 +9,76 @@ let
   call = lib.callPackageWith { inherit pkgs lib helpers; };
 
   # Build helpers recursively
-  helpers =
-    {
-      autocmd = call ./autocmd-helpers.nix { };
-      keymaps = call ./keymap-helpers.nix { };
-      lua = call ./to-lua.nix { };
-      toLuaObject = helpers.lua.toLua;
-      maintainers = import ./maintainers.nix;
-      neovim-plugin = call ./neovim-plugin.nix { };
-      nixvimTypes = call ./types.nix { };
-      vim-plugin = call ./vim-plugin.nix { };
-    }
-    // call ./builders.nix { }
-    // call ./deprecation.nix { }
-    // call ./options.nix { }
-    // call ./utils.nix { inherit _nixvimTests; };
+  helpers = {
+    autocmd = call ./autocmd-helpers.nix { };
+    builders = call ./builders.nix { };
+    deprecation = call ./deprecation.nix { };
+    keymaps = call ./keymap-helpers.nix { };
+    lua = call ./to-lua.nix { };
+    maintainers = import ./maintainers.nix;
+    neovim-plugin = call ./neovim-plugin.nix { };
+    nixvimTypes = call ./types.nix { };
+    options = call ./options.nix { };
+    utils = call ./utils.nix { inherit _nixvimTests; };
+    vim-plugin = call ./vim-plugin.nix { };
+
+    # Top-level helper aliases:
+    # TODO: deprecate some aliases
+
+    inherit (helpers.builders)
+      writeLua
+      writeByteCompiledLua
+      byteCompileLuaFile
+      byteCompileLuaHook
+      byteCompileLuaDrv
+      ;
+
+    inherit (helpers.deprecation) getOptionRecursive mkDeprecatedSubOptionModule transitionType;
+
+    inherit (helpers.options)
+      defaultNullOpts
+      mkCompositeOption
+      mkCompositeOption'
+      mkNullOrLua
+      mkNullOrLua'
+      mkNullOrLuaFn
+      mkNullOrLuaFn'
+      mkNullOrOption
+      mkNullOrOption'
+      mkNullOrStr
+      mkNullOrStr'
+      mkNullOrStrLuaFnOr
+      mkNullOrStrLuaFnOr'
+      mkNullOrStrLuaOr
+      mkNullOrStrLuaOr'
+      mkPackageOption
+      mkPluginPackageOption
+      mkSettingsOption
+      pluginDefaultText
+      ;
+
+    inherit (helpers.utils)
+      concatNonEmptyLines
+      emptyTable
+      enableExceptInTests
+      hasContent
+      ifNonNull'
+      listToUnkeyedAttrs
+      mkIfNonNull
+      mkIfNonNull'
+      mkRaw
+      mkRawKey
+      override
+      overrideDerivation
+      toRawKeys
+      toSnakeCase
+      upperFirstChar
+      wrapDo
+      wrapLuaForVimscript
+      wrapVimscriptForLua
+      ;
+
+    toLuaObject = helpers.lua.toLua;
+  };
 in
 helpers

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -1,6 +1,5 @@
 { lib, helpers }:
 with lib;
-with helpers;
 let
   # Render a plugin default string
   pluginDefaultText =
@@ -90,7 +89,7 @@ rec {
       args
       // {
         type = helpers.nixvimTypes.strLua;
-        apply = mkRaw;
+        apply = helpers.mkRaw;
       }
     );
   mkNullOrLua = description: mkNullOrLua' { inherit description; };
@@ -101,7 +100,7 @@ rec {
       args
       // {
         type = helpers.nixvimTypes.strLuaFn;
-        apply = mkRaw;
+        apply = helpers.mkRaw;
       }
     );
   mkNullOrLuaFn = description: mkNullOrLua' { inherit description; };
@@ -112,7 +111,7 @@ rec {
       args
       // {
         type = with helpers.nixvimTypes; either strLua type;
-        apply = v: if isString v then mkRaw v else v;
+        apply = v: if isString v then helpers.mkRaw v else v;
       }
     );
   mkNullOrStrLuaOr = type: description: mkNullOrStrLuaOr' { inherit type description; };
@@ -123,7 +122,7 @@ rec {
       args
       // {
         type = with helpers.nixvimTypes; either strLuaFn type;
-        apply = v: if isString v then mkRaw v else v;
+        apply = v: if isString v then helpers.mkRaw v else v;
       }
     );
   mkNullOrStrLuaFnOr = type: description: mkNullOrStrLuaFnOr' { inherit type description; };
@@ -268,7 +267,8 @@ rec {
                 "hint"
               ]);
             apply = mapNullable (
-              value: if isInt value then value else mkRaw "vim.diagnostic.severity.${strings.toUpper value}"
+              value:
+              if isInt value then value else helpers.mkRaw "vim.diagnostic.severity.${strings.toUpper value}"
             );
           }
         );
@@ -281,7 +281,7 @@ rec {
           // {
             type = with helpers.nixvimTypes; either ints.unsigned logLevel;
             apply = mapNullable (
-              value: if isInt value then value else mkRaw "vim.log.levels.${strings.toUpper value}"
+              value: if isInt value then value else helpers.mkRaw "vim.log.levels.${strings.toUpper value}"
             );
           }
         );


### PR DESCRIPTION
This is a small step towards later refactoring our custom `lib`, but doesn't yet make any breaking changes.

All subsections within `helpers` are now available as scoped (nested) attrs, e.g. `helpers.options.defaultNullOpts` or `helpers.utils.mkRaw`.

Everything that was previously accessible from the "top-level" of `helpers` still is, via aliases defined in `helpers.nix`.
In a future PR we should add `lib.warn` to some of those aliases, before later dropping them altogether.
We can discuss in the future which aliases should be deprecated/dropped and if anything else should be moved/renamed.
