### PR TITLE
treewide: standardize iconsPackage

### DIFF
--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -55,7 +55,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
   name = "barbar";
   originalName = "barbar.nvim";
   defaultPackage = pkgs.vimPlugins.barbar-nvim;
-  extraPlugins = [ pkgs.vimPlugins.nvim-web-devicons ];
 
   maintainers = [ maintainers.GaetanLepage ];
 
@@ -197,6 +196,11 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
     );
 
   extraOptions = {
+    iconsPackage = lib.nixvim.mkPackageOption {
+      name = "nvim-web-devicons";
+      default = pkgs.vimPlugins.nvim-web-devicons;
+    };
+
     keymaps = mapAttrs (
       optionName: funcName:
       mkNullOrOption' {
@@ -214,6 +218,8 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
   };
 
   extraConfig = cfg: {
+    extraPlugins = mkIf (cfg.iconsPackage != null) [ cfg.iconsPackage ];
+
     keymaps = filter (keymap: keymap != null) (
       # TODO: switch to `attrValues cfg.keymaps` when removing the deprecation warnings above:
       attrValues (filterAttrs (n: v: n != "silent") cfg.keymaps)

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -654,8 +654,15 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
       };
   };
 
+  extraOptions = {
+    iconsPackage = lib.nixvim.mkPackageOption {
+      name = "nvim-web-devicons";
+      default = pkgs.vimPlugins.nvim-web-devicons;
+    };
+  };
+
   extraConfig = cfg: {
-    extraPlugins = with pkgs.vimPlugins; [ nvim-web-devicons ];
+    extraPlugins = lib.mkIf (cfg.iconsPackage != null) [ cfg.iconsPackage ];
 
     opts.termguicolors = true;
   };

--- a/plugins/filetrees/chadtree.nix
+++ b/plugins/filetrees/chadtree.nix
@@ -16,6 +16,11 @@ in
 
     package = helpers.mkPluginPackageOption "chadtree" pkgs.vimPlugins.chadtree;
 
+    iconsPackage = helpers.mkPackageOption {
+      name = "nvim-web-devicons";
+      default = pkgs.vimPlugins.nvim-web-devicons;
+    };
+
     options = {
       follow = helpers.defaultNullOpts.mkBool true ''
         CHADTree will highlight currently open file, and open all its parents.
@@ -495,8 +500,8 @@ in
       extraPlugins =
         [ cfg.package ]
         ++ (optional (
-          cfg.theme == null || cfg.theme.iconGlyphSet == "devicons"
-        ) pkgs.vimPlugins.nvim-web-devicons);
+          cfg.iconsPackage != null && (cfg.theme == null || cfg.theme.iconGlyphSet == "devicons")
+        ) cfg.iconsPackage);
 
       extraConfigLua = ''
         vim.api.nvim_set_var("chadtree_settings", ${helpers.toLuaObject setupOptions})

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -57,6 +57,11 @@ in
 
       package = helpers.mkPluginPackageOption "neo-tree" pkgs.vimPlugins.neo-tree-nvim;
 
