### PR TITLE
Changed default telescope-borders to true instead of false

### DIFF
--- a/plugins/colorschemes/base16/default.nix
+++ b/plugins/colorschemes/base16/default.nix
@@ -41,7 +41,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     ];
 
   settingsExample = {
-    telescope_borders = true;
+    telescope_borders = false;
     indentblankline = false;
     dapui = false;
   };
@@ -51,7 +51,7 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       Whether to enable telescope integration.
     '';
 
-    telescope_borders = helpers.defaultNullOpts.mkBool false ''
+    telescope_borders = helpers.defaultNullOpts.mkBool true ''
       Whether to display borders around telescope's panel.
     '';
 

--- a/tests/test-sources/plugins/colorschemes/base16.nix
+++ b/tests/test-sources/plugins/colorschemes/base16.nix
@@ -12,7 +12,7 @@
 
       settings = {
         telescope = true;
-        telescope_borders = false;
+        telescope_borders = true;
         indentblankline = true;
         notify = true;
         ts_rainbow = true;


### PR DESCRIPTION
I have been struggling to figure out why my telescope didn't have borders, as it usually does when normally enabled. Then I came across this option and saw it was set to false by default. This changes it back to true to be consistent with every other default telescope configuration.