### PR TITLE
plugins/rustaceanvim: fix checkhealth error

### DIFF
--- a/modules/opts.nix
+++ b/modules/opts.nix
@@ -84,6 +84,6 @@ in
           ) optionsAttrs
         );
       in
-      mkIf (content != "") content;
+      mkIf (content != "") (mkOrder 600 content); # Move options to top of file below global table
   };
 }

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -285,12 +285,21 @@ in
         '';
       };
 
-      extraConfigLuaPre = lib.mkIf config.wrapRc ''
-        -- Ignore the user lua configuration
-        vim.opt.runtimepath:remove(vim.fn.stdpath('config'))              -- ~/.config/nvim
-        vim.opt.runtimepath:remove(vim.fn.stdpath('config') .. "/after")  -- ~/.config/nvim/after
-        vim.opt.runtimepath:remove(vim.fn.stdpath('data') .. "/site")     -- ~/.local/share/nvim/site
-      '';
+      extraConfigLuaPre = lib.mkOrder 100 (
+        # Add a global table at start of init
+        ''
+          -- Nixvim's internal module table
+          -- Can be used to share code throughout init.lua
+          local _M = {}
+        ''
+        + lib.optionalString config.wrapRc ''
+
+          -- Ignore the user lua configuration
+          vim.opt.runtimepath:remove(vim.fn.stdpath('config'))              -- ~/.config/nvim
+          vim.opt.runtimepath:remove(vim.fn.stdpath('config') .. "/after")  -- ~/.config/nvim/after
+          vim.opt.runtimepath:remove(vim.fn.stdpath('data') .. "/site")     -- ~/.local/share/nvim/site
+        ''
+      );
 
       extraPlugins = lib.mkIf config.wrapRc [ config.filesPlugin ];
     };

--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -225,7 +225,8 @@ in
           ${cfg.preConfig}
 
           local __lspServers = ${helpers.toLuaObject cfg.enabledServers}
-          local __lspOnAttach = function(client, bufnr)
+          -- Adding lspOnAttach function to nixvim module lua table so other plugins can hook into it.
+          _M.lspOnAttach = function(client, bufnr)
             ${updateCapabilities}
 
             ${cfg.onAttach}
@@ -239,7 +240,7 @@ in
           end
 
           local __setup = ${runWrappers cfg.setupWrappers "{
-            on_attach = __lspOnAttach,
+            on_attach = _M.lspOnAttach,
             capabilities = __lspCapabilities()
           }"}
 


### PR DESCRIPTION
Rustaceanvim will throw an error if the configuration is sourced after initialization. Our globals are defined at the top of the init.lua so moving the settings to leverage the globals option scope. If lsp is is enabled, we append the on_attach function to the config as a callback function so that it can be accessed properly on the global config.

An example of running into this can be had while configuring `plugins.neotest.settings.adapters` for usage with rustaceanvim. The setup involves initializing rustaceanvim before our lsp configuration is configured.
```lua
require('neotest').setup {
    -- ...,
    adapters = {
      -- ...,
      require('rustaceanvim.neotest')
    },
}
```

I am able to just set the mkOrder/mkBefore for the lsp `extraConfigLua` but, it would still be nice to not have to worry about ordering and store the rustaceanvim configuration utilizing our globals option. While working on this approach, I did add a couple commits for setting up the init.lua ordering to make sure we have access to the local module table and unset runtime paths immediately, followed by the options so that all other configurations can benefit from those variables. 