### PR TITLE
tests: group tests into several link-farms (10 tests per farm)

### DIFF
--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -71,6 +71,7 @@ let
       concatNonEmptyLines
       emptyTable
       enableExceptInTests
+      groupListBySize
       hasContent
       ifNonNull'
       listToUnkeyedAttrs

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -147,4 +147,23 @@ rec {
       ${string}
       EOF
     '';
+
+  # Split a list into a several sub-list, each with a max-size of `size`
+  groupListBySize =
+    size: list:
+    reverseList (
+      foldl' (
+        lists: item:
+        let
+          first = head lists;
+          rest = drop 1 lists;
+        in
+        if lists == [ ] then
+          [ [ item ] ]
+        else if length first < size then
+          [ (first ++ [ item ]) ] ++ rest
+        else
+          [ [ item ] ] ++ lists
+      ) [ ] list
+    );
 }

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -343,8 +343,8 @@ else
       results = pkgs.lib.concatStringsSep "\n" (
         builtins.map (result: ''
           ${result.name}:
-            expected: ${result.expected}
-            result: ${result.result}
+            expected: ${lib.generators.toPretty { } result.expected}
+            result: ${lib.generators.toPretty { } result.result}
         '') results
       );
     }

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -333,6 +333,47 @@ let
         "MIxEd"
       ];
     };
+
+    testGroupListBySize = {
+      expr = {
+        empty = helpers.groupListBySize 5 [ ];
+        "5/5" = helpers.groupListBySize 5 (lib.genList lib.id 5);
+        "13/5" = helpers.groupListBySize 5 (lib.genList lib.id 13);
+      };
+      expected = {
+        empty = [ ];
+        "5/5" = [
+          [
+            0
+            1
+            2
+            3
+            4
+          ]
+        ];
+        "13/5" = [
+          [
+            0
+            1
+            2
+            3
+            4
+          ]
+          [
+            5
+            6
+            7
+            8
+            9
+          ]
+          [
+            10
+            11
+            12
+          ]
+        ];
+      };
+    };
   };
 in
 if results == [ ] then


### PR DESCRIPTION
- **tests/lib-test: correctly print expected/result**
- **lib/util: add `groupListBySize`**
- **tests: group tests by 10**
- **flake-modules/devshell: update tests command with link-farm support**

In an attempt to strike a balance between having one very intensive test and _many_ smaller tests at the `checks.<system>.*` level, this PR groups the tests into bundles of 10, currently resulting in 28 `checks.<system>.test-*` link farms and 46 _total_ checks.

Quoting https://github.com/nix-community/nixvim/pull/2015#issuecomment-2285508636:
> On the old hardware we were using 16 workers for eval, now we are using 32. Only splitting the linkfarm up a bit (e.g. into 4) likely won't help much as they will still end up being evaluated at the same time but by more than that or by path should work.

We can always dial the group size up/down to find the right balance, but 28 groups of 10 feels like a good starting point (112 groups of 10, when multiplied by the 4 systems).

As per https://github.com/nix-community/nixvim/issues/1878#issuecomment-2240793881, we can test memory usage locally using:
```shell
nix run nixpkgs#nix-eval-jobs -- --workers 1 --check-cache-status --force-recurse --flake .#checks
```

cc @zowoq
cc @GaetanLepage

@traxys I've had to re-work some details of your `tests` shell script, supplying it with a pre-generated `tests.json` file, which looks like (full file: [tests.json](https://github.com/user-attachments/files/16655370/tests.json)):

```json
{
  "examples": "test-1.passthru.entries.examples",
  "extended-lib": "test-1.passthru.entries.extended-lib",
  "modules-clipboard": "test-1.passthru.entries.modules-clipboard",
  "modules-commands": "test-1.passthru.entries.modules-commands",
  "modules-editorconfig": "test-1.passthru.entries.modules-editorconfig",
  "modules-files": "test-1.passthru.entries.modules-files",
  "modules-filetypes": "test-2.passthru.entries.modules-filetypes",
  "modules-keymaps": "test-2.passthru.entries.modules-keymaps",
  "modules-lua-loader": "test-2.passthru.entries.modules-lua-loader",
  "modules-options": "test-2.passthru.entries.modules-options",
  "plugins-bufferlines-barbar": "test-3.passthru.entries.plugins-bufferlines-barbar",
  "plugins-bufferlines-bufferline": "test-3.passthru.entries.plugins-bufferlines-bufferline",
  "plugins-colorschemes-base16": "test-3.passthru.entries.plugins-colorschemes-base16",
  "plugins-colorschemes-catppuccin": "test-3.passthru.entries.plugins-colorschemes-catppuccin",
}
```


I _think_ doing this via `passthru` avoids IFD, but I'm unsure how much cost this has added to evaluating/building the devshell.

> [!Note]
> When using the `tests` command, you should no-longer pass a `"test-"` prefix.
> I figured the prefix was redundant in the context of `passthru.entries`.
