### PR TITLE
plugins/lualine: migrate to mkNeovimPlugin

### DIFF
--- a/plugins/colorschemes/base16/default.nix
+++ b/plugins/colorschemes/base16/default.nix
@@ -171,7 +171,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
   extraConfig = cfg: {
     plugins.airline.settings.theme = lib.mkIf cfg.setUpBar (lib.mkDefault name);
-    plugins.lualine.theme = lib.mkIf cfg.setUpBar (lib.mkDefault name);
+    plugins.lualine.settings.options.theme = lib.mkIf cfg.setUpBar (lib.mkDefault name);
     plugins.lightline.settings.colorscheme = lib.mkDefault null;
 
     opts.termguicolors = lib.mkDefault true;

--- a/tests/test-sources/example-configurations/issues.nix
+++ b/tests/test-sources/example-configurations/issues.nix
@@ -8,17 +8,19 @@
       lualine = {
         enable = true;
 
-        sectionSeparators = {
-          left = "";
-          right = "";
+        settings = {
+          options = {
+            section_separators = {
+              left = "";
+              right = "";
+            };
+            component_separators = {
+              left = "";
+              right = "";
+            };
+            theme = "auto";
+          };
         };
-
-        componentSeparators = {
-          left = "";
-          right = "";
-        };
-
-        theme = "auto";
       };
 
       goyo = {

--- a/tests/test-sources/plugins/statuslines/lualine.nix
+++ b/tests/test-sources/plugins/statuslines/lualine.nix
@@ -8,42 +8,46 @@
     plugins.lualine = {
       enable = true;
 
-      iconsEnabled = true;
-      theme = "auto";
-      componentSeparators = {
-        left = "";
-        right = "";
-      };
-      sectionSeparators = {
-        left = "";
-        right = "";
-      };
-      alwaysDivideMiddle = true;
-      globalstatus = false;
-      refresh = {
-        statusline = 1000;
-        tabline = 1000;
-        winbar = 1000;
-      };
-      sections = {
-        lualine_a = [ "mode" ];
-        lualine_b = [
-          "branch"
-          "diff"
-          "diagnostics"
-        ];
-        lualine_c = [ "filename" ];
-        lualine_x = [
-          "encoding"
-          "fileformat"
-          "filetype"
-        ];
-        lualine_y = [ "progress" ];
-        lualine_z = [ "location" ];
-      };
-      inactiveSections = {
-        lualine_c = [ "filename" ];
-        lualine_x = [ "location" ];
+      settings = {
+        options = {
+          icons_enabled = true;
+          theme = "auto";
+          component_separators = {
+            left = "";
+            right = "";
+          };
+          section_separators = {
+            left = "";
+            right = "";
+          };
+          always_divide_middle = true;
+          globalstatus = false;
+          refresh = {
+            statusline = 1000;
+            tabline = 1000;
+            winbar = 1000;
+          };
+        };
+        sections = {
+          lualine_a = [ "mode" ];
+          lualine_b = [
+            "branch"
+            "diff"
+            "diagnostics"
+          ];
+          lualine_c = [ "filename" ];
+          lualine_x = [
+            "encoding"
+            "fileformat"
+            "filetype"
+          ];
+          lualine_y = [ "progress" ];
+          lualine_z = [ "location" ];
+        };
+        inactive_sections = {
+          lualine_c = [ "filename" ];
+          lualine_x = [ "location" ];
+        };
       };
     };
   };
@@ -52,76 +56,97 @@
     extraPlugins = [ pkgs.vimPlugins.gruvbox-nvim ];
     plugins.lualine = {
       enable = true;
-      theme.__raw = ''
-        (function()
-          local custom_gruvbox = require("lualine.themes.gruvbox")
-          custom_gruvbox.normal.c.bg = '#112233'
-          return custom_gruvbox
-        end)()
-      '';
-      ignoreFocus = [
-        "NvimTree"
-        "neo-tree"
-      ];
-      disabledFiletypes = {
-        winbar = [ "neo-tree" ];
-      };
-      sections = {
-        lualine_c = [
-          # you can specify only the sections you want to change
-          {
-            name = "filename";
-            icon = "-";
-            extraConfig = {
+      settings = {
+        options = {
+          component_separators = "|";
+          theme.__raw = ''
+            (function()
+              local custom_gruvbox = require("lualine.themes.gruvbox")
+              custom_gruvbox.normal.c.bg = '#112233'
+              return custom_gruvbox
+            end)()
+          '';
+          ignore_focus = [
+            "NvimTree"
+            "neo-tree"
+          ];
+          disabled_filetypes = {
+            __unkeyed-1 = "startify";
+            winbar = [ "neo-tree" ];
+          };
+        };
+        sections = {
+          lualine_a = [
+            {
+              __unkeyed-1 = "mode";
+              separator.left = "";
+              padding.left = 2;
+            }
+          ];
+          lualine_c = [
+            # you can specify only the sections you want to change
+            {
+              __unkeyed-1 = "filename";
+              icon = "-";
               newfile_status = true;
               path = 1;
               shorting_target = 60;
+            }
+          ];
+          lualine_z = [
+            { __unkeyed-1 = "location"; }
+            { __unkeyed-1 = "%L"; } # total lines
+          ];
+        };
+        tabline = {
+          lualine_a = [
+            {
+              __unkeyed-1 = "buffers";
+              icon = {
+                __unkeyed-1 = "X";
+                align = "right";
+              };
+              mode = 4;
+              filetype_names = {
+                TelescopePrompt = "Telescope";
+                NvimTree = "NvimTree";
+              };
+              fmt = ''
+                function(value)
+                  return value
+                end
+              '';
+            }
+          ];
+          lualine_z = [
+            {
+              __unkeyed-1 = "tabs";
+              mode = 2;
+            }
+          ];
+        };
+        extensions = [
+          "nvim-tree"
+          {
+            sections = {
+              lualine_a = [ "filename" ];
             };
+            inactive_sections = {
+              lualine_x = [ "location" ];
+            };
+            filetypes = [ "markdown" ];
           }
-        ];
-        lualine_z = [
-          { name = "location"; }
-          { name = "%L"; } # total lines
         ];
       };
-      tabline = {
-        lualine_a = [
-          {
-            name = "buffers";
-            icon = {
-              icon = "X";
-              align = "right";
-            };
-            extraConfig.mode = 4;
-            extraConfig.filetype_names = {
-              TelescopePrompt = "Telescope";
-              NvimTree = "NvimTree";
-            };
-            fmt = ''
-              function(value)
-                return value
-              end
-            '';
-          }
-        ];
-        lualine_z = [
-          {
-            name = "tabs";
-            extraConfig.mode = 2;
-          }
-        ];
-      };
-      extensions = [
-        "nvim-tree"
-        {
-          sections = {
-            lualine_a = [ "filename" ];
-          };
-          inactive_sections = {
-            lualine_x = [ "location" ];
-          };
-          filetypes = [ "markdown" ];
-        }
+    };
+  };
+
+  disabled-list = {
+    plugins.lualine = {
+      enable = true;
+      settings.options.disabled_filetypes = [
+        "neo-tree"
+        "startify"
       ];
     };
   };


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/2191

Migrating to the current standards. Required using a transitionType for the component options that will help keep existing configurations working, but recommend switching to the new way of being explicit in your configuration to match upstream plugin declaration. 