### PR TITLE
tests: add regression test for warnings + assertions

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -25,8 +25,7 @@
           inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
         };
 
-        failing-tests = import ../tests/failing-tests.nix {
-          inherit pkgs;
+        failing-tests = pkgs.callPackage ../tests/failing-tests.nix {
           inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
         };
 

--- a/tests/failing-tests.nix
+++ b/tests/failing-tests.nix
@@ -1,22 +1,67 @@
 {
   pkgs,
+  linkFarmFromDrvs,
+  runCommandNoCCLocal,
   mkTestDerivationFromNixvimModule,
 }:
 let
-  inherit (pkgs.testers) testBuildFailure;
-
-  failed = testBuildFailure (mkTestDerivationFromNixvimModule {
-    name = "prints-hello-world";
-    module = {
-      extraConfigLua = ''
-        print('Hello, world!')
-      '';
-    };
-    inherit pkgs;
-  });
+  # Wraps a call to mkTestDerivationFromNixvimModule with testers.testBuildFailure
+  mkFailingNixvimTest =
+    args: pkgs.testers.testBuildFailure (mkTestDerivationFromNixvimModule ({ inherit pkgs; } // args));
 in
-pkgs.runCommand "failing-test" { inherit failed; } ''
-  grep -F 'Hello, world!' "$failed/testBuildFailure.log"
-  [[ 1 = $(cat "$failed/testBuildFailure.exit") ]]
-  touch $out
-''
+linkFarmFromDrvs "failing-tests" [
+  (runCommandNoCCLocal "fail-running-nvim"
+    {
+      failed = mkFailingNixvimTest {
+        name = "prints-hello-world";
+        module = {
+          extraConfigLua = ''
+            print('Hello, world!')
+          '';
+        };
+      };
+    }
+    ''
+      [[ 1 = $(cat "$failed/testBuildFailure.exit") ]]
+      grep -F 'ERROR: Hello, world!' "$failed/testBuildFailure.log"
+      touch $out
+    ''
+  )
+  (runCommandNoCCLocal "fail-on-warnings"
+    {
+      failed = mkFailingNixvimTest {
+        name = "warns-hello-world";
+        module = {
+          warnings = [ "Hello, world!" ];
+        };
+      };
+    }
+    ''
+      [[ 1 = $(cat "$failed/testBuildFailure.exit") ]]
+      grep -F 'Unexpected warnings:' "$failed/testBuildFailure.log"
+      grep -F 'Hello, world!' "$failed/testBuildFailure.log"
+      touch $out
+    ''
+  )
+  (runCommandNoCCLocal "fail-on-assertions"
+    {
+      failed = mkFailingNixvimTest {
+        name = "asserts-hello-world";
+        module = {
+          assertions = [
+            {
+              assertion = false;
+              message = "Hello, world!";
+            }
+          ];
+        };
+      };
+    }
+    ''
+      [[ 1 = $(cat "$failed/testBuildFailure.exit") ]]
+      grep -F 'Unexpected assertions:' "$failed/testBuildFailure.log"
+      grep -F 'Hello, world!' "$failed/testBuildFailure.log"
+      touch $out
+    ''
+  )
+]


### PR DESCRIPTION
Follow up to #2097, #2076, & #2048.

Expand "failing-tests" to also ensure warnings & assertions are correctly handled by `mkTestDerivationFromNixvimModule`.

Also did some minor cleanup:
- Call `failing-tests.nix` using `pkgs.callPackage`
- Replace repetive use of `testBuildFailure` with a wrapper
  `mkFailingNixvimTest`

You can run just the "failing" tests by using:
```shell
nix build .#checks.x86_64-linux.failing-tests

# Or for more detail:
nix build --show-trace --print-build-logs --verbose \
  .#checks.x86_64-linux.failing-tests
```

You can also use the `entries` passthu to access a specific sub-test:
```shell
nix build .#checks.x86_64-linux.failing-tests.entries.fail-on-assertions
```
_(tab-completion can help here)_

See also, [`linkFarmFromDrvs`](https://github.com/NixOS/nixpkgs/blob/0fefe244b14d6f140d98dff6ddeb648174fb29f5/pkgs/build-support/trivial-builders/default.nix#L545-L569)
