### PR TITLE
plugins/which-key: fix mkLuaFn examples; plugins/yazi: fix mkLuaFn examples

### DIFF
--- a/plugins/filetrees/yazi.nix
+++ b/plugins/filetrees/yazi.nix
@@ -46,11 +46,12 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
     enable_mouse_support = defaultNullOpts.mkBool false "Enables mouse support.";
 
     open_file_function = defaultNullOpts.mkLuaFn' {
-      pluginDefault.__raw = ''
-        function(chosen_file)
-          vim.cmd(string.format("edit %s", vim.fn.fnameescape(chosen_file)))
-        end
-      '';
+      pluginDefault = # Lua
+        ''
+          function(chosen_file)
+            vim.cmd(string.format("edit %s", vim.fn.fnameescape(chosen_file)))
+          end
+        '';
       description = ''
         What Neovim should do a when a file was opened (selected) in yazi.
 
@@ -92,10 +93,11 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
 
     hooks = {
       yazi_opened = defaultNullOpts.mkLuaFn' {
-        pluginDefault.__raw = ''
-          function(preselected_path, yazi_buffer_id, config)
-          end
-        '';
+        pluginDefault = # Lua
+          ''
+            function(preselected_path, yazi_buffer_id, config)
+            end
+          '';
         description = ''
           If you want to execute a custom action when yazi has been opened,
           you can define it here.
@@ -103,19 +105,21 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
       };
 
       yazi_closed_successfully = defaultNullOpts.mkLuaFn' {
-        pluginDefault.__raw = ''
-          function(chosen_file, config, state)
-          end
-        '';
+        pluginDefault = # Lua
+          ''
+            function(chosen_file, config, state)
+            end
+          '';
         description = "When yazi was successfully closed";
       };
 
       yazi_opened_multiple_files = defaultNullOpts.mkLuaFn' {
-        pluginDefault.__raw = ''
-          function(chosen_files)
-            vim.cmd("args" .. table.concat(chosen_files, " "))
-          end
-        '';
+        pluginDefault = # Lua
+          ''
+            function(chosen_files)
+              vim.cmd("args" .. table.concat(chosen_files, " "))
+            end
+          '';
         description = ''
           When yazi opened multiple files. The default is to send them to the
           quickfix list, but if you want to change that, you can define it here

--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -236,11 +236,12 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
     };
 
     filter = defaultNullOpts.mkLuaFn' {
-      pluginDefault.__raw = ''
-        function(mapping)
-          return true
-        end
-      '';
+      pluginDefault = # Lua
+        ''
+          function(mapping)
+            return true
+          end
+        '';
       description = "Filter used to exclude mappings";
     };
 
@@ -283,10 +284,12 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
     ] "Manually setup triggers";
 
     defer = defaultNullOpts.mkLuaFn' {
-      pluginDefault.__raw = ''
-        function(ctx)
-          return ctx.mode == "V" or ctx.mode == "<C-V>
-         end'';
+      pluginDefault = # Lua
+        ''
+          function(ctx)
+            return ctx.mode == "V" or ctx.mode == "<C-V>
+          end
+        '';
       description = ''
         Start hidden and wait for a key to be pressed before showing the popup.
 

--- a/tests/test-sources/plugins/filetrees/yazi.nix
+++ b/tests/test-sources/plugins/filetrees/yazi.nix
@@ -14,11 +14,12 @@
         use_yazi_client_id_flag = false;
         enable_mouse_support = false;
 
-        open_file_function.__raw = ''
-          function(chosen_file)
-            vim.cmd(string.format("edit %s", vim.fn.fnameescape(chosen_file)))
-          end
-        '';
+        open_file_function = # Lua
+          ''
+            function(chosen_file)
+              vim.cmd(string.format("edit %s", vim.fn.fnameescape(chosen_file)))
+            end
+          '';
 
         clipboard_register = "*";
 
@@ -37,21 +38,24 @@
         set_keymappings_function = null;
 
         hooks = {
-          yazi_opened.__raw = ''
-            function(preselected_path, yazi_buffer_id, config)
-            end
-          '';
+          yazi_opened = # Lua
+            ''
+              function(preselected_path, yazi_buffer_id, config)
+              end
+            '';
 
-          yazi_closed_successfully.__raw = ''
-            function(chosen_file, config, state)
-            end
-          '';
+          yazi_closed_successfully = # Lua
+            ''
+              function(chosen_file, config, state)
+              end
+            '';
 
-          yazi_opened_multiple_files.__raw = ''
-            function(chosen_files)
-              vim.cmd("args" .. table.concat(chosen_files, " "))
-            end
-          '';
+          yazi_opened_multiple_files = # Lua
+            ''
+              function(chosen_files)
+                vim.cmd("args" .. table.concat(chosen_files, " "))
+              end
+            '';
         };
 
         highlight_groups = {

--- a/tests/test-sources/plugins/utils/which-key.nix
+++ b/tests/test-sources/plugins/utils/which-key.nix
@@ -16,11 +16,12 @@
           end
         '';
 
-        filter.__raw = ''
-          function(mapping)
-              return true
+        filter = # Lua
+          ''
+            function(mapping)
+                return true
             end
-        '';
+          '';
 
         spec = [ ];
 
@@ -33,11 +34,12 @@
           }
         ];
 
-        defer.__raw = ''
-          function(ctx)
-            return ctx.mode == "V" or ctx.mode == "<C-V>"
-          end
-        '';
+        defer = # Lua
+          ''
+            function(ctx)
+              return ctx.mode == "V" or ctx.mode == "<C-V>"
+            end
+          '';
 
         plugins = {
           marks = true;


### PR DESCRIPTION
In reponse to https://github.com/nix-community/nixvim/pull/2000#discussion_r1712614882

Used `.__raw` but the type expects a regular string to be transformed into literal lua.