### PR TITLE
plugins/gitgutter: fix grepPackage

### DIFF
--- a/plugins/git/gitgutter.nix
+++ b/plugins/git/gitgutter.nix
@@ -193,7 +193,7 @@ in
         foldtext = "gitgutter#fold#foldtext";
       };
 
-      extraPackages = [ cfg.gitPackage ] ++ [ grepPackage ];
+      extraPackages = [ cfg.gitPackage ] ++ grepPackage;
 
       globals = {
         gitgutter_max_signs = mkIf (cfg.maxSigns != null) cfg.maxSigns;

--- a/tests/test-sources/plugins/git/git-worktree.nix
+++ b/tests/test-sources/plugins/git/git-worktree.nix
@@ -28,7 +28,7 @@
   };
 
   no-packages = {
-    plugins.neogit = {
+    plugins.git-worktree = {
       enable = true;
       gitPackage = null;
     };

--- a/tests/test-sources/plugins/git/gitgutter.nix
+++ b/tests/test-sources/plugins/git/gitgutter.nix
@@ -1,0 +1,41 @@
+{ lib, pkgs, ... }:
+{
+  empty = {
+    plugins.gitgutter.enable = true;
+  };
+
+  grep-command =
+    { config, ... }:
+    {
+      plugins.gitgutter = {
+        enable = true;
+        grep = {
+          package = pkgs.gnugrep;
+          command = "";
+        };
+      };
+      assertions = [
+        {
+          assertion =
+            config.extraPackages != [ ] && lib.any (x: x.pname or null == "gnugrep") config.extraPackages;
+          message = "gnugrep wasn't found when it was expected";
+        }
+      ];
+    };
+
+  no-packages =
+    { config, ... }:
+    {
+      globals.gitgutter_git_executable = lib.getExe pkgs.git;
+      plugins.gitgutter = {
+        enable = true;
+        gitPackage = null;
+      };
+      assertions = [
+        {
+          assertion = lib.all (x: x.pname or null != "git") config.extraPackages;
+          message = "A git package found in extraPackages when it wasn't expected";
+        }
+      ];
+    };
+}


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/2124 and adds some of the package assertions @MattSturgeon and I were playing around with in https://github.com/nix-community/nixvim/pull/2121

Looks like it needs to be refactored to newest standards, as well. But, that will be a different PR. 