### PR TITLE
tests: fix tests by enabling `wrapRc`

### DIFF
--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -60,6 +60,7 @@ let
               "mkTestDerivationFromNixvimModule: the `dontRun` argument is deprecated. You should use the `test.runNvim` module option instead."
               { config.test.runNvim = !dontRun; }
           ))
+          { wrapRc = true; }
         ];
         extraSpecialArgs = {
           defaultPkgs = pkgs;

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -4,6 +4,8 @@
   ...
 }:
 let
+  defaultPkgs = pkgs;
+
   # Create a nix derivation from a nixvim executable.
   # The build phase simply consists in running the provided nvim binary.
   mkTestDerivationFromNvim =
@@ -35,7 +37,7 @@ let
   mkTestDerivationFromNixvimModule =
     {
       name ? null,
-      pkgs ? pkgs,
+      pkgs ? defaultPkgs,
       module,
       extraSpecialArgs ? { },
       # TODO: Deprecated 2024-08-20, remove after 24.11


### PR DESCRIPTION
Since cbd1003d9d3dcc371f0602a66ff32af9f8c14490 I'm able to add _some_ invalid config definitions to modules the tests are using and get no build error.

For example `extraConfigLua = null;` should produce an invalid type error, but doesn't.

One less visible change in that commit is the move away from using the "standalone" wrapper (`makeNixvimWithModule`), which implicitly sets `wrapRc = true`.

Adding back `wrapRc` to the tests seems to fix the issue, however this makes me wonder if there's an underlying issue with wrapping/not-wrapping?

Perhaps we've simply uncovered a long-standing eval issue that is masked over by using `wrapRc`?
