### PR TITLE
modules/test: use `runCommand` and add `passthru`s

### DIFF
--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   config,
+  options,
   lib,
   ...
 }:
@@ -66,7 +67,20 @@ in
     in
     {
       test.derivation =
-        pkgs.runCommandNoCCLocal cfg.name { nativeBuildInputs = [ config.finalPackage ]; }
+        pkgs.runCommandNoCCLocal cfg.name
+          {
+            nativeBuildInputs = [ config.finalPackage ];
+
+            # Allow inspecting the test's module a little from the repl
+            # e.g.
+            # :lf .
+            # :p checks.x86_64-linux.test-1.passthru.entries.modules-autocmd.passthru.entries.example.passthru.config.extraConfigLua
+            #
+            # Yes, three levels of passthru is cursed.
+            passthru = {
+              inherit config options;
+            };
+          }
           (
             # First check warnings/assertions, then run nvim
             lib.optionalString (errors != "") ''


### PR DESCRIPTION

It was bothering me that the test used the fully blown `stdenv.mkDerevation` despite only needing to run a few commands. Therefore I've replaced it with `runCommand`. More specifically, `runCommandNoCCLocal` which should pull in fewer unnecessary build dependencies.

Additionally, I needed to add some pass-through attrs when debugging #2076, so I've created this PR to persist those. Maybe other stuff should be passed through too?
