### PR TITLE
tests: replace `helpers.enableExceptInTests` with module option

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,11 +3,10 @@
   makeNixvimWithModule,
   pkgs,
   lib ? pkgs.lib,
-  _nixvimTests ? false,
   ...
 }@args:
 {
   # Add all exported modules here
   check = import ../tests/test-derivation.nix { inherit makeNixvimWithModule lib pkgs; };
-  helpers = import ./helpers.nix (args // { inherit _nixvimTests; });
+  helpers = import ./helpers.nix { inherit pkgs lib; };
 }

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   lib ? pkgs.lib,
-  _nixvimTests ? false,
   ...
 }:
 let
@@ -24,7 +23,7 @@ let
     neovim-plugin = call ./neovim-plugin.nix { };
     nixvimTypes = call ./types.nix { };
     options = call ./options.nix { };
-    utils = call ./utils.nix { inherit _nixvimTests; };
+    utils = call ./utils.nix { };
     vim-plugin = call ./vim-plugin.nix { };
 
     # Top-level helper aliases:
@@ -70,7 +69,6 @@ let
     inherit (helpers.utils)
       concatNonEmptyLines
       emptyTable
-      enableExceptInTests
       groupListBySize
       hasContent
       ifNonNull'
@@ -94,6 +92,9 @@ let
 
     toLuaObject = helpers.lua.toLua;
     mkLuaInline = helpers.lua.mkInline;
+
+    # TODO: Removed 2024-08-20
+    enableExceptInTests = throw "enableExceptInTests has been removed, please use the `isTest` module option instead.";
   };
 in
 helpers

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  _nixvimTests,
-}:
+{ lib, helpers }:
 with lib;
 rec {
   # Whether a string contains something other than whitespaces
@@ -15,8 +11,6 @@ rec {
   listToUnkeyedAttrs =
     list:
     builtins.listToAttrs (lib.lists.imap0 (idx: lib.nameValuePair "__unkeyed-${toString idx}") list);
-
-  enableExceptInTests = !_nixvimTests;
 
   emptyTable = {
     "__empty" = null;

--- a/modules/misc/context.nix
+++ b/modules/misc/context.nix
@@ -10,5 +10,14 @@
       internal = true;
       visible = false;
     };
+    isTest = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether modules are being evaluated to build a test.
+      '';
+      internal = true;
+      visible = false;
+    };
   };
 }

--- a/tests/enable-except-in-tests.nix
+++ b/tests/enable-except-in-tests.nix
@@ -5,9 +5,9 @@
 }:
 let
   module =
-    { helpers, ... }:
+    { config, ... }:
     {
-      plugins.image.enable = helpers.enableExceptInTests;
+      plugins.image.enable = !config.isTest;
     };
 
   inTest = mkTestDerivationFromNixvimModule {

--- a/tests/test-derivation.nix
+++ b/tests/test-derivation.nix
@@ -16,7 +16,8 @@ let
       ...
     }@args:
     let
-      cfg = nvim.config.test;
+      result = nvim.extend { isTest = true; };
+      cfg = result.config.test;
       runNvim =
         lib.warnIf (args ? dontRun)
           "mkTestDerivationFromNvim: the `dontRun` argument is deprecated. You should use the `test.runNvim` module option instead."
@@ -26,7 +27,7 @@ let
       inherit name;
 
       nativeBuildInputs = [
-        nvim
+        result
         pkgs.docker-client
       ];
 
@@ -65,7 +66,6 @@ let
     let
       nvim = makeNixvimWithModule {
         inherit pkgs extraSpecialArgs;
-        _nixvimTests = true;
         module =
           if args ? dontRun then
             lib.warn

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -3,11 +3,10 @@ default_pkgs: self:
   pkgs ? default_pkgs,
   lib ? pkgs.lib,
   extraSpecialArgs ? { },
-  _nixvimTests ? false,
   module,
 }:
 let
-  helpers = import ../lib/helpers.nix { inherit pkgs lib _nixvimTests; };
+  helpers = import ../lib/helpers.nix { inherit pkgs lib; };
 
   inherit (helpers.modules) specialArgsWith;
 


### PR DESCRIPTION
As discussed on matrix, the current `helpers.enableExceptInTests` is problematic for a couple reasons:
- It only works with `mkTestDerivationFromNixvimModule`, not `mkTestDerivationFromNvim`
- We need to tell `helpers` whether or not it'll be used for tests

This resolves those, however it has its own issues:
- `mkTestDerivationFromNvim` effectively evaluates the modules twice (once before being called, then again internally)
- If #1989 is merged, users can bypass the test helpers and access `config.test.derivation` directly _anyway_
- `enableExceptInTests` is removed immediately, with no grace period for the deprecation

I wonder if it'd be better to not provide any direct support for distinguishing between test/non-test contexts?

Or perhaps we should double down on the `evalNixvimTest` function proposed in #1989's description and use that to set the context?