+      iconsPackage = helpers.mkPackageOption {
+        name = "nvim-web-devicons";
+        default = pkgs.vimPlugins.nvim-web-devicons;
+      };
+
       sources =
         helpers.defaultNullOpts.mkListOf types.str
           [
@@ -1116,10 +1121,9 @@ in
         // cfg.extraOptions;
     in
     mkIf cfg.enable {
-      extraPlugins = with pkgs.vimPlugins; [
+      extraPlugins = [
         cfg.package
-        nvim-web-devicons
-      ];
+      ] ++ lib.optional (cfg.iconsPackage != null) cfg.iconsPackage;
 
       extraConfigLua = ''
         require('neo-tree').setup(${helpers.toLuaObject setupOptions})

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -41,6 +41,11 @@ in
 
     package = helpers.mkPluginPackageOption "nvim-tree" pkgs.vimPlugins.nvim-tree-lua;
 
+    iconsPackage = helpers.mkPackageOption {
+      name = "nvim-web-devicons";
+      default = pkgs.vimPlugins.nvim-web-devicons;
+    };
+
     disableNetrw = helpers.defaultNullOpts.mkBool false "Disable netrw";
 
     hijackNetrw = helpers.defaultNullOpts.mkBool true "Hijack netrw";
@@ -1154,10 +1159,9 @@ in
       '';
     in
     mkIf cfg.enable {
-      extraPlugins = with pkgs.vimPlugins; [
+      extraPlugins = [
         cfg.package
-        nvim-web-devicons
-      ];
+      ] ++ lib.optional (cfg.iconsPackage != null) cfg.iconsPackage;
 
       autoCmd =
         (optional autoOpenEnabled {

--- a/plugins/git/diffview.nix
+++ b/plugins/git/diffview.nix
@@ -88,6 +88,11 @@ in
 
       package = helpers.mkPluginPackageOption "diffview" pkgs.vimPlugins.diffview-nvim;
 
+      iconsPackage = helpers.mkPackageOption {
+        name = "nvim-web-devicons";
+        default = pkgs.vimPlugins.nvim-web-devicons;
+      };
+
       diffBinaries = mkBool false ''
         Show diffs for binaries
       '';
@@ -817,7 +822,10 @@ in
       };
     in
     mkIf cfg.enable {
-      extraPlugins = [ cfg.package ] ++ (optional cfg.useIcons pkgs.vimPlugins.nvim-web-devicons);
+      extraPlugins = [
+        cfg.package
+      ] ++ (optional (cfg.iconsPackage != null && cfg.useIcons) cfg.iconsPackage);
+
       extraConfigLua = ''
         require("diffview").setup(${helpers.toLuaObject setupOptions})
       '';

--- a/plugins/lsp/lspsaga.nix
+++ b/plugins/lsp/lspsaga.nix
@@ -51,6 +51,11 @@ in
 
       package = helpers.mkPluginPackageOption "lspsaga" pkgs.vimPlugins.lspsaga-nvim;
 
+      iconsPackage = helpers.mkPackageOption {
+        name = "nvim-web-devicons";
+        default = pkgs.vimPlugins.nvim-web-devicons;
+      };
+
       ui = {
         border = helpers.defaultNullOpts.mkBorder "single" "lspsaga" "";
 
@@ -451,9 +456,11 @@ in
   };
 
   config = mkIf cfg.enable {
-    extraPlugins = [
-      cfg.package
-    ] ++ (optional (cfg.ui.devicon == null || cfg.ui.devicon) pkgs.vimPlugins.nvim-web-devicons);
+    extraPlugins =
+      [ cfg.package ]
+      ++ optional (
+        cfg.iconsPackage != null && (cfg.ui.devicon == null || cfg.ui.devicon)
+      ) cfg.iconsPackage;
 
     warnings = mkIf (
       # https://nvimdev.github.io/lspsaga/implement/#default-options

--- a/plugins/lsp/trouble.nix
+++ b/plugins/lsp/trouble.nix
@@ -11,8 +11,6 @@ helpers.neovim-plugin.mkNeovimPlugin config {
   originalName = "trouble-nvim";
   defaultPackage = pkgs.vimPlugins.trouble-nvim;
 
-  extraPlugins = with pkgs.vimPlugins; [ nvim-web-devicons ];
-
   maintainers = [ maintainers.loicreynier ];
 
   # TODO introduced 2024-03-15: remove 2024-05-15
@@ -301,5 +299,16 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     use_diagnostic_signs = helpers.defaultNullOpts.mkBool false ''
       Enabling this will use the signs defined in your lsp client
     '';
+  };
+
+  extraOptions = {
+    iconsPackage = helpers.mkPackageOption {
+      name = "nvim-web-devicons";
+      default = pkgs.vimPlugins.nvim-web-devicons;
+    };
+  };
+
+  extraConfig = cfg: {
+    extraPlugins = mkIf (cfg.iconsPackage != null) [ cfg.iconsPackage ];
   };
 }

--- a/plugins/utils/fzf-lua.nix
+++ b/plugins/utils/fzf-lua.nix
@@ -2,6 +2,7 @@
   lib,
   helpers,
   config,
+  options,
   pkgs,
   ...
 }:
@@ -47,10 +48,16 @@ helpers.neovim-plugin.mkNeovimPlugin config {
       example = pkgs.skim;
     };
 
+    # TODO: deprecated 2024-08-29 remove after 24.11
     iconsEnabled = mkOption {
       type = types.bool;
       description = "Toggle icon support. Installs nvim-web-devicons.";
-      default = true;
+      visible = false;
+    };
+
+    iconsPackage = helpers.mkPackageOption {
+      name = "nvim-web-devicons";
+      default = pkgs.vimPlugins.nvim-web-devicons;
     };
 
     profile = helpers.defaultNullOpts.mkEnumFirstDefault [
@@ -103,28 +110,44 @@ helpers.neovim-plugin.mkNeovimPlugin config {
     };
   };
 
-  extraConfig = cfg: {
-    extraPlugins = optional cfg.iconsEnabled pkgs.vimPlugins.nvim-web-devicons;
+  extraConfig =
+    cfg:
+    let
+      opt = options.plugins.fzf-lua;
+    in
+    {
+      # TODO: deprecated 2024-08-29 remove after 24.11
+      warnings = lib.mkIf opt.iconsEnabled.isDefined [
+        ''
+          nixvim (plugins.fzf-lua):
+          The option definition `plugins.fzf-lua.iconsEnabled' in ${showFiles opt.iconsEnabled.files} has been deprecated; please remove it.
+          You should use `plugins.fzf-lua.iconsPackage' instead.
+        ''
+      ];
 
-    extraPackages = optional (cfg.fzfPackage != null) cfg.fzfPackage;
+      extraPlugins = lib.mkIf (
+        cfg.iconsPackage != null && (opt.iconsEnabled.isDefined && cfg.iconsEnabled)
+      ) [ cfg.iconsPackage ];
 
-    plugins.fzf-lua.settings.__unkeyed_profile = cfg.profile;
+      extraPackages = [ cfg.fzfPackage ];
 
-    keymaps = mapAttrsToList (
-      key: mapping:
-      let
-        actionStr =
-          if isString mapping then
-            "${mapping}()"
-          else
-            "${mapping.action}(${helpers.toLuaObject mapping.settings})";
-      in
-      {
-        inherit key;
-        mode = mapping.mode or "n";
-        action.__raw = "function() require('fzf-lua').${actionStr} end";
-        options = mapping.options or { };
-      }
-    ) cfg.keymaps;
-  };
+      plugins.fzf-lua.settings.__unkeyed_profile = cfg.profile;
+
+      keymaps = mapAttrsToList (
+        key: mapping:
+        let
+          actionStr =
+            if isString mapping then
+              "${mapping}()"
+            else
+              "${mapping.action}(${helpers.toLuaObject mapping.settings})";
+        in
+        {
+          inherit key;
+          mode = mapping.mode or "n";
+          action.__raw = "function() require('fzf-lua').${actionStr} end";
+          options = mapping.options or { };
+        }
+      ) cfg.keymaps;
+    };
 }

--- a/tests/test-sources/plugins/bufferlines/barbar.nix
+++ b/tests/test-sources/plugins/bufferlines/barbar.nix
@@ -219,4 +219,12 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.barbar = {
+      enable = true;
+      iconsPackage = null;
+      settings.icons.filetype.enabled = false;
+    };
+  };
 }

--- a/tests/test-sources/plugins/bufferlines/bufferline.nix
+++ b/tests/test-sources/plugins/bufferlines/bufferline.nix
@@ -123,4 +123,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.bufferline = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }

--- a/tests/test-sources/plugins/filetrees/chadtree.nix
+++ b/tests/test-sources/plugins/filetrees/chadtree.nix
@@ -132,4 +132,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.chadtree = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }

