### PR TITLE
lib/modules: add `evalNixvim`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -16,4 +16,38 @@ rec {
       defaultPkgs = pkgs;
     }
     // extraSpecialArgs;
+
+  # Evaluate nixvim modules, checking warnings and assertions
+  evalNixvim =
+    {
+      modules ? [ ],
+      extraSpecialArgs ? { },
+      # Set to false to disable warnings and assertions
+      # Intended for use with tests, where we may not want to check assertions
+      # WARNING: This argument may be removed without notice:
+      check ? true,
+    }:
+    let
+      result = lib.evalModules {
+        modules = [ ../modules/top-level ] ++ modules;
+        specialArgs = specialArgsWith extraSpecialArgs;
+      };
+
+      failedAssertions = getAssertionMessages result.config.assertions;
+
+      checked =
+        if failedAssertions != [ ] then
+          throw "\nFailed assertions:\n${lib.concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
+        else
+          lib.showWarnings result.config.warnings result;
+    in
+    if check then checked else result;
+
+  # Return the messages for all assertions that failed
+  getAssertionMessages =
+    assertions:
+    lib.pipe assertions [
+      (lib.filter (x: !x.assertion))
+      (lib.map (x: x.message))
+    ];
 }


### PR DESCRIPTION
Evaluates a nixvim config, by default also checking warnings and assertions.

This used internally by the standalone wrapper.

I'm planning to use this to refactor the tests implementation:
- The tests don't need a "full" standalone build
- The tests should be able to expect/reject warnings/assertions
- Warnings should fail tests (unless marked as expected)

But I figured it'd be easier to test/review if I push this as a separate PR.
