### PR TITLE
readme: fix incorrect description

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ NixVim is a [Neovim](https://neovim.io) distribution built around
 configured through Nix, all while leaving room for your plugins and your vimrc.
 
 ## What does it look like?
-Here is a simple configuration that uses gruvbox as the colorscheme and uses the
-lightline plugin:
+Here is a simple configuration that uses catppuccin as the colorscheme and uses the
+lualine plugin:
 
 ```nix
 {


### PR DESCRIPTION
There was a [commit](https://github.com/nix-community/nixvim/commit/eac092c876e4c4861c6df0cff93e25b972b1842c) a couple of days ago that intended to fix this, but forgot to fix the text before the code block.