--- a/tests/test-sources/plugins/filetrees/neo-tree.nix
+++ b/tests/test-sources/plugins/filetrees/neo-tree.nix
@@ -437,4 +437,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.neo-tree = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }

--- a/tests/test-sources/plugins/filetrees/nvim-tree.nix
+++ b/tests/test-sources/plugins/filetrees/nvim-tree.nix
@@ -256,4 +256,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.nvim-tree = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }

--- a/tests/test-sources/plugins/git/diffview.nix
+++ b/tests/test-sources/plugins/git/diffview.nix
@@ -161,4 +161,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.diffview = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }

--- a/tests/test-sources/plugins/lsp/lspsaga.nix
+++ b/tests/test-sources/plugins/lsp/lspsaga.nix
@@ -170,4 +170,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.lspsaga = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }

--- a/tests/test-sources/plugins/lsp/trouble.nix
+++ b/tests/test-sources/plugins/lsp/trouble.nix
@@ -77,4 +77,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.trouble = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }

--- a/tests/test-sources/plugins/utils/alpha.nix
+++ b/tests/test-sources/plugins/utils/alpha.nix
@@ -34,7 +34,6 @@
     plugins.alpha = {
       enable = true;
 
-      iconsEnabled = true;
       layout = [
         {
           type = "padding";
@@ -98,6 +97,14 @@
           press_queue = "<M-CR>";
         };
       };
+    };
+  };
+
+  no-packages = {
+    plugins.alpha = {
+      enable = true;
+      theme = "dashboard";
+      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/utils/fzf-lua.nix
+++ b/tests/test-sources/plugins/utils/fzf-lua.nix
@@ -54,4 +54,11 @@
       };
     };
   };
+
+  no-packages = {
+    plugins.fzf-lua = {
+      enable = true;
+      iconsPackage = null;
+    };
+  };
 }


### PR DESCRIPTION
Follow up to discussion https://github.com/nix-community/nixvim/issues/2107#issuecomment-2316603375 to standardize how we handle the icons dependencies. Setting a default `iconsPackage` for each module that has been adding it as an `extraPlugins` and deprecating options that used to be a boolean specifically for this behavior. 

I see a few occurrences for `gitPackage` outside of the scope of my `iconsPackage` change, I will address those in a follow up PR. 