### PR TITLE
tests: move `tests.dontRun` to a module option

### DIFF
--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -10,7 +10,7 @@
       { pkgs, config, ... }:
       import ../lib {
         inherit pkgs lib;
-        inherit (config.legacyPackages) makeNixvim makeNixvimWithModule;
+        inherit (config.legacyPackages) makeNixvimWithModule;
       }
     )
   );

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,13 +1,13 @@
 # Args probably only needs pkgs and lib
 {
-  makeNixvim,
   makeNixvimWithModule,
   pkgs,
+  lib ? pkgs.lib,
   _nixvimTests ? false,
   ...
 }@args:
 {
   # Add all exported modules here
-  check = import ../tests/test-derivation.nix { inherit makeNixvim makeNixvimWithModule pkgs; };
+  check = import ../tests/test-derivation.nix { inherit makeNixvimWithModule lib pkgs; };
   helpers = import ./helpers.nix (args // { inherit _nixvimTests; });
 }

--- a/modules/top-level/default.nix
+++ b/modules/top-level/default.nix
@@ -8,5 +8,6 @@
     ../.
     ./files
     ./output.nix
+    ./test.nix
   ];
 }

--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+{
+  options.test = {
+    runNvim = lib.mkOption {
+      type = lib.types.bool;
+      description = "Whether to run `nvim` in the test.";
+      default = true;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -43,16 +43,7 @@ lib.pipe (testFiles ++ [ exampleFiles ]) [
     let
       # The test case can either be the actual definition,
       # or a child attr named `module`.
-      prepareModule =
-        case: if lib.isFunction case then case else case.module or (lib.removeAttrs case [ "tests" ]);
-
-      # Convert legacy `dontRun` definitions into `test.runNvim` option defs
-      dontRunModule =
-        case:
-        let
-          dontRun = case.tests.dontRun or false;
-        in
-        lib.optionalAttrs dontRun { test.runNvim = false; };
+      prepareModule = case: if lib.isFunction case then case else case.module or case;
 
       mkTest =
         { name, case }:
@@ -60,12 +51,7 @@ lib.pipe (testFiles ++ [ exampleFiles ]) [
           inherit name;
           path = mkTestDerivationFromNixvimModule {
             inherit name;
-            module = {
-              imports = [
-                (dontRunModule case)
-                (prepareModule case)
-              ];
-            };
+            module = prepareModule case;
             pkgs = pkgsUnfree;
           };
         };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -25,7 +25,7 @@ let
       [
         {
           name = "main";
-          case = builtins.removeAttrs config.programs.nixvim [
+          module = builtins.removeAttrs config.programs.nixvim [
             # This is not available to standalone modules, only HM & NixOS Modules
             "enable"
             # This is purely an example, it does not reflect a real usage
@@ -41,17 +41,12 @@ lib.pipe (testFiles ++ [ exampleFiles ]) [
   (builtins.map (
     file:
     let
-      # The test case can either be the actual definition,
-      # or a child attr named `module`.
-      prepareModule = case: if lib.isFunction case then case else case.module or case;
-
       mkTest =
-        { name, case }:
+        { name, module }:
         {
           inherit name;
           path = mkTestDerivationFromNixvimModule {
-            inherit name;
-            module = prepareModule case;
+            inherit name module;
             pkgs = pkgsUnfree;
           };
         };

--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -64,7 +64,7 @@ let
     { namespace, cases }:
     {
       name = lib.strings.concatStringsSep "-" namespace;
-      cases = lib.mapAttrsToList (name: case: { inherit case name; }) cases;
+      cases = lib.mapAttrsToList (name: module: { inherit module name; }) cases;
     };
 in
 # A list of the form [ { name = "..."; modules = [ /* test cases */ ]; } ]

--- a/tests/test-sources/extended-lib.nix
+++ b/tests/test-sources/extended-lib.nix
@@ -15,9 +15,7 @@ let
     };
 in
 {
-  top-level = {
-    inherit module;
-  };
+  top-level = module;
 
   files-module = {
     files."libtest.lua" = module;

--- a/tests/test-sources/modules/filetypes.nix
+++ b/tests/test-sources/modules/filetypes.nix
@@ -39,7 +39,7 @@
     };
   };
 
-  default-empty.module =
+  default-empty =
     { config, ... }:
     {
       files.test = { };

--- a/tests/test-sources/modules/lua-loader.nix
+++ b/tests/test-sources/modules/lua-loader.nix
@@ -1,6 +1,6 @@
 {
   # Test that nothing is configured by default
-  default.module =
+  default =
     { config, lib, ... }:
     {
       files."files_test.lua" = { };
@@ -18,7 +18,7 @@
     };
 
   # Test Lua loader enabled
-  enabled.module =
+  enabled =
     { config, lib, ... }:
     {
       luaLoader.enable = true;
@@ -38,7 +38,7 @@
     };
 
   # Test Lua loader disabled
-  disabled.module =
+  disabled =
     { config, lib, ... }:
     {
       luaLoader.enable = false;

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -6,7 +6,7 @@
   };
 
   # Test that all extraConfigs are present in output
-  all-configs.module =
+  all-configs =
     {
       config,
       pkgs,
@@ -64,7 +64,7 @@
         ++ mkConfigAssertions "test.vim" config.files."test.vim".content;
     };
 
-  files-default-empty.module =
+  files-default-empty =
     { config, helpers, ... }:
     {
       files = {

--- a/tests/test-sources/modules/performance/byte-compile-lua.nix
+++ b/tests/test-sources/modules/performance/byte-compile-lua.nix
@@ -24,7 +24,7 @@ let
   '';
 in
 {
-  default.module =
+  default =
     { config, ... }:
     {
       performance.byteCompileLua.enable = true;
@@ -107,7 +107,7 @@ in
 
     };
 
-  disabled.module =
+  disabled =
     { config, ... }:
     {
       performance.byteCompileLua.enable = false;

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -9,7 +9,7 @@ let
 in
 {
   # Test basic functionality
-  default.module =
+  default =
     { config, ... }:
     {
       performance.combinePlugins.enable = true;
@@ -40,7 +40,7 @@ in
     };
 
   # Test disabled option
-  disabled.module =
+  disabled =
     { config, ... }:
     {
       performance.combinePlugins.enable = false;
@@ -57,7 +57,7 @@ in
     };
 
   # Test that plugin dependencies are handled
-  dependencies.module =
+  dependencies =
     { config, ... }:
     {
       performance.combinePlugins.enable = true;
@@ -84,7 +84,7 @@ in
     };
 
   # Test that pathsToLink option works
-  paths-to-link.module =
+  paths-to-link =
     { config, ... }:
     {
       performance.combinePlugins = {
@@ -112,7 +112,7 @@ in
     };
 
   # Test that plugin python3 dependencies are handled
-  python-dependencies.module =
+  python-dependencies =
     { config, ... }:
     {
       performance.combinePlugins.enable = true;
@@ -139,7 +139,7 @@ in
     };
 
   # Test that optional plugins are handled
-  optional-plugins.module =
+  optional-plugins =
     { config, ... }:
     {
       performance.combinePlugins.enable = true;
@@ -197,7 +197,7 @@ in
     };
 
   # Test that plugin configs are handled
-  configs.module =
+  configs =
     { config, ... }:
     {
       performance.combinePlugins.enable = true;
@@ -240,7 +240,7 @@ in
     };
 
   # Test that config.filesPlugin is not combined
-  files-plugin.module =
+  files-plugin =
     { config, ... }:
     {
       performance.combinePlugins.enable = true;
@@ -310,7 +310,7 @@ in
     };
 
   # Test that standalonePlugins option works
-  standalone-plugins.module =
+  standalone-plugins =
     { config, ... }:
     {
       performance.combinePlugins = {

--- a/tests/test-sources/plugins/ai/chatgpt.nix
+++ b/tests/test-sources/plugins/ai/chatgpt.nix
@@ -1,12 +1,12 @@
 # We cannot run the test as loading the plugin requires a valid OPENAI_API_KEY
 {
   empty = {
-    tests.dontRun = true;
+    test.runNvim = false;
     plugins.chatgpt.enable = true;
   };
 
   defaults = {
-    tests.dontRun = true;
+    test.runNvim = false;
     plugins.chatgpt = {
       enable = true;
 
@@ -198,7 +198,7 @@
   };
 
   example = {
-    tests.dontRun = true;
+    test.runNvim = false;
     plugins.chatgpt = {
       enable = true;
 

--- a/tests/test-sources/plugins/completion/cmp-ai.nix
+++ b/tests/test-sources/plugins/completion/cmp-ai.nix
@@ -1,7 +1,7 @@
 {
   empty = {
     # We do not provide the required HF_API_KEY environment variable.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.cmp = {
       enable = true;
@@ -11,7 +11,7 @@
 
   example = {
     # We do not provide the required HF_API_KEY environment variable.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins = {
       cmp = {

--- a/tests/test-sources/plugins/completion/cmp-all-sources.nix
+++ b/tests/test-sources/plugins/completion/cmp-all-sources.nix
@@ -1,41 +1,39 @@
 { pkgs, ... }:
 {
-  all-sources = {
-    module =
-      { config, ... }:
-      {
-        plugins = {
-          copilot-lua = {
-            enable = true;
+  all-sources =
+    { config, ... }:
+    {
+      plugins = {
+        copilot-lua = {
+          enable = true;
 
-            panel.enabled = false;
-            suggestion.enabled = false;
-          };
+          panel.enabled = false;
+          suggestion.enabled = false;
+        };
 
-          cmp = {
-            enable = true;
-            settings.sources =
-              with pkgs.lib;
-              let
-                disabledSources = [
-                  # We do not provide the required HF_API_KEY environment variable.
-                  "cmp_ai"
-                  # Triggers the warning complaining about treesitter highlighting being disabled
-                  "otter"
-                ] ++ optional (pkgs.stdenv.hostPlatform.system == "aarch64-linux") "cmp_tabnine";
-              in
-              pipe config.cmpSourcePlugins [
-                # All known source names
-                attrNames
-                # Filter out disabled sources
-                (filter (name: !(elem name disabledSources)))
-                # Convert names to source attributes
-                (map (name: {
-                  inherit name;
-                }))
-              ];
-          };
+        cmp = {
+          enable = true;
+          settings.sources =
+            with pkgs.lib;
+            let
+              disabledSources = [
+                # We do not provide the required HF_API_KEY environment variable.
+                "cmp_ai"
+                # Triggers the warning complaining about treesitter highlighting being disabled
+                "otter"
+              ] ++ optional (pkgs.stdenv.hostPlatform.system == "aarch64-linux") "cmp_tabnine";
+            in
+            pipe config.cmpSourcePlugins [
+              # All known source names
+              attrNames
+              # Filter out disabled sources
+              (filter (name: !(elem name disabledSources)))
+              # Convert names to source attributes
+              (map (name: {
+                inherit name;
+              }))
+            ];
         };
       };
-  };
+    };
 }

--- a/tests/test-sources/plugins/completion/codeium-vim.nix
+++ b/tests/test-sources/plugins/completion/codeium-vim.nix
@@ -1,14 +1,14 @@
 {
   empty = {
     # For some reason, nvim hangs when using codeium-vim. After checking, it doesn't look like a bug though.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.codeium-vim.enable = true;
   };
 
   example = {
     # For some reason, nvim hangs when using codeium-vim. After checking, it doesn't look like a bug though.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.codeium-vim = {
       enable = true;

--- a/tests/test-sources/plugins/completion/coq.nix
+++ b/tests/test-sources/plugins/completion/coq.nix
@@ -3,23 +3,21 @@
     plugins.coq-nvim.enable = true;
   };
 
-  nixvim-defaults = {
-    module =
-      { pkgs, ... }:
-      {
-        plugins.coq-nvim = {
-          # It seems that the plugin has issues being executed in the same derivation
-          enable = !(pkgs.stdenv.isDarwin && pkgs.stdenv.isx86_64);
+  nixvim-defaults =
+    { pkgs, ... }:
+    {
+      plugins.coq-nvim = {
+        # It seems that the plugin has issues being executed in the same derivation
+        enable = !(pkgs.stdenv.isDarwin && pkgs.stdenv.isx86_64);
 
-          settings = {
-            xdg = true;
-            auto_start = true;
-            keymap.recommended = true;
-            completion.always = true;
-          };
+        settings = {
+          xdg = true;
+          auto_start = true;
+          keymap.recommended = true;
+          completion.always = true;
         };
       };
-  };
+    };
 
   artifacts = {
     plugins.coq-nvim = {

--- a/tests/test-sources/plugins/git/octo.nix
+++ b/tests/test-sources/plugins/git/octo.nix
@@ -1,14 +1,14 @@
 {
   empty = {
     # This test is flaky and fails non-deterministically
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.octo.enable = true;
   };
 
   example = {
     # This test is flaky and fails non-deterministically
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.octo = {
       enable = true;
@@ -28,7 +28,7 @@
 
   withFzfLuaPicker = {
     # This test is flaky and fails non-deterministically
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.octo = {
       enable = true;
@@ -38,7 +38,7 @@
 
   defaults = {
     # This test is flaky and fails non-deterministically
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.octo = {
       enable = true;

--- a/tests/test-sources/plugins/languages/treesitter/treesitter.nix
+++ b/tests/test-sources/plugins/languages/treesitter/treesitter.nix
@@ -83,7 +83,7 @@
 
   no-nix = {
     # TODO: See if we can build parsers (legacy way)
-    tests.dontRun = true;
+    test.runNvim = false;
     plugins.treesitter = {
       enable = true;
       nixGrammars = false;

--- a/tests/test-sources/plugins/neotest/gtest.nix
+++ b/tests/test-sources/plugins/neotest/gtest.nix
@@ -2,7 +2,7 @@
   example = {
     # We cannot test neotest-gtest as it tries to create file in the upper directory
     # https://github.com/alfaix/neotest-gtest/blob/6e794ac91f4c347e2ea5ddeb23d594f8fc64f2a8/lua/neotest-gtest/utils.lua#L10-L16
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins = {
       treesitter.enable = true;

--- a/tests/test-sources/plugins/none-ls.nix
+++ b/tests/test-sources/plugins/none-ls.nix
@@ -98,71 +98,69 @@
     };
   };
 
-  with-sources = {
-    module =
-      {
-        config,
-        options,
-        lib,
-        pkgs,
-        ...
-      }:
-      {
-        plugins.none-ls = {
-          # sandbox-exec: pattern serialization length 159032 exceeds maximum (65535)
-          enable = !pkgs.stdenv.isDarwin;
+  with-sources =
+    {
+      config,
+      options,
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      plugins.none-ls = {
+        # sandbox-exec: pattern serialization length 159032 exceeds maximum (65535)
+        enable = !pkgs.stdenv.isDarwin;
 
-          sources =
-            let
-              disabled =
-                [
-                  # As of 2024-03-22, pkgs.d2 is broken
-                  # TODO: re-enable this test when fixed
-                  "d2_fmt"
-                  # TODO: can this be re-enabled?
-                  "yamlfix"
-                ]
-                ++ (lib.optionals (pkgs.stdenv.isDarwin && pkgs.stdenv.isx86_64) [
-                  # As of 2024-03-27, pkgs.graalvm-ce (a dependency of pkgs.clj-kondo) is broken on x86_64-darwin
-                  # TODO: re-enable this test when fixed
-                  "clj_kondo"
-                ])
-                ++ (lib.optionals pkgs.stdenv.isDarwin [
-                  # As of 2024-05-22, python311Packages.k5test (one of ansible-lint's dependenvies) is broken on darwin
-                  # TODO: re-enable this test when fixed
-                  "ansible_lint"
-                  "clazy"
-                  "gdformat"
-                  "gdlint"
-                  "haml_lint"
-                  # As of 2024-06-29, pkgs.rubyfmt is broken on darwin
-                  # TODO: re-enable this test when fixed
-                  "rubyfmt"
-                  "verilator"
-                  "verible_verilog_format"
-                ])
-                ++ (lib.optionals pkgs.stdenv.isAarch64 [
-                  "semgrep"
-                  "smlfmt"
-                  # As of 2024-03-11, swift-format is broken on aarch64
-                  # TODO: re-enable this test when fixed
-                  "swift_format"
-                ]);
-            in
-            # Enable every none-ls source that has an option
+        sources =
+          let
+            disabled =
+              [
+                # As of 2024-03-22, pkgs.d2 is broken
+                # TODO: re-enable this test when fixed
+                "d2_fmt"
+                # TODO: can this be re-enabled?
+                "yamlfix"
+              ]
+              ++ (lib.optionals (pkgs.stdenv.isDarwin && pkgs.stdenv.isx86_64) [
+                # As of 2024-03-27, pkgs.graalvm-ce (a dependency of pkgs.clj-kondo) is broken on x86_64-darwin
+                # TODO: re-enable this test when fixed
+                "clj_kondo"
+              ])
+              ++ (lib.optionals pkgs.stdenv.isDarwin [
+                # As of 2024-05-22, python311Packages.k5test (one of ansible-lint's dependenvies) is broken on darwin
+                # TODO: re-enable this test when fixed
+                "ansible_lint"
+                "clazy"
+                "gdformat"
+                "gdlint"
+                "haml_lint"
+                # As of 2024-06-29, pkgs.rubyfmt is broken on darwin
+                # TODO: re-enable this test when fixed
+                "rubyfmt"
+                "verilator"
+                "verible_verilog_format"
+              ])
+              ++ (lib.optionals pkgs.stdenv.isAarch64 [
+                "semgrep"
+                "smlfmt"
+                # As of 2024-03-11, swift-format is broken on aarch64
+                # TODO: re-enable this test when fixed
+                "swift_format"
+              ]);
+          in
+          # Enable every none-ls source that has an option
+          lib.mapAttrs (
+            _:
             lib.mapAttrs (
-              _:
-              lib.mapAttrs (
-                sourceName: opts:
-                {
-                  # Enable unless disabled above
-                  enable = !(lib.elem sourceName disabled);
-                }
-                # Some sources have a package option with no default
-                // lib.optionalAttrs (opts ? package && !(opts.package ? default)) { package = null; }
-              )
-            ) options.plugins.none-ls.sources;
-        };
+              sourceName: opts:
+              {
+                # Enable unless disabled above
+                enable = !(lib.elem sourceName disabled);
+              }
+              # Some sources have a package option with no default
+              // lib.optionalAttrs (opts ? package && !(opts.package ? default)) { package = null; }
+            )
+          ) options.plugins.none-ls.sources;
       };
-  };
+    };
 }

--- a/tests/test-sources/plugins/pluginmanagers/lz-n.nix
+++ b/tests/test-sources/plugins/pluginmanagers/lz-n.nix
@@ -26,145 +26,141 @@ in
   };
 
   # single-plugin and priority of plugins.lz-n.settings to globals.lz-n
-  example-single-plugin = {
-    module =
-      { pkgs, lib, ... }:
-      {
-        extraPlugins = optionalPlugins [ pkgs.vimPlugins.neo-tree-nvim ];
+  example-single-plugin =
+    { pkgs, lib, ... }:
+    {
+      extraPlugins = optionalPlugins [ pkgs.vimPlugins.neo-tree-nvim ];
 
-        plugins.lz-n = {
-          enable = true;
-          settings = {
-            load = lib.mkDefault "vim.cmd.packadd";
-          };
-          plugins = [
-            # enabled, on keys as rawLua
-            {
-              __unkeyed-1 = "neo-tree.nvim";
-              enabled = ''
-                function()
-                return true
-                end
-              '';
-              keys = [
-                {
-                  __unkeyed-1 = "<leader>ft";
-                  __unkeyed-2 = "<CMD>Neotree toggle<CR>";
-                  desc = "NeoTree toggle";
-                }
-              ];
-              after = # lua
-                ''
-                  function()
-                    require("neo-tree").setup()
-                  end
-                '';
-            }
-          ];
+      plugins.lz-n = {
+        enable = true;
+        settings = {
+          load = lib.mkDefault "vim.cmd.packadd";
         };
-      };
-  };
-
-  example-multiple-plugin = {
-    module =
-      { pkgs, lib, ... }:
-      {
-        extraPlugins =
-          with pkgs.vimPlugins;
-          [ onedarker-nvim ]
-          ++ (optionalPlugins [
-            neo-tree-nvim
-            dial-nvim
-            vimtex
-            telescope-nvim
-            nvim-biscuits
-            crates-nvim
-          ]);
-
-        plugins.treesitter.enable = true;
-
-        plugins.lz-n = {
-          enable = true;
-          plugins = [
-            # enabled, on keys
-            {
-              __unkeyed-1 = "neo-tree.nvim";
-              enabled = ''
+        plugins = [
+          # enabled, on keys as rawLua
+          {
+            __unkeyed-1 = "neo-tree.nvim";
+            enabled = ''
+              function()
+              return true
+              end
+            '';
+            keys = [
+              {
+                __unkeyed-1 = "<leader>ft";
+                __unkeyed-2 = "<CMD>Neotree toggle<CR>";
+                desc = "NeoTree toggle";
+              }
+            ];
+            after = # lua
+              ''
                 function()
-                return true
+                  require("neo-tree").setup()
                 end
               '';
-              keys = [
-                {
-                  __unkeyed-1 = "<leader>ft";
-                  __unkeyed-2 = "<CMD>Neotree toggle<CR>";
-                  desc = "NeoTree toggle";
-                }
-              ];
-              after = # lua
-                ''
-                  function()
-                    require("neo-tree").setup()
-                  end
-                '';
-            }
-            # on keys as list of str and rawLua
-            {
-              __unkeyed-1 = "dial.nvim";
-              keys = [
-                "<C-a>"
-                { __raw = "{ '<C-x>'; mode = 'n' }"; }
-              ];
-            }
-            # beforeAll, before, on filetype
-            {
-              __unkeyed-1 = "vimtex";
-              ft = [ "plaintex" ];
-              beforeAll = # lua
-                ''
-                  function()
-                    vim.g.vimtex_compiler_method = "latexrun"
-                  end
-                '';
-              before = # lua
-                ''
-                  function()
-                    vim.g.vimtex_compiler_method = "latexmk"
-                  end
-                '';
-            }
-            # On event
-            {
-              __unkeyed-1 = "nvim-biscuits";
-              event.__raw = "{ 'BufEnter *.lua' }";
-              after.__raw = ''
+          }
+        ];
+      };
+    };
+
+  example-multiple-plugin =
+    { pkgs, lib, ... }:
+    {
+      extraPlugins =
+        with pkgs.vimPlugins;
+        [ onedarker-nvim ]
+        ++ (optionalPlugins [
+          neo-tree-nvim
+          dial-nvim
+          vimtex
+          telescope-nvim
+          nvim-biscuits
+          crates-nvim
+        ]);
+
+      plugins.treesitter.enable = true;
+
+      plugins.lz-n = {
+        enable = true;
+        plugins = [
+          # enabled, on keys
+          {
+            __unkeyed-1 = "neo-tree.nvim";
+            enabled = ''
+              function()
+              return true
+              end
+            '';
+            keys = [
+              {
+                __unkeyed-1 = "<leader>ft";
+                __unkeyed-2 = "<CMD>Neotree toggle<CR>";
+                desc = "NeoTree toggle";
+              }
+            ];
+            after = # lua
+              ''
                 function()
-                require('nvim-biscuits').setup({})
+                  require("neo-tree").setup()
                 end
               '';
-            }
-            # On command no setup function, priority
-            {
-              __unkeyed-1 = "telescope.nvim";
-              cmd = [ "Telescope" ];
-              priority = 500;
-            }
-            # On colorschme
-            {
-              __unkeyed-1 = "onedarker.nvim";
-              colorscheme = [ "onedarker" ];
-            }
-            # raw value
-            {
-              __raw = ''
-                {
-                    "crates.nvim",
-                    ft = "toml",
-                }
+          }
+          # on keys as list of str and rawLua
+          {
+            __unkeyed-1 = "dial.nvim";
+            keys = [
+              "<C-a>"
+              { __raw = "{ '<C-x>'; mode = 'n' }"; }
+            ];
+          }
+          # beforeAll, before, on filetype
+          {
+            __unkeyed-1 = "vimtex";
+            ft = [ "plaintex" ];
+            beforeAll = # lua
+              ''
+                function()
+                  vim.g.vimtex_compiler_method = "latexrun"
+                end
               '';
-            }
-          ];
-        };
+            before = # lua
+              ''
+                function()
+                  vim.g.vimtex_compiler_method = "latexmk"
+                end
+              '';
+          }
+          # On event
+          {
+            __unkeyed-1 = "nvim-biscuits";
+            event.__raw = "{ 'BufEnter *.lua' }";
+            after.__raw = ''
+              function()
+              require('nvim-biscuits').setup({})
+              end
+            '';
+          }
+          # On command no setup function, priority
+          {
+            __unkeyed-1 = "telescope.nvim";
+            cmd = [ "Telescope" ];
+            priority = 500;
+          }
+          # On colorschme
+          {
+            __unkeyed-1 = "onedarker.nvim";
+            colorscheme = [ "onedarker" ];
+          }
+          # raw value
+          {
+            __raw = ''
+              {
+                  "crates.nvim",
+                  ft = "toml",
+              }
+            '';
+          }
+        ];
       };
-  };
+    };
 }

--- a/tests/test-sources/plugins/telescope/default.nix
+++ b/tests/test-sources/plugins/telescope/default.nix
@@ -18,18 +18,16 @@
     };
   };
 
-  combine-plugins.module =
-    { config, ... }:
-    {
-      plugins.telescope.enable = true;
+  combine-plugins = {
+    plugins.telescope.enable = true;
 
-      performance.combinePlugins.enable = true;
+    performance.combinePlugins.enable = true;
 
-      extraConfigLuaPost = # lua
-        ''
-          -- I don't know how run telescope properly in test environment,
-          -- so just check that files exist
-          assert(vim.api.nvim_get_runtime_file("data/memes/planets/earth", false)[1], "telescope planets aren't found in runtime")
-        '';
-    };
+    extraConfigLuaPost = # lua
+      ''
+        -- I don't know how run telescope properly in test environment,
+        -- so just check that files exist
+        assert(vim.api.nvim_get_runtime_file("data/memes/planets/earth", false)[1], "telescope planets aren't found in runtime")
+      '';
+  };
 }

--- a/tests/test-sources/plugins/telescope/frecency.nix
+++ b/tests/test-sources/plugins/telescope/frecency.nix
@@ -1,7 +1,7 @@
 {
   empty = {
     # A warning is displayed on stdout
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.telescope = {
       enable = true;
@@ -11,7 +11,7 @@
 
   defaults = {
     # A warning is displayed on stdout
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.telescope = {
       enable = true;
@@ -46,7 +46,7 @@
 
   example = {
     # A warning is displayed on stdout
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.telescope = {
       enable = true;

--- a/tests/test-sources/plugins/ui/image.nix
+++ b/tests/test-sources/plugins/ui/image.nix
@@ -2,7 +2,7 @@
   empty = {
     # At runtime, the plugin tries to get the size of the terminal which doesn't exist in the
     # headless environment.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.image.enable = true;
   };
@@ -10,7 +10,7 @@
   defaults = {
     # At runtime, the plugin tries to get the size of the terminal which doesn't exist in the
     # headless environment.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.image = {
       enable = true;
@@ -67,7 +67,7 @@
   ueberzug-backend = {
     # At runtime, the plugin tries to get the size of the terminal which doesn't exist in the
     # headless environment.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.image = {
       enable = true;

--- a/tests/test-sources/plugins/utils/firenvim.nix
+++ b/tests/test-sources/plugins/utils/firenvim.nix
@@ -26,7 +26,7 @@
     };
   };
 
-  check-alias.module =
+  check-alias =
     { config, ... }:
     {
       assertions = [

--- a/tests/test-sources/plugins/utils/harpoon.nix
+++ b/tests/test-sources/plugins/utils/harpoon.nix
@@ -2,7 +2,7 @@
   empty = {
     # Harpoon expects to access `~/.local/share/nvim/harpoon.json` which is not available in the
     # test environment
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.harpoon.enable = true;
   };
@@ -10,7 +10,7 @@
   telescopeEnabled = {
     # Harpoon expects to access `~/.local/share/nvim/harpoon.json` which is not available in the
     # test environment
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.telescope = {
       enable = true;
@@ -75,7 +75,7 @@
   telescopeDisabled = {
     # Harpoon expects to access `~/.local/share/nvim/harpoon.json` which is not available in the
     # test environment
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.harpoon = {
       enable = true;

--- a/tests/test-sources/plugins/utils/neocord.nix
+++ b/tests/test-sources/plugins/utils/neocord.nix
@@ -1,13 +1,13 @@
 {
   empty = {
     # don't run tests as they try to access the network.
-    tests.dontRun = true;
+    test.runNvim = false;
     plugins.neocord.enable = true;
   };
 
   defaults = {
     # don't run tests as they try to access the network.
-    tests.dontRun = true;
+    test.runNvim = false;
     plugins.neocord = {
       enable = true;
 
@@ -39,7 +39,7 @@
 
   example = {
     # don't run tests as they try to access the network.
-    tests.dontRun = true;
+    test.runNvim = false;
     plugins.neocord = {
       enable = true;
 

--- a/tests/test-sources/plugins/utils/neorg.nix
+++ b/tests/test-sources/plugins/utils/neorg.nix
@@ -3,7 +3,7 @@
     # neorg should be re-packaged in nixpkgs from the luarocks `neorg` package.
     # In the meantime, disable the test.
     # TODO: re-enable when this will have been fixed upstream.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.neorg.enable = true;
   };
@@ -12,7 +12,7 @@
     # neorg should be re-packaged in nixpkgs from the luarocks `neorg` package.
     # In the meantime, disable the test.
     # TODO: re-enable when this will have been fixed upstream.
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins = {
       # Treesitter is required when using the "core.defaults" module.

--- a/tests/test-sources/plugins/utils/rest.nix
+++ b/tests/test-sources/plugins/utils/rest.nix
@@ -3,7 +3,7 @@
     # As of 2024-05-07, the lua dependencies of luaPackage.rest-nvim are not correctly propagated to
     # the vim plugin.
     # TODO: re-enable this test when this issue will have been fixed
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.rest.enable = true;
   };
@@ -12,7 +12,7 @@
     # As of 2024-05-07, the lua dependencies of luaPackage.rest-nvim are not correctly propagated to
     # the vim plugin.
     # TODO: re-enable this test when this issue will have been fixed
-    tests.dontRun = true;
+    test.runNvim = false;
 
     plugins.rest = {
       enable = true;


### PR DESCRIPTION
## Context
Historically, we've had a special `.tests` attr in test-cases that was removed before evaluating the test-case as a module.

This made defining function-modules awkward, because we can't use `removeAttrs` on a function. We either had to use `isFunction`, `isAttrs` or provide an alternative way to define function-modules; we went with defining function modules as `.module`.

This PR enables us to clean all of this up, by replacing the `tests` attr with a new `test` option set that _is_ evaluated by the module system.

## Overview
Introduces the `test` top-level module, for configuring nixvim test cases.

Replaces the `tests.dontRun` attr used in tests previously with a new `test.runNvim` option.

This further allows us to drop the special handling of attr/function modules and just treat _all_ test cases as modules.

## Deprecation
Deprecates the `dontRun` argument, historically passed to the test-derivation helpers (`mkTestDerivationFromNvim` and `mkTestDerivationFromNixvimModule`).

This is no longer used internally, but may be used by downstream (user) code. I've used `lib.warn` to recommend users use the new module option instead.

## Looking forward
In the future the `test` option-set could be used to define "expectations" such as _"XYZ assertion should be true"_ or _"a warning matching `regex` should be set"_. We may also consider building the test derivation as an output option (`config.test.derivation`?), instead of directing users to use separate helper functions.

## Review notes
Based on work started in #1989, which should simplify that PR once rebased.

NOTE: the vast majority of work in this PR is done in `modules/top-level/test.nix`, `tests/default.nix` and `tests/test-derivation.nix`; all changes in `tests/test-sources` are purely migration to the new system.
