### PR TITLE
update-scripts: Adapt to rust-analyzer option changes

### DIFF
--- a/generated/rust-analyzer.nix
+++ b/generated/rust-analyzer.nix
@@ -1987,15 +1987,18 @@
   };
   "rust-analyzer.workspace.discoverConfig" = {
     description = ''
-      Enables automatic discovery of projects using [`DiscoverWorkspaceConfig::command`].
+      Enables automatic discovery of projects using
+      \[`DiscoverWorkspaceConfig::command`\].
 
-      [`DiscoverWorkspaceConfig`] also requires setting `progress_label` and `files_to_watch`.
-      `progress_label` is used for the title in progress indicators, whereas `files_to_watch`
-      is used to determine which build system-specific files should be watched in order to
-      reload rust-analyzer.
+      \[`DiscoverWorkspaceConfig`\] also requires setting `progress_label` and
+      `files_to_watch`. `progress_label` is used for the title in progress
+      indicators, whereas `files_to_watch` is used to determine which build
+      system-specific files should be watched in order to reload
+      rust-analyzer.
 
       Below is an example of a valid configuration:
-      ```json
+
+      ``` json
       "rust-analyzer.workspace.discoverConfig": {
               "command": [
                       "rust-project",
@@ -2009,14 +2012,14 @@
       }
       ```
 
-      ## On `DiscoverWorkspaceConfig::command`
+      **On `DiscoverWorkspaceConfig::command`**
 
       **Warning**: This format is provisional and subject to change.
 
-      [`DiscoverWorkspaceConfig::command`] *must* return a JSON object
+      \[`DiscoverWorkspaceConfig::command`\] *must* return a JSON object
       corresponding to `DiscoverProjectData::Finished`:
 
-      ```norun
+      ``` norun
       #[derive(Debug, Clone, Deserialize, Serialize)]
       #[serde(tag = "kind")]
       #[serde(rename_all = "snake_case")]
@@ -2029,7 +2032,7 @@
 
       As JSON, `DiscoverProjectData::Finished` is:
 
-      ```json
+      ``` json
       {
               // the internally-tagged representation of the enum.
               "kind": "finished",
@@ -2051,7 +2054,7 @@
       which will be substituted with the JSON-serialized form of the following
       enum:
 
-      ```norun
+      ``` norun
       #[derive(PartialEq, Clone, Debug, Serialize)]
       #[serde(rename_all = "camelCase")]
       pub enum DiscoverArgument {
@@ -2062,7 +2065,7 @@
 
       The JSON representation of `DiscoverArgument::Path` is:
 
-      ```json
+      ``` json
       {
               "path": "src/main.rs"
       }
@@ -2070,17 +2073,17 @@
 
       Similarly, the JSON representation of `DiscoverArgument::Buildfile` is:
 
-      ```
-      {
-              "buildfile": "BUILD"
-      }
-      ```
+          {
+                  "buildfile": "BUILD"
+          }
 
-      `DiscoverArgument::Path` is used to find and generate a `rust-project.json`,
-      and therefore, a workspace, whereas `DiscoverArgument::buildfile` is used to
-      to update an existing workspace. As a reference for implementors,
-      buck2's `rust-project` will likely be useful:
+      `DiscoverArgument::Path` is used to find and generate a
+      `rust-project.json`, and therefore, a workspace, whereas
+      `DiscoverArgument::buildfile` is used to to update an existing
+      workspace. As a reference for implementors, buck2's `rust-project` will
+      likely be useful:
       https://github.com/facebook/buck2/tree/main/integrations/rust-project.
+
     '';
     pluginDefault = null;
     type = {

--- a/plugins/lsp/language-servers/rust-analyzer-config.nix
+++ b/plugins/lsp/language-servers/rust-analyzer-config.nix
@@ -37,6 +37,16 @@ let
         lib.types.int
     else if kind == "object" then
       lib.types.attrsOf lib.types.anything
+    else if kind == "submodule" then
+      lib.types.submodule {
+        options = lib.mapAttrs (
+          _: ty:
+          lib.mkOption {
+            type = mkRustAnalyzerType ty;
+            description = "";
+          }
+        ) typeInfo.options;
+      }
     else if kind == "string" then
       lib.types.str
     else if kind == "boolean" then

--- a/update-scripts/default.nix
+++ b/update-scripts/default.nix
@@ -25,5 +25,5 @@ lib.fix (self: {
   # Derivations that build the generated files
   efmls-configs-sources = pkgs.callPackage ./efmls-configs.nix { };
   none-ls-builtins = pkgs.callPackage ./none-ls.nix { };
-  rust-analyzer-options = pkgs.callPackage ./rust-analyzer.nix { };
+  rust-analyzer-options = pkgs.callPackage ./rust-analyzer { };
 })

--- a/update-scripts/rust-analyzer.nix
+++ b/update-scripts/rust-analyzer.nix
@@ -43,6 +43,7 @@ let
       maximum ? null,
       items ? null,
       anyOf ? null,
+      properties ? null,
       # Not used in the function, but anyOf values contain it
       enumDescriptions ? null,
     }@property:
@@ -95,6 +96,13 @@ let
       {
         kind = type;
         inherit minimum maximum;
+      }
+    else if type == "object" && properties != null then
+      {
+        kind = "submodule";
+        options = lib.mapAttrs (
+          name: value: mkRustAnalyzerOptionType false "${property_name}.${name}" value
+        ) properties;
       }
     else if
       lib.elem type [

--- a/update-scripts/rust-analyzer/heading_filter.lua
+++ b/update-scripts/rust-analyzer/heading_filter.lua
@@ -1,0 +1,3 @@
+function Header(elem)
+	return pandoc.Strong(elem.content)
+end


### PR DESCRIPTION
A newly introduced option added two unhandled cases:
- Sub-module like `properties`
- Descriptions containing markdown headings

In order to avoid shelling out to pandoc to filter _each_ markdown description we only check if there _could_ be an header, and call pandoc in that case. This currently results in pandoc being only called for the newly introduced option