### PR TITLE
workflows/update: only run upstream

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -34,6 +34,7 @@ jobs:
     name: Update the flake inputs and generate options
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    if: github.event_name != 'schedule' || github.repository == 'nix-community/nixvim'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/2006

Tested running workflow on my repo: 

- Using upstream as repo check (skips running) https://github.com/khaneliman/nixvim/actions/runs/10426474651
- Using my own repo check (runs update) https://github.com/khaneliman/nixvim/actions/runs/10426526382/job/28879614530
