### PR TITLE
tests/plugins/lsp: re-enable tests

### DIFF
--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -117,9 +117,7 @@
             clojure-lsp.enable = true;
             cmake.enable = true;
             csharp-ls.enable = true;
-            # TODO: re-enable when pkg is fixed and available
-            # https://github.com/NixOS/nixpkgs/pull/335559
-            # cssls.enable = true;
+            cssls.enable = true;
             dagger.enable = true;
             dartls.enable = true;
             denols.enable = true;
@@ -130,9 +128,7 @@
             efm.enable = true;
             elmls.enable = true;
             emmet-ls.enable = true;
-            # TODO: re-enable when pkg is fixed and available
-            # https://github.com/NixOS/nixpkgs/pull/335559
-            # eslint.enable = true;
+            eslint.enable = true;
             elixirls.enable = true;
             fortls.enable = true;
             # pkgs.fsautocomplete only supports linux platforms
@@ -144,15 +140,11 @@
             graphql.enable = true;
             helm-ls.enable = true;
             hls.enable = true;
-            # TODO: re-enable when pkg is fixed and available
-            # https://github.com/NixOS/nixpkgs/pull/335559
-            # html.enable = true;
+            html.enable = true;
             htmx.enable = true;
             java-language-server.enable = true;
             jdt-language-server.enable = true;
-            # TODO: re-enable when pkg is fixed and available
-            # https://github.com/NixOS/nixpkgs/pull/335559
-            # jsonls.enable = true;
+            jsonls.enable = true;
             jsonnet-ls.enable = true;
             julials.enable = true;
             kotlin-language-server.enable = true;

--- a/tests/test-sources/plugins/lsp/jsonls.nix
+++ b/tests/test-sources/plugins/lsp/jsonls.nix
@@ -4,9 +4,7 @@
       enable = true;
 
       servers.jsonls = {
-        # TODO: re-enable when pkg is fixed and available
-        # https://github.com/NixOS/nixpkgs/pull/335559
-        # enable = true;
+        enable = true;
 
         settings = {
           format = {

--- a/tests/test-sources/plugins/lsp/schemastore.nix
+++ b/tests/test-sources/plugins/lsp/schemastore.nix
@@ -1,16 +1,11 @@
 {
   empty = {
-    # TODO: remove once json is re-enabled
-    test.checkWarnings = false;
-
     plugins = {
       lsp = {
         enable = true;
 
         servers = {
-          # TODO: re-enable when pkg is fixed and available
-          # https://github.com/NixOS/nixpkgs/pull/335559
-          # jsonls.enable = true;
+          jsonls.enable = true;
           yamlls.enable = true;
         };
       };
@@ -20,17 +15,12 @@
   };
 
   example = {
-    # TODO: remove once json is re-enabled
-    test.checkWarnings = false;
-
     plugins = {
       lsp = {
         enable = true;
 
         servers = {
-          # TODO: re-enable when pkg is fixed and available
-          # https://github.com/NixOS/nixpkgs/pull/335559
-          # jsonls.enable = true;
+          jsonls.enable = true;
           yamlls.enable = true;
         };
       };
@@ -75,15 +65,10 @@
   };
 
   withJson = {
-    # TODO: remove once json is re-enabled
-    test.checkWarnings = false;
-
     plugins = {
       lsp = {
         enable = true;
-        # TODO: re-enable when pkg is fixed and available
-        # https://github.com/NixOS/nixpkgs/pull/335559
-        # servers.jsonls.enable = true;
+        servers.jsonls.enable = true;
       };
 
       schemastore = {


### PR DESCRIPTION
Follow up to [flake.lock update](https://github.com/nix-community/nixvim/pull/2056). Looks like nixpkgs was updated so we can now re-enable tests on the `vscode-langservers-extended` based lsps mentioned in https://github.com/nix-community/nixvim/issues/2043. 