### PR TITLE
tests: simplify fetch-tests slightly

### DIFF
--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -5,26 +5,25 @@
   helpers,
 }:
 let
-  # Import a test file into the form { name = ""; file = ""; modules = []; }
+  # Import a test file into the form { name = ""; file = ""; cases = {}; }
   handleTestFile =
     file: namespace:
     let
       fnOrAttrs = import file;
+    in
+    {
+      inherit file;
+      name = lib.strings.concatStringsSep "-" namespace;
       cases =
         if builtins.isFunction fnOrAttrs then
           # Call the function
           fnOrAttrs { inherit pkgs lib helpers; }
         else
           fnOrAttrs;
-    in
-    {
-      inherit file;
-      name = lib.strings.concatStringsSep "-" namespace;
-      modules = lib.mapAttrsToList (name: module: { inherit name module; }) cases;
     };
 
   # Recurse into all directories, extracting files as we find them.
-  # This returns a list of { name; file; modules;  } attrsets.
+  # This returns a list of { name; file; cases;  } attrsets.
   fetchTests =
     path: namespace:
     let
@@ -50,5 +49,4 @@ let
       builtins.concatLists
     ];
 in
-# A list of the form [ { name = "..."; modules = [ /* test case modules */ ]; } ]
 fetchTests root [ ]


### PR DESCRIPTION
Simplify by reducing the number of transformations done to the test-files' test-case modules attr.

Since `pkgs.linkFarm` can accept _either_ a list or an attrset, we don't need to transform the attrset into a list.

This has no functional change, and only slightly simplifies some internals. It may end up being redundant if we re-structure the tests again, but I spotted the slight over-complication while working on #2100 so figured I'd make a PR.
