### PR TITLE
Add indent option to nvim-orgmode

### DIFF
--- a/plugins/languages/nvim-orgmode.nix
+++ b/plugins/languages/nvim-orgmode.nix
@@ -21,10 +21,16 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin config {
     org_default_notes_file = defaultNullOpts.mkStr "" ''
       A path to the default notes file.
     '';
+    org_startup_indented = defaultNullOpts.mkBool false ''
+      When set to true, uses Virtual indents to align content visually.
+      The indents are only visual, they are not saved to the file.
+      When set to false, does not add any Virtual indentation.
+    '';
   };
 
   settingsExample = {
     org_agenda_files = "~/orgfiles/**/*";
     org_default_notes_file = "~/orgfiles/refile.org";
+    org_startup_indented = true;
   };
 }

--- a/tests/test-sources/plugins/languages/orgmode.nix
+++ b/tests/test-sources/plugins/languages/orgmode.nix
@@ -9,6 +9,7 @@
       settings = {
         org_agenda_files = "";
         org_default_notes_file = "";
+        org_startup_indented = false;
       };
     };
   };
@@ -20,6 +21,7 @@
       settings = {
         org_agenda_files = "~/orgfiles/**/*";
         org_default_notes_file = "~/orgfiles/refile.org";
+        org_startup_indented = true;
       };
     };
   };


### PR DESCRIPTION
This PR adds the `org_startup_indented` option to nvim-orgmode.