### PR TITLE
lib: provide an "extended lib" to our modules

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -40,6 +40,8 @@ let
     pkgs = pkgsDoc;
   };
 
+  inherit (helpers.modules) specialArgs;
+
   nixvimPath = toString ./..;
 
   gitHubDeclaration = user: repo: branch: subpath: {
@@ -75,16 +77,7 @@ let
 
   options-json =
     (pkgsDoc.nixosOptionsDoc {
-      inherit
-        (lib.evalModules {
-          inherit modules;
-          specialArgs = {
-            inherit helpers;
-            defaultPkgs = pkgsDoc;
-          };
-        })
-        options
-        ;
+      inherit (lib.evalModules { inherit modules specialArgs; }) options;
       inherit transformOptions;
       warningsAreErrors = false;
     }).optionsJSON;
@@ -113,10 +106,10 @@ in
     # > sandbox-exec: pattern serialization length 69298 exceeds maximum (65535)
     docs = pkgsDoc.callPackage ./mdbook {
       inherit
-        helpers
         modules
         hmOptions
         transformOptions
+        specialArgs
         ;
       # TODO: Find how to handle stable when 24.11 lands
       search = mkSearch "/nixvim/search/";

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -1,18 +1,15 @@
 {
   pkgs,
   lib,
-  modules,
+  evaledModules,
   nixosOptionsDoc,
   transformOptions,
   hmOptions,
   search,
-  specialArgs,
 }:
 with lib;
 let
-  options = lib.evalModules { inherit modules specialArgs; };
-
-  inherit (options.config.meta) nixvimInfo;
+  inherit (evaledModules.config.meta) nixvimInfo;
 
   mkMDDoc =
     options:
@@ -62,7 +59,7 @@ let
       moduleDoc =
         let
           info = optionalAttrs (hasAttrByPath path nixvimInfo) (getAttrFromPath path nixvimInfo);
-          maintainers = lib.unique (options.config.meta.maintainers.${info.file} or [ ]);
+          maintainers = lib.unique (evaledModules.config.meta.maintainers.${info.file} or [ ]);
           maintainersNames = builtins.map maintToMD maintainers;
           maintToMD = m: if m ? github then "[${m.name}](https://github.com/${m.github})" else m.name;
         in
@@ -179,7 +176,7 @@ let
     recurse modules;
 
   docs = rec {
-    modules = processModulesRec (removeUnwanted options.options);
+    modules = processModulesRec (removeUnwanted evaledModules.options);
     commands = mapModulesToString (
       name: opts:
       let

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -2,21 +2,15 @@
   pkgs,
   lib,
   modules,
-  helpers,
   nixosOptionsDoc,
   transformOptions,
   hmOptions,
   search,
+  specialArgs,
 }:
 with lib;
 let
-  options = lib.evalModules {
-    inherit modules;
-    specialArgs = {
-      inherit helpers;
-      defaultPkgs = pkgs;
-    };
-  };
+  options = lib.evalModules { inherit modules specialArgs; };
 
   inherit (options.config.meta) nixvimInfo;
 

--- a/lib/extend-lib.nix
+++ b/lib/extend-lib.nix
@@ -1,0 +1,11 @@
+# Extends nixpkg's lib with our functions, as expected by our modules
+{ lib, helpers }:
+lib.extend (
+  final: prev: {
+    # Include our custom lib
+    nixvim = helpers;
+
+    # Merge in our maintainers
+    maintainers = prev.maintainers // import ./maintainers.nix;
+  }
+)

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -6,16 +6,20 @@
 }:
 let
   # Used when importing parts of helpers
-  call = lib.callPackageWith { inherit pkgs lib helpers; };
+  call = lib.callPackageWith {
+    # TODO: deprecate/remove using `helpers` in the subsections
+    inherit pkgs helpers;
+    lib = helpers.extendedLib;
+  };
 
   # Build helpers recursively
   helpers = {
     autocmd = call ./autocmd-helpers.nix { };
     builders = call ./builders.nix { };
     deprecation = call ./deprecation.nix { };
+    extendedLib = call ./extend-lib.nix { inherit lib; };
     keymaps = call ./keymap-helpers.nix { };
     lua = call ./to-lua.nix { };
-    maintainers = import ./maintainers.nix;
     neovim-plugin = call ./neovim-plugin.nix { };
     nixvimTypes = call ./types.nix { };
     options = call ./options.nix { };
@@ -77,6 +81,9 @@ let
       wrapLuaForVimscript
       wrapVimscriptForLua
       ;
+
+    # TODO: Deprecate this `maintainers` alias
+    inherit (helpers.extendedLib) maintainers;
 
     toLuaObject = helpers.lua.toLua;
   };

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -20,6 +20,7 @@ let
     extendedLib = call ./extend-lib.nix { inherit lib; };
     keymaps = call ./keymap-helpers.nix { };
     lua = call ./to-lua.nix { };
+    modules = call ./modules.nix { };
     neovim-plugin = call ./neovim-plugin.nix { };
     nixvimTypes = call ./types.nix { };
     options = call ./options.nix { };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  lib,
+  helpers,
+}:
+rec {
+  # Minimal specialArgs required to evaluate nixvim modules
+  specialArgs = specialArgsWith { };
+
+  # Build specialArgs for evaluating nixvim modules
+  specialArgsWith =
+    extraSpecialArgs:
+    {
+      # TODO: deprecate `helpers`
+      inherit lib helpers;
+      defaultPkgs = pkgs;
+    }
+    // extraSpecialArgs;
+}

--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -3,7 +3,7 @@
   config,
   options,
   lib,
-  helpers,
+  specialArgs,
   ...
 }:
 let
