### PR TITLE
flake-modules/dev: treefmt ignore .editorconfig

### DIFF
--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -41,6 +41,7 @@
 
         settings = {
           global.excludes = [
+            ".editorconfig"
             ".envrc"
             ".git-blame-ignore-revs"
             ".gitignore"


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/1945

I didn't see an ini formatter that we could use for this file, so we can just ignore it like we do a few other files. 