### PR TITLE
tests: test the tests fail when expected

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -25,6 +25,11 @@
           inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
         };
 
+        failing-tests = import ../tests/failing-tests.nix {
+          inherit pkgs;
+          inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
+        };
+
         no-flake = import ../tests/no-flake.nix {
           inherit system;
           inherit (self.lib.${system}.check) mkTestDerivationFromNvim;

--- a/tests/failing-tests.nix
+++ b/tests/failing-tests.nix
@@ -1,0 +1,22 @@
+{
+  pkgs,
+  mkTestDerivationFromNixvimModule,
+}:
+let
+  inherit (pkgs.testers) testBuildFailure;
+
+  failed = testBuildFailure (mkTestDerivationFromNixvimModule {
+    name = "prints-hello-world";
+    module = {
+      extraConfigLua = ''
+        print('Hello, world!')
+      '';
+    };
+    inherit pkgs;
+  });
+in
+pkgs.runCommand "failing-test" { inherit failed; } ''
+  grep -F 'Hello, world!' "$failed/testBuildFailure.log"
+  [[ 1 = $(cat "$failed/testBuildFailure.exit") ]]
+  touch $out
+''


### PR DESCRIPTION
Adds a regression test for #2076. This test ensures that `extraConfigLua` is used in `finalPackage` and that the test will fail correctly when running `nvim` results in unexpected output.

I was hoping to also test more explicitly that an eval failure would be triggered when `extraConfigLua` is set to something invalid, but verifying the `"Hello, world!"` string makes it into the build log should cover most of those cases too.

At the very least this regression test ensures:
- `extraConfigLua` is used in the `init.lua` used to run `nvim` in the test
- `test.runNvim` correctly fails when neovim prints unexpected stdout

I used [`pkgs.testers.testBuildFailure`](https://nixos.org/manual/nixpkgs/unstable/#tester-testBuildFailure) as a helper, to aid in expecting a derivation build to fail.