@@ -11,10 +11,7 @@ let
 
   fileModuleType = types.submoduleWith {
     shorthandOnlyDefinesConfig = true;
-    specialArgs = {
-      inherit helpers;
-      defaultPkgs = pkgs;
-    };
+    inherit specialArgs;
     # Don't include the modules in the docs, as that'd be redundant
     modules = lib.optionals (!config.isDocs) [
       ../../.

--- a/tests/test-sources/extended-lib.nix
+++ b/tests/test-sources/extended-lib.nix
@@ -1,0 +1,25 @@
+let
+  module =
+    { lib, helpers, ... }:
+    {
+      assertions = [
+        {
+          assertion = lib ? nixvim;
+          message = "lib.nixvim should be defined";
+        }
+        {
+          assertion = lib.nixvim == helpers;
+          message = "lib.nixvim and helpers should be aliases";
+        }
+      ];
+    };
+in
+{
+  top-level = {
+    inherit module;
+  };
+
+  files-module = {
+    files."libtest.lua" = module;
+  };
+}

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -27,6 +27,7 @@ in
           darwinConfig = config;
           defaultPkgs = pkgs;
           helpers = config.lib.nixvim;
+          lib = config.lib.nixvim.extendedLib;
         };
         modules = [
           ./modules/darwin.nix

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -23,12 +23,7 @@ in
       default = { };
       type = types.submoduleWith {
         shorthandOnlyDefinesConfig = true;
-        specialArgs = {
-          darwinConfig = config;
-          defaultPkgs = pkgs;
-          helpers = config.lib.nixvim;
-          lib = config.lib.nixvim.extendedLib;
-        };
+        specialArgs = config.lib.nixvim.modules.specialArgsWith { darwinConfig = config; };
         modules = [
           ./modules/darwin.nix
           ../modules/top-level

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -22,12 +22,7 @@ in
       default = { };
       type = types.submoduleWith {
         shorthandOnlyDefinesConfig = true;
-        specialArgs = {
-          hmConfig = config;
-          defaultPkgs = pkgs;
-          helpers = config.lib.nixvim;
-          lib = config.lib.nixvim.extendedLib;
-        };
+        specialArgs = config.lib.nixvim.modules.specialArgsWith { hmConfig = config; };
         modules = [
           ./modules/hm.nix
           ../modules/top-level

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -26,6 +26,7 @@ in
           hmConfig = config;
           defaultPkgs = pkgs;
           helpers = config.lib.nixvim;
+          lib = config.lib.nixvim.extendedLib;
         };
         modules = [
           ./modules/hm.nix

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -23,12 +23,7 @@ in
       default = { };
       type = types.submoduleWith {
         shorthandOnlyDefinesConfig = true;
-        specialArgs = {
-          nixosConfig = config;
-          defaultPkgs = pkgs;
-          helpers = config.lib.nixvim;
-          lib = config.lib.nixvim.extendedLib;
-        };
+        specialArgs = config.lib.nixvim.modules.specialArgsWith { nixosConfig = config; };
         modules = [
           ./modules/nixos.nix
           ../modules/top-level

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -27,6 +27,7 @@ in
           nixosConfig = config;
           defaultPkgs = pkgs;
           helpers = config.lib.nixvim;
+          lib = config.lib.nixvim.extendedLib;
         };
         modules = [
           ./modules/nixos.nix

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -31,6 +31,7 @@ let
         ];
         specialArgs = {
           inherit helpers;
+          lib = helpers.extendedLib;
           defaultPkgs = pkgs;
         } // extraSpecialArgs;
       };

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -1,14 +1,15 @@
 default_pkgs: self:
 {
   pkgs ? default_pkgs,
+  lib ? pkgs.lib,
   extraSpecialArgs ? { },
   _nixvimTests ? false,
   module,
 }:
 let
-  inherit (pkgs) lib;
-
   helpers = import ../lib/helpers.nix { inherit pkgs lib _nixvimTests; };
+
+  inherit (helpers.modules) specialArgsWith;
 
   handleAssertions =
     config:
@@ -29,11 +30,7 @@ let
           ./modules/standalone.nix
           ../modules/top-level
         ];
-        specialArgs = {
-          inherit helpers;
-          lib = helpers.extendedLib;
-          defaultPkgs = pkgs;
-        } // extraSpecialArgs;
+        specialArgs = specialArgsWith extraSpecialArgs;
       };
       config = handleAssertions evaledModule.config;
     in


### PR DESCRIPTION
lib/extend-lib.nix returns a nixpkg's `lib`, extended with our own helpers available as `lib.nixvim`.

The extended lib also merges our maintainer list into `lib.maintainers`.

This is exposed as `helpers.extendedLib`, but when evaluating our modules it should be assigned to `specialArgs.lib`.

Outside of our modules you must still access our helpers via `config.lib.nixvim` or `config.lib.nixvim.extendedLib`.

Within helpers' sub-sections, `lib` is the extended lib.

I added a test, but currently it is only run with a standalone build. For completeness it'd be nice to also run the test with out other module wrappers, but I'm not sure the best way to go about this.

This PR makes **no restructuring changes** to the lib's layout, as discussed in the doc. #1962 is a first step towards doing that, but also makes no breaking changes.