### PR TITLE
top-level/output: include meta in package

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -251,7 +251,7 @@ in
             name = "neovim-byte-compiled-${lib.getVersion config.package}";
             paths = [ config.package ];
             # Required attributes from original neovim package
-            inherit (config.package) lua;
+            inherit (config.package) lua meta;
             nativeBuildInputs = [ helpers.byteCompileLuaHook ];
             postBuild = ''
               # Replace Nvim's binary symlink with a regular file,


### PR DESCRIPTION
In preparation for next flake update. Required to prevent errors due to missing license information in neovim-wrapper when using `performance.byteCompileLua.nvimRuntime`.
 
I was seeing this error due to missing required meta attributes:
```
 error: attribute 'license' missing
       at /nix/store/sfycwi72zfjsspidinx56ajaiffpyh17-source/pkgs/applications/editors/neovim/wrapper.nix:210:9:
          209|         mainProgram
          210|         license
             |         ^
          211|         maintainers
```