### PR TITLE
modules/keymap: improve `lua` deprecation

### DIFF
--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -193,12 +193,17 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   extraOptions = {
     keymaps = mapAttrs (
       optionName: funcName:
-      helpers.mkNullOrOption (helpers.keymaps.mkMapOptionSubmodule {
-        defaults = {
-          mode = "n";
-          action = "<Cmd>Buffer${funcName}<CR>";
+      helpers.mkNullOrOption' {
+        type = helpers.keymaps.mkMapOptionSubmodule {
+          defaults = {
+            mode = "n";
+            action = "<Cmd>Buffer${funcName}<CR>";
+          };
+          lua = true;
         };
-      }) "Keymap for function Buffer${funcName}"
+        apply = v: if v == null then null else helpers.keymaps.removeDeprecatedMapAttrs v;
+        description = "Keymap for function Buffer${funcName}";
+      }
     ) keymapsActions;
   };
 

--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -47,7 +47,8 @@ in
         };
 
         extra = mkOption {
-          type = with types; listOf helpers.keymaps.mapOptionSubmodule;
+          type = with types; listOf helpers.keymaps.deprecatedMapOptionSubmodule;
+          apply = map helpers.keymaps.removeDeprecatedMapAttrs;
           description = ''
             Extra keymaps to register when an LSP is attached.
             This can be used to customise LSP behaviour, for example with "telescope" or the "Lspsaga" plugin, as seen in the examples.

--- a/plugins/utils/tmux-navigator.nix
+++ b/plugins/utils/tmux-navigator.nix
@@ -179,8 +179,10 @@ helpers.vim-plugin.mkVimPlugin config {
             ];
             example = "left";
           };
+          lua = true;
         }
       );
+      apply = map helpers.keymaps.removeDeprecatedMapAttrs;
     };
   };
 


### PR DESCRIPTION
- Replace nullable lua option with a no-default option.
- Made it so the deprecated option is only declared when `lua = true` is passed.
- Replace `normalizeMappings` with a `removeDeprecatedMapAttrs` helper.
- Added warnings for **all options** that historically had `lua` support.

This supersedes and closes #1795

## Removing the attr from the final value

I'd like to do something like this directly in `mkMapOptionSubmodule`, however it doesn't seem to do what you'd expect...

```nix
type // {
  merge = loc: defs: builtins.removeAttrs (type.merge loc defs) [ "lua" ];
};
```

Therefore I've instead added `apply` functions to each keymap option that removes the `lua` attr.

See this [message on matrix](https://matrix.to/#/!wfudwzqQUiJYJnqfSY:nixos.org/$UjMlZGRb5mPCxWdvv6DDGOnuk95ahtuX3TzSHr5dO-w?via=nixos.org&via=matrix.org&via=nixos.dev).

## Showing the warning for all uses

Previously, we only checked the `keymaps` option in our deprecation warning.

We could instead have a `lib.warn` in the `action`'s `apply` function when we call `mkRaw`, however this wouldn't have access to `loc` or `defs` to print a proper warning.

If overriding the `merge` function worked correctly, we could do it there, however I think this is fine for this PR, we can always improve things further in future work.

For now, `modules/keymaps.nix` is responsible for showing warnings for all options that previously had a `lua` sub-option.