### PR TITLE
plugins/nvim-jdtls: allow lua on nvim-jdtls.data

### DIFF
--- a/plugins/languages/nvim-jdtls.nix
+++ b/plugins/languages/nvim-jdtls.nix
@@ -44,7 +44,7 @@ in
     '';
 
     data = mkOption {
-      type = types.nullOr types.str;
+      type = helpers.nixvimTypes.maybeRaw (with types; nullOr str);
       default = null;
       example = "/home/YOUR_USERNAME/.cache/jdtls/workspace";
       description = ''


### PR DESCRIPTION
Make it possible to set data directory with lua, so it can be project-dependent.

JDTLS requires separate data directory for every project.

This PR enables users to set e.g.

```nix
data.__raw = "vim.fn.stdpath 'cache' .. '/jdtls/' .. vim.fn.fnamemodify(vim.fn.getcwd(), ':t')";
```

and thus satisfy this requirement.