### PR TITLE
plugins/none-ls: fix due to upstream renaming prisma

### DIFF
--- a/plugins/lsp/language-servers/efmls-configs-pkgs.nix
+++ b/plugins/lsp/language-servers/efmls-configs-pkgs.nix
@@ -94,7 +94,6 @@ pkgs: {
       vulture
       ;
     inherit (nodePackages)
-      eslint
       eslint_d
       prettier
       alex
@@ -113,6 +112,10 @@ pkgs: {
     cmake_lint = cmake-format;
     dartfmt = dart;
     dotnet_format = dotnet-runtime;
+    # TODO: Added 2024-08-31; remove 2024-11-31
+    # eslint was moved out of nodePackages set without alias
+    # Using fallback as a transition period
+    eslint = pkgs.eslint or pkgs.nodePackages.eslint;
     fish_indent = fish;
     gofmt = go;
     goimports = go-tools;

--- a/plugins/none-ls/packages.nix
+++ b/plugins/none-ls/packages.nix
@@ -155,7 +155,10 @@ pkgs: {
       phpcbf = pkgs.phpPackages.php-codesniffer;
       phpcsfixer = pkgs.phpPackages.php-cs-fixer;
       phpcs = pkgs.phpPackages.php-codesniffer;
-      prisma_format = pkgs.nodePackages.prisma;
+      # TODO: Added 2024-08-31; remove 2024-11-31
+      # prisma was moved out of nodePackages set without alias
+      # Using fallback as a transition period
+      prisma_format = pkgs.prisma or pkgs.nodePackages.prisma;
       ptop = pkgs.fpc;
       puppet_lint = pkgs.puppet-lint;
       qmlformat = pkgs.qt6.qtdeclarative;


### PR DESCRIPTION
See #2125

due to https://github.com/NixOS/nixpkgs/pull/337521

This has already been merged in `unstable` and thus `nixvim` will fail on up-to-date `home-manager` or `NixOS` deployments, but not on older configs. Unfortunately, `nixpkgs`  missed to apply an alias for the package.

Due to this change `nix flake check --all-systems` fails with 
```
       … while checking flake output 'checks'

         at «none»:0: (source not available)

       … while checking the derivation 'checks.x86_64-linux.extend'

         at «none»:0: (source not available)

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'prisma' missing

       at /nix/store/cvgwzs7pal633x4q03lp6wzcrk7g66q9-source/plugins/none-ls/packages.nix:158:23:

          157|       phpcs = pkgs.phpPackages.php-codesniffer;
          158|       prisma_format = pkgs.prisma;
             |                       ^
          159|       ptop = pkgs.fpc;
       Did you mean prism?
```

EDIT:
This PR also fixes the move of `eslint` to `pkgs` which will fix:

`error: Alias eslint is still in node-packages.nix` which is due to https://github.com/NixOS/nixpkgs/pull/337888/