### PR TITLE
Fix for obsolete nerdfont icons

### DIFF
--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -76,8 +76,8 @@ in
               TODO = { icon = " "; color = "info"; };
               HACK = { icon = " "; color = "warning"; };
               WARN = { icon = " "; color = "warning"; alt = [ "WARNING" "XXX" ]; };
-              PERF = { icon = " "; alt = [ "OPTIM" "PERFORMANCE" "OPTIMIZE" ]; };
-              NOTE = { icon = " "; color = "hint"; alt = [ "INFO" ]; };
+              PERF = { icon = " ", alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
+              NOTE = { icon = " ", color = "hint", alt = { "INFO" } },
               TEST = { icon = "⏲ "; color = "test"; alt = [ "TESTING" "PASSED" "FAILED" ]; };
             };
             ```


### PR DESCRIPTION
These two icons are removed from nerdfont.
See https://www.nerdfonts.com/cheat-sheet and search for `clock_fast` and `message_reply_text`