### PR TITLE
plugins/nvim-orgmode: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -95,4 +95,10 @@
     githubId = 30784060;
     name = "Pedro Sánchez";
   };
+  refaelsh = {
+    email = "refaelsh@pm.me";
+    github = "refaelsh";
+    githubId = 2750775;
+    name = "Refael Sheinker";
+  };
 }

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -76,6 +76,7 @@
     ./languages/markdown/preview.nix
     ./languages/nix.nix
     ./languages/nvim-jdtls.nix
+    ./languages/nvim-orgmode.nix
     ./languages/openscad.nix
     ./languages/otter.nix
     ./languages/parinfer-rust.nix

--- a/plugins/languages/nvim-orgmode.nix
+++ b/plugins/languages/nvim-orgmode.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+  name = "orgmode";
+  originalName = "nvim-orgmode";
+  defaultPackage = pkgs.vimPlugins.orgmode;
+
+  maintainers = [ lib.nixvim.maintainers.refaelsh ];
+
+  settingsOptions = {
+    org_agenda_files = defaultNullOpts.mkNullable (with lib.types; either str (listOf str)) "" ''
+      A path for Org agenda files.
+    '';
+    org_default_notes_file = defaultNullOpts.mkStr "" ''
+      A path to the default notes file.
+    '';
+  };
+
+  settingsExample = {
+    org_agenda_files = "~/orgfiles/**/*";
+    org_default_notes_file = "~/orgfiles/refile.org";
+  };
+}

--- a/tests/test-sources/plugins/languages/orgmode.nix
+++ b/tests/test-sources/plugins/languages/orgmode.nix
@@ -1,0 +1,26 @@
+{
+  empty = {
+    plugins.orgmode.enable = true;
+  };
+
+  default = {
+    plugins.orgmode = {
+      enable = true;
+      settings = {
+        org_agenda_files = "";
+        org_default_notes_file = "";
+      };
+    };
+  };
+
+  example = {
+    plugins.orgmode = {
+      enable = true;
+
+      settings = {
+        org_agenda_files = "~/orgfiles/**/*";
+        org_default_notes_file = "~/orgfiles/refile.org";
+      };
+    };
+  };
+}


### PR DESCRIPTION
I want to add this plugin to Nixvim: https://github.com/nvim-orgmode/orgmode.
It is already in Nixpkgs here: https://search.nixos.org/packages?channel=24.05&show=vimPlugins.orgmode&from=0&size=50&sort=relevance&type=packages&query=orgmode.
I followed the following docs: https://github.com/nix-community/nixvim/blob/main/CONTRIBUTING.md.

I hope I did everything right.
Furthermore, I especially have doubts about the `tests` parts of the docs, I am not that good at Nix to understand what is said there.

Thanks in advance for reviewing this PR.
