### PR TITLE
wrappers: add our lib to the host's `_module.args`

### DIFF
--- a/docs/user-guide/helpers.md
+++ b/docs/user-guide/helpers.md
@@ -23,6 +23,18 @@ in
 }
 ```
 
+Or you can access the extended `lib` used in standalone builds via the `nixvimLib` module arg:
+
+```nix
+{ nixvimLib, ... }:
+{
+  # You can use nixvimLib.nixvim in your config
+  fooOption = nixvimLib.nixvim.mkRaw "print('hello')";
+}
+```
+
+This "extended" lib, includes everything normally in `lib`, along with some additions from nixvim.
+
 **Note:** the `lib` argument passed to modules is entirely unrelated to the `lib` _option_ accessed as `config.lib`!
 
 A certain number of helpers are defined that can be useful:

--- a/docs/user-guide/helpers.md
+++ b/docs/user-guide/helpers.md
@@ -1,16 +1,17 @@
 # Helpers
 
-If Nixvim is built using the standalone method, you can access our `helpers` as a module arg:
+If Nixvim is built using the standalone method, you can access our "helpers" as part of the `lib` module arg:
 
 ```nix
-{ helpers, ... }:
+{ lib, ... }:
 {
-  # Your config
+  # You can use lib.nixvim in your config
+  fooOption = lib.nixvim.mkRaw "print('hello')";
 }
 ```
 
 If Nixvim is being used as as a home-manager module, a nixos module, or as a dawwin module,
-helpers can be accessed via the `config.lib` option:
+our "helpers" can be accessed via the `config.lib` option:
 
 ```nix
 { config, ... }:
@@ -21,6 +22,8 @@ in
   # Your config
 }
 ```
+
+**Note:** the `lib` argument passed to modules is entirely unrelated to the `lib` _option_ accessed as `config.lib`!
 
 A certain number of helpers are defined that can be useful:
 

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -44,9 +44,15 @@ in
   ];
 
   config = mkMerge [
-    # Make our lib available to the host modules
-    # TODO: import top-level ../lib
-    { lib.nixvim = lib.mkDefault (import ../lib/helpers.nix { inherit pkgs lib; }); }
+    {
+      # Make our lib available to the host modules
+      # TODO: import top-level ../lib
+      lib.nixvim = lib.mkDefault (import ../lib/helpers.nix { inherit pkgs lib; });
+
+      # Make nixvim's "extended" lib available to the host's module args
+      _module.args.nixvimLib = lib.mkDefault config.lib.nixvim.extendedLib;
+    }
+
     # Propagate extraFiles to the host modules
     (optionalAttrs (filesOpt != null) (
       mkIf (!cfg.wrapRc) (


### PR DESCRIPTION
Make our custom "helpers" lib available to host modules as `_module.args.nixvimLib`, as an alternative to accessing via `config.lib`.

We didn't do this before because `helpers` was too generic of a name, but `nixvimLib` should be ok.

e.g:

```nix
{ lib, nixvimLib, ... }:
{
  programs.nixvim.someOption = nixvimLib.mkRaw "print('Hi')";
}
```

Should we consider also making the alias available to nixvim modules? Can always be done later.

## Update

I've made it so that the `nixvimLib` arg in the host modules is equivalent to the `lib` arg in the nixvim modules; i.e. nixvim's "extended" nixpkgs lib.