### PR TITLE
lib/types: merge into `extendedLib`

### DIFF
--- a/lib/autocmd-helpers.nix
+++ b/lib/autocmd-helpers.nix
@@ -39,7 +39,7 @@ rec {
       A textual description of this autocommand.
     '';
 
-    callback = helpers.mkNullOrOption (with types; either str helpers.nixvimTypes.rawLua) ''
+    callback = helpers.mkNullOrOption (with types; either str rawLua) ''
       A function or a string.
       - if a string, the name of a Vimscript function to call when this autocommand is triggered.
       - Otherwise, a Lua function which is called when this autocommand is triggered.

--- a/lib/extend-lib.nix
+++ b/lib/extend-lib.nix
@@ -1,5 +1,9 @@
 # Extends nixpkg's lib with our functions, as expected by our modules
-{ lib, helpers }:
+{
+  call,
+  lib,
+  helpers,
+}:
 lib.extend (
   final: prev: {
     # Include our custom lib
@@ -7,5 +11,8 @@ lib.extend (
 
     # Merge in our maintainers
     maintainers = prev.maintainers // import ./maintainers.nix;
+
+    # Merge in our custom types
+    types = call ./types.nix { } // prev.types;
   }
 )

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -8,7 +8,7 @@ let
   # Used when importing parts of helpers
   call = lib.callPackageWith {
     # TODO: deprecate/remove using `helpers` in the subsections
-    inherit pkgs helpers;
+    inherit call pkgs helpers;
     lib = helpers.extendedLib;
   };
 
@@ -22,7 +22,6 @@ let
     lua = call ./to-lua.nix { };
     modules = call ./modules.nix { };
     neovim-plugin = call ./neovim-plugin.nix { };
-    nixvimTypes = call ./types.nix { };
     options = call ./options.nix { };
     utils = call ./utils.nix { inherit _nixvimTests; };
     vim-plugin = call ./vim-plugin.nix { };
@@ -91,6 +90,9 @@ let
 
     # TODO: Deprecate this `maintainers` alias
     inherit (helpers.extendedLib) maintainers;
+
+    # TODO: Deprecate the old `nixvimTypes` alias?
+    nixvimTypes = helpers.extendedLib.types;
 
     toLuaObject = helpers.lua.toLua;
     mkLuaInline = helpers.lua.mkInline;

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -117,7 +117,7 @@ rec {
           // (optionalAttrs (isAttrs action || action) {
             action = mkOption (
               {
-                type = helpers.nixvimTypes.maybeRaw str;
+                type = maybeRaw str;
                 description = "The action to execute.";
                 apply = v: if options.lua.isDefined or false && config.lua then helpers.mkRaw v else v;
               }

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -80,7 +80,7 @@ rec {
     );
   mkCompositeOption = description: options: mkCompositeOption' { inherit description options; };
 
-  mkNullOrStr' = args: mkNullOrOption' (args // { type = with helpers.nixvimTypes; maybeRaw str; });
+  mkNullOrStr' = args: mkNullOrOption' (args // { type = with types; maybeRaw str; });
   mkNullOrStr = description: mkNullOrStr' { inherit description; };
 
   mkNullOrLua' =
@@ -88,7 +88,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = helpers.nixvimTypes.strLua;
+        type = types.strLua;
         apply = helpers.mkRaw;
       }
     );
@@ -99,7 +99,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = helpers.nixvimTypes.strLuaFn;
+        type = types.strLuaFn;
         apply = helpers.mkRaw;
       }
     );
@@ -110,7 +110,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = with helpers.nixvimTypes; either strLua type;
+        type = with types; either strLua type;
         apply = v: if isString v then helpers.mkRaw v else v;
       }
     );
@@ -121,7 +121,7 @@ rec {
     mkNullOrOption' (
       args
       // {
-        type = with helpers.nixvimTypes; either strLuaFn type;
+        type = with types; either strLuaFn type;
         apply = v: if isString v then helpers.mkRaw v else v;
       }
     );
