### PR TITLE
colorschemes/catppuccin: add byteCompile option

### DIFF
--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -6,10 +6,20 @@
   ...
 }:
 with lib;
+let
+  flavours = [
+    "latte"
+    "mocha"
+    "frappe"
+    "macchiato"
+  ];
+in
 helpers.neovim-plugin.mkNeovimPlugin config {
   name = "catppuccin";
   isColorscheme = true;
   defaultPackage = pkgs.vimPlugins.catppuccin-nvim;
+  installPackage = false;
+  callSetup = false;
 
   maintainers = [ maintainers.GaetanLepage ];
 
@@ -114,182 +124,173 @@ helpers.neovim-plugin.mkNeovimPlugin config {
         disableUnderline = "no_underline";
       };
 
-  settingsOptions =
-    let
-      flavours = [
-        "latte"
-        "mocha"
-        "frappe"
-        "macchiato"
-      ];
-    in
-    {
-      compile_path = helpers.defaultNullOpts.mkStr {
-        __raw = "vim.fn.stdpath 'cache' .. '/catppuccin'";
-      } "Set the compile cache directory.";
+  settingsOptions = {
+    compile_path = helpers.defaultNullOpts.mkStr {
+      __raw = "vim.fn.stdpath 'cache' .. '/catppuccin'";
+    } "Set the compile cache directory.";
 
-      flavour = helpers.mkNullOrOption (types.enum (flavours ++ [ "auto" ])) ''
-        Theme flavour.
-      '';
+    flavour = helpers.mkNullOrOption (types.enum (flavours ++ [ "auto" ])) ''
+      Theme flavour.
+    '';
 
-      background =
-        let
-          mkBackgroundStyle =
-            name:
-            helpers.defaultNullOpts.mkEnumFirstDefault flavours ''
-              Background for `${name}` background.
-            '';
-        in
-        {
-          light = mkBackgroundStyle "light";
+    background =
+      let
+        mkBackgroundStyle =
+          name:
+          helpers.defaultNullOpts.mkEnumFirstDefault flavours ''
+            Background for `${name}` background.
+          '';
+      in
+      {
+        light = mkBackgroundStyle "light";
 
-          dark = mkBackgroundStyle "dark";
-        };
-
-      transparent_background = helpers.defaultNullOpts.mkBool false ''
-        Enable Transparent background.
-      '';
-
-      show_end_of_buffer = helpers.defaultNullOpts.mkBool false ''
-        Show the '~' characters after the end of buffers.
-      '';
-
-      term_colors = helpers.defaultNullOpts.mkBool false ''
-        Configure the colors used when opening a :terminal in Neovim.
-      '';
-
-      dim_inactive = {
-        enabled = helpers.defaultNullOpts.mkBool false ''
-          If true, dims the background color of inactive window or buffer or split.
-        '';
-
-        shade = helpers.defaultNullOpts.mkStr "dark" ''
-          Sets the shade to apply to the inactive split or window or buffer.
-        '';
-
-        percentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.15 ''
-          percentage of the shade to apply to the inactive window, split or buffer.
-        '';
+        dark = mkBackgroundStyle "dark";
       };
 
-      no_italic = helpers.defaultNullOpts.mkBool false ''
-        Force no italic.
+    transparent_background = helpers.defaultNullOpts.mkBool false ''
+      Enable Transparent background.
+    '';
+
+    show_end_of_buffer = helpers.defaultNullOpts.mkBool false ''
+      Show the '~' characters after the end of buffers.
+    '';
+
+    term_colors = helpers.defaultNullOpts.mkBool false ''
+      Configure the colors used when opening a :terminal in Neovim.
+    '';
+
+    dim_inactive = {
+      enabled = helpers.defaultNullOpts.mkBool false ''
+        If true, dims the background color of inactive window or buffer or split.
       '';
 
-      no_bold = helpers.defaultNullOpts.mkBool false ''
-        Force no bold.
+      shade = helpers.defaultNullOpts.mkStr "dark" ''
+        Sets the shade to apply to the inactive split or window or buffer.
       '';
 
-      no_underline = helpers.defaultNullOpts.mkBool false ''
-        Force no underline.
-      '';
-
-      styles = {
-        comments = helpers.defaultNullOpts.mkListOf types.str [ "italic" ] ''
-          Define comments highlight properties.
-        '';
-
-        conditionals = helpers.defaultNullOpts.mkListOf types.str [ "italic" ] ''
-          Define conditionals highlight properties.
-        '';
-
-        loops = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define loops highlight properties.
-        '';
-
-        functions = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define functions highlight properties.
-        '';
-
-        keywords = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define keywords highlight properties.
-        '';
-
-        strings = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define strings highlight properties.
-        '';
-
-        variables = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define variables highlight properties.
-        '';
-
-        numbers = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define numbers highlight properties.
-        '';
-
-        booleans = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define booleans highlight properties.
-        '';
-
-        properties = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define properties highlight properties.
-        '';
-
-        types = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define types highlight properties.
-        '';
-
-        operators = helpers.defaultNullOpts.mkListOf types.str [ ] ''
-          Define operators highlight properties.
-        '';
-      };
-
-      color_overrides = genAttrs (flavours ++ [ "all" ]) (
-        flavour:
-        helpers.defaultNullOpts.mkAttrsOf types.str { } (
-          if flavour == "all" then
-            "Override colors for all the flavours."
-          else
-            "Override colors for the ${flavour} flavour."
-        )
-      );
-
-      custom_highlights = helpers.mkNullOrStrLuaFnOr (with types; attrsOf anything) ''
-        Override specific highlight groups to use other groups or a hex color.
-        You can provide either a lua function or directly an attrs.
-
-        Example:
-        ```lua
-          function(colors)
-            return {
-              Comment = { fg = colors.flamingo },
-              ["@constant.builtin"] = { fg = colors.peach, style = {} },
-              ["@comment"] = { fg = colors.surface2, style = { "italic" } },
-            }
-          end
-        ```
-
-        Default: `{}`
-      '';
-
-      default_integrations = helpers.defaultNullOpts.mkBool true ''
-        Some integrations are enabled by default, you can control this behaviour with this option.
-      '';
-
-      integrations = helpers.mkNullOrOption (with types; attrsOf anything) ''
-        Catppuccin provides theme support for other plugins in the Neovim ecosystem and extended
-        Neovim functionality through _integrations_.
-
-        To enable/disable an integration you just need to set it to `true`/`false`.
-
-        Example:
-        ```nix
-          {
-            cmp = true;
-            gitsigns = true;
-            nvimtree = true;
-            treesitter = true;
-            notify = false;
-            mini = {
-              enabled = true;
-              indentscope_color = "";
-            };
-          }
-        ```
-
-        Default: see plugin source.
+      percentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.15 ''
+        percentage of the shade to apply to the inactive window, split or buffer.
       '';
     };
+
+    no_italic = helpers.defaultNullOpts.mkBool false ''
+      Force no italic.
+    '';
+
+    no_bold = helpers.defaultNullOpts.mkBool false ''
+      Force no bold.
+    '';
+
+    no_underline = helpers.defaultNullOpts.mkBool false ''
+      Force no underline.
+    '';
+
+    styles = {
+      comments = helpers.defaultNullOpts.mkListOf types.str [ "italic" ] ''
+        Define comments highlight properties.
+      '';
+
+      conditionals = helpers.defaultNullOpts.mkListOf types.str [ "italic" ] ''
+        Define conditionals highlight properties.
+      '';
+
+      loops = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define loops highlight properties.
+      '';
+
+      functions = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define functions highlight properties.
+      '';
+
+      keywords = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define keywords highlight properties.
+      '';
+
+      strings = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define strings highlight properties.
+      '';
+
+      variables = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define variables highlight properties.
+      '';
+
+      numbers = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define numbers highlight properties.
+      '';
+
+      booleans = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define booleans highlight properties.
+      '';
+
+      properties = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define properties highlight properties.
+      '';
+
+      types = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define types highlight properties.
+      '';
+
+      operators = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        Define operators highlight properties.
+      '';
+    };
+
+    color_overrides = genAttrs (flavours ++ [ "all" ]) (
+      flavour:
+      helpers.defaultNullOpts.mkAttrsOf types.str { } (
+        if flavour == "all" then
+          "Override colors for all the flavours."
+        else
+          "Override colors for the ${flavour} flavour."
+      )
+    );
+
+    custom_highlights = helpers.mkNullOrStrLuaFnOr (with types; attrsOf anything) ''
+      Override specific highlight groups to use other groups or a hex color.
+      You can provide either a lua function or directly an attrs.
+
+      Example:
+      ```lua
+        function(colors)
+          return {
+            Comment = { fg = colors.flamingo },
+            ["@constant.builtin"] = { fg = colors.peach, style = {} },
+            ["@comment"] = { fg = colors.surface2, style = { "italic" } },
+          }
+        end
+      ```
+
+      Default: `{}`
+    '';
+
+    default_integrations = helpers.defaultNullOpts.mkBool true ''
+      Some integrations are enabled by default, you can control this behaviour with this option.
+    '';
+
+    integrations = helpers.mkNullOrOption (with types; attrsOf anything) ''
+      Catppuccin provides theme support for other plugins in the Neovim ecosystem and extended
+      Neovim functionality through _integrations_.
+
+      To enable/disable an integration you just need to set it to `true`/`false`.
+
+      Example:
+      ```nix
+        {
+          cmp = true;
+          gitsigns = true;
+          nvimtree = true;
+          treesitter = true;
+          notify = false;
+          mini = {
+            enabled = true;
+            indentscope_color = "";
+          };
+        }
+      ```
+
+      Default: see plugin source.
+    '';
+  };
 
   settingsExample = {
     flavour = "mocha";
@@ -316,5 +317,67 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     };
   };
 
-  extraConfig = cfg: { opts.termguicolors = mkDefault true; };
+  extraOptions = {
+    byteCompile = mkOption {
+      type = types.bool;
+      description = ''
+        Whether to byte compile the colorscheme during build step.
+        When enabled, `setup()` function and any runtime re-configuration won't
+        be available. Default flavour is `mocha`. `flavour = "auto"` is not
+        supported, set it explicitly. Flavours can be switched in runtime with
+        `:colorscheme catppuccin-frappe`, `:colorscheme catppuccin-latte` etc.
+      '';
+      default = false;
+      example = true;
+    };
+  };
+
+  extraConfig = cfg: {
+    extraPlugins =
+      let
+        # Neovim which byte compiles catppuccin colorscheme to current directory
+        neovim = pkgs.neovim.override {
+          configure = {
+            packages.catppuccin-nvim.start = [ cfg.package ];
+
+            # Byte compile the colorscheme to current directory
+            customRC = helpers.wrapLuaForVimscript ''
+              require("catppuccin").setup(${
+                helpers.toLuaObject (cfg.settings // { compile_path = helpers.mkRaw "vim.uv.cwd()"; })
+              })
+            '';
+          };
+        };
+
+        pname = lib.getName cfg.package;
+        version = lib.getVersion cfg.package;
+        byteCompiledPackage = pkgs.vimUtils.toVimPlugin (
+          pkgs.runCommandLocal pname { inherit pname version; } ''
+            HOME=$(mktemp -d) ${lib.getExe neovim} --headless +q
+
+            mkdir -p $out/colors
+
+            # Copy all flavours to $out/colors
+            ${lib.concatMapStrings (flavour: ''
+              cp ${flavour} $out/colors/catppuccin-${flavour}.lua
+            '') flavours}
+            # Default flavour
+            cp ${
+              # Using upstream default for dark background
+              if cfg.settings.flavour != null && cfg.settings.flavour != "auto" then
+                cfg.settings.flavour
+              else
+                "mocha"
+            } $out/colors/catppuccin.lua
+          ''
+        );
+      in
+      if cfg.byteCompile then [ byteCompiledPackage ] else [ cfg.package ];
+
+    extraConfigLuaPre = mkIf (!cfg.byteCompile) ''
+      require("catppuccin").setup(${helpers.toLuaObject cfg.settings})
+    '';
+
+    colorscheme = mkDefault "catppuccin";
+  };
 }

--- a/tests/test-sources/plugins/colorschemes/catppuccin.nix
+++ b/tests/test-sources/plugins/colorschemes/catppuccin.nix
@@ -153,4 +153,75 @@
       };
     };
   };
