### PR TITLE
plugins/lsp/bufls: init

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -49,6 +49,11 @@ let
       description = "Biome, Toolchain of the Web";
     }
     {
+      name = "bufls";
+      description = "Prototype for a Protobuf language server compatible with Buf.";
+      package = pkgs.buf-language-server;
+    }
+    {
       name = "ccls";
       description = "ccls for C/C++";
     }

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -111,6 +111,7 @@
             bashls.enable = true;
             beancount.enable = true;
             biome.enable = true;
+            bufls.enable = true;
             ccls.enable = true;
             clangd.enable = true;
             clojure-lsp.enable = true;


### PR DESCRIPTION
Adding bufls language server to the lsp plugin.

Tested with `checks`, as well as editing protobuf files with my own config, pointed at my fork. Seems to work as expected.