### PR TITLE
lib/*-plugins: initial support for `lib.mkPackageOption`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,8 @@ The vast majority of plugins fall into one of those two categories:
   - `name`: The name of the plugin. The resulting nixvim module will have `plugins.<name>` as a path.\
     For a plugin named `foo-bar.nvim`, set this to `foo-bar` (subject to exceptions).
   - `originalName`: The "real" name of the plugin (i.e. `foo-bar.nvim`). This is used mostly in documentation.
-  - `defaultPackage`: The nixpkgs package for this plugin (e.g. `pkgs.vimPlugins.foo-bar-nvim`).
+  - `package`: The nixpkgs package attr for this plugin
+     e.g. `"foo-bar-nvim` for `pkgs.vimPlugins.foo-bar-nvim`, or `[ "hello" "world" ]` for `pkgs.hello.world`.
   - `maintainers`: Register yourself as a maintainer for this plugin:
     - `[lib.maintainers.JosephFourier]` if you are already registered as a [`nixpkgs` maintainer](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix)
     - `[helpers.maintainers.GaspardMonge]` otherwise. (Also add yourself to [`maintainers.nix`](lib/maintainers.nix))

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -29,6 +29,8 @@ The [nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/#managing-plugins-w
 
 When using NixVim it is possible to encounter an error of the type `attribute 'name' missing`, for example it could look like:
 
+<!-- TODO: Update example now that we use `mkPackageOption` -->
+
 ```
        (stack trace truncated; use '--show-trace' to show the full trace)
 

--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -28,13 +28,12 @@ with lib;
       colorscheme ? name,
       # options
       originalName ? name,
-      # WARNING: `defaultPackage` is deprecated by `package`,
-      defaultPackage ? throw "mkVimPlugin called without either `package` or `defaultPackage`.",
       # Can be a string, a list of strings, or a module option:
       # - A string will be intrpreted as `pkgs.vimPlugins.${package}`
       # - A list will be interpreted as a "pkgs path", e.g. `pkgs.${elem1}.${elem2}.${etc...}`
       # - An option will be used as-is, but should be built using `lib.mkPackageOption`
-      package ? helpers.mkPluginPackageOption originalName defaultPackage,
+      # Defaults to `name`, i.e. `pkgs.vimPlugins.${name}`
+      package ? name,
       settingsOptions ? { },
       settingsExample ? null,
       settingsDescription ? "Options provided to the `require('${luaName}')${setup}` function.",

--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -17,7 +17,7 @@ with lib;
     {
       name,
       maintainers,
-      url ? defaultPackage.meta.homepage,
+      url ? throw "default",
       imports ? [ ],
       description ? null,
       # deprecations
@@ -28,7 +28,13 @@ with lib;
       colorscheme ? name,
       # options
       originalName ? name,
-      defaultPackage,
+      # WARNING: `defaultPackage` is deprecated by `package`,
+      defaultPackage ? throw "mkVimPlugin called without either `package` or `defaultPackage`.",
+      # Can be a string, a list of strings, or a module option:
+      # - A string will be intrpreted as `pkgs.vimPlugins.${package}`
+      # - A list will be interpreted as a "pkgs path", e.g. `pkgs.${elem1}.${elem2}.${etc...}`
+      # - An option will be used as-is, but should be built using `lib.mkPackageOption`
+      package ? helpers.mkPluginPackageOption originalName defaultPackage,
       settingsOptions ? { },
       settingsExample ? null,
       settingsDescription ? "Options provided to the `require('${luaName}')${setup}` function.",
@@ -42,22 +48,78 @@ with lib;
       extraPackages ? [ ],
       callSetup ? true,
       installPackage ? true,
-    }:
+    }@args:
     let
       namespace = if isColorscheme then "colorschemes" else "plugins";
+
+      module =
+        {
+          config,
+          options,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.${namespace}.${name};
+          opt = options.${namespace}.${name};
+          extraConfigNamespace = if isColorscheme then "extraConfigLuaPre" else "extraConfigLua";
+        in
+        {
+          meta = {
+            inherit maintainers;
+            nixvimInfo = {
+              inherit description;
+              url = args.url or opt.package.default.meta.homepage;
+              path = [
+                namespace
+                name
+              ];
+            };
+          };
+
+          options.${namespace}.${name} =
+            {
+              enable = mkEnableOption originalName;
+              package =
+                if lib.isOption package then
+                  package
+                else
+                  lib.mkPackageOption pkgs originalName {
+                    default =
+                      if builtins.isList package then
+                        package
+                      else
+                        [
+                          "vimPlugins"
+                          package
+                        ];
+                  };
+            }
+            // optionalAttrs hasSettings {
+              settings = helpers.mkSettingsOption {
+                description = settingsDescription;
+                options = settingsOptions;
+                example = settingsExample;
+              };
+            }
+            // extraOptions;
+
+          config = mkIf cfg.enable (mkMerge [
+            {
+              extraPlugins = (optional installPackage cfg.package) ++ extraPlugins;
+              inherit extraPackages;
+            }
+            (optionalAttrs callSetup {
+              ${extraConfigNamespace} = ''
+                require('${luaName}')${setup}(${optionalString (cfg ? settings) (helpers.toLuaObject cfg.settings)})
+              '';
+            })
+            (optionalAttrs (isColorscheme && (colorscheme != null)) { colorscheme = mkDefault colorscheme; })
+            (extraConfig cfg)
+          ]);
+        };
     in
     {
-      meta = {
-        inherit maintainers;
-        nixvimInfo = {
-          inherit description url;
-          path = [
-            namespace
-            name
-          ];
-        };
-      };
-
       imports =
         let
           basePluginPath = [
@@ -67,49 +129,10 @@ with lib;
           settingsPath = basePluginPath ++ [ "settings" ];
         in
         imports
+        ++ [ module ]
         ++ (optional deprecateExtraOptions (
           mkRenamedOptionModule (basePluginPath ++ [ "extraOptions" ]) settingsPath
         ))
-        ++ (nixvim.mkSettingsRenamedOptionModules basePluginPath settingsPath optionsRenamedToSettings)
-        ++ [
-          (
-            { config, ... }:
-            {
-              config =
-                let
-                  cfg = config.${namespace}.${name};
-                  extraConfigNamespace = if isColorscheme then "extraConfigLuaPre" else "extraConfigLua";
-                in
-                mkIf cfg.enable (mkMerge [
-                  {
-                    extraPlugins = (optional installPackage cfg.package) ++ extraPlugins;
-                    inherit extraPackages;
-                  }
-                  (optionalAttrs callSetup {
-                    ${extraConfigNamespace} = ''
-                      require('${luaName}')${setup}(${optionalString (cfg ? settings) (helpers.toLuaObject cfg.settings)})
-                    '';
-                  })
-                  (optionalAttrs (isColorscheme && (colorscheme != null)) { colorscheme = mkDefault colorscheme; })
-                  (extraConfig cfg)
-                ]);
-            }
-          )
-        ];
-
-      options.${namespace}.${name} =
-        {
-          enable = mkEnableOption originalName;
-
-          package = helpers.mkPluginPackageOption originalName defaultPackage;
-        }
-        // optionalAttrs hasSettings {
-          settings = helpers.mkSettingsOption {
-            description = settingsDescription;
-            options = settingsOptions;
-            example = settingsExample;
-          };
-        }
-        // extraOptions;
+        ++ (nixvim.mkSettingsRenamedOptionModules basePluginPath settingsPath optionsRenamedToSettings);
     };
 }

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -308,6 +308,7 @@ rec {
         );
     };
 
+  # TODO: Deprecated 2024-09-02; remove once all internal uses are gone
   mkPackageOption =
     args:
     # A default package is required
@@ -326,6 +327,7 @@ rec {
       }
     );
 
+  # TODO: Deprecated 2024-09-02; remove once all internal uses are gone
   mkPluginPackageOption =
     name: default:
     mkOption {

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -16,13 +16,12 @@ with lib;
       colorscheme ? name,
       # options
       originalName ? name,
-      # WARNING: `defaultPackage` is deprecated by `package`,
-      defaultPackage ? throw "mkVimPlugin called without either `package` or `defaultPackage`.",
       # Can be a string, a list of strings, or a module option:
       # - A string will be intrpreted as `pkgs.vimPlugins.${package}`
       # - A list will be interpreted as a "pkgs path", e.g. `pkgs.${elem1}.${elem2}.${etc...}`
       # - An option will be used as-is, but should be built using `lib.mkPackageOption`
-      package ? helpers.mkPluginPackageOption originalName defaultPackage,
+      # Defaults to `name`, i.e. `pkgs.vimPlugins.${name}`
+      package ? name,
       settingsOptions ? { },
       settingsExample ? null,
       globalPrefix ? "",

--- a/plugins/TEMPLATE.nix
+++ b/plugins/TEMPLATE.nix
@@ -1,15 +1,11 @@
-{
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "my-plugin";
   originalName = "my-plugin.nvim"; # TODO replace (or remove entirely if it is the same as `name`)
-  defaultPackage = pkgs.vimPlugins.my-plugin-nvim; # TODO replace
+  package = "my-plugin-nvim"; # TODO replace
 
   maintainers = [ lib.maintainers.MyName ]; # TODO replace with your name
 

--- a/plugins/ai/chatgpt.nix
+++ b/plugins/ai/chatgpt.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "chatgpt";
   originalName = "ChatGPT.nvim";
-  defaultPackage = pkgs.vimPlugins.ChatGPT-nvim;
+  package = "ChatGPT-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ai/copilot-chat.nix
+++ b/plugins/ai/copilot-chat.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "copilot-chat";
   originalName = "CopilotChat.nvim";
   luaName = "CopilotChat";
-  defaultPackage = pkgs.vimPlugins.CopilotChat-nvim;
+  package = "CopilotChat-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -53,7 +53,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "barbar";
   originalName = "barbar.nvim";
-  defaultPackage = pkgs.vimPlugins.barbar-nvim;
+  package = "barbar-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/bufferlines/barbecue.nix
+++ b/plugins/bufferlines/barbecue.nix
@@ -1,15 +1,11 @@
-{
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "barbecue";
   originalName = "barbecue.nvim";
-  defaultPackage = pkgs.vimPlugins.barbecue-nvim;
+  package = "barbecue-nvim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -10,7 +10,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "bufferline";
   originalName = "bufferline.nvim";
-  defaultPackage = pkgs.vimPlugins.bufferline-nvim;
+  package = "bufferline-nvim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/bufferlines/navic.nix
+++ b/plugins/bufferlines/navic.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
@@ -10,7 +6,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "navic";
   originalName = "nvim-navic";
   luaName = "nvim-navic";
-  defaultPackage = pkgs.vimPlugins.nvim-navic;
+  package = "nvim-navic";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/colorschemes/ayu.nix
+++ b/plugins/colorschemes/ayu.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "ayu";
   isColorscheme = true;
   originalName = "neovim-ayu";
-  defaultPackage = pkgs.vimPlugins.neovim-ayu;
+  package = "neovim-ayu";
   # The colorscheme option is set by the `setup` function.
   colorscheme = null;
   callSetup = false;

--- a/plugins/colorschemes/base16/default.nix
+++ b/plugins/colorschemes/base16/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -13,7 +12,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   inherit name luaName originalName;
   setup = ".with_config";
-  defaultPackage = pkgs.vimPlugins.base16-nvim;
+  package = "base16-nvim";
   isColorscheme = true;
 
   maintainers = with lib.maintainers; [

--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "catppuccin";
   isColorscheme = true;
-  defaultPackage = pkgs.vimPlugins.catppuccin-nvim;
+  package = "catppuccin-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/cyberdream.nix
+++ b/plugins/colorschemes/cyberdream.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "cyberdream";
   isColorscheme = true;
   originalName = "cyberdream.nvim";
-  defaultPackage = pkgs.vimPlugins.cyberdream-nvim;
+  package = "cyberdream-nvim";
 
   maintainers = [ lib.nixvim.maintainers.AndresBermeoMarinelli ];
 

--- a/plugins/colorschemes/dracula-nvim.nix
+++ b/plugins/colorschemes/dracula-nvim.nix
@@ -1,14 +1,9 @@
-{
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "dracula-nvim";
   originalName = "dracula.nvim ";
   luaName = "dracula";
   colorscheme = "dracula";
-  defaultPackage = pkgs.vimPlugins.dracula-nvim;
   isColorscheme = true;
 
   maintainers = [ lib.nixvim.maintainers.refaelsh ];

--- a/plugins/colorschemes/everforest.nix
+++ b/plugins/colorschemes/everforest.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -17,7 +16,6 @@ in
 lib.nixvim.vim-plugin.mkVimPlugin {
   name = "everforest";
   isColorscheme = true;
-  defaultPackage = pkgs.vimPlugins.everforest;
   globalPrefix = "everforest_";
 
   maintainers = [ lib.nixvim.maintainers.sheemap ];

--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  pkgs,
   ...
 }:
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "gruvbox";
   isColorscheme = true;
   originalName = "gruvbox.nvim";
-  defaultPackage = pkgs.vimPlugins.gruvbox-nvim;
+  package = "gruvbox-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/kanagawa.nix
+++ b/plugins/colorschemes/kanagawa.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -11,7 +10,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "kanagawa";
   isColorscheme = true;
   originalName = "kanagawa.nvim";
-  defaultPackage = pkgs.vimPlugins.kanagawa-nvim;
+  package = "kanagawa-nvim";
 
   description = ''
     You can select the theme in two ways:

--- a/plugins/colorschemes/melange.nix
+++ b/plugins/colorschemes/melange.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  pkgs,
   ...
 }:
 lib.nixvim.vim-plugin.mkVimPlugin {
   name = "melange";
   isColorscheme = true;
   originalName = "melange-nvim";
-  defaultPackage = pkgs.vimPlugins.melange-nvim;
+  package = "melange-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/modus.nix
+++ b/plugins/colorschemes/modus.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "modus";
   luaName = "modus-themes";
   originalName = "modus-themes.nvim";
-  defaultPackage = pkgs.vimPlugins.modus-themes-nvim;
+  package = "modus-themes-nvim";
   isColorscheme = true;
 
   maintainers = [ lib.nixvim.maintainers.nwjsmith ];

--- a/plugins/colorschemes/nightfox.nix
+++ b/plugins/colorschemes/nightfox.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -11,7 +10,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "nightfox";
   isColorscheme = true;
   originalName = "nightfox.nvim";
-  defaultPackage = pkgs.vimPlugins.nightfox-nvim;
+  package = "nightfox-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ lib.nixvim.vim-plugin.mkVimPlugin {
   name = "nord";
   isColorscheme = true;
   originalName = "nord.nvim";
-  defaultPackage = pkgs.vimPlugins.nord-nvim;
+  package = "nord-nvim";
   globalPrefix = "nord_";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/colorschemes/one.nix
+++ b/plugins/colorschemes/one.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  pkgs,
   ...
 }:
 lib.nixvim.vim-plugin.mkVimPlugin {
   name = "one";
   isColorscheme = true;
   originalName = "vim-one";
-  defaultPackage = pkgs.vimPlugins.vim-one;
+  package = "vim-one";
   globalPrefix = "one_";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/colorschemes/onedark.nix
+++ b/plugins/colorschemes/onedark.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  pkgs,
   ...
 }:
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "onedark";
   isColorscheme = true;
   originalName = "onedark.nvim";
-  defaultPackage = pkgs.vimPlugins.onedark-nvim;
+  package = "onedark-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/oxocarbon.nix
+++ b/plugins/colorschemes/oxocarbon.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  pkgs,
   ...
 }:
 lib.nixvim.vim-plugin.mkVimPlugin {
   name = "oxocarbon";
   isColorscheme = true;
   originalName = "oxocarbon.nvim";
-  defaultPackage = pkgs.vimPlugins.oxocarbon-nvim;
+  package = "oxocarbon-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -10,7 +10,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "palette";
   isColorscheme = true;
   originalName = "palette.nvim";
-  defaultPackage = pkgs.vimPlugins.palette-nvim;
+  package = "palette-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/poimandres.nix
+++ b/plugins/colorschemes/poimandres.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "poimandres";
   isColorscheme = true;
   originalName = "poimandres.nvim";
-  defaultPackage = pkgs.vimPlugins.poimandres-nvim;
+  package = "poimandres-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/rose-pine.nix
+++ b/plugins/colorschemes/rose-pine.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -9,7 +8,6 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "rose-pine";
   isColorscheme = true;
-  defaultPackage = pkgs.vimPlugins.rose-pine;
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/tokyonight.nix
+++ b/plugins/colorschemes/tokyonight.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "tokyonight";
   isColorscheme = true;
   originalName = "tokyonight.nvim";
-  defaultPackage = pkgs.vimPlugins.tokyonight-nvim;
+  package = "tokyonight-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/colorschemes/vscode.nix
+++ b/plugins/colorschemes/vscode.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "vscode";
   isColorscheme = true;
   originalName = "vscode-nvim";
-  defaultPackage = pkgs.vimPlugins.vscode-nvim;
+  package = "vscode-nvim";
   colorscheme = null; # Color scheme is set by `require.("vscode").load()`
   callSetup = false;
 

--- a/plugins/completion/cmp/default.nix
+++ b/plugins/completion/cmp/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 let
@@ -11,7 +10,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "cmp";
   originalName = "nvim-cmp";
-  defaultPackage = pkgs.vimPlugins.nvim-cmp;
+  package = "nvim-cmp";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/completion/cmp/sources/_mk-cmp-plugin.nix
+++ b/plugins/completion/cmp/sources/_mk-cmp-plugin.nix
@@ -7,7 +7,10 @@
 {
   pluginName,
   sourceName,
-  defaultPackage ? pkgs.vimPlugins.${pluginName},
+  package ? lib.mkPackageOption pkgs [
+    "vimPlugins"
+    pluginName
+  ] { },
   maintainers ? [ lib.maintainers.GaetanLepage ],
   imports ? [ ],
   ...
@@ -18,7 +21,7 @@ helpers.vim-plugin.mkVimPlugin (
     "sourceName"
   ]
   // {
-    inherit defaultPackage maintainers;
+    inherit package maintainers;
     name = pluginName;
 
     imports = imports ++ [

--- a/plugins/completion/codeium-vim.nix
+++ b/plugins/completion/codeium-vim.nix
@@ -37,7 +37,6 @@ in
 helpers.vim-plugin.mkVimPlugin {
   name = "codeium-vim";
   originalName = "codeium.vim";
-  defaultPackage = pkgs.vimPlugins.codeium-vim;
   globalPrefix = "codeium_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/completion/copilot-vim.nix
+++ b/plugins/completion/copilot-vim.nix
@@ -9,7 +9,6 @@ with helpers.vim-plugin;
 helpers.vim-plugin.mkVimPlugin {
   name = "copilot-vim";
   originalName = "copilot.vim";
-  defaultPackage = pkgs.vimPlugins.copilot-vim;
   globalPrefix = "copilot_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/completion/coq.nix
+++ b/plugins/completion/coq.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "coq-nvim";
   originalName = "coq_nvim";
-  defaultPackage = pkgs.vimPlugins.coq_nvim;
+  package = "coq_nvim";
 
   maintainers = [
     maintainers.traxys

--- a/plugins/filetrees/yazi.nix
+++ b/plugins/filetrees/yazi.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "yazi";
   originalName = "yazi.nvim";
-  defaultPackage = pkgs.vimPlugins.yazi-nvim;
+  package = "yazi-nvim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/git/committia.nix
+++ b/plugins/git/committia.nix
@@ -6,7 +6,7 @@
 helpers.vim-plugin.mkVimPlugin {
   name = "committia";
   originalName = "committia.vim";
-  defaultPackage = pkgs.vimPlugins.committia-vim;
+  package = "committia-vim";
   globalPrefix = "committia_";
 
   maintainers = [ helpers.maintainers.alisonjenkins ];

--- a/plugins/git/fugitive.nix
+++ b/plugins/git/fugitive.nix
@@ -7,7 +7,7 @@
 helpers.vim-plugin.mkVimPlugin {
   name = "fugitive";
   originalName = "vim-fugitive";
-  defaultPackage = pkgs.vimPlugins.vim-fugitive;
+  package = "vim-fugitive";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/git/git-conflict.nix
+++ b/plugins/git/git-conflict.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "git-conflict";
   originalName = "git-conflict.nvim";
-  defaultPackage = pkgs.vimPlugins.git-conflict-nvim;
+  package = "git-conflict-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/git/gitblame.nix
+++ b/plugins/git/gitblame.nix
@@ -10,7 +10,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "gitblame";
   originalName = "git-blame.nvim";
-  defaultPackage = pkgs.vimPlugins.git-blame-nvim;
+  package = "git-blame-nvim";
 
   maintainers = with lib.maintainers; [ GaetanLepage ];
 

--- a/plugins/git/gitignore.nix
+++ b/plugins/git/gitignore.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -10,7 +9,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "gitignore";
   originalName = "gitignore.nvim";
-  defaultPackage = pkgs.vimPlugins.gitignore-nvim;
+  package = "gitignore-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/git/gitsigns/default.nix
+++ b/plugins/git/gitsigns/default.nix
@@ -9,7 +9,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "gitsigns";
   originalName = "gitsigns.nvim";
-  defaultPackage = pkgs.vimPlugins.gitsigns-nvim;
+  package = "gitsigns-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/git/lazygit.nix
+++ b/plugins/git/lazygit.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "lazygit";
   originalName = "lazygit.nvim";
-  defaultPackage = pkgs.vimPlugins.lazygit-nvim;
+  package = "lazygit-nvim";
   globalPrefix = "lazygit_";
 
   maintainers = [ helpers.maintainers.AndresBermeoMarinelli ];

--- a/plugins/git/neogit/default.nix
+++ b/plugins/git/neogit/default.nix
@@ -8,7 +8,6 @@
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "neogit";
-  defaultPackage = pkgs.vimPlugins.neogit;
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/git/octo.nix
+++ b/plugins/git/octo.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "octo";
   originalName = "octo.nvim";
-  defaultPackage = pkgs.vimPlugins.octo-nvim;
+  package = "octo-nvim";
 
   maintainers = [ helpers.maintainers.svl ];
 

--- a/plugins/languages/cmake-tools.nix
+++ b/plugins/languages/cmake-tools.nix
@@ -1,13 +1,12 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "cmake-tools";
   originalName = "cmake-tools.nvim";
-  defaultPackage = pkgs.vimPlugins.cmake-tools-nvim;
+  package = "cmake-tools-nvim";
 
   maintainers = [ helpers.maintainers.NathanFelber ];
 

--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "debugprint";
   originalName = "debugprint.nvim";
-  defaultPackage = pkgs.vimPlugins.debugprint-nvim;
+  package = "debugprint-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/languages/godot.nix
+++ b/plugins/languages/godot.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "godot";
   originalName = "vim-godot";
-  defaultPackage = pkgs.vimPlugins.vim-godot;
+  package = "vim-godot";
   globalPrefix = "godot_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/languages/haskell-scope-highlighting.nix
+++ b/plugins/languages/haskell-scope-highlighting.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   helpers,
   config,
   ...
@@ -9,7 +8,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "haskell-scope-highlighting";
   originalName = "haskell-scope-highlighting.nvim";
-  defaultPackage = pkgs.vimPlugins.haskell-scope-highlighting-nvim;
+  package = "haskell-scope-highlighting-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/languages/julia/julia-cell.nix
+++ b/plugins/languages/julia/julia-cell.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 let
@@ -39,7 +38,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "julia-cell";
   originalName = "vim-julia-cell";
-  defaultPackage = pkgs.vimPlugins.vim-julia-cell;
+  package = "vim-julia-cell";
   globalPrefix = "julia_cell_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -9,7 +9,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "ledger";
   originalName = "vim-ledger";
-  defaultPackage = pkgs.vimPlugins.vim-ledger;
+  package = "vim-ledger";
   globalPrefix = "ledger_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "ltex-extra";
   originalName = "ltex_extra.nvim";
-  defaultPackage = pkgs.vimPlugins.ltex_extra-nvim;
+  package = "ltex_extra-nvim";
 
   maintainers = [ maintainers.loicreynier ];
 

--- a/plugins/languages/markdown/glow.nix
+++ b/plugins/languages/markdown/glow.nix
@@ -7,7 +7,7 @@
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "glow";
   originalName = "glow.nvim";
-  defaultPackage = pkgs.vimPlugins.glow-nvim;
+  package = "glow-nvim";
 
   maintainers = [ lib.maintainers.getchoo ];
 

--- a/plugins/languages/markdown/markdown-preview.nix
+++ b/plugins/languages/markdown/markdown-preview.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "markdown-preview";
   originalName = "markdown-preview.nvim";
-  defaultPackage = pkgs.vimPlugins.markdown-preview-nvim;
+  package = "markdown-preview-nvim";
   globalPrefix = "mkdp_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/languages/markdown/markview.nix
+++ b/plugins/languages/markdown/markview.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "markview";
   originalName = "markview.nvim";
-  defaultPackage = pkgs.vimPlugins.markview-nvim;
+  package = "markview-nvim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/languages/markdown/preview.nix
+++ b/plugins/languages/markdown/preview.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "preview";
   originalName = "Preview.nvim";
-  defaultPackage = pkgs.vimPlugins.Preview-nvim;
+  package = "Preview-nvim";
 
   hasSettings = false;
 

--- a/plugins/languages/nix.nix
+++ b/plugins/languages/nix.nix
@@ -1,13 +1,12 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "nix";
   originalName = "vim-nix";
-  defaultPackage = pkgs.vimPlugins.vim-nix;
+  package = "vim-nix";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/languages/nvim-orgmode.nix
+++ b/plugins/languages/nvim-orgmode.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -9,7 +8,6 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "orgmode";
   originalName = "nvim-orgmode";
-  defaultPackage = pkgs.vimPlugins.orgmode;
 
   maintainers = [ lib.nixvim.maintainers.refaelsh ];
 

--- a/plugins/languages/otter.nix
+++ b/plugins/languages/otter.nix
@@ -2,13 +2,12 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "otter";
   originalName = "otter.nvim";
-  defaultPackage = pkgs.vimPlugins.otter-nvim;
+  package = "otter-nvim";
 
   maintainers = [ lib.maintainers.perchun ];
 

--- a/plugins/languages/parinfer-rust.nix
+++ b/plugins/languages/parinfer-rust.nix
@@ -1,12 +1,10 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "parinfer-rust";
-  defaultPackage = pkgs.vimPlugins.parinfer-rust;
   globalPrefix = "parinfer_";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/languages/python/jupytext.nix
+++ b/plugins/languages/python/jupytext.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "jupytext";
   originalName = "jupytext.nvim";
-  defaultPackage = pkgs.vimPlugins.jupytext-nvim;
+  package = "jupytext-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/languages/qmk.nix
+++ b/plugins/languages/qmk.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "qmk";
   originalName = "qmk.nvim";
-  defaultPackage = pkgs.vimPlugins.qmk-nvim;
+  package = "qmk-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/languages/rust/rustaceanvim/default.nix
+++ b/plugins/languages/rust/rustaceanvim/default.nix
@@ -8,7 +8,6 @@
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "rustaceanvim";
-  defaultPackage = pkgs.vimPlugins.rustaceanvim;
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/languages/sniprun.nix
+++ b/plugins/languages/sniprun.nix
@@ -1,13 +1,11 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "sniprun";
-  defaultPackage = pkgs.vimPlugins.sniprun;
   url = "https://github.com/michaelb/sniprun";
 
   maintainers = with maintainers; [

--- a/plugins/languages/tagbar.nix
+++ b/plugins/languages/tagbar.nix
@@ -6,7 +6,6 @@
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "tagbar";
-  defaultPackage = pkgs.vimPlugins.tagbar;
   globalPrefix = "tagbar_";
   extraPackages = [ pkgs.ctags ];
 

--- a/plugins/languages/texpresso.nix
+++ b/plugins/languages/texpresso.nix
@@ -10,7 +10,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "texpresso";
   originalName = "texpresso.vim";
-  defaultPackage = pkgs.vimPlugins.texpresso-vim;
+  package = "texpresso-vim";
 
   maintainers = [ maintainers.nickhu ];
 

--- a/plugins/languages/treesitter/treesitter-context.nix
+++ b/plugins/languages/treesitter/treesitter-context.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "treesitter-context";
   originalName = "nvim-treesitter-context";
-  defaultPackage = pkgs.vimPlugins.nvim-treesitter-context;
+  package = "nvim-treesitter-context";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -10,7 +10,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "treesitter";
   originalName = "nvim-treesitter";
   luaName = "nvim-treesitter.configs";
-  defaultPackage = pkgs.vimPlugins.nvim-treesitter;
+  package = "nvim-treesitter";
 
   description = ''
     Provides an interface to [tree-sitter]

--- a/plugins/languages/treesitter/ts-autotag.nix
+++ b/plugins/languages/treesitter/ts-autotag.nix
@@ -2,7 +2,6 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
@@ -10,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "ts-autotag";
   originalName = "nvim-ts-autotag";
   luaName = "nvim-ts-autotag";
-  defaultPackage = pkgs.vimPlugins.nvim-ts-autotag;
+  package = "nvim-ts-autotag";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/languages/typst/typst-vim.nix
+++ b/plugins/languages/typst/typst-vim.nix
@@ -8,7 +8,6 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "typst-vim";
   originalName = "typst.vim";
-  defaultPackage = pkgs.vimPlugins.typst-vim;
   globalPrefix = "typst_";
 
   # Add the typst compiler to nixvim packages

--- a/plugins/languages/vim-slime.nix
+++ b/plugins/languages/vim-slime.nix
@@ -1,14 +1,12 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
 mkVimPlugin {
   name = "vim-slime";
-  defaultPackage = pkgs.vimPlugins.vim-slime;
   globalPrefix = "slime_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/languages/vimtex.nix
+++ b/plugins/languages/vimtex.nix
@@ -7,7 +7,6 @@
 with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "vimtex";
-  defaultPackage = pkgs.vimPlugins.vimtex;
   globalPrefix = "vimtex_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/languages/zig.nix
+++ b/plugins/languages/zig.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "zig";
   originalName = "zig.vim";
-  defaultPackage = pkgs.vimPlugins.zig-vim;
+  package = "zig-vim";
   globalPrefix = "zig_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/lsp/conform-nvim.nix
+++ b/plugins/lsp/conform-nvim.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -11,7 +10,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "conform-nvim";
   luaName = "conform";
   originalName = "conform.nvim";
-  defaultPackage = pkgs.vimPlugins.conform-nvim;
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
@@ -11,7 +10,7 @@ let
     {
       name = "ansiblels";
       description = "ansiblels for Ansible";
-      package = pkgs.ansible-language-server;
+      package = "ansible-language-server";
       cmd = cfg: [
         "${cfg.package}/bin/ansible-language-server"
         "--stdio"
@@ -28,7 +27,7 @@ let
     {
       name = "astro";
       description = "astrols for Astro";
-      package = pkgs.astro-language-server;
+      package = "astro-language-server";
       cmd = cfg: [
         "${cfg.package}/bin/astro-ls"
         "--stdio"
@@ -37,12 +36,12 @@ let
     {
       name = "bashls";
       description = "bashls for bash";
-      package = pkgs.bash-language-server;
+      package = "bash-language-server";
     }
     {
       name = "beancount";
       description = "beancount-language-server";
-      package = pkgs.beancount-language-server;
+      package = "beancount-language-server";
     }
     {
       name = "biome";
@@ -51,7 +50,7 @@ let
     {
       name = "bufls";
       description = "Prototype for a Protobuf language server compatible with Buf.";
-      package = pkgs.buf-language-server;
+      package = "buf-language-server";
     }
     {
       name = "ccls";
@@ -60,29 +59,27 @@ let
     {
       name = "clangd";
       description = "clangd LSP for C/C++";
-      package = pkgs.clang-tools;
+      package = "clang-tools";
     }
     {
       name = "clojure-lsp";
       description = "clojure-lsp for Clojure";
       serverName = "clojure_lsp";
-      package = pkgs.clojure-lsp;
     }
     {
       name = "cmake";
       description = "cmake language server";
-      package = pkgs.cmake-language-server;
+      package = "cmake-language-server";
     }
     {
       name = "csharp-ls";
       description = "csharp-ls for C#";
-      package = pkgs.csharp-ls;
       serverName = "csharp_ls";
     }
     {
       name = "cssls";
       description = "cssls for CSS";
-      package = pkgs.vscode-langservers-extracted;
+      package = "vscode-langservers-extracted";
       cmd = cfg: [
         "${cfg.package}/bin/vscode-css-language-server"
         "--stdio"
@@ -91,19 +88,19 @@ let
     {
       name = "dagger";
       description = "dagger for Cuelang";
-      package = pkgs.cuelsp;
+      package = "cuelsp";
     }
     {
       name = "dartls";
       description = "dart language-server";
-      package = pkgs.dart;
+      package = "dart";
       settingsOptions = import ./dartls-settings.nix { inherit lib helpers; };
       settings = cfg: { dart = cfg; };
     }
     {
       name = "denols";
       description = "denols for Deno";
-      package = pkgs.deno;
+      package = "deno";
     }
     {
       name = "dhall-lsp-server";
@@ -114,7 +111,10 @@ let
       name = "digestif";
       description = "digestif for LaTeX";
       # luaPackages.digestif is currently broken, using lua54Packages instead
-      package = pkgs.lua54Packages.digestif;
+      package = [
+        "lua54Packages"
+        "digestif"
+      ];
     }
     {
       name = "docker-compose-language-service";
@@ -124,7 +124,7 @@ let
     {
       name = "dockerls";
       description = "dockerls for Dockerfile";
-      package = pkgs.dockerfile-language-server-nodejs;
+      package = "dockerfile-language-server-nodejs";
       cmd = cfg: [
         "${cfg.package}/bin/docker-langserver"
         "--stdio"
@@ -133,22 +133,24 @@ let
     {
       name = "efm";
       description = "efm-langserver for misc tools";
-      package = pkgs.efm-langserver;
+      package = "efm-langserver";
     }
     {
       name = "elmls";
       description = "elmls for Elm";
-      package = pkgs.elmPackages.elm-language-server;
+      package = [
+        "elmPackages"
+        "elm-language-server"
+      ];
     }
     {
       name = "emmet-ls";
       description = "emmet_ls, emmet support based on LSP";
-      package = pkgs.emmet-ls;
       serverName = "emmet_ls";
     }
     {
       name = "eslint";
-      package = pkgs.vscode-langservers-extracted;
+      package = "vscode-langservers-extracted";
       cmd = cfg: [
         "${cfg.package}/bin/vscode-eslint-language-server"
         "--stdio"
@@ -156,7 +158,7 @@ let
     }
     {
       name = "elixirls";
-      package = pkgs.elixir-ls;
+      package = "elixir-ls";
       cmd = cfg: [ "${cfg.package}/bin/elixir-ls" ];
     }
     {
@@ -172,12 +174,11 @@ let
     {
       name = "fsautocomplete";
       description = "fsautocomplete for F#";
-      package = pkgs.fsautocomplete;
     }
     {
       name = "futhark-lsp";
       description = "futhark-lsp for Futhark";
-      package = pkgs.futhark;
+      package = "futhark";
       serverName = "futhark_lsp";
     }
     {
@@ -197,12 +198,15 @@ let
       name = "golangci-lint-ls";
       description = "golangci-lint-ls for Go";
       serverName = "golangci_lint_ls";
-      package = pkgs.golangci-lint-langserver;
+      package = "golangci-lint-langserver";
     }
     {
       name = "graphql";
       description = "graphql for GraphQL";
-      package = pkgs.nodePackages.graphql-language-service-cli;
+      package = [
+        "nodePackages"
+        "graphql-language-service-cli"
+      ];
     }
     {
       name = "helm-ls";
@@ -212,7 +216,7 @@ let
     {
       name = "hls";
       description = "haskell language server";
-      package = pkgs.haskell-language-server;
+      package = "haskell-language-server";
       cmd = cfg: [
         "haskell-language-server-wrapper"
         "--lsp"
@@ -221,7 +225,7 @@ let
     {
       name = "html";
       description = "HTML language server from `vscode-langservers-extracted`";
-      package = pkgs.vscode-langservers-extracted;
+      package = "vscode-langservers-extracted";
       cmd = cfg: [
         "${cfg.package}/bin/vscode-html-language-server"
         "--stdio"
@@ -230,12 +234,15 @@ let
     {
       name = "htmx";
       description = "htmx for HTMX";
-      package = pkgs.htmx-lsp;
+      package = "htmx-lsp";
     }
     {
       name = "intelephense";
       description = "intelephense for PHP";
-      package = pkgs.nodePackages.intelephense;
+      package = [
+        "nodePackages"
+        "intelephense"
+      ];
     }
     {
       name = "java-language-server";
@@ -252,7 +259,7 @@ let
     {
       name = "jsonls";
       description = "jsonls for JSON";
-      package = pkgs.vscode-langservers-extracted;
+      package = "vscode-langservers-extracted";
       cmd = cfg: [
         "${cfg.package}/bin/vscode-json-language-server"
         "--stdio"
@@ -262,7 +269,7 @@ let
     {
       name = "jsonnet-ls";
       description = "jsonnet language server";
-      package = pkgs.jsonnet-language-server;
+      package = "jsonnet-language-server";
       serverName = "jsonnet_ls";
       settingsOptions = import ./jsonnet-ls-settings.nix { inherit lib helpers; };
     }
@@ -281,7 +288,7 @@ let
     {
       name = "leanls";
       description = "leanls for Lean";
-      package = pkgs.lean4;
+      package = "lean4";
     }
     {
       name = "lemminx";
@@ -294,14 +301,14 @@ let
     {
       name = "ltex";
       description = "ltex-ls for LanguageTool";
-      package = pkgs.ltex-ls;
+      package = "ltex-ls";
       settingsOptions = import ./ltex-settings.nix { inherit lib helpers; };
       settings = cfg: { ltex = cfg; };
     }
     {
       name = "lua-ls";
       description = "lua-ls for Lua";
-      package = pkgs.lua-language-server;
+      package = "lua-language-server";
       serverName = "lua_ls";
       settingsOptions = import ./lua-ls-settings.nix { inherit lib helpers; };
       settings = cfg: { Lua = cfg; };
@@ -309,7 +316,6 @@ let
     {
       name = "marksman";
       description = "marksman for Markdown";
-      package = pkgs.marksman;
     }
     {
       name = "metals";
@@ -318,7 +324,7 @@ let
     {
       name = "nextls";
       description = "The language server for Elixir that just works.";
-      package = pkgs.next-ls;
+      package = "next-ls";
       cmd = cfg: [
         "nextls"
         "--stdio"
@@ -332,13 +338,13 @@ let
     {
       name = "nickel-ls";
       description = "nls for Nickel";
-      package = pkgs.nls;
+      package = "nls";
       serverName = "nickel_ls";
     }
     {
       name = "nil-ls";
       description = "nil for Nix";
-      package = pkgs.nil;
+      package = "nil";
       serverName = "nil_ls";
       settingsOptions = import ./nil-ls-settings.nix { inherit lib helpers; };
       settings = cfg: { nil = cfg; };
@@ -346,12 +352,11 @@ let
     {
       name = "nimls";
       description = "nimls for Nim";
-      package = pkgs.nimlsp;
+      package = "nimlsp";
     }
     {
       name = "nixd";
       description = "nixd for Nix";
-      package = pkgs.nixd;
       settings = cfg: { nixd = cfg; };
       settingsOptions = import ./nixd-settings.nix { inherit lib helpers; };
       extraConfig = cfg: {
@@ -369,17 +374,19 @@ let
     {
       name = "ocamllsp";
       description = "ocamllsp for OCaml";
-      package = pkgs.ocamlPackages.ocaml-lsp;
+      package = [
+        "ocamlPackages"
+        "ocaml-lsp"
+      ];
     }
     {
       name = "ols";
       description = "ols for the Odin programming language";
-      package = pkgs.ols;
     }
     {
       name = "omnisharp";
       description = "OmniSharp language server for C#";
-      package = pkgs.omnisharp-roslyn;
+      package = "omnisharp-roslyn";
       cmd = cfg: [ "${cfg.package}/bin/OmniSharp" ];
       settings = cfg: { omnisharp = cfg; };
       settingsOptions = {
@@ -438,39 +445,51 @@ let
     {
       name = "perlpls";
       description = "PLS for Perl";
-      package = pkgs.perlPackages.PLS;
+      package = [
+        "perlPackages"
+        "PLS"
+      ];
     }
     {
       name = "pest-ls";
       description = "pest_ls for pest";
-      package = pkgs.pest-ide-tools;
+      package = "pest-ide-tools";
       serverName = "pest_ls";
     }
     {
       name = "phpactor";
       description = "phpactor for PHP";
-      package = pkgs.phpactor;
+      package = "phpactor";
     }
     {
       name = "prismals";
       description = "prismals for Prisma";
-      package = pkgs.nodePackages."@prisma/language-server";
+      package = [
+        "nodePackages"
+        "@prisma/language-server"
+      ];
     }
     {
       name = "prolog-ls";
       description = "prolog_ls for SWI-Prolog";
       serverName = "prolog_ls";
-      package = pkgs.swiProlog;
+      package = "swiProlog";
     }
     {
       name = "purescriptls";
       description = "purescriptls for PureScript";
-      package = pkgs.nodePackages.purescript-language-server;
+      package = [
+        "nodePackages"
+        "purescript-language-server"
+      ];
     }
     {
       name = "pylsp";
       description = "pylsp for Python";
-      package = pkgs.python3Packages.python-lsp-server;
+      package = [
+        "python3Packages"
+        "python-lsp-server"
+      ];
       settings = cfg: { pylsp = cfg; };
     }
     {
@@ -484,7 +503,10 @@ let
     {
       name = "r-language-server";
       description = "languageserver for R";
-      package = pkgs.rPackages.languageserver;
+      package = [
+        "rPackages"
+        "languageserver"
+      ];
       serverName = "r_language_server";
     }
     {
@@ -505,10 +527,6 @@ let
     {
       name = "ruff-lsp";
       description = "ruff-lsp, for Python";
-      # TODO: Added 2024-08-19; remove 2024-11-19
-      # Ruff-lsp was moved out of python3Packages set without alias
-      # Using fallback as a transition period
-      package = pkgs.ruff-lsp or pkgs.python3Packages.ruff-lsp;
       serverName = "ruff_lsp";
     }
     {
@@ -527,12 +545,15 @@ let
     {
       name = "solargraph";
       description = "solargraph for Ruby";
-      package = pkgs.rubyPackages.solargraph;
+      package = [
+        "rubyPackages"
+        "solargraph"
+      ];
     }
     {
       name = "sourcekit";
       description = "sourcekit language server for Swift and C/C++/Objective-C";
-      package = pkgs.sourcekit-lsp;
+      package = "sourcekit-lsp";
     }
     {
       name = "sqls";
@@ -541,17 +562,22 @@ let
     {
       name = "svelte";
       description = "svelte language server for Svelte";
-      package = pkgs.nodePackages.svelte-language-server;
+      package = [
+        "nodePackages"
+        "svelte-language-server"
+      ];
     }
     {
       name = "tailwindcss";
       description = "tailwindcss language server for tailwindcss";
-      package = pkgs.nodePackages."@tailwindcss/language-server";
+      package = [
+        "nodePackages"
+        "@tailwindcss/language-server"
+      ];
     }
     {
       name = "taplo";
       description = "taplo for TOML";
-      package = pkgs.taplo;
     }
     {
       name = "templ";
@@ -560,7 +586,7 @@ let
     {
       name = "terraformls";
       description = "terraform-ls for terraform";
-      package = pkgs.terraform-ls;
+      package = "terraform-ls";
     }
     {
       name = "texlab";
@@ -578,7 +604,7 @@ let
     {
       name = "tsserver";
       description = "tsserver for TypeScript";
-      package = pkgs.typescript-language-server;
+      package = "typescript-language-server";
     }
     {
       name = "typos-lsp";
@@ -589,13 +615,12 @@ let
       name = "typst-lsp";
       serverName = "typst_lsp";
       description = "typst-lsp for typst";
-      package = pkgs.typst-lsp;
     }
     {
       name = "vala-ls";
       description = "vala_ls for Vala";
       serverName = "vala_ls";
-      package = pkgs.vala-language-server;
+      package = "vala-language-server";
     }
     {
       name = "vhdl-ls";
@@ -626,17 +651,23 @@ let
     {
       name = "vuels";
       description = "vuels for Vue";
-      package = pkgs.nodePackages.vls;
+      package = [
+        "nodePackages"
+        "vls"
+      ];
     }
     {
       name = "volar";
       description = "@volar/vue-language-server for Vue";
-      package = pkgs.nodePackages."@volar/vue-language-server";
+      package = [
+        "nodePackages"
+        "@volar/vue-language-server"
+      ];
     }
     {
       name = "yamlls";
       description = "yamlls for YAML";
-      package = pkgs.yaml-language-server;
+      package = "yaml-language-server";
       settings = cfg: { yaml = cfg; };
     }
     {
@@ -648,7 +679,7 @@ in
 {
   imports =
     let
-      mkLsp = import ./_mk-lsp.nix { inherit lib config pkgs; };
+      mkLsp = import ./_mk-lsp.nix;
       lspModules = map mkLsp servers;
     in
     lspModules

--- a/plugins/lsp/lsp-lines.nix
+++ b/plugins/lsp/lsp-lines.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "lsp-lines";
   luaName = "lsp_lines";
   originalName = "lsp_lines.nvim";
-  defaultPackage = pkgs.vimPlugins.lsp_lines-nvim;
+  package = "lsp_lines-nvim";
 
   # This plugin has no settings; it is configured via vim.diagnostic.config
   hasSettings = false;

--- a/plugins/lsp/lsp-status.nix
+++ b/plugins/lsp/lsp-status.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "lsp-status";
   originalName = "lsp-status.nvim";
-  defaultPackage = pkgs.vimPlugins.lsp-status-nvim;
+  package = "lsp-status-nvim";
   maintainers = [ helpers.maintainers.b3nb5n ];
 
   settingsOptions =

--- a/plugins/lsp/nvim-lightbulb.nix
+++ b/plugins/lsp/nvim-lightbulb.nix
@@ -1,13 +1,11 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "nvim-lightbulb";
-  defaultPackage = pkgs.vimPlugins.nvim-lightbulb;
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/lsp/schemastore.nix
+++ b/plugins/lsp/schemastore.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "schemastore";
   originalName = "SchemaStore.nvim";
-  defaultPackage = pkgs.vimPlugins.SchemaStore-nvim;
+  package = "SchemaStore-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/lsp/trouble.nix
+++ b/plugins/lsp/trouble.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "trouble";
   originalName = "trouble-nvim";
-  defaultPackage = pkgs.vimPlugins.trouble-nvim;
+  package = "trouble-nvim";
 
   maintainers = [ maintainers.loicreynier ];
 

--- a/plugins/neotest/default.nix
+++ b/plugins/neotest/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,6 @@ let
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "neotest";
-  defaultPackage = pkgs.vimPlugins.neotest;
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -3,7 +3,6 @@
   helpers,
   config,
   options,
-  pkgs,
   ...
 }:
 with lib;
@@ -11,7 +10,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "none-ls";
   originalName = "none-ls.nvim";
   luaName = "null-ls";
-  defaultPackage = pkgs.vimPlugins.none-ls-nvim;
+  package = "none-ls-nvim";
 
   maintainers = [ maintainers.MattSturgeon ];
 

--- a/plugins/pluginmanagers/lz-n.nix
+++ b/plugins/pluginmanagers/lz-n.nix
@@ -1,7 +1,6 @@
 {
   lib,
   options,
-  pkgs,
   ...
 }:
 with lib;
@@ -12,7 +11,6 @@ nixvim.neovim-plugin.mkNeovimPlugin {
   name = "lz-n";
   originalName = "lz.n";
   maintainers = [ maintainers.psfloyd ];
-  defaultPackage = pkgs.vimPlugins.lz-n;
 
   settingsDescription = ''
     Options provided to `vim.g.lz_n`.

--- a/plugins/snippets/nvim-snippets.nix
+++ b/plugins/snippets/nvim-snippets.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -10,7 +9,6 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "nvim-snippets";
   luaName = "snippets";
-  defaultPackage = pkgs.vimPlugins.nvim-snippets;
 
   maintainers = [ lib.maintainers.psfloyd ];
 

--- a/plugins/statuslines/airline.nix
+++ b/plugins/statuslines/airline.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "airline";
   originalName = "vim-airline";
-  defaultPackage = pkgs.vimPlugins.vim-airline;
+  package = "vim-airline";
   globalPrefix = "airline_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/statuslines/lightline.nix
+++ b/plugins/statuslines/lightline.nix
@@ -1,7 +1,6 @@
 {
   lib,
   options,
-  pkgs,
   ...
 }:
 let
@@ -11,7 +10,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "lightline";
   originalName = "lightline.vim";
-  defaultPackage = pkgs.vimPlugins.lightline-vim;
+  package = "lightline-vim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -17,7 +17,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "telescope";
   originalName = "telescope.nvim";
-  defaultPackage = pkgs.vimPlugins.telescope-nvim;
+  package = "telescope-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/telescope/extensions/_helpers.nix
+++ b/plugins/telescope/extensions/_helpers.nix
@@ -1,12 +1,18 @@
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 let
-  inherit (lib.nixvim) mkPluginPackageOption mkSettingsOption toSnakeCase;
+  inherit (lib.nixvim) mkSettingsOption toSnakeCase;
+  inherit (lib) mkPackageOption;
 in
 rec {
   mkExtension =
     {
       name,
-      defaultPackage,
+      package,
       extensionName ? name,
       settingsOptions ? { },
       settingsExample ? null,
@@ -41,7 +47,12 @@ rec {
       options.plugins.telescope.extensions.${name} = {
         enable = lib.mkEnableOption "the `${name}` telescope extension";
 
-        package = mkPluginPackageOption name defaultPackage;
+        package = mkPackageOption pkgs name {
+          default = [
+            "vimPlugins"
+            package
+          ];
+        };
 
         settings = mkSettingsOption {
           description = "settings for the `${name}` telescope extension.";

--- a/plugins/telescope/extensions/file-browser.nix
+++ b/plugins/telescope/extensions/file-browser.nix
@@ -12,7 +12,7 @@ in
 telescopeHelpers.mkExtension {
   name = "file-browser";
   extensionName = "file_browser";
-  defaultPackage = pkgs.vimPlugins.telescope-file-browser-nvim;
+  package = "telescope-file-browser-nvim";
 
   # TODO: introduced 2024-03-24, remove on 2024-05-24
   optionsRenamedToSettings = [

--- a/plugins/telescope/extensions/frecency.nix
+++ b/plugins/telescope/extensions/frecency.nix
@@ -10,7 +10,7 @@ let
 in
 (import ./_helpers.nix { inherit lib config pkgs; }).mkExtension {
   name = "frecency";
-  defaultPackage = pkgs.vimPlugins.telescope-frecency-nvim;
+  package = "telescope-frecency-nvim";
 
   # TODO: introduced 2024-03-24, remove on 2024-05-24
   optionsRenamedToSettings = [

--- a/plugins/telescope/extensions/fzf-native.nix
+++ b/plugins/telescope/extensions/fzf-native.nix
@@ -10,7 +10,7 @@ in
 (import ./_helpers.nix { inherit lib config pkgs; }).mkExtension {
   name = "fzf-native";
   extensionName = "fzf";
-  defaultPackage = pkgs.vimPlugins.telescope-fzf-native-nvim;
+  package = "telescope-fzf-native-nvim";
 
   # TODO: introduced 2024-03-24, remove on 2024-05-24
   optionsRenamedToSettings = [

--- a/plugins/telescope/extensions/fzy-native.nix
+++ b/plugins/telescope/extensions/fzy-native.nix
@@ -10,7 +10,7 @@ in
 (import ./_helpers.nix { inherit lib config pkgs; }).mkExtension {
   name = "fzy-native";
   extensionName = "fzy_native";
-  defaultPackage = pkgs.vimPlugins.telescope-fzy-native-nvim;
+  package = "telescope-fzy-native-nvim";
 
   # TODO: introduced 2024-03-24, remove on 2024-05-24
   optionsRenamedToSettings = [

--- a/plugins/telescope/extensions/media-files.nix
+++ b/plugins/telescope/extensions/media-files.nix
@@ -11,7 +11,7 @@ in
 (import ./_helpers.nix { inherit lib config pkgs; }).mkExtension {
   name = "media-files";
   extensionName = "media_files";
-  defaultPackage = pkgs.vimPlugins.telescope-media-files-nvim;
+  package = "telescope-media-files-nvim";
 
   # TODO: introduced 2024-03-24, remove on 2024-05-24
   imports =

--- a/plugins/telescope/extensions/ui-select.nix
+++ b/plugins/telescope/extensions/ui-select.nix
@@ -6,7 +6,7 @@
 }:
 (import ./_helpers.nix { inherit lib config pkgs; }).mkExtension {
   name = "ui-select";
-  defaultPackage = pkgs.vimPlugins.telescope-ui-select-nvim;
+  package = "telescope-ui-select-nvim";
 
   settingsExample = {
     specific_opts.codeactions = false;

--- a/plugins/telescope/extensions/undo.nix
+++ b/plugins/telescope/extensions/undo.nix
@@ -11,7 +11,7 @@ let
 in
 telescopeHelpers.mkExtension {
   name = "undo";
-  defaultPackage = pkgs.vimPlugins.telescope-undo-nvim;
+  package = "telescope-undo-nvim";
 
   # TODO: introduced 2024-03-24, remove on 2024-05-24
   optionsRenamedToSettings = [

--- a/plugins/ui/edgy.nix
+++ b/plugins/ui/edgy.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "edgy";
   originalName = "edgy.nvim";
-  defaultPackage = pkgs.vimPlugins.edgy-nvim;
+  package = "edgy-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ui/headlines.nix
+++ b/plugins/ui/headlines.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "headlines";
   originalName = "headlines.nvim";
-  defaultPackage = pkgs.vimPlugins.headlines-nvim;
+  package = "headlines-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ui/neoscroll.nix
+++ b/plugins/ui/neoscroll.nix
@@ -1,5 +1,4 @@
 {
-  pkgs,
   lib,
   helpers,
   ...
@@ -8,7 +7,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "neoscroll";
   originalName = "neoscroll.nvim";
-  defaultPackage = pkgs.vimPlugins.neoscroll-nvim;
+  package = "neoscroll-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ui/specs.nix
+++ b/plugins/ui/specs.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "specs";
   originalName = "specs.nvim";
-  defaultPackage = pkgs.vimPlugins.specs-nvim;
+  package = "specs-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ui/statuscol.nix
+++ b/plugins/ui/statuscol.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "statuscol";
   originalName = "statuscol.nvim";
-  defaultPackage = pkgs.vimPlugins.statuscol-nvim;
+  package = "statuscol-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ui/transparent.nix
+++ b/plugins/ui/transparent.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "transparent";
   originalName = "transparent.nvim";
-  defaultPackage = pkgs.vimPlugins.transparent-nvim;
+  package = "transparent-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ui/twilight.nix
+++ b/plugins/ui/twilight.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "twilight";
   originalName = "twilight.nvim";
-  defaultPackage = pkgs.vimPlugins.twilight-nvim;
+  package = "twilight-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/ui/virt-column.nix
+++ b/plugins/ui/virt-column.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "virt-column";
   originalName = "virt-column.nvim";
-  defaultPackage = pkgs.vimPlugins.virt-column-nvim;
+  package = "virt-column-nvim";
 
   maintainers = [ helpers.maintainers.alisonjenkins ];
 

--- a/plugins/ui/zen-mode.nix
+++ b/plugins/ui/zen-mode.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "zen-mode";
   originalName = "zen-mode.nvim";
-  defaultPackage = pkgs.vimPlugins.zen-mode-nvim;
+  package = "zen-mode-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/arrow.nix
+++ b/plugins/utils/arrow.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "arrow";
   originalName = "arrow.nvim";
-  defaultPackage = pkgs.vimPlugins.arrow-nvim;
+  package = "arrow-nvim";
 
   maintainers = [ maintainers.hmajid2301 ];
 

--- a/plugins/utils/auto-save.nix
+++ b/plugins/utils/auto-save.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "auto-save";
   originalName = "auto-save.nvim";
-  defaultPackage = pkgs.vimPlugins.auto-save-nvim;
+  package = "auto-save-nvim";
 
   maintainers = [ helpers.maintainers.braindefender ];
 

--- a/plugins/utils/bacon.nix
+++ b/plugins/utils/bacon.nix
@@ -1,11 +1,10 @@
 {
   helpers,
-  pkgs,
   ...
 }:
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "bacon";
-  defaultPackage = pkgs.vimPlugins.nvim-bacon;
+  package = "nvim-bacon";
   maintainers = [ helpers.maintainers.alisonjenkins ];
 
   settingsOptions = {

--- a/plugins/utils/baleia.nix
+++ b/plugins/utils/baleia.nix
@@ -1,12 +1,11 @@
 {
   helpers,
-  pkgs,
   ...
 }:
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "baleia";
   originalName = "baleia.nvim";
-  defaultPackage = pkgs.vimPlugins.baleia-nvim;
+  package = "baleia-nvim";
 
   maintainers = [ helpers.maintainers.alisonjenkins ];
 

--- a/plugins/utils/better-escape.nix
+++ b/plugins/utils/better-escape.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "better-escape";
   originalName = "better-escape.nvim";
   luaName = "better_escape";
-  defaultPackage = pkgs.vimPlugins.better-escape-nvim;
+  package = "better-escape-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/bufdelete.nix
+++ b/plugins/utils/bufdelete.nix
@@ -1,6 +1,5 @@
 {
   helpers,
-  pkgs,
   lib,
   ...
 }:
@@ -8,7 +7,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "bufdelete";
   originalName = "bufdelete.nvim";
-  defaultPackage = pkgs.vimPlugins.bufdelete-nvim;
+  package = "bufdelete-nvim";
   globalPrefix = "bufdelete_";
 
   maintainers = [ maintainers.MattSturgeon ];

--- a/plugins/utils/ccc.nix
+++ b/plugins/utils/ccc.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "ccc";
   originalName = "ccc.nvim";
-  defaultPackage = pkgs.vimPlugins.ccc-nvim;
+  package = "ccc-nvim";
 
   maintainers = [ helpers.maintainers.JanKremer ];
 

--- a/plugins/utils/cloak.nix
+++ b/plugins/utils/cloak.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "cloak";
   originalName = "cloak.nvim";
-  defaultPackage = pkgs.vimPlugins.cloak-nvim;
+  package = "cloak-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/codesnap.nix
+++ b/plugins/utils/codesnap.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "codesnap";
   originalName = "codesnap.nvim";
-  defaultPackage = pkgs.vimPlugins.codesnap-nvim;
+  package = "codesnap-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/comment-box.nix
+++ b/plugins/utils/comment-box.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -9,7 +8,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "comment-box";
   originalName = "comment-box.nvim";
-  defaultPackage = pkgs.vimPlugins.comment-box-nvim;
+  package = "comment-box-nvim";
   description = ''
     Clarify and beautify your comments and plain text files using boxes and lines.
   '';

--- a/plugins/utils/comment.nix
+++ b/plugins/utils/comment.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "comment";
   originalName = "Comment.nvim";
   luaName = "Comment";
-  defaultPackage = pkgs.vimPlugins.comment-nvim;
+  package = "comment-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/competitest.nix
+++ b/plugins/utils/competitest.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "competitest";
   originalName = "competitest.nvim";
-  defaultPackage = pkgs.vimPlugins.competitest-nvim;
+  package = "competitest-nvim";
 
   maintainers = [ helpers.maintainers.svl ];
 

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "dashboard";
   originalName = "dashboard-nvim";
-  defaultPackage = pkgs.vimPlugins.dashboard-nvim;
+  package = "dashboard-nvim";
 
   maintainers = [ maintainers.MattSturgeon ];
 

--- a/plugins/utils/direnv.nix
+++ b/plugins/utils/direnv.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "direnv";
   originalName = "direnv.vim";
-  defaultPackage = pkgs.vimPlugins.direnv-vim;
+  package = "direnv-vim";
   globalPrefix = "direnv_";
   extraPackages = [ pkgs.direnv ];
 

--- a/plugins/utils/dressing.nix
+++ b/plugins/utils/dressing.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "dressing";
   originalName = "dressing.nvim";
-  defaultPackage = pkgs.vimPlugins.dressing-nvim;
+  package = "dressing-nvim";
 
   maintainers = [ helpers.maintainers.AndresBermeoMarinelli ];
 

--- a/plugins/utils/emmet.nix
+++ b/plugins/utils/emmet.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "emmet";
   originalName = "emmet-vim";
-  defaultPackage = pkgs.vimPlugins.emmet-vim;
+  package = "emmet-vim";
   globalPrefix = "user_emmet_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/utils/endwise.nix
+++ b/plugins/utils/endwise.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  pkgs,
   helpers,
   ...
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "endwise";
   originalName = "vim-endwise";
-  defaultPackage = pkgs.vimPlugins.vim-endwise;
+  package = "vim-endwise";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/utils/firenvim.nix
+++ b/plugins/utils/firenvim.nix
@@ -2,7 +2,6 @@
   lib,
   config,
   options,
-  pkgs,
   ...
 }:
 let
@@ -11,7 +10,6 @@ let
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "firenvim";
-  defaultPackage = pkgs.vimPlugins.firenvim;
 
   maintainers = with lib.maintainers; [ GaetanLepage ];
 

--- a/plugins/utils/flash.nix
+++ b/plugins/utils/flash.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "flash";
   originalName = "flash.nvim";
-  defaultPackage = pkgs.vimPlugins.flash-nvim;
+  package = "flash-nvim";
 
   maintainers = with maintainers; [
     traxys

--- a/plugins/utils/fzf-lua.nix
+++ b/plugins/utils/fzf-lua.nix
@@ -32,7 +32,6 @@ let
 in
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "fzf-lua";
-  defaultPackage = pkgs.vimPlugins.fzf-lua;
 
   extraPackages = [ pkgs.fzf ];
 

--- a/plugins/utils/goyo.nix
+++ b/plugins/utils/goyo.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with helpers.vim-plugin;
@@ -9,7 +8,7 @@ with lib;
 mkVimPlugin {
   name = "goyo";
   originalName = "goyo.vim";
-  defaultPackage = pkgs.vimPlugins.goyo-vim;
+  package = "goyo-vim";
   globalPrefix = "goyo_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/utils/guess-indent.nix
+++ b/plugins/utils/guess-indent.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "guess-indent";
   originalName = "guess-indent.nvim";
-  defaultPackage = pkgs.vimPlugins.guess-indent-nvim;
+  package = "guess-indent-nvim";
 
   maintainers = [ helpers.maintainers.GGORG ];
 

--- a/plugins/utils/hop.nix
+++ b/plugins/utils/hop.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "hop";
   originalName = "hop.nvim";
-  defaultPackage = pkgs.vimPlugins.hop-nvim;
+  package = "hop-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/hydra/default.nix
+++ b/plugins/utils/hydra/default.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "hydra";
   originalName = "hydra.nvim";
-  defaultPackage = pkgs.vimPlugins.hydra-nvim;
+  package = "hydra-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/improved-search.nix
+++ b/plugins/utils/improved-search.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -10,7 +9,7 @@ with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "improved-search";
   originalName = "improved-search.nvim";
-  defaultPackage = pkgs.vimPlugins.improved-search-nvim;
+  package = "improved-search-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/indent-blankline.nix
+++ b/plugins/utils/indent-blankline.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "indent-blankline";
   originalName = "indent-blankline.nvim";
   luaName = "ibl";
-  defaultPackage = pkgs.vimPlugins.indent-blankline-nvim;
+  package = "indent-blankline-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/indent-o-matic.nix
+++ b/plugins/utils/indent-o-matic.nix
@@ -1,13 +1,11 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "indent-o-matic";
-  defaultPackage = pkgs.vimPlugins.indent-o-matic;
   maintainers = [ helpers.maintainers.alisonjenkins ];
   settingsOptions = {
     max_lines =

--- a/plugins/utils/instant.nix
+++ b/plugins/utils/instant.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "instant";
   originalName = "instant.nvim";
-  defaultPackage = pkgs.vimPlugins.instant-nvim;
+  package = "instant-nvim";
   globalPrefix = "instant_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "magma-nvim";
   originalName = "magma-nvim";
-  defaultPackage = pkgs.vimPlugins.magma-nvim-goose;
+  package = "magma-nvim-goose";
   globalPrefix = "magma_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/utils/molten.nix
+++ b/plugins/utils/molten.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "molten";
   originalName = "molten-nvim";
-  defaultPackage = pkgs.vimPlugins.molten-nvim;
+  package = "molten-nvim";
   globalPrefix = "molten_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/utils/neoclip.nix
+++ b/plugins/utils/neoclip.nix
@@ -8,7 +8,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "neoclip";
   originalName = "nvim-neoclip.lua";
-  defaultPackage = pkgs.vimPlugins.nvim-neoclip-lua;
+  package = "nvim-neoclip-lua";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/neocord.nix
+++ b/plugins/utils/neocord.nix
@@ -1,13 +1,11 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "neocord";
-  defaultPackage = pkgs.vimPlugins.neocord;
 
   maintainers = [ ];
 

--- a/plugins/utils/nvim-autopairs.nix
+++ b/plugins/utils/nvim-autopairs.nix
@@ -2,13 +2,11 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "nvim-autopairs";
-  defaultPackage = pkgs.vimPlugins.nvim-autopairs;
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/obsidian/default.nix
+++ b/plugins/utils/obsidian/default.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "obsidian";
   originalName = "obsidian.nvim";
-  defaultPackage = pkgs.vimPlugins.obsidian-nvim;
+  package = "obsidian-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "oil";
   originalName = "oil.nvim";
-  defaultPackage = pkgs.vimPlugins.oil-nvim;
+  package = "oil-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/project-nvim.nix
+++ b/plugins/utils/project-nvim.nix
@@ -1,7 +1,6 @@
 {
   lib,
   config,
-  pkgs,
   ...
 }:
 let
@@ -11,7 +10,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "project-nvim";
   originalName = "project.nvim";
   luaName = "project_nvim";
-  defaultPackage = pkgs.vimPlugins.project-nvim;
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/utils/refactoring.nix
+++ b/plugins/utils/refactoring.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "refactoring";
   originalName = "refactoring.nvim";
-  defaultPackage = pkgs.vimPlugins.refactoring-nvim;
+  package = "refactoring-nvim";
 
   maintainers = [ maintainers.MattSturgeon ];
 

--- a/plugins/utils/rest.nix
+++ b/plugins/utils/rest.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "rest";
   originalName = "rest.nvim";
   luaName = "rest-nvim";
-  defaultPackage = pkgs.vimPlugins.rest-nvim;
+  package = "rest-nvim";
 
   extraPackages = [ pkgs.curl ];
 

--- a/plugins/utils/sandwich.nix
+++ b/plugins/utils/sandwich.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "sandwich";
   originalName = "vim-sandwich";
-  defaultPackage = pkgs.vimPlugins.vim-sandwich;
+  package = "vim-sandwich";
   globalPrefix = "sandwich_";
 
   description = ''

--- a/plugins/utils/scope.nix
+++ b/plugins/utils/scope.nix
@@ -1,12 +1,11 @@
 {
   lib,
-  pkgs,
   ...
 }:
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "scope";
   originalName = "scope.nvim";
-  defaultPackage = pkgs.vimPlugins.scope-nvim;
+  package = "scope-nvim";
 
   maintainers = [ lib.maintainers.insipx ];
 

--- a/plugins/utils/sleuth.nix
+++ b/plugins/utils/sleuth.nix
@@ -1,13 +1,12 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "sleuth";
   originalName = "vim-sleuth";
-  defaultPackage = pkgs.vimPlugins.vim-sleuth;
+  package = "vim-sleuth";
   globalPrefix = "sleuth_";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/utils/smart-splits.nix
+++ b/plugins/utils/smart-splits.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  pkgs,
   helpers,
   ...
 }:
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "smart-splits";
   originalName = "smart-splits.nvim";
-  defaultPackage = pkgs.vimPlugins.smart-splits-nvim;
+  package = "smart-splits-nvim";
 
   maintainers = [ lib.maintainers.foo-dogsquared ];
 

--- a/plugins/utils/spectre.nix
+++ b/plugins/utils/spectre.nix
@@ -9,7 +9,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "spectre";
   originalName = "nvim-spectre";
-  defaultPackage = pkgs.vimPlugins.nvim-spectre;
+  package = "nvim-spectre";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/startify/default.nix
+++ b/plugins/utils/startify/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +8,7 @@ with helpers.vim-plugin;
 mkVimPlugin {
   name = "startify";
   originalName = "vim-startify";
-  defaultPackage = pkgs.vimPlugins.vim-startify;
+  package = "vim-startify";
   globalPrefix = "startify_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/utils/surround.nix
+++ b/plugins/utils/surround.nix
@@ -1,13 +1,12 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "surround";
   originalName = "surround.vim";
-  defaultPackage = pkgs.vimPlugins.vim-surround;
+  package = "vim-surround";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/utils/tmux-navigator.nix
+++ b/plugins/utils/tmux-navigator.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "tmux-navigator";
   originalName = "vim-tmux-navigator";
-  defaultPackage = pkgs.vimPlugins.vim-tmux-navigator;
+  package = "vim-tmux-navigator";
   globalPrefix = "tmux_navigator_";
 
   maintainers = [ maintainers.MattSturgeon ];

--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -19,7 +19,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "todo-comments";
   originalName = "todo-comments.nvim";
-  defaultPackage = pkgs.vimPlugins.todo-comments-nvim;
+  package = "todo-comments-nvim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/utils/toggleterm.nix
+++ b/plugins/utils/toggleterm.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "toggleterm";
   originalName = "toggleterm.nvim";
-  defaultPackage = pkgs.vimPlugins.toggleterm-nvim;
+  package = "toggleterm-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/trim.nix
+++ b/plugins/utils/trim.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "trim";
   originalName = "trim.nvim";
-  defaultPackage = pkgs.vimPlugins.trim-nvim;
+  package = "trim-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/undotree.nix
+++ b/plugins/utils/undotree.nix
@@ -1,14 +1,12 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
 mkVimPlugin {
   name = "undotree";
-  defaultPackage = pkgs.vimPlugins.undotree;
   globalPrefix = "undotree_";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/utils/vim-css-color.nix
+++ b/plugins/utils/vim-css-color.nix
@@ -1,11 +1,8 @@
 {
   helpers,
-  pkgs,
   ...
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "vim-css-color";
-  defaultPackage = pkgs.vimPlugins.vim-css-color;
-
   maintainers = [ helpers.maintainers.DanielLaing ];
 }

--- a/plugins/utils/wakatime.nix
+++ b/plugins/utils/wakatime.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "wakatime";
   originalName = "vim-wakatime";
-  defaultPackage = pkgs.vimPlugins.vim-wakatime;
+  package = "vim-wakatime";
 
   maintainers = [ maintainers.GaetanLepage ];
 }

--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   options,
   ...
 }:
@@ -79,7 +78,7 @@ in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "which-key";
   originalName = "which-key.nvim";
-  defaultPackage = pkgs.vimPlugins.which-key-nvim;
+  package = "which-key-nvim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/utils/yanky.nix
+++ b/plugins/utils/yanky.nix
@@ -9,7 +9,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "yanky";
   originalName = "yanky.nvim";
-  defaultPackage = pkgs.vimPlugins.yanky-nvim;
+  package = "yanky-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/utils/zellij.nix
+++ b/plugins/utils/zellij.nix
@@ -1,13 +1,12 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "zellij";
   originalName = "zellij.nvim";
-  defaultPackage = pkgs.vimPlugins.zellij-nvim;
+  package = "zellij-nvim";
 
   maintainers = [ lib.maintainers.hmajid2301 ];
 

--- a/plugins/utils/zk.nix
+++ b/plugins/utils/zk.nix
@@ -9,7 +9,7 @@ with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "zk";
   originalName = "zk.nvim";
-  defaultPackage = pkgs.vimPlugins.zk-nvim;
+  package = "zk-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];
 


### PR DESCRIPTION
## Summary

Adds initial support for receiving a package _option_ instead of a package _derivation_ in `mkVimPlugin` and `mkNeovimPlugin`. This is done to enable the use of [`lib.mkPackageOption`](https://nixos.org/manual/nixos/unstable/#sec-option-declarations-util-mkPackageOption) as discussed in #1950.

This soft-deprecates our current helpers, `lib.nixvim.mkPluginPackageOption` and `lib.nixvim.mkPackageOption`.

Also implemented this for the plugin [TEMPLATE](https://github.com/nix-community/nixvim/pull/2139/files#diff-93af850d88bc329f8ac9a11854624cfd9cf99d723bac17464f4dac5993425f3d), [cmp sources](https://github.com/nix-community/nixvim/pull/2139/files#diff-961bb62e8020d29c7e320ed7a45345f1fa86e338342bb44df02bd161e7ff96c2), telescope extensions, and [lsp language-servers](https://github.com/nix-community/nixvim/pull/2139/files#diff-84e25e99a6dafddf43e738af5502df469f8deb4f4eed194544c2de10133abe00).

## Why

An option with a package default, will be rendered using `lib.generators.toPretty` as (e.g.) `<derivation vimplugin-cmp-ai-2024-08-01>`.

We could specify a `defaultText` for all our package options, e.g. `defaultText = lib.literalExpression "pkgs.cmp-ai"`, however `lib.mkPackageOption` automates this by setting both `default` and `defaultText` based on an attr-path.

#### Screenshots

<details><summary>Before+after screenshots</summary>
<p>

### Before

![image](https://github.com/user-attachments/assets/98ec614e-926f-4504-ad9e-e384766350ed)

### After

![image](https://github.com/user-attachments/assets/4c707f13-3150-4b21-aa3f-9708bf8e20a7)

</p>
</details>

## Alternative/future approach

It would be **possible** to have `mk*Plugin` handle calling `lib.mkPackageOption` internally, however it'd have to do so within an imported module in order to gain access to the (correct) `pkgs` arg[^1].

We may need to do this _anyway_ to also gain access to `options` and `config` without having to pass them into the helpers, but that is out of scope for this PR...

See this POC:

<details><summary>Proof of concept</summary>
<p>

```nix
mkNeovimPlugin =
  {
    name,
    defaultPackage,
    # omitted for clarity
  }:
  {
    imports = [
      # Import a module, so we have access to the "correct" pkgs
      ({ config, options, pkgs, ... }: {
        options.plugins.${name} = {
          enable = lib.mkEnableOption name;
          package =
            if lib.isOption defaultPackage then
              defaultPackage
            else
              lib.mkPackageOption pkgs name {
                default = defaultPackage;
              };
        };
      })
    ];
    # Rest omitted for clarity
  }
```

</p>
</details> 

[^1]: As part of `helpers`, we do have access to _a_ `pkgs`, but it may not be the correct one configured for use within the module eval. Incidentally, this is making me think we should separate out all helper functions that rely on `pkgs` and put them somewhere else so that `helpers` doesn't need a `pkgs`.
