### PR TITLE
modules/test: check warnings/assertions

### DIFF
--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -62,6 +62,9 @@ let
         extraSpecialArgs = {
           defaultPkgs = pkgs;
         } // extraSpecialArgs;
+        # Don't check assertions/warnings while evaluating nixvim config
+        # We'll let the test derivation handle that
+        check = false;
       };
     in
     result.config.test.derivation;

--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -6,6 +6,9 @@
 }:
 let
   cfg = config.test;
+
+  inherit (config) warnings;
+  assertions = lib.nixvim.modules.getAssertionMessages config.assertions;
 in
 {
   options.test = {
@@ -18,6 +21,18 @@ in
     runNvim = lib.mkOption {
       type = lib.types.bool;
       description = "Whether to run `nvim` in the test.";
+      default = true;
+    };
+
+    checkWarnings = lib.mkOption {
+      type = lib.types.bool;
+      description = "Whether to check `config.warnings` in the test.";
+      default = true;
+    };
+
+    checkAssertions = lib.mkOption {
+      type = lib.types.bool;
+      description = "Whether to check `config.assertions` in the test.";
       default = true;
     };
 
@@ -38,19 +53,42 @@ in
 
       nativeBuildInputs = [ config.finalPackage ];
 
-      # We need to set HOME because neovim will try to create some files
-      #
-      # Because neovim does not return an exitcode when quitting we need to check if there are
-      # errors on stderr
-      buildPhase = lib.optionalString cfg.runNvim ''
-        mkdir -p .cache/nvim
+      # First check warnings/assertions, then run nvim
+      buildPhase =
+        let
+          showErr =
+            name: lines:
+            lib.optionalString (lines != [ ]) ''
+              Unexpected ${name}:
+              ${lib.concatStringsSep "\n" (lib.map (v: "- ${v}") lines)}
+            '';
 
-        output=$(HOME=$(realpath .) nvim -mn --headless "+q" 2>&1 >/dev/null)
-        if [[ -n $output ]]; then
-          echo "ERROR: $output"
+          toCheck =
+            lib.optionalAttrs cfg.checkWarnings { inherit warnings; }
+            // lib.optionalAttrs cfg.checkAssertions { inherit assertions; };
+
+          errors = lib.foldlAttrs (
+            err: name: lines:
+            err + showErr name lines
+          ) "" toCheck;
+        in
+        lib.optionalString (errors != "") ''
+          echo -n ${lib.escapeShellArg errors}
           exit 1
-        fi
-      '';
+        ''
+        # We need to set HOME because neovim will try to create some files
+        #
+        # Because neovim does not return an exitcode when quitting we need to check if there are
+        # errors on stderr
+        + lib.optionalString cfg.runNvim ''
+          mkdir -p .cache/nvim
+
+          output=$(HOME=$(realpath .) nvim -mn --headless "+q" 2>&1 >/dev/null)
+          if [[ -n $output ]]; then
+            echo "ERROR: $output"
+            exit 1
+          fi
+        '';
 
       # If we don't do this nix is not happy
       installPhase = ''

--- a/tests/test-sources/plugins/lsp/schemastore.nix
+++ b/tests/test-sources/plugins/lsp/schemastore.nix
@@ -1,5 +1,8 @@
 {
   empty = {
+    # TODO: remove once json is re-enabled
+    test.checkWarnings = false;
+
     plugins = {
       lsp = {
         enable = true;
@@ -17,6 +20,9 @@
   };
 
   example = {
+    # TODO: remove once json is re-enabled
+    test.checkWarnings = false;
+
     plugins = {
       lsp = {
         enable = true;
@@ -69,6 +75,9 @@
   };
 
   withJson = {
+    # TODO: remove once json is re-enabled
+    test.checkWarnings = false;
+
     plugins = {
       lsp = {
         enable = true;

--- a/tests/test-sources/plugins/utils/nvim-osc52.nix
+++ b/tests/test-sources/plugins/utils/nvim-osc52.nix
@@ -1,10 +1,9 @@
-{ pkgs, ... }:
 {
   empty = {
     plugins.nvim-osc52.enable = true;
 
     # Hide warnings, since this plugin is deprecated
-    warnings = pkgs.lib.mkForce [ ];
+    test.checkWarnings = false;
   };
 
   defaults = {
@@ -22,6 +21,6 @@
     };
 
     # Hide warnings, since this plugin is deprecated
-    warnings = pkgs.lib.mkForce [ ];
+    test.checkWarnings = false;
   };
 }


### PR DESCRIPTION
Extracted from #1989 to reduce its scope. Also based on earlier work from #1986.

This PR moves responsibility for assertions/warnings in tests to the test derivation, instead of printing/throwing them.

They are still printed/thrown when building a non-test nixvim build.

Additionally, two new options are added to control this behaviour. Both default to `true`:
- `test.checkWarnings`: Whether to check `config.warnings` in the test.
- `test.checkAssertions`: Whether to check `config.assertions` in the test.

> [!NOTE]
> Only _module_ warnings/assertions defined using the respective options from `assertions.nix` are checked.
> Anything printed manually with `lib.warn`, `builtins.trace`, etc, or errors thrown with `assert`, `throw`, `abort`, etc _will not_ be handled correctly by the test.
> - Errors would still fail CI; the test would fail before even running
> - Warnings printed manually will just print to the console, bypassing the test

In the future we can expand on this to allow "expecting" assertions, which will make our test system more flexible.