### PR TITLE
plugins/neotest: add neotest-golang

### DIFF
--- a/plugins/neotest/adapters-list.nix
+++ b/plugins/neotest/adapters-list.nix
@@ -25,6 +25,9 @@
   go = {
     treesitter-parser = "go";
   };
+  golang = {
+    treesitter-parser = "go";
+  };
   gradle = {
     treesitter-parser = "kotlin,java";
   };

--- a/tests/test-sources/plugins/neotest/default.nix
+++ b/tests/test-sources/plugins/neotest/default.nix
@@ -17,6 +17,7 @@
           elixir.enable = true;
           foundry.enable = true;
           go.enable = true;
+          golang.enable = true;
           gradle.enable = true;
           # We cannot test neotest-gtest as it tries to create file in the upper directory
           # https://github.com/alfaix/neotest-gtest/blob/6e794ac91f4c347e2ea5ddeb23d594f8fc64f2a8/lua/neotest-gtest/utils.lua#L10-L16

--- a/tests/test-sources/plugins/neotest/golang.nix
+++ b/tests/test-sources/plugins/neotest/golang.nix
@@ -1,0 +1,26 @@
+{
+  example = {
+    plugins = {
+      treesitter.enable = true;
+      neotest = {
+        enable = true;
+
+        adapters.golang = {
+          enable = true;
+
+          settings = {
+            dap_go_enabled = true;
+            testify_enabled = false;
+            warn_test_name_dupes = true;
+            warn_test_not_executed = true;
+            args = [
+              "-v"
+              "-race"
+              "-count=1"
+            ];
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [neotest-golang](https://github.com/fredrikaverpil/neotest-golang/). Which seems to resolve some issues with the current neotest-go adapter most people use. 


Fixes: #1995 