@@ -149,8 +149,7 @@ rec {
         type: pluginDefault: description:
         mkNullable' { inherit type pluginDefault description; };
 
-      mkNullableWithRaw' =
-        { type, ... }@args: mkNullable' (args // { type = helpers.nixvimTypes.maybeRaw type; });
+      mkNullableWithRaw' = { type, ... }@args: mkNullable' (args // { type = types.maybeRaw type; });
       mkNullableWithRaw =
         type: pluginDefault: description:
         mkNullableWithRaw' { inherit type pluginDefault description; };
@@ -186,19 +185,17 @@ rec {
       mkStr' = args: mkNullableWithRaw' (args // { type = types.str; });
       mkStr = pluginDefault: description: mkStr' { inherit pluginDefault description; };
 
-      mkAttributeSet' = args: mkNullable' (args // { type = helpers.nixvimTypes.attrs; });
+      mkAttributeSet' = args: mkNullable' (args // { type = types.attrs; });
       mkAttributeSet = pluginDefault: description: mkAttributeSet' { inherit pluginDefault description; };
 
       mkListOf' =
-        { type, ... }@args:
-        mkNullable' (args // { type = with helpers.nixvimTypes; listOf (maybeRaw type); });
+        { type, ... }@args: mkNullable' (args // { type = with types; listOf (maybeRaw type); });
       mkListOf =
         type: pluginDefault: description:
         mkListOf' { inherit type pluginDefault description; };
 
       mkAttrsOf' =
-        { type, ... }@args:
-        mkNullable' (args // { type = with helpers.nixvimTypes; attrsOf (maybeRaw type); });
+        { type, ... }@args: mkNullable' (args // { type = with types; attrsOf (maybeRaw type); });
       mkAttrsOf =
         type: pluginDefault: description:
         mkAttrsOf' { inherit type pluginDefault description; };
@@ -239,7 +236,7 @@ rec {
         mkNullableWithRaw' (
           (filterAttrs (n: v: n != "name") args)
           // {
-            type = helpers.nixvimTypes.border;
+            type = types.border;
             description = concatStringsSep "\n" (
               (optional (description != "") description)
               ++ [
@@ -279,7 +276,7 @@ rec {
         mkNullOrOption' (
           args
           // {
-            type = with helpers.nixvimTypes; either ints.unsigned logLevel;
+            type = with types; either ints.unsigned logLevel;
             apply = mapNullable (
               value: if isInt value then value else helpers.mkRaw "vim.log.levels.${strings.toUpper value}"
             );
@@ -295,7 +292,7 @@ rec {
         mkNullable' (
           args
           // {
-            type = helpers.nixvimTypes.highlight;
+            type = types.highlight;
             inherit description;
           }
         );

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -16,6 +16,8 @@ let
   isRawType = v: v ? __raw && isString v.__raw;
 in
 rec {
+  # TODO: deprecate in favor of types.rawLua.check
+  # Or move to utils, lua, etc?
   inherit isRawType;
 
   rawLua = mkOptionType {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,3 +1,4 @@
+# Custom types to be included in `lib.types`
 { lib, helpers }:
 with lib;
 with helpers;
@@ -91,5 +92,3 @@ rec {
       }";
     };
 }
-# Allow to do `with nixvimTypes;` instead of `with types;`
-// lib.types

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -115,7 +115,7 @@ rec {
       null
     else if isString r then
       { __raw = r; }
-    else if helpers.nixvimTypes.isRawType r then
+    else if types.isRawType r then
       r
     else
       throw "mkRaw: invalid input: ${generators.toPretty { multiline = false; } r}";


### PR DESCRIPTION
- **lib/types: merge into `extendedLib`**
- **lib: migrate `helpers.nixvimTypes` -> `lib.types`**

As discussed in https://github.com/nix-community/nixvim/pull/1975#discussion_r1702774343

I think this is the cleanest way for us to have custom option types, however we do loose some clarity. You can no longer tell at a glance whether a type is from nixvim or nixpkgs.

@GaetanLepage seems on board, what's your view @traxys?
