### PR TITLE
flake-modules/devshell: add getopt runtimeInput

### DIFF
--- a/flake-modules/dev/devshell.nix
+++ b/flake-modules/dev/devshell.nix
@@ -37,6 +37,7 @@
                   launchTest = pkgs.writeShellApplication {
                     name = "launch-tests";
                     runtimeInputs = with pkgs; [
+                      getopt
                       jq
                       fzf
                     ];


### PR DESCRIPTION
Use a consistent behavior of getopt in launchtests.sh. Wasn't able to use tests command on macbook without including this because the macOS getopt didn't support our usage.