### PR TITLE
lib/keymap: allow extra options/modules in `mkMapOptionSubmodule`

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -82,17 +82,26 @@ rec {
 
   mkMapOptionSubmodule =
     {
+      # Allow overriding defaults for key, action, mode, etc
       defaults ? { },
+
       # key and action can be true/false to enable/disable adding the option,
       # or an attrset to enable the option and add/override mkOption args.
       key ? true,
       action ? true,
       lua ? false, # WARNING: for historic use only - do not use in new options!
+
+      # Allow passing additional options or modules to the submodule
+      # Useful for plugin-specific features
+      extraOptions ? { },
+      extraModules ? [ ],
     }:
     with types;
     submodule (
       { config, options, ... }:
       {
+        imports = extraModules;
+
         options =
           (optionalAttrs (isAttrs key || key) {
             key = mkOption (
@@ -135,7 +144,8 @@ rec {
           // {
             mode = mkModeOption defaults.mode or "";
             options = mapConfigOptions;
-          };
+          }
+          // extraOptions;
       }
     );
 


### PR DESCRIPTION
This is needed to allow plugins to add bespoke features to their keymap submodules without having to re-implement the whole thing.

cc @khaneliman as this may be useful in todo-comments
