### PR TITLE
docs/mdbook: move description to bottom

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -66,11 +66,17 @@ let
         # Make sure this path has a valid info attrset
         if info ? file && info ? description && info ? url then
           "# ${lib.last path}\n\n"
-          + (lib.optionalString (info.description != null) "${info.description}\n\n")
           + (lib.optionalString (info.url != null) "**URL:** [${info.url}](${info.url})\n\n")
           + (lib.optionalString (
             maintainers != [ ]
           ) "**Maintainers:** ${lib.concatStringsSep ", " maintainersNames}\n\n")
+          + lib.optionalString (info.description != null) ''
+
+            ---
+
+            ${info.description}
+
+          ''
         else
           null;
     };


### PR DESCRIPTION
Long descriptions for plugins will shove the plugin's source link and maintainer information far down the page. Since those are fairly short and the description is a variable size. Moving below to maintain consistent placement.

Before:
![image](https://github.com/user-attachments/assets/468bb6f5-3a88-4fa9-ab1c-0a09ec9573ed)

After:
![image](https://github.com/user-attachments/assets/38a72e57-b17a-499f-94c0-2062bd2161e6)
