### PR TITLE
plugins/firenvim: fix aliasing `settings` into `globals`

### DIFF
--- a/plugins/utils/firenvim.nix
+++ b/plugins/utils/firenvim.nix
@@ -1,6 +1,7 @@
 {
   lib,
   config,
+  options,
   pkgs,
   ...
 }:
@@ -73,17 +74,21 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
   '';
 
   callSetup = false;
-  extraConfig = cfg: {
-    warnings =
-      lib.optional
-        (
-          config.performance.combinePlugins.enable
-          && !(lib.elem "firenvim" config.performance.combinePlugins.standalonePlugins)
-        )
-        ''
-          Nixvim (plugins.firenvim): Using `performance.combinePlugins` breaks `firenvim`.
-          Add this plugin to `performance.combinePlugins.standalonePlugins` to prevent any issue.
-        '';
-    globals.firenvim_config = lib.modules.mkAliasAndWrapDefsWithPriority lib.id cfg.settings;
-  };
+  extraConfig =
+    let
+      opt = options.plugins.firenvim;
+    in
+    cfg: {
+      warnings =
+        lib.optional
+          (
+            config.performance.combinePlugins.enable
+            && !(lib.elem "firenvim" config.performance.combinePlugins.standalonePlugins)
+          )
+          ''
+            Nixvim (plugins.firenvim): Using `performance.combinePlugins` breaks `firenvim`.
+            Add this plugin to `performance.combinePlugins.standalonePlugins` to prevent any issue.
+          '';
+      globals.firenvim_config = lib.modules.mkAliasAndWrapDefsWithPriority lib.id opt.settings;
+    };
 }

--- a/tests/test-sources/plugins/utils/firenvim.nix
+++ b/tests/test-sources/plugins/utils/firenvim.nix
@@ -25,4 +25,32 @@
       };
     };
   };
+
+  check-alias.module =
+    { config, ... }:
+    {
+      assertions = [
+        {
+          assertion = config.globals ? firenvim_config;
+          message = "`firenvim_config` should be present in globals";
+        }
+        {
+          assertion = config.globals.firenvim_config.globalSettings.alt or null == "all";
+          message = "`globalSettings` should be have set `alt = \"all\"`";
+        }
+        {
+          assertion = config.globals.firenvim_config.localSettings.".*".cmdline or null == "neovim";
+          message = "`localSettings` should be have set `\".*\".cmdline = \"neovim\"`";
+        }
+      ];
+
+      plugins.firenvim = {
+        enable = true;
+
+        settings = {
+          globalSettings.alt = "all";
+          localSettings.".*".cmdline = "neovim";
+        };
+      };
+    };
 }


### PR DESCRIPTION
Follow up to #1983

Needed to use `options.*.settings` instead of `config.*.settings`.

I was concerned that the test-case didn't pick up on this, so I added an new test case with some basic assertions.
