### PR TITLE
plugins/which-key: fix icon examples

### DIFF
--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -13,21 +13,24 @@ let
   opt = options.plugins.which-key;
 
   specExamples = [
-    # Basic group
+    # Basic group with custom icon
     {
       __unkeyed-1 = "<leader>b";
-      group = "󰓩 Buffers";
+      group = "Buffers";
+      icon = "󰓩 ";
     }
     # Non-default mode
     {
       __unkeyed = "<leader>c";
       mode = "v";
-      group = "󰄄 Codesnap";
+      group = "Codesnap";
+      icon = "󰄄 ";
     }
     # Group within group
     {
       __unkeyed-1 = "<leader>bs";
-      group = "󰒺 Sort";
+      group = "Sort";
+      icon = "󰒺 ";
     }
     # Nested mappings for inheritance
     {


### PR DESCRIPTION
Which-key implemented proper icon support, utilize the icon attribute to properly override/set icons so that alignment doesn't get thrown off and it's inherited with child mappings did something similar in my own config to fix the weird rendering https://github.com/khaneliman/khanelivim/commit/13a38e596f092c2afbfa34d6e4f1a7b05137733d