+
+  byte-compiled-empty = {
+    colorschemes.catppuccin = {
+      enable = true;
+      byteCompile = true;
+    };
+
+    extraConfigLuaPost = ''
+      assert(
+        vim.g.colors_name == "catppuccin-mocha",
+        "Expected catppuccin-mocha colorscheme, got " .. vim.g.colors_name
+      )
+
+      assert(
+        not pcall(require, "catppuccin"),
+        "catppuccin module is not expected to be available when the colorscheme is byte compiled"
+      )
+
+      -- Can switch flavours without errors
+      vim.cmd.colorscheme("catppuccin")
+      vim.cmd.colorscheme("catppuccin-latte")
+      vim.cmd.colorscheme("catppuccin-frappe")
+      vim.cmd.colorscheme("catppuccin-macchiato")
+      vim.cmd.colorscheme("catppuccin-mocha")
+    '';
+  };
+
+  byte-compilation-disabled-by-default = {
+    colorschemes.catppuccin.enable = true;
+
+    extraConfigLuaPost = ''
+      assert(
+        pcall(require, "catppuccin"),
+        "catppuccin module is expected to be available when the colorscheme is not byte compiled"
+      )
+    '';
+  };
+
+  byte-compiled-settings = {
+    colorschemes.catppuccin = {
+      enable = true;
+      byteCompile = true;
+      settings = {
+        flavour = "macchiato";
+        term_colors = true;
+        custom_highlights = {
+          TestHL = {
+            fg = "#ffffff";
+          };
+        };
+      };
+    };
+
+    extraConfigLuaPost = ''
+      -- Flavour is set in settings
+      assert(
+        vim.g.colors_name == "catppuccin-macchiato",
+        "Expected catppuccin-macchiato colorscheme, got " .. vim.g.colors_name
+      )
+
+      -- Terminal colors
+      assert(vim.g.terminal_color_15, "Terminal colors are not set, even though enabled in settings")
+
+      -- Custom highlight
+      test_hl = vim.api.nvim_get_hl(0, { name = "TestHL" })
+      assert(
+        vim.deep_equal(test_hl, { fg = 0xffffff }),
+        "Expected TestHL to be set and equal to { fg = '#ffffff' }, got " .. vim.inspect(test_hl)
+      )
+    '';
+  };
 }


### PR DESCRIPTION
This commit adds `colorschemes.catppuccin.byteCompile` options. If enabled it byte compiles the colorscheme. Resulting package has only colorschemes itself in `colors` directory, no any other files. Colorschemes are byte compiled with all provided settings. This is achieved by running neovim instance with configured catppuccin colorscheme and copying byte compiled colorschemes from the cache directory.

Upstream plugin has support for `flavour = "auto"`. In that case setup function loads a flavour based on current background. Currently byteCompile option doesn't support this behavior. If the user didn't set flavour in settings, mocha flavour is used (upstream default for dark background). In theory additional logic can be added for checking current `globalOpts.background` (and its aliases) to emulate upstream 'auto' behavior, but it would compilcate things, so it's not handled by this commit.

Setting `opts.termguicolors` was dropped here, because it's already explicitly set by catppuccin colorscheme.