### PR TITLE
lib/*-plugin: drop `config` arg

### DIFF
--- a/plugins/TEMPLATE.nix
+++ b/plugins/TEMPLATE.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "my-plugin";
   originalName = "my-plugin.nvim"; # TODO replace (or remove entirely if it is the same as `name`)
   defaultPackage = pkgs.vimPlugins.my-plugin-nvim; # TODO replace

--- a/plugins/ai/chatgpt.nix
+++ b/plugins/ai/chatgpt.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "chatgpt";
   originalName = "ChatGPT.nvim";
   defaultPackage = pkgs.vimPlugins.ChatGPT-nvim;

--- a/plugins/ai/copilot-chat.nix
+++ b/plugins/ai/copilot-chat.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "copilot-chat";
   originalName = "CopilotChat.nvim";
   luaName = "CopilotChat";

--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -51,7 +50,7 @@ let
     orderByWindowNumber = "OrderByWindowNumber";
   };
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "barbar";
   originalName = "barbar.nvim";
   defaultPackage = pkgs.vimPlugins.barbar-nvim;

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts nixvimTypes mkSettingsRenamedOptionModules;
   types = nixvimTypes;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "bufferline";
   originalName = "bufferline.nvim";
   defaultPackage = pkgs.vimPlugins.bufferline-nvim;

--- a/plugins/colorschemes/ayu.nix
+++ b/plugins/colorschemes/ayu.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts toLuaObject;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "ayu";
   isColorscheme = true;
   originalName = "neovim-ayu";

--- a/plugins/colorschemes/base16/default.nix
+++ b/plugins/colorschemes/base16/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -11,7 +10,7 @@ let
   luaName = "base16-colorscheme";
   originalName = "base16.nvim";
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   inherit name luaName originalName;
   setup = ".with_config";
   defaultPackage = pkgs.vimPlugins.base16-nvim;

--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption mkNullOrStrLuaFnOr;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "catppuccin";
   isColorscheme = true;
   defaultPackage = pkgs.vimPlugins.catppuccin-nvim;

--- a/plugins/colorschemes/cyberdream.nix
+++ b/plugins/colorschemes/cyberdream.nix
@@ -1,5 +1,4 @@
 {
-  config,
   lib,
   pkgs,
   ...
@@ -7,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "cyberdream";
   isColorscheme = true;
   originalName = "cyberdream.nvim";

--- a/plugins/colorschemes/everforest.nix
+++ b/plugins/colorschemes/everforest.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -15,7 +14,7 @@ let
     ] pluginDefault desc;
 
 in
-lib.nixvim.vim-plugin.mkVimPlugin config {
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "everforest";
   isColorscheme = true;
   defaultPackage = pkgs.vimPlugins.everforest;

--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "gruvbox";
   isColorscheme = true;
   originalName = "gruvbox.nvim";

--- a/plugins/colorschemes/kanagawa.nix
+++ b/plugins/colorschemes/kanagawa.nix
@@ -1,14 +1,13 @@
 {
   lib,
   pkgs,
-  config,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "kanagawa";
   isColorscheme = true;
   originalName = "kanagawa.nvim";

--- a/plugins/colorschemes/melange.nix
+++ b/plugins/colorschemes/melange.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin config {
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "melange";
   isColorscheme = true;
   originalName = "melange-nvim";

--- a/plugins/colorschemes/modus.nix
+++ b/plugins/colorschemes/modus.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "modus";
   luaName = "modus-themes";
   originalName = "modus-themes.nvim";

--- a/plugins/colorschemes/nightfox.nix
+++ b/plugins/colorschemes/nightfox.nix
@@ -1,14 +1,13 @@
 {
   lib,
   pkgs,
-  config,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "nightfox";
   isColorscheme = true;
   originalName = "nightfox.nvim";

--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin config {
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "nord";
   isColorscheme = true;
   originalName = "nord.nvim";

--- a/plugins/colorschemes/one.nix
+++ b/plugins/colorschemes/one.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin config {
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "one";
   isColorscheme = true;
   originalName = "vim-one";

--- a/plugins/colorschemes/onedark.nix
+++ b/plugins/colorschemes/onedark.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "onedark";
   isColorscheme = true;
   originalName = "onedark.nvim";

--- a/plugins/colorschemes/oxocarbon.nix
+++ b/plugins/colorschemes/oxocarbon.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin config {
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "oxocarbon";
   isColorscheme = true;
   originalName = "oxocarbon.nvim";

--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "palette";
   isColorscheme = true;
   originalName = "palette.nvim";

--- a/plugins/colorschemes/poimandres.nix
+++ b/plugins/colorschemes/poimandres.nix
@@ -1,13 +1,12 @@
 {
   lib,
   pkgs,
-  config,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "poimandres";
   isColorscheme = true;
   originalName = "poimandres.nvim";

--- a/plugins/colorschemes/rose-pine.nix
+++ b/plugins/colorschemes/rose-pine.nix
@@ -1,13 +1,12 @@
 {
   lib,
   pkgs,
-  config,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "rose-pine";
   isColorscheme = true;
   defaultPackage = pkgs.vimPlugins.rose-pine;

--- a/plugins/colorschemes/tokyonight.nix
+++ b/plugins/colorschemes/tokyonight.nix
@@ -1,13 +1,12 @@
 {
   lib,
   pkgs,
-  config,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "tokyonight";
   isColorscheme = true;
   originalName = "tokyonight.nvim";

--- a/plugins/colorschemes/vscode.nix
+++ b/plugins/colorschemes/vscode.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts toLuaObject;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "vscode";
   isColorscheme = true;
   originalName = "vscode-nvim";

--- a/plugins/completion/cmp/default.nix
+++ b/plugins/completion/cmp/default.nix
@@ -2,14 +2,13 @@
   lib,
   helpers,
   pkgs,
-  config,
   ...
-}@args:
+}:
 let
   cmpOptions = import ./options { inherit lib helpers; };
 in
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "cmp";
   originalName = "nvim-cmp";
   defaultPackage = pkgs.vimPlugins.nvim-cmp;

--- a/plugins/completion/cmp/sources/_mk-cmp-plugin.nix
+++ b/plugins/completion/cmp/sources/_mk-cmp-plugin.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
@@ -13,7 +12,7 @@
   imports ? [ ],
   ...
 }@args:
-helpers.vim-plugin.mkVimPlugin config (
+helpers.vim-plugin.mkVimPlugin (
   builtins.removeAttrs args [
     "pluginName"
     "sourceName"

--- a/plugins/completion/codeium-vim.nix
+++ b/plugins/completion/codeium-vim.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
@@ -35,7 +34,7 @@ let
     };
   };
 in
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "codeium-vim";
   originalName = "codeium.vim";
   defaultPackage = pkgs.vimPlugins.codeium-vim;

--- a/plugins/completion/copilot-vim.nix
+++ b/plugins/completion/copilot-vim.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "copilot-vim";
   originalName = "copilot.vim";
   defaultPackage = pkgs.vimPlugins.copilot-vim;

--- a/plugins/completion/coq.nix
+++ b/plugins/completion/coq.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "coq-nvim";
   originalName = "coq_nvim";
   defaultPackage = pkgs.vimPlugins.coq_nvim;

--- a/plugins/filetrees/yazi.nix
+++ b/plugins/filetrees/yazi.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   types = lib.nixvim.nixvimTypes;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "yazi";
   originalName = "yazi.nvim";
   defaultPackage = pkgs.vimPlugins.yazi-nvim;

--- a/plugins/git/committia.nix
+++ b/plugins/git/committia.nix
@@ -1,10 +1,9 @@
 {
-  config,
   helpers,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "committia";
   originalName = "committia.vim";
   defaultPackage = pkgs.vimPlugins.committia-vim;

--- a/plugins/git/fugitive.nix
+++ b/plugins/git/fugitive.nix
@@ -1,11 +1,10 @@
 {
-  config,
   lib,
   helpers,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "fugitive";
   originalName = "vim-fugitive";
   defaultPackage = pkgs.vimPlugins.vim-fugitive;

--- a/plugins/git/git-conflict.nix
+++ b/plugins/git/git-conflict.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "git-conflict";
   originalName = "git-conflict.nvim";
   defaultPackage = pkgs.vimPlugins.git-conflict-nvim;

--- a/plugins/git/gitblame.nix
+++ b/plugins/git/gitblame.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkPackageOption;
   types = lib.nixvim.nixvimTypes;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "gitblame";
   originalName = "git-blame.nvim";
   defaultPackage = pkgs.vimPlugins.git-blame-nvim;

--- a/plugins/git/gitignore.nix
+++ b/plugins/git/gitignore.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
 # We use `mkVimPlugin` to avoid having a `settings` option.
 # Indeed, this plugin is not configurable in the common sense (no `setup` function).
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "gitignore";
   originalName = "gitignore.nvim";
   defaultPackage = pkgs.vimPlugins.gitignore-nvim;

--- a/plugins/git/gitsigns/default.nix
+++ b/plugins/git/gitsigns/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "gitsigns";
   originalName = "gitsigns.nvim";
   defaultPackage = pkgs.vimPlugins.gitsigns-nvim;

--- a/plugins/git/lazygit.nix
+++ b/plugins/git/lazygit.nix
@@ -1,12 +1,11 @@
 {
-  config,
   lib,
   helpers,
   pkgs,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "lazygit";
   originalName = "lazygit.nvim";
   defaultPackage = pkgs.vimPlugins.lazygit-nvim;

--- a/plugins/git/neogit/default.nix
+++ b/plugins/git/neogit/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "neogit";
   defaultPackage = pkgs.vimPlugins.neogit;
 

--- a/plugins/git/octo.nix
+++ b/plugins/git/octo.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "octo";
   originalName = "octo.nvim";
   defaultPackage = pkgs.vimPlugins.octo-nvim;

--- a/plugins/languages/cmake-tools.nix
+++ b/plugins/languages/cmake-tools.nix
@@ -1,11 +1,10 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "cmake-tools";
   originalName = "cmake-tools.nvim";
   defaultPackage = pkgs.vimPlugins.cmake-tools-nvim;

--- a/plugins/languages/debugprint.nix
+++ b/plugins/languages/debugprint.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "debugprint";
   originalName = "debugprint.nvim";
   defaultPackage = pkgs.vimPlugins.debugprint-nvim;

--- a/plugins/languages/godot.nix
+++ b/plugins/languages/godot.nix
@@ -1,12 +1,11 @@
 {
-  config,
   lib,
   helpers,
   pkgs,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "godot";
   originalName = "vim-godot";
   defaultPackage = pkgs.vimPlugins.vim-godot;

--- a/plugins/languages/haskell-scope-highlighting.nix
+++ b/plugins/languages/haskell-scope-highlighting.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "haskell-scope-highlighting";
   originalName = "haskell-scope-highlighting.nvim";
   defaultPackage = pkgs.vimPlugins.haskell-scope-highlighting-nvim;

--- a/plugins/languages/julia/julia-cell.nix
+++ b/plugins/languages/julia/julia-cell.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
@@ -37,7 +36,7 @@ let
   };
 in
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "julia-cell";
   originalName = "vim-julia-cell";
   defaultPackage = pkgs.vimPlugins.vim-julia-cell;

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "ledger";
   originalName = "vim-ledger";
   defaultPackage = pkgs.vimPlugins.vim-ledger;

--- a/plugins/languages/ltex-extra.nix
+++ b/plugins/languages/ltex-extra.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "ltex-extra";
   originalName = "ltex_extra.nvim";
   defaultPackage = pkgs.vimPlugins.ltex_extra-nvim;

--- a/plugins/languages/markdown/glow.nix
+++ b/plugins/languages/markdown/glow.nix
@@ -1,11 +1,10 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "glow";
   originalName = "glow.nvim";
   defaultPackage = pkgs.vimPlugins.glow-nvim;

--- a/plugins/languages/markdown/markdown-preview.nix
+++ b/plugins/languages/markdown/markdown-preview.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "markdown-preview";
   originalName = "markdown-preview.nvim";
   defaultPackage = pkgs.vimPlugins.markdown-preview-nvim;

--- a/plugins/languages/markdown/markview.nix
+++ b/plugins/languages/markdown/markview.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "markview";
   originalName = "markview.nvim";
   defaultPackage = pkgs.vimPlugins.markview-nvim;

--- a/plugins/languages/markdown/preview.nix
+++ b/plugins/languages/markdown/preview.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "preview";
   originalName = "Preview.nvim";
   defaultPackage = pkgs.vimPlugins.Preview-nvim;

--- a/plugins/languages/nix.nix
+++ b/plugins/languages/nix.nix
@@ -1,11 +1,10 @@
 {
-  config,
   lib,
   helpers,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "nix";
   originalName = "vim-nix";
   defaultPackage = pkgs.vimPlugins.vim-nix;

--- a/plugins/languages/nvim-orgmode.nix
+++ b/plugins/languages/nvim-orgmode.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "orgmode";
   originalName = "nvim-orgmode";
   defaultPackage = pkgs.vimPlugins.orgmode;

--- a/plugins/languages/otter.nix
+++ b/plugins/languages/otter.nix
@@ -5,7 +5,7 @@
   pkgs,
   ...
 }:
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "otter";
   originalName = "otter.nvim";
   defaultPackage = pkgs.vimPlugins.otter-nvim;

--- a/plugins/languages/parinfer-rust.nix
+++ b/plugins/languages/parinfer-rust.nix
@@ -1,11 +1,10 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "parinfer-rust";
   defaultPackage = pkgs.vimPlugins.parinfer-rust;
   globalPrefix = "parinfer_";

--- a/plugins/languages/python/jupytext.nix
+++ b/plugins/languages/python/jupytext.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "jupytext";
   originalName = "jupytext.nvim";
   defaultPackage = pkgs.vimPlugins.jupytext-nvim;

--- a/plugins/languages/qmk.nix
+++ b/plugins/languages/qmk.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "qmk";
   originalName = "qmk.nvim";
   defaultPackage = pkgs.vimPlugins.qmk-nvim;

--- a/plugins/languages/rust/rustaceanvim/default.nix
+++ b/plugins/languages/rust/rustaceanvim/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "rustaceanvim";
   defaultPackage = pkgs.vimPlugins.rustaceanvim;
 

--- a/plugins/languages/sniprun.nix
+++ b/plugins/languages/sniprun.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "sniprun";
   defaultPackage = pkgs.vimPlugins.sniprun;
   url = "https://github.com/michaelb/sniprun";

--- a/plugins/languages/tagbar.nix
+++ b/plugins/languages/tagbar.nix
@@ -1,11 +1,10 @@
 {
   helpers,
-  config,
   pkgs,
   lib,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "tagbar";
   defaultPackage = pkgs.vimPlugins.tagbar;
   globalPrefix = "tagbar_";

--- a/plugins/languages/texpresso.nix
+++ b/plugins/languages/texpresso.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
 # This plugin has no configuration, so we use `mkVimPlugin` without the `globalPrefix` argument to
 # avoid the creation of the `settings` option.
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "texpresso";
   originalName = "texpresso.vim";
   defaultPackage = pkgs.vimPlugins.texpresso-vim;

--- a/plugins/languages/treesitter/treesitter-context.nix
+++ b/plugins/languages/treesitter/treesitter-context.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "treesitter-context";
   originalName = "nvim-treesitter-context";
   defaultPackage = pkgs.vimPlugins.nvim-treesitter-context;

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "treesitter";
   originalName = "nvim-treesitter";
   luaName = "nvim-treesitter.configs";

--- a/plugins/languages/treesitter/ts-autotag.nix
+++ b/plugins/languages/treesitter/ts-autotag.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "ts-autotag";
   originalName = "nvim-ts-autotag";
   luaName = "nvim-ts-autotag";

--- a/plugins/languages/typst/typst-vim.nix
+++ b/plugins/languages/typst/typst-vim.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "typst-vim";
   originalName = "typst.vim";
   defaultPackage = pkgs.vimPlugins.typst-vim;

--- a/plugins/languages/vim-slime.nix
+++ b/plugins/languages/vim-slime.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "vim-slime";
   defaultPackage = pkgs.vimPlugins.vim-slime;
   globalPrefix = "slime_";

--- a/plugins/languages/vimtex.nix
+++ b/plugins/languages/vimtex.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "vimtex";
   defaultPackage = pkgs.vimPlugins.vimtex;
   globalPrefix = "vimtex_";

--- a/plugins/languages/zig.nix
+++ b/plugins/languages/zig.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "zig";
   originalName = "zig.vim";
   defaultPackage = pkgs.vimPlugins.zig-vim;

--- a/plugins/lsp/conform-nvim.nix
+++ b/plugins/lsp/conform-nvim.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts mkRaw;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "conform-nvim";
   luaName = "conform";
   originalName = "conform.nvim";

--- a/plugins/lsp/lsp-lines.nix
+++ b/plugins/lsp/lsp-lines.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "lsp-lines";
   luaName = "lsp_lines";
   originalName = "lsp_lines.nvim";

--- a/plugins/lsp/lsp-status.nix
+++ b/plugins/lsp/lsp-status.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "lsp-status";
   originalName = "lsp-status.nvim";
   defaultPackage = pkgs.vimPlugins.lsp-status-nvim;

--- a/plugins/lsp/nvim-lightbulb.nix
+++ b/plugins/lsp/nvim-lightbulb.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "nvim-lightbulb";
   defaultPackage = pkgs.vimPlugins.nvim-lightbulb;
 

--- a/plugins/lsp/schemastore.nix
+++ b/plugins/lsp/schemastore.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "schemastore";
   originalName = "SchemaStore.nvim";
   defaultPackage = pkgs.vimPlugins.SchemaStore-nvim;

--- a/plugins/lsp/trouble.nix
+++ b/plugins/lsp/trouble.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "trouble";
   originalName = "trouble-nvim";
   defaultPackage = pkgs.vimPlugins.trouble-nvim;

--- a/plugins/neotest/default.nix
+++ b/plugins/neotest/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ with lib;
 let
   inherit (lib.nixvim) mkRaw;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "neotest";
   defaultPackage = pkgs.vimPlugins.neotest;
 

--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -7,7 +7,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "none-ls";
   originalName = "none-ls.nvim";
   luaName = "null-ls";

--- a/plugins/pluginmanagers/lz-n.nix
+++ b/plugins/pluginmanagers/lz-n.nix
@@ -1,7 +1,6 @@
 {
   lib,
   options,
-  config,
   pkgs,
   ...
 }:
@@ -9,7 +8,7 @@ with lib;
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-nixvim.neovim-plugin.mkNeovimPlugin config {
+nixvim.neovim-plugin.mkNeovimPlugin {
   name = "lz-n";
   originalName = "lz.n";
   maintainers = [ maintainers.psfloyd ];

--- a/plugins/snippets/nvim-snippets.nix
+++ b/plugins/snippets/nvim-snippets.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "nvim-snippets";
   luaName = "snippets";
   defaultPackage = pkgs.vimPlugins.nvim-snippets;

--- a/plugins/statuslines/airline.nix
+++ b/plugins/statuslines/airline.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "airline";
   originalName = "vim-airline";
   defaultPackage = pkgs.vimPlugins.vim-airline;

--- a/plugins/statuslines/lightline.nix
+++ b/plugins/statuslines/lightline.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  config,
   options,
   pkgs,
   ...
@@ -9,7 +8,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "lightline";
   originalName = "lightline.vim";
   defaultPackage = pkgs.vimPlugins.lightline-vim;

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -14,7 +14,7 @@ let
     ;
 in
 # TODO:add support for additional filetypes. This requires autocommands!
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "telescope";
   originalName = "telescope.nvim";
   defaultPackage = pkgs.vimPlugins.telescope-nvim;

--- a/plugins/ui/edgy.nix
+++ b/plugins/ui/edgy.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "edgy";
   originalName = "edgy.nvim";
   defaultPackage = pkgs.vimPlugins.edgy-nvim;

--- a/plugins/ui/headlines.nix
+++ b/plugins/ui/headlines.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "headlines";
   originalName = "headlines.nvim";
   defaultPackage = pkgs.vimPlugins.headlines-nvim;

--- a/plugins/ui/neoscroll.nix
+++ b/plugins/ui/neoscroll.nix
@@ -1,12 +1,11 @@
 {
   pkgs,
-  config,
   lib,
   helpers,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "neoscroll";
   originalName = "neoscroll.nvim";
   defaultPackage = pkgs.vimPlugins.neoscroll-nvim;

--- a/plugins/ui/specs.nix
+++ b/plugins/ui/specs.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "specs";
   originalName = "specs.nvim";
   defaultPackage = pkgs.vimPlugins.specs-nvim;

--- a/plugins/ui/statuscol.nix
+++ b/plugins/ui/statuscol.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "statuscol";
   originalName = "statuscol.nvim";
   defaultPackage = pkgs.vimPlugins.statuscol-nvim;

--- a/plugins/ui/transparent.nix
+++ b/plugins/ui/transparent.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "transparent";
   originalName = "transparent.nvim";
   defaultPackage = pkgs.vimPlugins.transparent-nvim;

--- a/plugins/ui/twilight.nix
+++ b/plugins/ui/twilight.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "twilight";
   originalName = "twilight.nvim";
   defaultPackage = pkgs.vimPlugins.twilight-nvim;

--- a/plugins/ui/virt-column.nix
+++ b/plugins/ui/virt-column.nix
@@ -2,11 +2,10 @@
   lib,
   helpers,
   pkgs,
-  config,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "virt-column";
   originalName = "virt-column.nvim";
   defaultPackage = pkgs.vimPlugins.virt-column-nvim;

--- a/plugins/ui/zen-mode.nix
+++ b/plugins/ui/zen-mode.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "zen-mode";
   originalName = "zen-mode.nvim";
   defaultPackage = pkgs.vimPlugins.zen-mode-nvim;

--- a/plugins/utils/arrow.nix
+++ b/plugins/utils/arrow.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "arrow";
   originalName = "arrow.nvim";
   defaultPackage = pkgs.vimPlugins.arrow-nvim;

--- a/plugins/utils/auto-save.nix
+++ b/plugins/utils/auto-save.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "auto-save";
   originalName = "auto-save.nvim";
   defaultPackage = pkgs.vimPlugins.auto-save-nvim;

--- a/plugins/utils/bacon.nix
+++ b/plugins/utils/bacon.nix
@@ -1,10 +1,9 @@
 {
   helpers,
   pkgs,
-  config,
   ...
 }:
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "bacon";
   defaultPackage = pkgs.vimPlugins.nvim-bacon;
   maintainers = [ helpers.maintainers.alisonjenkins ];

--- a/plugins/utils/baleia.nix
+++ b/plugins/utils/baleia.nix
@@ -1,10 +1,9 @@
 {
   helpers,
   pkgs,
-  config,
   ...
 }:
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "baleia";
   originalName = "baleia.nvim";
   defaultPackage = pkgs.vimPlugins.baleia-nvim;

--- a/plugins/utils/better-escape.nix
+++ b/plugins/utils/better-escape.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "better-escape";
   originalName = "better-escape.nvim";
   luaName = "better_escape";

--- a/plugins/utils/bufdelete.nix
+++ b/plugins/utils/bufdelete.nix
@@ -1,12 +1,11 @@
 {
-  config,
   helpers,
   pkgs,
   lib,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "bufdelete";
   originalName = "bufdelete.nvim";
   defaultPackage = pkgs.vimPlugins.bufdelete-nvim;

--- a/plugins/utils/ccc.nix
+++ b/plugins/utils/ccc.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "ccc";
   originalName = "ccc.nvim";
   defaultPackage = pkgs.vimPlugins.ccc-nvim;

--- a/plugins/utils/cloak.nix
+++ b/plugins/utils/cloak.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "cloak";
   originalName = "cloak.nvim";
   defaultPackage = pkgs.vimPlugins.cloak-nvim;

--- a/plugins/utils/codesnap.nix
+++ b/plugins/utils/codesnap.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "codesnap";
   originalName = "codesnap.nvim";
   defaultPackage = pkgs.vimPlugins.codesnap-nvim;

--- a/plugins/utils/comment-box.nix
+++ b/plugins/utils/comment-box.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "comment-box";
   originalName = "comment-box.nvim";
   defaultPackage = pkgs.vimPlugins.comment-box-nvim;

--- a/plugins/utils/comment.nix
+++ b/plugins/utils/comment.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "comment";
   originalName = "Comment.nvim";
   luaName = "Comment";

--- a/plugins/utils/competitest.nix
+++ b/plugins/utils/competitest.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "competitest";
   originalName = "competitest.nvim";
   defaultPackage = pkgs.vimPlugins.competitest-nvim;

--- a/plugins/utils/dashboard.nix
+++ b/plugins/utils/dashboard.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "dashboard";
   originalName = "dashboard-nvim";
   defaultPackage = pkgs.vimPlugins.dashboard-nvim;

--- a/plugins/utils/direnv.nix
+++ b/plugins/utils/direnv.nix
@@ -1,12 +1,11 @@
 {
-  config,
   helpers,
   pkgs,
   lib,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "direnv";
   originalName = "direnv.vim";
   defaultPackage = pkgs.vimPlugins.direnv-vim;

--- a/plugins/utils/dressing.nix
+++ b/plugins/utils/dressing.nix
@@ -1,12 +1,11 @@
 {
-  config,
   lib,
   helpers,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "dressing";
   originalName = "dressing.nvim";
   defaultPackage = pkgs.vimPlugins.dressing-nvim;

--- a/plugins/utils/emmet.nix
+++ b/plugins/utils/emmet.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "emmet";
   originalName = "emmet-vim";
   defaultPackage = pkgs.vimPlugins.emmet-vim;

--- a/plugins/utils/endwise.nix
+++ b/plugins/utils/endwise.nix
@@ -1,11 +1,10 @@
 {
-  config,
   lib,
   pkgs,
   helpers,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "endwise";
   originalName = "vim-endwise";
   defaultPackage = pkgs.vimPlugins.vim-endwise;

--- a/plugins/utils/firenvim.nix
+++ b/plugins/utils/firenvim.nix
@@ -9,7 +9,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   types = lib.nixvim.nixvimTypes;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "firenvim";
   defaultPackage = pkgs.vimPlugins.firenvim;
 

--- a/plugins/utils/flash.nix
+++ b/plugins/utils/flash.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "flash";
   originalName = "flash.nvim";
   defaultPackage = pkgs.vimPlugins.flash-nvim;

--- a/plugins/utils/fzf-lua.nix
+++ b/plugins/utils/fzf-lua.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  config,
   options,
   pkgs,
   ...
@@ -31,7 +30,7 @@ let
     };
   };
 in
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "fzf-lua";
   defaultPackage = pkgs.vimPlugins.fzf-lua;
 

--- a/plugins/utils/goyo.nix
+++ b/plugins/utils/goyo.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with helpers.vim-plugin;
 with lib;
-mkVimPlugin config {
+mkVimPlugin {
   name = "goyo";
   originalName = "goyo.vim";
   defaultPackage = pkgs.vimPlugins.goyo-vim;

--- a/plugins/utils/guess-indent.nix
+++ b/plugins/utils/guess-indent.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "guess-indent";
   originalName = "guess-indent.nvim";
   defaultPackage = pkgs.vimPlugins.guess-indent-nvim;

--- a/plugins/utils/hop.nix
+++ b/plugins/utils/hop.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "hop";
   originalName = "hop.nvim";
   defaultPackage = pkgs.vimPlugins.hop-nvim;

--- a/plugins/utils/hydra/default.nix
+++ b/plugins/utils/hydra/default.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "hydra";
   originalName = "hydra.nvim";
   defaultPackage = pkgs.vimPlugins.hydra-nvim;

--- a/plugins/utils/improved-search.nix
+++ b/plugins/utils/improved-search.nix
@@ -1,14 +1,13 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
 # This plugin is only configured through keymaps, so we use `mkVimPlugin` without the
 # `globalPrefix` argument to avoid the creation of the `settings` option.
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "improved-search";
   originalName = "improved-search.nvim";
   defaultPackage = pkgs.vimPlugins.improved-search-nvim;

--- a/plugins/utils/indent-blankline.nix
+++ b/plugins/utils/indent-blankline.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "indent-blankline";
   originalName = "indent-blankline.nvim";
   luaName = "ibl";

--- a/plugins/utils/indent-o-matic.nix
+++ b/plugins/utils/indent-o-matic.nix
@@ -2,11 +2,10 @@
   lib,
   helpers,
   pkgs,
-  config,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "indent-o-matic";
   defaultPackage = pkgs.vimPlugins.indent-o-matic;
   maintainers = [ helpers.maintainers.alisonjenkins ];

--- a/plugins/utils/instant.nix
+++ b/plugins/utils/instant.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "instant";
   originalName = "instant.nvim";
   defaultPackage = pkgs.vimPlugins.instant-nvim;

--- a/plugins/utils/magma-nvim.nix
+++ b/plugins/utils/magma-nvim.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "magma-nvim";
   originalName = "magma-nvim";
   defaultPackage = pkgs.vimPlugins.magma-nvim-goose;

--- a/plugins/utils/molten.nix
+++ b/plugins/utils/molten.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "molten";
   originalName = "molten-nvim";
   defaultPackage = pkgs.vimPlugins.molten-nvim;

--- a/plugins/utils/neoclip.nix
+++ b/plugins/utils/neoclip.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "neoclip";
   originalName = "nvim-neoclip.lua";
   defaultPackage = pkgs.vimPlugins.nvim-neoclip-lua;

--- a/plugins/utils/neocord.nix
+++ b/plugins/utils/neocord.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "neocord";
   defaultPackage = pkgs.vimPlugins.neocord;
 

--- a/plugins/utils/nvim-autopairs.nix
+++ b/plugins/utils/nvim-autopairs.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "nvim-autopairs";
   defaultPackage = pkgs.vimPlugins.nvim-autopairs;
 

--- a/plugins/utils/obsidian/default.nix
+++ b/plugins/utils/obsidian/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "obsidian";
   originalName = "obsidian.nvim";
   defaultPackage = pkgs.vimPlugins.obsidian-nvim;

--- a/plugins/utils/oil.nix
+++ b/plugins/utils/oil.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "oil";
   originalName = "oil.nvim";
   defaultPackage = pkgs.vimPlugins.oil-nvim;

--- a/plugins/utils/refactoring.nix
+++ b/plugins/utils/refactoring.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "refactoring";
   originalName = "refactoring.nvim";
   defaultPackage = pkgs.vimPlugins.refactoring-nvim;

--- a/plugins/utils/rest.nix
+++ b/plugins/utils/rest.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "rest";
   originalName = "rest.nvim";
   luaName = "rest-nvim";

--- a/plugins/utils/sandwich.nix
+++ b/plugins/utils/sandwich.nix
@@ -1,12 +1,11 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "sandwich";
   originalName = "vim-sandwich";
   defaultPackage = pkgs.vimPlugins.vim-sandwich;

--- a/plugins/utils/scope.nix
+++ b/plugins/utils/scope.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  config,
   pkgs,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "scope";
   originalName = "scope.nvim";
   defaultPackage = pkgs.vimPlugins.scope-nvim;

--- a/plugins/utils/sleuth.nix
+++ b/plugins/utils/sleuth.nix
@@ -1,11 +1,10 @@
 {
-  config,
   lib,
   helpers,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "sleuth";
   originalName = "vim-sleuth";
   defaultPackage = pkgs.vimPlugins.vim-sleuth;

--- a/plugins/utils/smart-splits.nix
+++ b/plugins/utils/smart-splits.nix
@@ -1,11 +1,10 @@
 {
-  config,
   lib,
   pkgs,
   helpers,
   ...
 }:
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "smart-splits";
   originalName = "smart-splits.nvim";
   defaultPackage = pkgs.vimPlugins.smart-splits-nvim;

--- a/plugins/utils/spectre.nix
+++ b/plugins/utils/spectre.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "spectre";
   originalName = "nvim-spectre";
   defaultPackage = pkgs.vimPlugins.nvim-spectre;

--- a/plugins/utils/startify/default.nix
+++ b/plugins/utils/startify/default.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "startify";
   originalName = "vim-startify";
   defaultPackage = pkgs.vimPlugins.vim-startify;

--- a/plugins/utils/surround.nix
+++ b/plugins/utils/surround.nix
@@ -1,11 +1,10 @@
 {
-  config,
   lib,
   helpers,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "surround";
   originalName = "surround.vim";
   defaultPackage = pkgs.vimPlugins.vim-surround;

--- a/plugins/utils/tmux-navigator.nix
+++ b/plugins/utils/tmux-navigator.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "tmux-navigator";
   originalName = "vim-tmux-navigator";
   defaultPackage = pkgs.vimPlugins.vim-tmux-navigator;

--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -16,7 +16,7 @@ let
   types = lib.nixvim.nixvimTypes;
 
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "todo-comments";
   originalName = "todo-comments.nvim";
   defaultPackage = pkgs.vimPlugins.todo-comments-nvim;

--- a/plugins/utils/toggleterm.nix
+++ b/plugins/utils/toggleterm.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "toggleterm";
   originalName = "toggleterm.nvim";
   defaultPackage = pkgs.vimPlugins.toggleterm-nvim;

--- a/plugins/utils/trim.nix
+++ b/plugins/utils/trim.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "trim";
   originalName = "trim.nvim";
   defaultPackage = pkgs.vimPlugins.trim-nvim;

--- a/plugins/utils/undotree.nix
+++ b/plugins/utils/undotree.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  config,
   helpers,
   pkgs,
   ...
 }:
 with lib;
 with helpers.vim-plugin;
-mkVimPlugin config {
+mkVimPlugin {
   name = "undotree";
   defaultPackage = pkgs.vimPlugins.undotree;
   globalPrefix = "undotree_";

--- a/plugins/utils/vim-css-color.nix
+++ b/plugins/utils/vim-css-color.nix
@@ -1,10 +1,9 @@
 {
-  config,
   helpers,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "vim-css-color";
   defaultPackage = pkgs.vimPlugins.vim-css-color;
 

--- a/plugins/utils/wakatime.nix
+++ b/plugins/utils/wakatime.nix
@@ -1,12 +1,11 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
 with lib;
-helpers.vim-plugin.mkVimPlugin config {
+helpers.vim-plugin.mkVimPlugin {
   name = "wakatime";
   originalName = "vim-wakatime";
   defaultPackage = pkgs.vimPlugins.vim-wakatime;

--- a/plugins/utils/which-key.nix
+++ b/plugins/utils/which-key.nix
@@ -1,7 +1,6 @@
 {
   lib,
   pkgs,
-  config,
   options,
   ...
 }:
@@ -77,7 +76,7 @@ let
   ];
 
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin config {
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "which-key";
   originalName = "which-key.nvim";
   defaultPackage = pkgs.vimPlugins.which-key-nvim;

--- a/plugins/utils/yanky.nix
+++ b/plugins/utils/yanky.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "yanky";
   originalName = "yanky.nvim";
   defaultPackage = pkgs.vimPlugins.yanky-nvim;

--- a/plugins/utils/zellij.nix
+++ b/plugins/utils/zellij.nix
@@ -1,11 +1,10 @@
 {
   lib,
   helpers,
-  config,
   pkgs,
   ...
 }:
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "zellij";
   originalName = "zellij.nvim";
   defaultPackage = pkgs.vimPlugins.zellij-nvim;

--- a/plugins/utils/zk.nix
+++ b/plugins/utils/zk.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-helpers.neovim-plugin.mkNeovimPlugin config {
+helpers.neovim-plugin.mkNeovimPlugin {
   name = "zk";
   originalName = "zk.nvim";
   defaultPackage = pkgs.vimPlugins.zk-nvim;


### PR DESCRIPTION
- **lib/vim-plugin: drop `config` arg**
- **lib/neovim-plugin: drop `config` arg**

Instead of passing in `config` explicitly, we can access it via an imported module.

This will work better if we need to access additional module args, such as `options` or `pkgs`.