### PR TITLE
tests: use a link-farm again, but only per-file

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   fetchTests = import ./fetch-tests.nix;
-  test-derivation = import ./test-derivation.nix { inherit pkgs makeNixvimWithModule lib; };
+  test-derivation = import ./test-derivation.nix { inherit pkgs makeNixvimWithModule; };
   inherit (test-derivation) mkTestDerivationFromNixvimModule;
 
   # List of files containing configurations

--- a/tests/test-derivation.nix
+++ b/tests/test-derivation.nix
@@ -1,63 +1,40 @@
-{
-  pkgs,
-  lib ? pkgs.lib,
-  makeNixvimWithModule,
-  ...
-}:
+{ pkgs, makeNixvimWithModule, ... }:
 let
   # Create a nix derivation from a nixvim executable.
   # The build phase simply consists in running the provided nvim binary.
   mkTestDerivationFromNvim =
     {
       name,
-      nvim ? null,
-      tests ? [ ],
+      nvim,
       dontRun ? false,
       ...
     }:
-    # At least one of these should be undefined
-    assert lib.assertMsg (tests == [ ] || nvim == null) "Both nvim & tests can't be supplied";
-    let
-      nvimAsList = lib.optional (nvim != null) {
-        derivation = nvim;
-        inherit name dontRun;
-      };
-
-      testList = tests ++ nvimAsList;
-    in
     pkgs.stdenv.mkDerivation {
       inherit name;
 
-      nativeBuildInputs = [ pkgs.docker-client ];
+      nativeBuildInputs = [
+        nvim
+        pkgs.docker-client
+      ];
 
       dontUnpack = true;
       # We need to set HOME because neovim will try to create some files
       #
       # Because neovim does not return an exitcode when quitting we need to check if there are
       # errors on stderr
-      buildPhase = lib.optionalString (!dontRun) (
-        ''
-          mkdir -p .cache/nvim
-        ''
-        + lib.concatStringsSep "\n" (
-          builtins.map (
-            {
-              derivation,
-              name,
-              dontRun ? false,
-            }:
-            lib.optionalString (!dontRun) ''
-              echo "Running test for ${name}"
+      buildPhase =
+        if !dontRun then
+          ''
+            mkdir -p .cache/nvim
 
-              output=$(HOME=$(realpath .) ${lib.getExe derivation} -mn --headless "+q" 2>&1 >/dev/null)
-              if [[ -n $output ]]; then
-                echo "ERROR: $output"
-                exit 1
-              fi
-            ''
-          ) testList
-        )
-      );
+            output=$(HOME=$(realpath .) nvim -mn --headless "+q" 2>&1 >/dev/null)
+            if [[ -n $output ]]; then
+            	echo "ERROR: $output"
+              exit 1
+            fi
+          ''
+        else
+          '''';
 
       # If we don't do this nix is not happy
       installPhase = ''
@@ -71,35 +48,17 @@ let
     {
       name ? "nixvim-check",
       pkgs ? pkgs,
-      module ? null,
-      tests ? [ ],
+      module,
       extraSpecialArgs ? { },
       dontRun ? false,
     }:
-    # At least one of these should be undefined
-    assert lib.assertMsg (tests == [ ] || module == null) "Both module & tests can't be supplied";
     let
-      moduleAsList = lib.optional (module != null) { inherit module name; };
-      moduleList = tests ++ moduleAsList;
-      testDerivations = builtins.map (
-        {
-          module,
-          name,
-          dontRun ? false,
-        }:
-        {
-          derivation = makeNixvimWithModule {
-            inherit pkgs module extraSpecialArgs;
-            _nixvimTests = true;
-          };
-          inherit name dontRun;
-        }
-      ) moduleList;
+      nvim = makeNixvimWithModule {
+        inherit pkgs module extraSpecialArgs;
+        _nixvimTests = true;
+      };
     in
-    mkTestDerivationFromNvim {
-      inherit name dontRun;
-      tests = testDerivations;
-    };
+    mkTestDerivationFromNvim { inherit name nvim dontRun; };
 in
 {
   inherit mkTestDerivationFromNvim mkTestDerivationFromNixvimModule;


### PR DESCRIPTION
- **tests: use a link-farm again, but only per-file**
- **Revert "tests: Allow to test multiple derivations in a single test derivation"**

This is one change picked from #1989, which reduces the scope of that refactoring PR.

This doesn't take any steps to reduce the number of checks we have on the flake, but it does remove some fragile derivation code that was attempting to optimise derivation-count in an area where (AFAICT) this should not affect buildbot.

cc @zowoq (buildbot maintainer) @traxys (reverted commit author)
