### PR TITLE
bug: add missing `helpers` import

### DIFF
--- a/plugins/neotest/adapters.nix
+++ b/plugins/neotest/adapters.nix
@@ -6,7 +6,7 @@
 }:
 with lib;
 let
-  inherit (lib.nixvim) mkPluginPackageOption mkSettingsOption;
+  inherit (lib.nixvim) mkPluginPackageOption mkSettingsOption toLuaObject;
   supportedAdapters = import ./adapters-list.nix;
 
   mkAdapter =


### PR DESCRIPTION
| Field        | Description |
|--------------|-------------|
| Plugin       | `neotest`  | <!-- [REQUIRED] affected NixVim plugin(s) -->
| Nixpkgs      | `unstable` | <!-- [REQUIRED] `unstable` or specific version -->
| Home Manager | `unstable` | <!-- [OPTIONAL] `unstable` or specific version -->

<!-- IMPORTANT -->
- [x] I have read the [FAQ](https://nix-community.github.io/nixvim/user-guide/faq.html) and my bug is not listed there.

## Description

When attempting to build this configuration snippet:

```nix
{ config, lib, pkgs, ... }: {
  config = {

    programs.nixvim.plugins.neotest = {
      enable = true;

      adapters = {
        rspec = {
          enable = true;
          settings = {
            root_files = [ "README.md" "flake.lock" "flake.nix" "README.mkd" ];
          };
        };
      };
    };
  };
}
```

I had an error:

```shell
error:
       … while calling the 'head' builtin

         at /nix/store/j8pbrsb3nybdap3hhg9kw0ffqd4rlbx6-source/lib/attrsets.nix:1575:11:

         1574|         || pred here (elemAt values 1) (head values) then
         1575|           head values
             |           ^
         1576|         else

       … while evaluating the attribute 'value'

         at /nix/store/j8pbrsb3nybdap3hhg9kw0ffqd4rlbx6-source/lib/modules.nix:821:9:

          820|     in warnDeprecation opt //
          821|       { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          822|         inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: undefined variable 'toLuaObject'

       at /nix/store/lmpwiwcimdgz2083glllhyf22rvqzfi8-source/plugins/neotest/adapters.nix:49:86:

           48|             let
           49|               settingsString = optionalString (cfg.settings != { }) (settingsSuffix (toLuaObject cfg.settings));
             |
```

Upon investigating, I saw that `plugins/neotest/adapters.nix` had a bare `toLuaObject` call, and did not import the `helpers` module like many other locations. I forked, made the change to import helpers, which resolved the issue.

The checks would not complete on my machine (pinned CPUs and did not return after 20m, I suspect this issue is local to me), but the format-on-commit seems to have taken so the change reflects that.
