### PR TITLE
treewide: migrate to `lib.mkPackageOption`

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -9,6 +9,9 @@
       makeNixvimWithModule,
       ...
     }:
+    let
+      evaluatedNixvim = helpers.modules.evalNixvim { check = false; };
+    in
     {
       checks = {
         extra-args-tests = import ../tests/extra-args.nix {
@@ -43,6 +46,8 @@
         maintainers = import ../tests/maintainers.nix { inherit pkgs; };
 
         generated = pkgs.callPackage ../tests/generated.nix { };
+
+        package-options = pkgs.callPackage ../tests/package-options.nix { inherit evaluatedNixvim; };
       } // import ../tests { inherit pkgs pkgsUnfree helpers; };
     };
 }

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -2,6 +2,12 @@
 let
   inherit (lib) types;
 
+  removed = lib.mapAttrs (name: msg: throw "${name} is removed. ${msg}") {
+    # Removed 2024-09-05
+    mkPackageOption = "Use `lib.mkPackageOption` instead.";
+    mkPluginPackageOption = "Use `lib.mkPackageOption` instead.";
+  };
+
   # Render a plugin default string
   pluginDefaultText =
     {
@@ -313,34 +319,6 @@ rec {
         );
     };
 
-  # TODO: Deprecated 2024-09-02; remove once all internal uses are gone
-  mkPackageOption =
-    args:
-    # A default package is required
-    assert args ? default;
-    # `name` must be present if `description` is missing
-    assert (!args ? description) -> args ? name;
-    mkNullOrOption' (
-      (lib.filterAttrs (n: _: n != "name") args)
-      // {
-        type = types.package;
-        description =
-          args.description or ''
-            Which package to use for `${args.name}`.
-            Set to `null` to disable its automatic installation.
-          '';
-      }
-    );
-
-  # TODO: Deprecated 2024-09-02; remove once all internal uses are gone
-  mkPluginPackageOption =
-    name: default:
-    lib.mkOption {
-      type = types.package;
-      inherit default;
-      description = "Which package to use for the ${name} plugin.";
-    };
-
   mkSettingsOption =
     {
       options ? { },
@@ -371,3 +349,4 @@ rec {
           example;
     };
 }
+// removed

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (lib) types mkOption;
+  inherit (lib) types mkOption mkPackageOption;
   inherit (lib) optional optionalString optionalAttrs;
 in
 {
@@ -39,10 +39,8 @@ in
       description = "Enable Node provider.";
     };
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.neovim-unwrapped;
-      description = "Neovim to use for NixVim.";
+    package = mkPackageOption pkgs "Neovim" {
+      default = "neovim-unwrapped";
     };
 
     wrapRc = mkOption {

--- a/plugins/ai/chatgpt.nix
+++ b/plugins/ai/chatgpt.nix
@@ -13,9 +13,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ maintainers.GaetanLepage ];
 
   extraOptions = {
-    curlPackage = helpers.mkPackageOption {
-      name = "curl";
-      default = pkgs.curl;
+    curlPackage = lib.mkPackageOption pkgs "curl" {
+      nullable = true;
     };
   };
 

--- a/plugins/bufferlines/barbar.nix
+++ b/plugins/bufferlines/barbar.nix
@@ -195,10 +195,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     );
 
   extraOptions = {
-    iconsPackage = lib.nixvim.mkPackageOption {
-      name = "nvim-web-devicons";
-      default = pkgs.vimPlugins.nvim-web-devicons;
-    };
+    iconsPackage = lib.mkPackageOption pkgs [
+      "vimPlugins"
+      "nvim-web-devicons"
+    ] { nullable = true; };
 
     keymaps = mapAttrs (
       optionName: funcName:

--- a/plugins/bufferlines/bufferline.nix
+++ b/plugins/bufferlines/bufferline.nix
@@ -654,10 +654,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   };
 
   extraOptions = {
-    iconsPackage = lib.nixvim.mkPackageOption {
-      name = "nvim-web-devicons";
-      default = pkgs.vimPlugins.nvim-web-devicons;
-    };
+    iconsPackage = lib.mkPackageOption pkgs [
+      "vimPlugins"
+      "nvim-web-devicons"
+    ] { nullable = true; };
   };
 
   extraConfig = cfg: {

--- a/plugins/colorschemes/dracula.nix
+++ b/plugins/colorschemes/dracula.nix
@@ -13,7 +13,12 @@ in
     colorschemes.dracula = {
       enable = lib.mkEnableOption "dracula";
 
-      package = lib.nixvim.mkPluginPackageOption "dracula" pkgs.vimPlugins.dracula-vim;
+      package = lib.mkPackageOption pkgs "dracula" {
+        default = [
+          "vimPlugins"
+          "dracula-vim"
+        ];
+      };
 
       bold = lib.mkOption {
         type = types.bool;

--- a/plugins/completion/cmp/sources/cmp-fish.nix
+++ b/plugins/completion/cmp/sources/cmp-fish.nix
@@ -13,9 +13,8 @@ in
   meta.maintainers = [ maintainers.GaetanLepage ];
 
   options.plugins.cmp-fish = {
-    fishPackage = helpers.mkPackageOption {
-      name = "fish";
-      default = pkgs.fish;
+    fishPackage = lib.mkPackageOption pkgs "fish" {
+      nullable = true;
     };
   };
 

--- a/plugins/completion/copilot-lua.nix
+++ b/plugins/completion/copilot-lua.nix
@@ -19,7 +19,12 @@ in
       // {
         enable = mkEnableOption "copilot.lua";
 
-        package = helpers.mkPluginPackageOption "copilot.lua" pkgs.vimPlugins.copilot-lua;
+        package = lib.mkPackageOption pkgs "copilot.lua" {
+          default = [
+            "vimPlugins"
+            "copilot-lua"
+          ];
+        };
 
         panel = {
           enabled = helpers.defaultNullOpts.mkBool true "Enable the panel.";

--- a/plugins/completion/coq-thirdparty.nix
+++ b/plugins/completion/coq-thirdparty.nix
@@ -13,7 +13,12 @@ in
   options.plugins.coq-thirdparty = {
     enable = mkEnableOption "coq-thirdparty";
 
-    package = helpers.mkPluginPackageOption "coq-thirdparty" pkgs.vimPlugins.coq-thirdparty;
+    package = lib.mkPackageOption pkgs "coq-thirdparty" {
+      default = [
+        "vimPlugins"
+        "coq-thirdparty"
+      ];
+    };
 
     sources = mkOption {
       type = types.listOf (

--- a/plugins/completion/coq.nix
+++ b/plugins/completion/coq.nix
@@ -16,11 +16,14 @@ helpers.neovim-plugin.mkNeovimPlugin {
   ];
 
   extraOptions = {
+    # TODO: should this enable option be replaced with `nullable = true` in the package option?
     installArtifacts = mkEnableOption "and install coq-artifacts";
-    artifactsPackage = mkOption {
-      type = types.package;
-      description = "Package to use for coq-artifacts (when enabled with installArtifacts)";
-      default = pkgs.vimPlugins.coq-artifacts;
+    artifactsPackage = mkPackageOption pkgs "coq-artifacts" {
+      extraDescription = "Installed when `installArtifacts` is enabled.";
+      default = [
+        "vimPlugins"
+        "coq-artifacts"
+      ];
     };
   };
 

--- a/plugins/completion/lspkind.nix
+++ b/plugins/completion/lspkind.nix
@@ -13,7 +13,12 @@ in
   options.plugins.lspkind = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "lspkind.nvim";
 
-    package = helpers.mkPluginPackageOption "lspkind" pkgs.vimPlugins.lspkind-nvim;
+    package = lib.mkPackageOption pkgs "lspkind" {
+      default = [
+        "vimPlugins"
+        "lspkind-nvim"
+      ];
+    };
 
     mode = helpers.defaultNullOpts.mkEnum [
       "text"

--- a/plugins/dap/dap-go.nix
+++ b/plugins/dap/dap-go.nix
@@ -14,7 +14,12 @@ in
   options.plugins.dap.extensions.dap-go = {
     enable = mkEnableOption "dap-go";
 
-    package = helpers.mkPluginPackageOption "dap-go" pkgs.vimPlugins.nvim-dap-go;
+    package = lib.mkPackageOption pkgs "dap-go" {
+      default = [
+        "vimPlugins"
+        "nvim-dap-go"
+      ];
+    };
 
     dapConfigurations = helpers.mkNullOrOption (types.listOf dapHelpers.configurationOption) ''
       Additional dap configurations.

--- a/plugins/dap/dap-python.nix
+++ b/plugins/dap/dap-python.nix
@@ -14,7 +14,12 @@ in
   options.plugins.dap.extensions.dap-python = {
     enable = mkEnableOption "dap-python";
 
-    package = helpers.mkPluginPackageOption "dap-python" pkgs.vimPlugins.nvim-dap-python;
+    package = lib.mkPackageOption pkgs "dap-python" {
+      default = [
+        "vimPlugins"
+        "nvim-dap-python"
+      ];
+    };
 
     adapterPythonPath = mkOption {
       default = "${pkgs.python3.withPackages (ps: with ps; [ debugpy ])}/bin/python3";

--- a/plugins/dap/dap-ui.nix
+++ b/plugins/dap/dap-ui.nix
@@ -59,7 +59,12 @@ in
   options.plugins.dap.extensions.dap-ui = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "dap-ui";
 
-    package = helpers.mkPluginPackageOption "dap-ui" pkgs.vimPlugins.nvim-dap-ui;
+    package = lib.mkPackageOption pkgs "dap-ui" {
+      default = [
+        "vimPlugins"
+        "nvim-dap-ui"
+      ];
+    };
 
     controls = {
       enabled = helpers.defaultNullOpts.mkBool true "Enable controls";

--- a/plugins/dap/dap-virtual-text.nix
+++ b/plugins/dap/dap-virtual-text.nix
@@ -13,7 +13,12 @@ in
   options.plugins.dap.extensions.dap-virtual-text = {
     enable = mkEnableOption "dap-virtual-text";
 
-    package = helpers.mkPluginPackageOption "dap-virtual-text" pkgs.vimPlugins.nvim-dap-virtual-text;
+    package = lib.mkPackageOption pkgs "dap-virtual-text" {
+      default = [
+        "vimPlugins"
+        "nvim-dap-virtual-text"
+      ];
+    };
 
     enabledCommands = helpers.defaultNullOpts.mkBool true ''
       Create commands `DapVirtualTextEnable`, `DapVirtualTextDisable`, `DapVirtualTextToggle`.

--- a/plugins/dap/default.nix
+++ b/plugins/dap/default.nix
@@ -22,7 +22,12 @@ with dapHelpers;
   options.plugins.dap = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "dap";
 
-    package = helpers.mkPluginPackageOption "dap" pkgs.vimPlugins.nvim-dap;
+    package = lib.mkPackageOption pkgs "dap" {
+      default = [
+        "vimPlugins"
+        "nvim-dap"
+      ];
+    };
 
     adapters = helpers.mkCompositeOption "Dap adapters." {
       executables = mkAdapterOption "executable" executableAdapterOption;

--- a/plugins/filetrees/chadtree.nix
+++ b/plugins/filetrees/chadtree.nix
@@ -14,7 +14,12 @@ in
   options.plugins.chadtree = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "chadtree";
 
-    package = helpers.mkPluginPackageOption "chadtree" pkgs.vimPlugins.chadtree;
+    package = lib.mkPackageOption pkgs "chadtree" {
+      default = [
+        "vimPlugins"
+        "chadtree"
+      ];
+    };
 
     iconsPackage = lib.mkPackageOption pkgs [
       "vimPlugins"

--- a/plugins/filetrees/chadtree.nix
+++ b/plugins/filetrees/chadtree.nix
@@ -16,10 +16,10 @@ in
 
     package = helpers.mkPluginPackageOption "chadtree" pkgs.vimPlugins.chadtree;
 
-    iconsPackage = helpers.mkPackageOption {
-      name = "nvim-web-devicons";
-      default = pkgs.vimPlugins.nvim-web-devicons;
-    };
+    iconsPackage = lib.mkPackageOption pkgs [
+      "vimPlugins"
+      "nvim-web-devicons"
+    ] { nullable = true; };
 
     options = {
       follow = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -62,9 +62,8 @@ in
         "nvim-web-devicons"
       ] { nullable = true; };
 
-      gitPackage = helpers.mkPackageOption {
-        name = "git";
-        default = pkgs.git;
+      gitPackage = lib.mkPackageOption pkgs "git" {
+        nullable = true;
       };
 
       sources =

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -57,10 +57,10 @@ in
 
       package = helpers.mkPluginPackageOption "neo-tree" pkgs.vimPlugins.neo-tree-nvim;
 
-      iconsPackage = helpers.mkPackageOption {
-        name = "nvim-web-devicons";
-        default = pkgs.vimPlugins.nvim-web-devicons;
-      };
+      iconsPackage = lib.mkPackageOption pkgs [
+        "vimPlugins"
+        "nvim-web-devicons"
+      ] { nullable = true; };
 
       gitPackage = helpers.mkPackageOption {
         name = "git";

--- a/plugins/filetrees/neo-tree.nix
+++ b/plugins/filetrees/neo-tree.nix
@@ -55,7 +55,12 @@ in
     // {
       enable = mkEnableOption "neo-tree";
 
-      package = helpers.mkPluginPackageOption "neo-tree" pkgs.vimPlugins.neo-tree-nvim;
+      package = lib.mkPackageOption pkgs "neo-tree" {
+        default = [
+          "vimPlugins"
+          "neo-tree-nvim"
+        ];
+      };
 
       iconsPackage = lib.mkPackageOption pkgs [
         "vimPlugins"

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -41,10 +41,10 @@ in
 
     package = helpers.mkPluginPackageOption "nvim-tree" pkgs.vimPlugins.nvim-tree-lua;
 
-    iconsPackage = helpers.mkPackageOption {
-      name = "nvim-web-devicons";
-      default = pkgs.vimPlugins.nvim-web-devicons;
-    };
+    iconsPackage = lib.mkPackageOption pkgs [
+      "vimPlugins"
+      "nvim-web-devicons"
+    ] { nullable = true; };
 
     gitPackage = helpers.mkPackageOption {
       name = "git";

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -46,9 +46,8 @@ in
       "nvim-web-devicons"
     ] { nullable = true; };
 
-    gitPackage = helpers.mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
 
     disableNetrw = helpers.defaultNullOpts.mkBool false "Disable netrw";

--- a/plugins/filetrees/nvim-tree.nix
+++ b/plugins/filetrees/nvim-tree.nix
@@ -39,7 +39,12 @@ in
   options.plugins.nvim-tree = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-tree";
 
-    package = helpers.mkPluginPackageOption "nvim-tree" pkgs.vimPlugins.nvim-tree-lua;
+    package = lib.mkPackageOption pkgs "nvim-tree" {
+      default = [
+        "vimPlugins"
+        "nvim-tree-lua"
+      ];
+    };
 
     iconsPackage = lib.mkPackageOption pkgs [
       "vimPlugins"

--- a/plugins/git/committia.nix
+++ b/plugins/git/committia.nix
@@ -1,5 +1,6 @@
 {
   helpers,
+  lib,
   pkgs,
   ...
 }:
@@ -47,9 +48,8 @@ helpers.vim-plugin.mkVimPlugin {
   };
 
   extraOptions = {
-    gitPackage = helpers.mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
   };
 

--- a/plugins/git/diffview.nix
+++ b/plugins/git/diffview.nix
@@ -88,10 +88,10 @@ in
 
       package = helpers.mkPluginPackageOption "diffview" pkgs.vimPlugins.diffview-nvim;
 
-      iconsPackage = helpers.mkPackageOption {
-        name = "nvim-web-devicons";
-        default = pkgs.vimPlugins.nvim-web-devicons;
-      };
+      iconsPackage = lib.mkPackageOption pkgs [
+        "vimPlugins"
+        "nvim-web-devicons"
+      ] { nullable = true; };
 
       diffBinaries = mkBool false ''
         Show diffs for binaries

--- a/plugins/git/diffview.nix
+++ b/plugins/git/diffview.nix
@@ -86,7 +86,12 @@ in
     // {
       enable = mkEnableOption "diffview";
 
-      package = helpers.mkPluginPackageOption "diffview" pkgs.vimPlugins.diffview-nvim;
+      package = lib.mkPackageOption pkgs "diffview" {
+        default = [
+          "vimPlugins"
+          "diffview-nvim"
+        ];
+      };
 
       iconsPackage = lib.mkPackageOption pkgs [
         "vimPlugins"

--- a/plugins/git/fugitive.nix
+++ b/plugins/git/fugitive.nix
@@ -13,9 +13,8 @@ helpers.vim-plugin.mkVimPlugin {
 
   # In typical tpope fashion, this plugin has no config options
   extraOptions = {
-    gitPackage = helpers.mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
   };
 

--- a/plugins/git/git-conflict.nix
+++ b/plugins/git/git-conflict.nix
@@ -13,9 +13,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ maintainers.GaetanLepage ];
 
   extraOptions = {
-    gitPackage = helpers.mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
   };
 

--- a/plugins/git/git-worktree.nix
+++ b/plugins/git/git-worktree.nix
@@ -14,7 +14,12 @@ in
     plugins.git-worktree = {
       enable = mkEnableOption "git-worktree";
 
-      package = helpers.mkPluginPackageOption "git-worktree" pkgs.vimPlugins.git-worktree-nvim;
+      package = lib.mkPackageOption pkgs "git-worktree" {
+        default = [
+          "vimPlugins"
+          "git-worktree-nvim"
+        ];
+      };
 
       gitPackage = lib.mkPackageOption pkgs "git" {
         nullable = true;

--- a/plugins/git/git-worktree.nix
+++ b/plugins/git/git-worktree.nix
@@ -16,9 +16,8 @@ in
 
       package = helpers.mkPluginPackageOption "git-worktree" pkgs.vimPlugins.git-worktree-nvim;
 
-      gitPackage = helpers.mkPackageOption {
-        name = "git";
-        default = pkgs.git;
+      gitPackage = lib.mkPackageOption pkgs "git" {
+        nullable = true;
       };
 
       enableTelescope = mkEnableOption "telescope integration";

--- a/plugins/git/gitblame.nix
+++ b/plugins/git/gitblame.nix
@@ -4,7 +4,7 @@
   ...
 }:
 let
-  inherit (lib.nixvim) defaultNullOpts mkPackageOption;
+  inherit (lib.nixvim) defaultNullOpts;
   types = lib.nixvim.nixvimTypes;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
@@ -128,9 +128,8 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   };
 
   extraOptions = {
-    gitPackage = mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
   };
 

--- a/plugins/git/gitgutter.nix
+++ b/plugins/git/gitgutter.nix
@@ -14,7 +14,12 @@ in
     plugins.gitgutter = {
       enable = mkEnableOption "gitgutter";
 
-      package = helpers.mkPluginPackageOption "gitgutter" pkgs.vimPlugins.gitgutter;
+      package = lib.mkPackageOption pkgs "gitgutter" {
+        default = [
+          "vimPlugins"
+          "gitgutter"
+        ];
+      };
 
       gitPackage = lib.mkPackageOption pkgs "git" {
         nullable = true;

--- a/plugins/git/gitgutter.nix
+++ b/plugins/git/gitgutter.nix
@@ -16,9 +16,8 @@ in
 
       package = helpers.mkPluginPackageOption "gitgutter" pkgs.vimPlugins.gitgutter;
 
-      gitPackage = helpers.mkPackageOption {
-        name = "git";
-        default = pkgs.git;
+      gitPackage = lib.mkPackageOption pkgs "git" {
+        nullable = true;
       };
 
       recommendedSettings = mkOption {

--- a/plugins/git/gitlinker.nix
+++ b/plugins/git/gitlinker.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.gitlinker = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "gitlinker.nvim";
 
-    package = helpers.mkPluginPackageOption "gitlinker.nvim" pkgs.vimPlugins.gitlinker-nvim;
+    package = lib.mkPackageOption pkgs "gitlinker.nvim" {
+      default = [
+        "vimPlugins"
+        "gitlinker-nvim"
+      ];
+    };
 
     remote = helpers.mkNullOrOption types.str "Force the use of a specific remote.";
 

--- a/plugins/git/gitmessenger.nix
+++ b/plugins/git/gitmessenger.nix
@@ -12,7 +12,12 @@ with lib;
   options.plugins.gitmessenger = {
     enable = mkEnableOption "gitmessenger";
 
-    package = helpers.mkPluginPackageOption "git-messenger" pkgs.vimPlugins.git-messenger-vim;
+    package = lib.mkPackageOption pkgs "git-messenger" {
+      default = [
+        "vimPlugins"
+        "git-messenger-vim"
+      ];
+    };
 
     closeOnCursorMoved = helpers.defaultNullOpts.mkBool true ''
       A popup window is no longer closed automatically when moving a cursor after the window is

--- a/plugins/git/gitsigns/default.nix
+++ b/plugins/git/gitsigns/default.nix
@@ -242,9 +242,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
     ];
 
   extraOptions = {
-    gitPackage = helpers.mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
   };
 

--- a/plugins/git/lazygit.nix
+++ b/plugins/git/lazygit.nix
@@ -70,14 +70,12 @@ helpers.vim-plugin.mkVimPlugin {
   };
 
   extraOptions = {
-    gitPackage = helpers.mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
 
-    lazygitPackage = helpers.mkPackageOption {
-      name = "lazygit";
-      default = pkgs.lazygit;
+    lazygitPackage = lib.mkPackageOption pkgs "lazygit" {
+      nullable = true;
     };
   };
 

--- a/plugins/git/neogit/default.nix
+++ b/plugins/git/neogit/default.nix
@@ -101,9 +101,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
   };
 
   extraOptions = {
-    gitPackage = helpers.mkPackageOption {
-      name = "git";
-      default = pkgs.git;
+    gitPackage = lib.mkPackageOption pkgs "git" {
+      nullable = true;
     };
   };
 

--- a/plugins/languages/clangd-extensions.nix
+++ b/plugins/languages/clangd-extensions.nix
@@ -98,7 +98,12 @@ in
   options.plugins.clangd-extensions = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "clangd_extensions, plugins implementing clangd LSP extensions";
 
-    package = helpers.mkPluginPackageOption "clangd_extensions.nvim" pkgs.vimPlugins.clangd_extensions-nvim;
+    package = lib.mkPackageOption pkgs "clangd_extensions.nvim" {
+      default = [
+        "vimPlugins"
+        "clangd_extensions-nvim"
+      ];
+    };
 
     enableOffsetEncodingWorkaround = mkEnableOption ''
       utf-16 offset encoding. This is used to work around the warning:

--- a/plugins/languages/godot.nix
+++ b/plugins/languages/godot.nix
@@ -14,9 +14,9 @@ helpers.vim-plugin.mkVimPlugin {
   maintainers = [ maintainers.GaetanLepage ];
 
   extraOptions = {
-    godotPackage = helpers.mkPackageOption {
-      name = "godot";
-      default = pkgs.godot_4;
+    godotPackage = lib.mkPackageOption pkgs "godot" {
+      nullable = true;
+      default = "godot_4";
     };
   };
 

--- a/plugins/languages/helm.nix
+++ b/plugins/languages/helm.nix
@@ -15,7 +15,12 @@ in
   options.plugins.helm = {
     enable = mkEnableOption "vim-helm";
 
-    package = helpers.mkPluginPackageOption "vim-helm" pkgs.vimPlugins.vim-helm;
+    package = lib.mkPackageOption pkgs "vim-helm" {
+      default = [
+        "vimPlugins"
+        "vim-helm"
+      ];
+    };
   };
 
   config = mkIf cfg.enable { extraPlugins = [ cfg.package ]; };

--- a/plugins/languages/lean.nix
+++ b/plugins/languages/lean.nix
@@ -13,7 +13,12 @@ in
   options.plugins.lean = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "lean-nvim";
 
-    package = helpers.mkPluginPackageOption "lean-nvim" pkgs.vimPlugins.lean-nvim;
+    package = lib.mkPackageOption pkgs "lean-nvim" {
+      default = [
+        "vimPlugins"
+        "lean-nvim"
+      ];
+    };
 
     leanPackage = lib.mkPackageOption pkgs "lean" {
       nullable = true;

--- a/plugins/languages/lean.nix
+++ b/plugins/languages/lean.nix
@@ -15,9 +15,9 @@ in
 
     package = helpers.mkPluginPackageOption "lean-nvim" pkgs.vimPlugins.lean-nvim;
 
-    leanPackage = helpers.mkPackageOption {
-      name = "lean";
-      default = pkgs.lean4;
+    leanPackage = lib.mkPackageOption pkgs "lean" {
+      nullable = true;
+      default = "lean4";
     };
 
     lsp = helpers.defaultNullOpts.mkNullable (

--- a/plugins/languages/ledger.nix
+++ b/plugins/languages/ledger.nix
@@ -45,9 +45,8 @@ mkVimPlugin {
     ];
 
   extraOptions = {
-    ledgerPackage = helpers.mkPackageOption {
-      name = "ledger";
-      default = pkgs.ledger;
+    ledgerPackage = lib.mkPackageOption pkgs "ledger" {
+      nullable = true;
     };
   };
 

--- a/plugins/languages/lint.nix
+++ b/plugins/languages/lint.nix
@@ -137,7 +137,12 @@ in
   options.plugins.lint = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-lint";
 
-    package = helpers.mkPluginPackageOption "nvim-lint" pkgs.vimPlugins.nvim-lint;
+    package = lib.mkPackageOption pkgs "nvim-lint" {
+      default = [
+        "vimPlugins"
+        "nvim-lint"
+      ];
+    };
 
     lintersByFt = mkOption {
       type = with types; attrsOf (listOf str);

--- a/plugins/languages/markdown/glow.nix
+++ b/plugins/languages/markdown/glow.nix
@@ -72,13 +72,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
   };
 
   extraOptions = {
-    glowPackage = helpers.mkPackageOption {
-      description = ''
-        Which package to use for `glow` in your `$PATH`.
-        Set to `null` to disable its automatic installation.
-      '';
-      default = pkgs.glow;
-      defaultText = lib.literalExpression "pkgs.glow";
+    glowPackage = lib.mkPackageOption pkgs "glow" {
+      nullable = true;
     };
   };
 

--- a/plugins/languages/nvim-jdtls.nix
+++ b/plugins/languages/nvim-jdtls.nix
@@ -13,7 +13,12 @@ in
   options.plugins.nvim-jdtls = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-jdtls";
 
-    package = helpers.mkPluginPackageOption "nvim-jdtls" pkgs.vimPlugins.nvim-jdtls;
+    package = lib.mkPackageOption pkgs "nvim-jdtls" {
+      default = [
+        "vimPlugins"
+        "nvim-jdtls"
+      ];
+    };
 
     cmd = helpers.mkNullOrOption (types.listOf types.str) ''
       The command that starts the language server.

--- a/plugins/languages/openscad.nix
+++ b/plugins/languages/openscad.nix
@@ -13,7 +13,12 @@ in
   options.plugins.openscad = {
     enable = mkEnableOption "openscad.nvim, a plugin to manage OpenSCAD files";
 
-    package = helpers.mkPluginPackageOption "openscad.nvim" pkgs.vimPlugins.openscad-nvim;
+    package = lib.mkPackageOption pkgs "openscad.nvim" {
+      default = [
+        "vimPlugins"
+        "openscad-nvim"
+      ];
+    };
 
     fuzzyFinder = helpers.defaultNullOpts.mkEnum [
       "skim"

--- a/plugins/languages/plantuml-syntax.nix
+++ b/plugins/languages/plantuml-syntax.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.plantuml-syntax = {
     enable = mkEnableOption "plantuml syntax support";
 
-    package = helpers.mkPluginPackageOption "plantuml-syntax" pkgs.vimPlugins.plantuml-syntax;
+    package = lib.mkPackageOption pkgs "plantuml-syntax" {
+      default = [
+        "vimPlugins"
+        "plantuml-syntax"
+      ];
+    };
 
     setMakeprg = mkOption {
       type = types.bool;

--- a/plugins/languages/rust/rust-tools.nix
+++ b/plugins/languages/rust/rust-tools.nix
@@ -12,7 +12,12 @@ in
 {
   options.plugins.rust-tools = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "rust tools plugins";
-    package = helpers.mkPluginPackageOption "rust-tools" pkgs.vimPlugins.rust-tools-nvim;
+    package = lib.mkPackageOption pkgs "rust-tools" {
+      default = [
+        "vimPlugins"
+        "rust-tools-nvim"
+      ];
+    };
     serverPackage = lib.mkPackageOption pkgs "rust-analyzer" {
       nullable = true;
     };

--- a/plugins/languages/rust/rust-tools.nix
+++ b/plugins/languages/rust/rust-tools.nix
@@ -13,9 +13,8 @@ in
   options.plugins.rust-tools = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "rust tools plugins";
     package = helpers.mkPluginPackageOption "rust-tools" pkgs.vimPlugins.rust-tools-nvim;
-    serverPackage = helpers.mkPackageOption {
-      name = "rust-analyzer";
-      default = pkgs.rust-analyzer;
+    serverPackage = lib.mkPackageOption pkgs "rust-analyzer" {
+      nullable = true;
     };
 
     executor = helpers.defaultNullOpts.mkEnumFirstDefault [

--- a/plugins/languages/rust/rustaceanvim/default.nix
+++ b/plugins/languages/rust/rustaceanvim/default.nix
@@ -16,9 +16,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
   optionsRenamedToSettings = import ./renamed-options.nix;
 
   extraOptions = {
-    rustAnalyzerPackage = helpers.mkPackageOption {
-      name = "rust-analyzer";
-      default = pkgs.rust-analyzer;
+    rustAnalyzerPackage = lib.mkPackageOption pkgs "rust-analyzer" {
+      nullable = true;
     };
   };
 

--- a/plugins/languages/texpresso.nix
+++ b/plugins/languages/texpresso.nix
@@ -15,9 +15,8 @@ helpers.vim-plugin.mkVimPlugin {
   maintainers = [ maintainers.nickhu ];
 
   extraOptions = {
-    texpressoPackage = helpers.mkPackageOption {
-      name = "texpresso";
-      default = pkgs.texpresso;
+    texpressoPackage = lib.mkPackageOption pkgs "texpresso" {
+      nullable = true;
     };
   };
 

--- a/plugins/languages/treesitter/hmts.nix
+++ b/plugins/languages/treesitter/hmts.nix
@@ -15,7 +15,12 @@ in
   options.plugins.hmts = {
     enable = mkEnableOption "hmts.nvim";
 
-    package = helpers.mkPluginPackageOption "hmts.nvim" pkgs.vimPlugins.hmts-nvim;
+    package = lib.mkPackageOption pkgs "hmts.nvim" {
+      default = [
+        "vimPlugins"
+        "hmts-nvim"
+      ];
+    };
   };
 
   config = mkIf cfg.enable {

--- a/plugins/languages/treesitter/rainbow-delimiters.nix
+++ b/plugins/languages/treesitter/rainbow-delimiters.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.rainbow-delimiters = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "rainbow-delimiters.nvim";
 
-    package = helpers.mkPluginPackageOption "rainbow-delimiters.nvim" pkgs.vimPlugins.rainbow-delimiters-nvim;
+    package = lib.mkPackageOption pkgs "rainbow-delimiters.nvim" {
+      default = [
+        "vimPlugins"
+        "rainbow-delimiters-nvim"
+      ];
+    };
 
     strategy = helpers.defaultNullOpts.mkAttrsOf' {
       type = types.enum [

--- a/plugins/languages/treesitter/treesitter-refactor.nix
+++ b/plugins/languages/treesitter/treesitter-refactor.nix
@@ -18,7 +18,12 @@ with lib;
     {
       enable = mkEnableOption "treesitter-refactor (requires plugins.treesitter.enable to be true)";
 
-      package = helpers.mkPluginPackageOption "treesitter-refactor" pkgs.vimPlugins.nvim-treesitter-refactor;
+      package = lib.mkPackageOption pkgs "treesitter-refactor" {
+        default = [
+          "vimPlugins"
+          "nvim-treesitter-refactor"
+        ];
+      };
 
       highlightDefinitions = {
         inherit disable;

--- a/plugins/languages/treesitter/treesitter-textobjects.nix
+++ b/plugins/languages/treesitter/treesitter-textobjects.nix
@@ -41,7 +41,12 @@ with lib;
     // {
       enable = mkEnableOption "treesitter-textobjects (requires plugins.treesitter.enable to be true)";
 
-      package = helpers.mkPluginPackageOption "treesitter-textobjects" pkgs.vimPlugins.nvim-treesitter-textobjects;
+      package = lib.mkPackageOption pkgs "treesitter-textobjects" {
+        default = [
+          "vimPlugins"
+          "nvim-treesitter-textobjects"
+        ];
+      };
 
       select = {
         enable = helpers.defaultNullOpts.mkBool false ''

--- a/plugins/languages/treesitter/treesitter.nix
+++ b/plugins/languages/treesitter/treesitter.nix
@@ -303,16 +303,11 @@ helpers.neovim-plugin.mkNeovimPlugin {
   extraOptions = {
     folding = mkEnableOption "tree-sitter based folding";
 
-    gccPackage = helpers.mkPackageOption {
-      name = "gcc";
-      default = pkgs.gcc;
-      defaultText = literalExpression "pkgs.gcc";
-      example = literalExpression "pkgs.gcc14";
-      description = ''
-        Which package (if any) to be added as the GCC compiler.
-
+    gccPackage = lib.mkPackageOption pkgs "gcc" {
+      nullable = true;
+      example = "pkgs.gcc14";
+      extraDescription = ''
         This is required to build grammars if you are not using `nixGrammars`.
-        To disable the installation of GCC, set this option to `null`.
       '';
     };
 
@@ -358,28 +353,18 @@ helpers.neovim-plugin.mkNeovimPlugin {
       description = "Whether to enable Nixvim injections, e.g. highlighting `extraConfigLua` as lua.";
     };
 
-    nodejsPackage = helpers.mkPackageOption {
-      name = "nodejs";
-      default = pkgs.nodejs;
-      defaultText = literalExpression "pkgs.nodejs";
-      example = literalExpression "pkgs.nodejs_22";
-      description = ''
-        Which package (if any) to be added as the nodejs package.
-
+    nodejsPackage = lib.mkPackageOption pkgs "nodejs" {
+      nullable = true;
+      example = "pkgs.nodejs_22";
+      extraDescription = ''
         This is required to build grammars if you are not using `nixGrammars`.
-        To disable the installation of NodeJS, set this option to `null`.
       '';
     };
 
-    treesitterPackage = helpers.mkPackageOption {
-      name = "tree-sitter";
-      default = pkgs.tree-sitter;
-      defaultText = literalExpression "pkgs.tree-sitter";
-      description = ''
-        Which package (if any) to be added as the tree-sitter binary.
-
+    treesitterPackage = lib.mkPackageOption pkgs "tree-sitter" {
+      nullable = true;
+      extraDescription = ''
         This is required to build grammars if you are not using `nixGrammars`.
-        To disable the installation of tree-sitter, set this option to `null`.
       '';
     };
   };

--- a/plugins/languages/treesitter/ts-context-commentstring.nix
+++ b/plugins/languages/treesitter/ts-context-commentstring.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.ts-context-commentstring = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-ts-context-commentstring";
 
-    package = helpers.mkPluginPackageOption "ts-context-commentstring" pkgs.vimPlugins.nvim-ts-context-commentstring;
+    package = lib.mkPackageOption pkgs "ts-context-commentstring" {
+      default = [
+        "vimPlugins"
+        "nvim-ts-context-commentstring"
+      ];
+    };
 
     skipTsContextCommentStringModule = mkOption {
       type = types.bool;

--- a/plugins/languages/typescript-tools.nix
+++ b/plugins/languages/typescript-tools.nix
@@ -12,7 +12,12 @@ in
 {
   options.plugins.typescript-tools = {
     enable = mkEnableOption "typescript-tools";
-    package = helpers.mkPluginPackageOption "typescript-tools" pkgs.vimPlugins.typescript-tools-nvim;
+    package = lib.mkPackageOption pkgs "typescript-tools" {
+      default = [
+        "vimPlugins"
+        "typescript-tools-nvim"
+      ];
+    };
 
     onAttach = helpers.defaultNullOpts.mkLuaFn "__lspOnAttach" "Lua code to run when tsserver attaches to a buffer.";
     handlers = mkOption {

--- a/plugins/languages/vimtex.nix
+++ b/plugins/languages/vimtex.nix
@@ -54,9 +54,13 @@ helpers.vim-plugin.mkVimPlugin {
   };
 
   extraOptions = {
-    texlivePackage = helpers.mkPackageOption {
-      name = "texlive";
-      default = pkgs.texlive.combined.scheme-medium;
+    texlivePackage = lib.mkPackageOption pkgs "texlive" {
+      nullable = true;
+      default = [
+        "texlive"
+        "combined"
+        "scheme-medium"
+      ];
     };
   };
 

--- a/plugins/lsp/fidget.nix
+++ b/plugins/lsp/fidget.nix
@@ -145,7 +145,12 @@ in
     plugins.fidget = helpers.neovim-plugin.extraOptionsOptions // {
       enable = mkEnableOption "fidget-nvim";
 
-      package = helpers.mkPluginPackageOption "fidget-nvim" pkgs.vimPlugins.fidget-nvim;
+      package = lib.mkPackageOption pkgs "fidget-nvim" {
+        default = [
+          "vimPlugins"
+          "fidget-nvim"
+        ];
+      };
 
       # Options related to LSP progress subsystem
       progress = {

--- a/plugins/lsp/inc-rename.nix
+++ b/plugins/lsp/inc-rename.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.inc-rename = {
     enable = mkEnableOption "inc-rename, a plugin previewing LSP renaming";
 
-    package = helpers.mkPluginPackageOption "inc-rename" pkgs.vimPlugins.inc-rename-nvim;
+    package = lib.mkPackageOption pkgs "inc-rename" {
+      default = [
+        "vimPlugins"
+        "inc-rename-nvim"
+      ];
+    };
 
     cmdName = helpers.defaultNullOpts.mkStr "IncRename" "the name of the command";
 

--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -13,7 +13,12 @@ in
   options.plugins.efmls-configs = {
     enable = lib.mkEnableOption "efmls-configs, premade configurations for efm-langserver";
 
-    package = helpers.mkPluginPackageOption "efmls-configs-nvim" pkgs.vimPlugins.efmls-configs-nvim;
+    package = lib.mkPackageOption pkgs "efmls-configs-nvim" {
+      default = [
+        "vimPlugins"
+        "efmls-configs-nvim"
+      ];
+    };
 
     externallyManagedPackages = lib.mkOption {
       type = with lib.types; either (enum [ "all" ]) (listOf str);

--- a/plugins/lsp/language-servers/pylsp.nix
+++ b/plugins/lsp/language-servers/pylsp.nix
@@ -11,10 +11,8 @@ let
 in
 {
   options.plugins.lsp.servers.pylsp = {
-    pythonPackage = mkOption {
-      type = lib.types.package;
-      description = "Python package to use for lsp.";
-      default = pkgs.python3;
+    pythonPackage = mkPackageOption pkgs "python" {
+      default = "python3";
     };
 
     # All settings are documented here:

--- a/plugins/lsp/language-servers/rust-analyzer.nix
+++ b/plugins/lsp/language-servers/rust-analyzer.nix
@@ -18,11 +18,8 @@ in
       description = "Whether to install `cargo`.";
     };
 
-    cargoPackage = mkOption {
-      type = types.package;
-      default = pkgs.cargo;
-      description = "Which package to use for `cargo`.";
-    };
+    # TODO: make nullable?
+    cargoPackage = mkPackageOption pkgs "cargo" { };
 
     installRustc = mkOption {
       type = with types; nullOr bool;
@@ -31,11 +28,8 @@ in
       description = "Whether to install `rustc`.";
     };
 
-    rustcPackage = mkOption {
-      type = types.package;
-      default = pkgs.rustc;
-      description = "Which package to use for `rustc`.";
-    };
+    # TODO: make nullable
+    rustcPackage = mkPackageOption pkgs "rustc" { };
   };
   config = mkIf cfg.enable {
     warnings =

--- a/plugins/lsp/lsp-format.nix
+++ b/plugins/lsp/lsp-format.nix
@@ -13,7 +13,12 @@ in
   options.plugins.lsp-format = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "lsp-format.nvim";
 
-    package = helpers.mkPluginPackageOption "lsp-format.nvim" pkgs.vimPlugins.lsp-format-nvim;
+    package = lib.mkPackageOption pkgs "lsp-format.nvim" {
+      default = [
+        "vimPlugins"
+        "lsp-format-nvim"
+      ];
+    };
 
     setup = mkOption {
       type =

--- a/plugins/lsp/lspsaga.nix
+++ b/plugins/lsp/lspsaga.nix
@@ -49,7 +49,12 @@ in
     plugins.lspsaga = helpers.neovim-plugin.extraOptionsOptions // {
       enable = mkEnableOption "lspsaga.nvim";
 
-      package = helpers.mkPluginPackageOption "lspsaga" pkgs.vimPlugins.lspsaga-nvim;
+      package = lib.mkPackageOption pkgs "lspsaga" {
+        default = [
+          "vimPlugins"
+          "lspsaga-nvim"
+        ];
+      };
 
       iconsPackage = lib.mkPackageOption pkgs [
         "vimPlugins"

--- a/plugins/lsp/lspsaga.nix
+++ b/plugins/lsp/lspsaga.nix
@@ -51,10 +51,10 @@ in
 
       package = helpers.mkPluginPackageOption "lspsaga" pkgs.vimPlugins.lspsaga-nvim;
 
-      iconsPackage = helpers.mkPackageOption {
-        name = "nvim-web-devicons";
-        default = pkgs.vimPlugins.nvim-web-devicons;
-      };
+      iconsPackage = lib.mkPackageOption pkgs [
+        "vimPlugins"
+        "nvim-web-devicons"
+      ] { nullable = true; };
 
       ui = {
         border = helpers.defaultNullOpts.mkBorder "single" "lspsaga" "";

--- a/plugins/lsp/trouble.nix
+++ b/plugins/lsp/trouble.nix
@@ -301,10 +301,10 @@ helpers.neovim-plugin.mkNeovimPlugin {
   };
 
   extraOptions = {
-    iconsPackage = helpers.mkPackageOption {
-      name = "nvim-web-devicons";
-      default = pkgs.vimPlugins.nvim-web-devicons;
-    };
+    iconsPackage = lib.mkPackageOption pkgs [
+      "vimPlugins"
+      "nvim-web-devicons"
+    ] { nullable = true; };
   };
 
   extraConfig = cfg: {

--- a/plugins/lsp/wtf.nix
+++ b/plugins/lsp/wtf.nix
@@ -31,7 +31,12 @@ in
     plugins.wtf = helpers.neovim-plugin.extraOptionsOptions // {
       enable = mkEnableOption "wtf.nvim";
 
-      package = helpers.mkPluginPackageOption "wtf.nvim" pkgs.vimPlugins.wtf-nvim;
+      package = lib.mkPackageOption pkgs "wtf.nvim" {
+        default = [
+          "vimPlugins"
+          "wtf-nvim"
+        ];
+      };
 
       keymaps = mapAttrs (
         action: defaults:

--- a/plugins/neotest/adapters.nix
+++ b/plugins/neotest/adapters.nix
@@ -6,7 +6,7 @@
 }:
 with lib;
 let
-  inherit (lib.nixvim) mkPluginPackageOption mkSettingsOption toLuaObject;
+  inherit (lib.nixvim) mkSettingsOption toLuaObject;
   supportedAdapters = import ./adapters-list.nix;
 
   mkAdapter =
@@ -20,7 +20,12 @@ let
       options.plugins.neotest.adapters.${name} = {
         enable = mkEnableOption name;
 
-        package = mkPluginPackageOption name pkgs.vimPlugins.${packageName};
+        package = lib.mkPackageOption pkgs name {
+          default = [
+            "vimPlugins"
+            packageName
+          ];
+        };
 
         settings = mkSettingsOption { description = "settings for the `${name}` adapter."; };
       };

--- a/plugins/pluginmanagers/lazy.nix
+++ b/plugins/pluginmanagers/lazy.nix
@@ -41,9 +41,8 @@ in
     plugins.lazy = {
       enable = mkEnableOption "lazy.nvim";
 
-      gitPackage = helpers.mkPackageOption {
-        name = "git";
-        default = pkgs.git;
+      gitPackage = lib.mkPackageOption pkgs "git" {
+        nullable = true;
       };
 
       plugins =

--- a/plugins/pluginmanagers/packer.nix
+++ b/plugins/pluginmanagers/packer.nix
@@ -14,9 +14,8 @@ in
     plugins.packer = {
       enable = mkEnableOption "packer.nvim";
 
-      gitPackage = helpers.mkPackageOption {
-        name = "git";
-        default = pkgs.git;
+      gitPackage = lib.mkPackageOption pkgs "git" {
+        nullable = true;
       };
 
       plugins =

--- a/plugins/snippets/friendly-snippets.nix
+++ b/plugins/snippets/friendly-snippets.nix
@@ -15,7 +15,12 @@ in
   options.plugins.friendly-snippets = {
     enable = mkEnableOption "friendly-snippets";
 
-    package = helpers.mkPluginPackageOption "friendly-snippets" pkgs.vimPlugins.friendly-snippets;
+    package = lib.mkPackageOption pkgs "friendly-snippets" {
+      default = [
+        "vimPlugins"
+        "friendly-snippets"
+      ];
+    };
   };
 
   config = mkIf cfg.enable {

--- a/plugins/snippets/luasnip/default.nix
+++ b/plugins/snippets/luasnip/default.nix
@@ -65,7 +65,12 @@ in
   options.plugins.luasnip = {
     enable = mkEnableOption "luasnip";
 
-    package = helpers.mkPluginPackageOption "luasnip" pkgs.vimPlugins.luasnip;
+    package = lib.mkPackageOption pkgs "luasnip" {
+      default = [
+        "vimPlugins"
+        "luasnip"
+      ];
+    };
 
     settings = mkOption {
       type = with types; attrsOf anything;

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -106,7 +106,12 @@ in
     plugins.lualine = {
       enable = mkEnableOption "lualine";
 
-      package = helpers.mkPluginPackageOption "lualine" pkgs.vimPlugins.lualine-nvim;
+      package = lib.mkPackageOption pkgs "lualine" {
+        default = [
+          "vimPlugins"
+          "lualine-nvim"
+        ];
+      };
 
       gitPackage = lib.mkPackageOption pkgs "git" {
         nullable = true;

--- a/plugins/statuslines/lualine.nix
+++ b/plugins/statuslines/lualine.nix
@@ -108,9 +108,8 @@ in
 
       package = helpers.mkPluginPackageOption "lualine" pkgs.vimPlugins.lualine-nvim;
 
-      gitPackage = helpers.mkPackageOption {
-        name = "git";
-        default = pkgs.git;
+      gitPackage = lib.mkPackageOption pkgs "git" {
+        nullable = true;
       };
 
       iconsEnabled = mkOption {

--- a/plugins/telescope/default.nix
+++ b/plugins/telescope/default.nix
@@ -91,10 +91,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       '';
     };
 
-    iconsPackage = mkPackageOption {
-      name = "nvim-web-devicons";
-      default = pkgs.vimPlugins.nvim-web-devicons;
-    };
+    iconsPackage = lib.mkPackageOption pkgs [
+      "vimPlugins"
+      "nvim-web-devicons"
+    ] { nullable = true; };
   };
 
   callSetup = false;

--- a/plugins/telescope/extensions/media-files.nix
+++ b/plugins/telescope/extensions/media-files.nix
@@ -53,7 +53,7 @@ in
           {
             name,
             desc,
-            package ? pkgs.${name},
+            package ? name,
             enabledByDefault ? false,
           }:
           {
@@ -66,11 +66,7 @@ in
               '';
             };
 
-            package = mkOption {
-              type = types.package;
-              default = package;
-              description = "The package to use for the ${name} dependency.";
-            };
+            package = mkPackageOption pkgs name { default = package; };
           };
       in
       {
@@ -82,7 +78,7 @@ in
 
         imageMagick = mkDepOption {
           name = "ImageMagick";
-          package = pkgs.imagemagick;
+          package = "imagemagick";
           desc = "Required for svg previews.";
         };
 
@@ -93,7 +89,7 @@ in
 
         pdftoppm = mkDepOption {
           name = "pdmtoppm";
-          package = pkgs.poppler_utils;
+          package = "poppler_utils";
           desc = "Required for pdf preview support.";
         };
 

--- a/plugins/ui/image.nix
+++ b/plugins/ui/image.nix
@@ -15,7 +15,12 @@ in
   options.plugins.image = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "image.nvim";
 
-    package = helpers.mkPluginPackageOption "image.nvim" pkgs.vimPlugins.image-nvim;
+    package = lib.mkPackageOption pkgs "image.nvim" {
+      default = [
+        "vimPlugins"
+        "image-nvim"
+      ];
+    };
 
     backend =
       helpers.defaultNullOpts.mkEnumFirstDefault

--- a/plugins/ui/noice.nix
+++ b/plugins/ui/noice.nix
@@ -17,7 +17,12 @@ with lib;
         vim, regex, lua, bash, markdown, markdown_inline
     '';
 
-    package = helpers.mkPluginPackageOption "noice" pkgs.vimPlugins.noice-nvim;
+    package = lib.mkPackageOption pkgs "noice" {
+      default = [
+        "vimPlugins"
+        "noice-nvim"
+      ];
+    };
 
     cmdline = {
       enabled = helpers.defaultNullOpts.mkBool true "enables Noice cmdline UI";

--- a/plugins/utils/alpha.nix
+++ b/plugins/utils/alpha.nix
@@ -54,7 +54,12 @@ in
     plugins.alpha = {
       enable = mkEnableOption "alpha-nvim";
 
-      package = helpers.mkPluginPackageOption "alpha-nvim" pkgs.vimPlugins.alpha-nvim;
+      package = lib.mkPackageOption pkgs "alpha-nvim" {
+        default = [
+          "vimPlugins"
+          "alpha-nvim"
+        ];
+      };
 
       # TODO: deprecated 2024-08-29 remove after 24.11
       iconsEnabled = mkOption {

--- a/plugins/utils/alpha.nix
+++ b/plugins/utils/alpha.nix
@@ -63,10 +63,10 @@ in
         visible = false;
       };
 
-      iconsPackage = helpers.mkPackageOption {
-        name = "nvim-web-devicons";
-        default = pkgs.vimPlugins.nvim-web-devicons;
-      };
+      iconsPackage = lib.mkPackageOption pkgs [
+        "vimPlugins"
+        "nvim-web-devicons"
+      ] { nullable = true; };
 
       theme = mkOption {
         type = with helpers.nixvimTypes; nullOr (maybeRaw str);

--- a/plugins/utils/auto-session.nix
+++ b/plugins/utils/auto-session.nix
@@ -13,7 +13,12 @@ in
   options.plugins.auto-session = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "auto-session";
 
-    package = helpers.mkPluginPackageOption "auto-session" pkgs.vimPlugins.auto-session;
+    package = lib.mkPackageOption pkgs "auto-session" {
+      default = [
+        "vimPlugins"
+        "auto-session"
+      ];
+    };
 
     logLevel = helpers.defaultNullOpts.mkEnum [
       "debug"

--- a/plugins/utils/autoclose.nix
+++ b/plugins/utils/autoclose.nix
@@ -15,7 +15,12 @@ in
   options.plugins.autoclose = {
     enable = mkEnableOption "autoclose.nvim";
 
-    package = helpers.mkPluginPackageOption "autoclose.nvim" pkgs.vimPlugins.autoclose-nvim;
+    package = lib.mkPackageOption pkgs "autoclose.nvim" {
+      default = [
+        "vimPlugins"
+        "autoclose-nvim"
+      ];
+    };
 
     keys = helpers.mkNullOrOption (with types; attrsOf anything) ''
       Configures various options, such as shortcuts for pairs, what pair of characters to use in the

--- a/plugins/utils/clipboard-image.nix
+++ b/plugins/utils/clipboard-image.nix
@@ -88,7 +88,12 @@ in
   options.plugins.clipboard-image = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "clipboard-image.nvim";
 
-    package = helpers.mkPluginPackageOption "clipboard-image.nvim" pkgs.vimPlugins.clipboard-image-nvim;
+    package = lib.mkPackageOption pkgs "clipboard-image.nvim" {
+      default = [
+        "vimPlugins"
+        "clipboard-image-nvim"
+      ];
+    };
 
     clipboardPackage = mkOption {
       type = with types; nullOr package;

--- a/plugins/utils/commentary.nix
+++ b/plugins/utils/commentary.nix
@@ -16,7 +16,12 @@ in
     plugins.commentary = {
       enable = mkEnableOption "commentary";
 
-      package = helpers.mkPluginPackageOption "commentary" pkgs.vimPlugins.vim-commentary;
+      package = lib.mkPackageOption pkgs "commentary" {
+        default = [
+          "vimPlugins"
+          "vim-commentary"
+        ];
+      };
     };
   };
 

--- a/plugins/utils/conjure.nix
+++ b/plugins/utils/conjure.nix
@@ -13,7 +13,12 @@ in
   options.plugins.conjure = {
     enable = mkEnableOption "Conjure";
 
-    package = helpers.mkPluginPackageOption "conjure" pkgs.vimPlugins.conjure;
+    package = lib.mkPackageOption pkgs "conjure" {
+      default = [
+        "vimPlugins"
+        "conjure"
+      ];
+    };
   };
 
   config = mkIf cfg.enable { extraPlugins = [ cfg.package ]; };

--- a/plugins/utils/coverage.nix
+++ b/plugins/utils/coverage.nix
@@ -63,7 +63,12 @@ in
   options.plugins.coverage = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-coverage";
 
-    package = helpers.mkPluginPackageOption "nvim-coverage" pkgs.vimPlugins.nvim-coverage;
+    package = lib.mkPackageOption pkgs "nvim-coverage" {
+      default = [
+        "vimPlugins"
+        "nvim-coverage"
+      ];
+    };
 
     keymapsSilent = mkOption {
       type = types.bool;

--- a/plugins/utils/cursorline.nix
+++ b/plugins/utils/cursorline.nix
@@ -13,7 +13,12 @@ in
   options.plugins.cursorline = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-cursorline";
 
-    package = helpers.mkPluginPackageOption "nvim-cursorline" pkgs.vimPlugins.nvim-cursorline;
+    package = lib.mkPackageOption pkgs "nvim-cursorline" {
+      default = [
+        "vimPlugins"
+        "nvim-cursorline"
+      ];
+    };
 
     cursorline = {
       enable = helpers.defaultNullOpts.mkBool true "Show / hide cursorline in connection with cursor moving.";

--- a/plugins/utils/easyescape.nix
+++ b/plugins/utils/easyescape.nix
@@ -14,7 +14,12 @@ in
     plugins.easyescape = {
       enable = mkEnableOption "easyescape";
 
-      package = helpers.mkPluginPackageOption "easyescape" pkgs.vimPlugins.vim-easyescape;
+      package = lib.mkPackageOption pkgs "easyescape" {
+        default = [
+          "vimPlugins"
+          "vim-easyescape"
+        ];
+      };
     };
   };
   config = mkIf cfg.enable { extraPlugins = [ cfg.package ]; };

--- a/plugins/utils/floaterm.nix
+++ b/plugins/utils/floaterm.nix
@@ -200,7 +200,12 @@ in
     {
       enable = mkEnableOption "floaterm";
 
-      package = helpers.mkPluginPackageOption "floaterm" pkgs.vimPlugins.vim-floaterm;
+      package = lib.mkPackageOption pkgs "floaterm" {
+        default = [
+          "vimPlugins"
+          "vim-floaterm"
+        ];
+      };
 
       keymaps = keymapOptions;
     }

--- a/plugins/utils/fzf-lua.nix
+++ b/plugins/utils/fzf-lua.nix
@@ -40,10 +40,9 @@ helpers.neovim-plugin.mkNeovimPlugin {
   inherit settingsOptions settingsExample;
 
   extraOptions = {
-    fzfPackage = helpers.mkPackageOption {
-      name = "fzf";
-      default = pkgs.fzf;
-      example = pkgs.skim;
+    fzfPackage = lib.mkPackageOption pkgs "fzf" {
+      nullable = true;
+      example = "pkgs.skim";
     };
 
     # TODO: deprecated 2024-08-29 remove after 24.11

--- a/plugins/utils/fzf-lua.nix
+++ b/plugins/utils/fzf-lua.nix
@@ -53,10 +53,10 @@ helpers.neovim-plugin.mkNeovimPlugin {
       visible = false;
     };
 
-    iconsPackage = helpers.mkPackageOption {
-      name = "nvim-web-devicons";
-      default = pkgs.vimPlugins.nvim-web-devicons;
-    };
+    iconsPackage = lib.mkPackageOption pkgs [
+      "vimPlugins"
+      "nvim-web-devicons"
+    ] { nullable = true; };
 
     profile = helpers.defaultNullOpts.mkEnumFirstDefault [
       "default"

--- a/plugins/utils/hardtime.nix
+++ b/plugins/utils/hardtime.nix
@@ -14,7 +14,12 @@ in
     plugins.hardtime = helpers.neovim-plugin.extraOptionsOptions // {
       enable = mkEnableOption "hardtime";
 
-      package = helpers.mkPluginPackageOption "hardtime" pkgs.vimPlugins.hardtime-nvim;
+      package = lib.mkPackageOption pkgs "hardtime" {
+        default = [
+          "vimPlugins"
+          "hardtime-nvim"
+        ];
+      };
 
       maxTime = helpers.defaultNullOpts.mkUnsignedInt 1000 ''
         Maximum time (in milliseconds) to consider key presses as repeated.

--- a/plugins/utils/harpoon.nix
+++ b/plugins/utils/harpoon.nix
@@ -25,7 +25,12 @@ in
   options.plugins.harpoon = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "harpoon";
 
-    package = helpers.mkPluginPackageOption "harpoon" pkgs.vimPlugins.harpoon;
+    package = lib.mkPackageOption pkgs "harpoon" {
+      default = [
+        "vimPlugins"
+        "harpoon"
+      ];
+    };
 
     enableTelescope = mkEnableOption "telescope integration";
 

--- a/plugins/utils/illuminate.nix
+++ b/plugins/utils/illuminate.nix
@@ -87,7 +87,12 @@ in
     // {
       enable = mkEnableOption "vim-illuminate";
 
-      package = mkPluginPackageOption "vim-illuminate" pkgs.vimPlugins.vim-illuminate;
+      package = lib.mkPackageOption pkgs "vim-illuminate" {
+        default = [
+          "vimPlugins"
+          "vim-illuminate"
+        ];
+      };
 
       filetypeOverrides =
         helpers.defaultNullOpts.mkAttrsOf (types.submodule { options = commonOptions; }) { }

--- a/plugins/utils/intellitab.nix
+++ b/plugins/utils/intellitab.nix
@@ -14,7 +14,12 @@ in
     plugins.intellitab = {
       enable = mkEnableOption "intellitab.nvim";
 
-      package = helpers.mkPluginPackageOption "intellitab.nvim" pkgs.vimPlugins.intellitab-nvim;
+      package = lib.mkPackageOption pkgs "intellitab.nvim" {
+        default = [
+          "vimPlugins"
+          "intellitab-nvim"
+        ];
+      };
     };
   };
 

--- a/plugins/utils/lastplace.nix
+++ b/plugins/utils/lastplace.nix
@@ -13,7 +13,12 @@ with lib;
   options.plugins.lastplace = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "lastplace";
 
-    package = helpers.mkPluginPackageOption "lastplace" pkgs.vimPlugins.nvim-lastplace;
+    package = lib.mkPackageOption pkgs "lastplace" {
+      default = [
+        "vimPlugins"
+        "nvim-lastplace"
+      ];
+    };
 
     ignoreBuftype = helpers.defaultNullOpts.mkListOf types.str [
       "quickfix"

--- a/plugins/utils/leap.nix
+++ b/plugins/utils/leap.nix
@@ -13,7 +13,12 @@ in
   options.plugins.leap = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "leap.nvim";
 
-    package = helpers.mkPluginPackageOption "leap.nvim" pkgs.vimPlugins.leap-nvim;
+    package = lib.mkPackageOption pkgs "leap.nvim" {
+      default = [
+        "vimPlugins"
+        "leap-nvim"
+      ];
+    };
 
     addDefaultMappings = mkOption {
       type = types.bool;

--- a/plugins/utils/mark-radar.nix
+++ b/plugins/utils/mark-radar.nix
@@ -13,7 +13,12 @@ in
   options.plugins.mark-radar = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "mark-radar";
 
-    package = helpers.mkPluginPackageOption "mark-radar" pkgs.vimPlugins.mark-radar-nvim;
+    package = lib.mkPackageOption pkgs "mark-radar" {
+      default = [
+        "vimPlugins"
+        "mark-radar-nvim"
+      ];
+    };
 
     setDefaultMappings = helpers.defaultNullOpts.mkBool true "Whether to set default mappings.";
 

--- a/plugins/utils/marks.nix
+++ b/plugins/utils/marks.nix
@@ -15,7 +15,12 @@ in
   options.plugins.marks = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "marks.nvim";
 
-    package = helpers.mkPluginPackageOption "marks.nvim" pkgs.vimPlugins.marks-nvim;
+    package = lib.mkPackageOption pkgs "marks.nvim" {
+      default = [
+        "vimPlugins"
+        "marks-nvim"
+      ];
+    };
 
     builtinMarks =
       helpers.defaultNullOpts.mkListOf

--- a/plugins/utils/mini.nix
+++ b/plugins/utils/mini.nix
@@ -13,7 +13,12 @@ in
   options.plugins.mini = {
     enable = mkEnableOption "mini.nvim";
 
-    package = helpers.mkPluginPackageOption "mini.nvim" pkgs.vimPlugins.mini-nvim;
+    package = lib.mkPackageOption pkgs "mini.nvim" {
+      default = [
+        "vimPlugins"
+        "mini-nvim"
+      ];
+    };
 
     modules = mkOption {
       type = with types; attrsOf attrs;

--- a/plugins/utils/mkdnflow.nix
+++ b/plugins/utils/mkdnflow.nix
@@ -13,7 +13,12 @@ in
   options.plugins.mkdnflow = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "mkdnflow.nvim";
 
-    package = helpers.mkPluginPackageOption "mkdnflow.nvim" pkgs.vimPlugins.mkdnflow-nvim;
+    package = lib.mkPackageOption pkgs "mkdnflow.nvim" {
+      default = [
+        "vimPlugins"
+        "mkdnflow-nvim"
+      ];
+    };
 
     modules =
       mapAttrs

--- a/plugins/utils/multicursors.nix
+++ b/plugins/utils/multicursors.nix
@@ -48,7 +48,12 @@ in
     plugins.multicursors = helpers.neovim-plugin.extraOptionsOptions // {
       enable = mkEnableOption "multicursors.nvim";
 
-      package = helpers.mkPluginPackageOption "multicursors.nvim" pkgs.vimPlugins.multicursors-nvim;
+      package = lib.mkPackageOption pkgs "multicursors.nvim" {
+        default = [
+          "vimPlugins"
+          "multicursors-nvim"
+        ];
+      };
 
       debugMode = helpers.defaultNullOpts.mkBool false "Enable debug mode.";
 

--- a/plugins/utils/navbuddy.nix
+++ b/plugins/utils/navbuddy.nix
@@ -16,7 +16,12 @@ in
   options.plugins.navbuddy = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-navbuddy";
 
-    package = helpers.mkPluginPackageOption "nvim-navbuddy" pkgs.vimPlugins.nvim-navbuddy;
+    package = lib.mkPackageOption pkgs "nvim-navbuddy" {
+      default = [
+        "vimPlugins"
+        "nvim-navbuddy"
+      ];
+    };
 
     window = {
       border = helpers.defaultNullOpts.mkBorder "rounded" "window border" ''

--- a/plugins/utils/neogen.nix
+++ b/plugins/utils/neogen.nix
@@ -47,7 +47,12 @@ in
   options.plugins.neogen = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "neogen";
 
-    package = helpers.mkPluginPackageOption "neogen" pkgs.vimPlugins.neogen;
+    package = lib.mkPackageOption pkgs "neogen" {
+      default = [
+        "vimPlugins"
+        "neogen"
+      ];
+    };
 
     keymaps = mapAttrs (
       optionsName: properties: helpers.mkNullOrOption types.str properties.description

--- a/plugins/utils/neorg.nix
+++ b/plugins/utils/neorg.nix
@@ -13,7 +13,12 @@ with lib;
   options.plugins.neorg = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "neorg";
 
-    package = helpers.mkPluginPackageOption "neorg" pkgs.vimPlugins.neorg;
+    package = lib.mkPackageOption pkgs "neorg" {
+      default = [
+        "vimPlugins"
+        "neorg"
+      ];
+    };
 
     lazyLoading = helpers.defaultNullOpts.mkBool false '''';
 

--- a/plugins/utils/netman.nix
+++ b/plugins/utils/netman.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.netman = {
     enable = mkEnableOption "netman.nvim, a framework to access remote resources";
 
-    package = helpers.mkPluginPackageOption "netman.nvim" pkgs.vimPlugins.netman-nvim;
+    package = lib.mkPackageOption pkgs "netman.nvim" {
+      default = [
+        "vimPlugins"
+        "netman-nvim"
+      ];
+    };
 
     neoTreeIntegration = mkEnableOption "support for netman as a neo-tree source";
   };

--- a/plugins/utils/nix-develop.nix
+++ b/plugins/utils/nix-develop.nix
@@ -13,7 +13,12 @@ in
   options.plugins.nix-develop = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nix-develop.nvim";
 
-    package = helpers.mkPluginPackageOption "nix-develop.nvim" pkgs.vimPlugins.nix-develop-nvim;
+    package = lib.mkPackageOption pkgs "nix-develop.nvim" {
+      default = [
+        "vimPlugins"
+        "nix-develop-nvim"
+      ];
+    };
 
     ignoredVariables = mkOption {
       type = with types; attrsOf bool;

--- a/plugins/utils/notify.nix
+++ b/plugins/utils/notify.nix
@@ -13,7 +13,12 @@ in
   options.plugins.notify = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-notify";
 
-    package = helpers.mkPluginPackageOption "nvim-notify" pkgs.vimPlugins.nvim-notify;
+    package = lib.mkPackageOption pkgs "nvim-notify" {
+      default = [
+        "vimPlugins"
+        "nvim-notify"
+      ];
+    };
 
     level = helpers.defaultNullOpts.mkLogLevel "info" ''
       Minimum log level to display. See `vim.log.levels`.

--- a/plugins/utils/nvim-bqf.nix
+++ b/plugins/utils/nvim-bqf.nix
@@ -13,7 +13,12 @@ in
   options.plugins.nvim-bqf = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-bqf";
 
-    package = helpers.mkPluginPackageOption "nvim-bqf" pkgs.vimPlugins.nvim-bqf;
+    package = lib.mkPackageOption pkgs "nvim-bqf" {
+      default = [
+        "vimPlugins"
+        "nvim-bqf"
+      ];
+    };
 
     autoEnable = helpers.defaultNullOpts.mkBool true ''
       Enable nvim-bqf in quickfix window automatically.

--- a/plugins/utils/nvim-colorizer.nix
+++ b/plugins/utils/nvim-colorizer.nix
@@ -104,7 +104,12 @@ in
     plugins.nvim-colorizer = {
       enable = mkEnableOption "nvim-colorizer";
 
-      package = helpers.mkPluginPackageOption "nvim-colorizer" pkgs.vimPlugins.nvim-colorizer-lua;
+      package = lib.mkPackageOption pkgs "nvim-colorizer" {
+        default = [
+          "vimPlugins"
+          "nvim-colorizer-lua"
+        ];
+      };
 
       fileTypes = mkOption {
         description = "Enable and/or configure highlighting for certain filetypes";

--- a/plugins/utils/nvim-osc52.nix
+++ b/plugins/utils/nvim-osc52.nix
@@ -27,7 +27,12 @@ with lib;
       '';
     };
 
-    package = helpers.mkPluginPackageOption "nvim-osc52" pkgs.vimPlugins.nvim-osc52;
+    package = lib.mkPackageOption pkgs "nvim-osc52" {
+      default = [
+        "vimPlugins"
+        "nvim-osc52"
+      ];
+    };
 
     maxLength = helpers.defaultNullOpts.mkInt 0 "Maximum length of selection (0 for no limit)";
     silent = helpers.defaultNullOpts.mkBool false "Disable message on successful copy";

--- a/plugins/utils/nvim-ufo.nix
+++ b/plugins/utils/nvim-ufo.nix
@@ -13,7 +13,12 @@ in
   options.plugins.nvim-ufo = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "nvim-ufo";
 
-    package = helpers.mkPluginPackageOption "nvim-ufo" pkgs.vimPlugins.nvim-ufo;
+    package = lib.mkPackageOption pkgs "nvim-ufo" {
+      default = [
+        "vimPlugins"
+        "nvim-ufo"
+      ];
+    };
 
     openFoldHlTimeout = helpers.defaultNullOpts.mkInt 400 ''
       Time in millisecond between the range to be highlgihted and to be cleared

--- a/plugins/utils/ollama.nix
+++ b/plugins/utils/ollama.nix
@@ -63,7 +63,12 @@ in
   options.plugins.ollama = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "ollama.nvim";
 
-    package = helpers.mkPluginPackageOption "ollama.nvim" pkgs.vimPlugins.ollama-nvim;
+    package = lib.mkPackageOption pkgs "ollama.nvim" {
+      default = [
+        "vimPlugins"
+        "ollama-nvim"
+      ];
+    };
 
     model = helpers.defaultNullOpts.mkStr "mistral" ''
       The default model to use.

--- a/plugins/utils/persistence.nix
+++ b/plugins/utils/persistence.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.persistence = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "persistence.nvim";
 
-    package = helpers.mkPluginPackageOption "persistence.nvim" pkgs.vimPlugins.persistence-nvim;
+    package = lib.mkPackageOption pkgs "persistence.nvim" {
+      default = [
+        "vimPlugins"
+        "persistence-nvim"
+      ];
+    };
 
     dir = helpers.defaultNullOpts.mkStr {
       __raw = ''vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/")'';

--- a/plugins/utils/presence-nvim.nix
+++ b/plugins/utils/presence-nvim.nix
@@ -13,7 +13,12 @@ in
   options = {
     plugins.presence-nvim = helpers.neovim-plugin.extraOptionsOptions // {
       enable = mkEnableOption "presence-nvim";
-      package = helpers.mkPluginPackageOption "presence-nvim" pkgs.vimPlugins.presence-nvim;
+      package = lib.mkPackageOption pkgs "presence-nvim" {
+        default = [
+          "vimPlugins"
+          "presence-nvim"
+        ];
+      };
 
       # General options.
       autoUpdate = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/utils/quickmath.nix
+++ b/plugins/utils/quickmath.nix
@@ -13,7 +13,12 @@ in
   options.plugins.quickmath = {
     enable = mkEnableOption "quickmath.nvim";
 
-    package = helpers.mkPluginPackageOption "quickmath.nvim" pkgs.vimPlugins.quickmath-nvim;
+    package = lib.mkPackageOption pkgs "quickmath.nvim" {
+      default = [
+        "vimPlugins"
+        "quickmath-nvim"
+      ];
+    };
 
     keymap = {
       key = helpers.mkNullOrOption types.str "Keymap to run the `:Quickmath` command.";

--- a/plugins/utils/spectre.nix
+++ b/plugins/utils/spectre.nix
@@ -229,39 +229,54 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   extraOptions =
     let
-      userCommandSettings = config.plugins.spectre.settings.default;
+      defaults = config.plugins.spectre.settings.default;
 
+      # NOTE: changes here should also be reflected in the `defaultText` below
       findPackages = {
         rg = pkgs.ripgrep;
       };
 
+      # NOTE: changes here should also be reflected in the `defaultText` below
       replacePackages = {
         sed = pkgs.gnused;
         inherit (pkgs) sd;
       };
-
-      # `toString` will turn `null` into `"null"` to allow for the attrs indexation.
-      findDefaultPackage = findPackages.${toString userCommandSettings.find.cmd} or null;
-      replaceDefaultPackage = replacePackages.${toString userCommandSettings.replace.cmd} or null;
     in
     {
-      findPackage = helpers.mkPackageOption {
-        default = findDefaultPackage;
-        description = ''
-          Which package to install for the find command.
-          Defaults to `pkgs.$\{settings.default.find.cmd}`.
+      findPackage = lib.mkOption {
+        type = with lib.types; nullOr package;
+        default = findPackages.${toString defaults.find.cmd} or null;
+        defaultText = literalMD ''
+          Based on the value defined in `config.plugins.spectre.settings.default.find.cmd`,
+          if the value defined there is a key in the attrset below, then the corresponding value is used. Otherwise the default will be `null`.
 
-          Set to `null` to prevent the installation.
+          ```nix
+          {
+            rg = pkgs.ripgrep;
+          }
+          ```
+        '';
+        description = ''
+          The package to use for the find command.
         '';
       };
 
-      replacePackage = helpers.mkPackageOption {
-        default = replaceDefaultPackage;
-        description = ''
-          Which package to install for the find command.
-          Defaults to `pkgs.$\{settings.default.replace.cmd}`.
+      replacePackage = lib.mkOption {
+        type = with lib.types; nullOr package;
+        default = replacePackages.${toString defaults.replace.cmd} or null;
+        defaultText = literalMD ''
+          Based on the value defined in `config.plugins.spectre.settings.default.replace.cmd`,
+          if the value defined there is a key in the attrset below, then the corresponding value is used. Otherwise the default will be `null`.
 
-          Set to `null` to prevent the installation.
+          ```nix
+          {
+            sd = pkgs.sd;
+            sed = pkgs.gnused;
+          }
+          ```
+        '';
+        description = ''
+          The package to use for the replace command.
         '';
       };
     };

--- a/plugins/utils/spider.nix
+++ b/plugins/utils/spider.nix
@@ -14,7 +14,12 @@ in
   options.plugins.${pluginName} = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption pluginName;
 
-    package = helpers.mkPluginPackageOption pluginName pkgs.vimPlugins.nvim-spider;
+    package = lib.mkPackageOption pkgs pluginName {
+      default = [
+        "vimPlugins"
+        "nvim-spider"
+      ];
+    };
 
     skipInsignificantPunctuation = helpers.defaultNullOpts.mkBool true "Whether to skip insignificant punctuation.";
 

--- a/plugins/utils/startup.nix
+++ b/plugins/utils/startup.nix
@@ -15,7 +15,12 @@ in
   options.plugins.startup = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "startup.nvim";
 
-    package = helpers.mkPluginPackageOption "startup.nvim" pkgs.vimPlugins.startup-nvim;
+    package = lib.mkPackageOption pkgs "startup.nvim" {
+      default = [
+        "vimPlugins"
+        "startup-nvim"
+      ];
+    };
 
     theme = helpers.defaultNullOpts.mkStr "dashboard" ''
       Use a pre-defined theme.

--- a/plugins/utils/todo-comments.nix
+++ b/plugins/utils/todo-comments.nix
@@ -10,7 +10,6 @@ let
     defaultNullOpts
     keymaps
     mkNullOrOption'
-    mkPackageOption
     transitionType
     ;
   types = lib.nixvim.nixvimTypes;
@@ -405,9 +404,8 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           todoTelescope = "TodoTelescope";
         };
 
-    ripgrepPackage = mkPackageOption {
-      name = "ripgrep";
-      default = pkgs.ripgrep;
+    ripgrepPackage = lib.mkPackageOption pkgs "ripgrep" {
+      nullable = true;
     };
   };
 

--- a/plugins/utils/vim-bbye.nix
+++ b/plugins/utils/vim-bbye.nix
@@ -13,7 +13,12 @@ in
   options.plugins.vim-bbye = {
     enable = mkEnableOption "vim-bbye";
 
-    package = helpers.mkPluginPackageOption "vim-bbye" pkgs.vimPlugins.vim-bbye;
+    package = lib.mkPackageOption pkgs "vim-bbye" {
+      default = [
+        "vimPlugins"
+        "vim-bbye"
+      ];
+    };
 
     keymapsSilent = mkOption {
       type = types.bool;

--- a/plugins/utils/vim-matchup.nix
+++ b/plugins/utils/vim-matchup.nix
@@ -10,7 +10,12 @@ with lib;
   options.plugins.vim-matchup = {
     enable = mkEnableOption "vim-matchup";
 
-    package = helpers.mkPluginPackageOption "vim-matchup" pkgs.vimPlugins.vim-matchup;
+    package = lib.mkPackageOption pkgs "vim-matchup" {
+      default = [
+        "vimPlugins"
+        "vim-matchup"
+      ];
+    };
 
     treesitterIntegration = {
       enable = mkEnableOption "treesitter integration";

--- a/plugins/utils/wilder.nix
+++ b/plugins/utils/wilder.nix
@@ -66,7 +66,12 @@ in
   options.plugins.wilder = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "wilder-nvim";
 
-    package = helpers.mkPluginPackageOption "wilder-nvim" pkgs.vimPlugins.wilder-nvim;
+    package = lib.mkPackageOption pkgs "wilder-nvim" {
+      default = [
+        "vimPlugins"
+        "wilder-nvim"
+      ];
+    };
 
     ### Setup options ###
     enableCmdlineEnter = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/utils/zk.nix
+++ b/plugins/utils/zk.nix
@@ -108,9 +108,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
   };
 
   extraOptions = {
-    zkPackage = helpers.mkPackageOption {
-      name = "zk";
-      default = pkgs.zk;
+    zkPackage = lib.mkPackageOption pkgs "zk" {
+      nullable = true;
     };
   };
   extraConfig = cfg: {

--- a/tests/package-options.nix
+++ b/tests/package-options.nix
@@ -1,0 +1,90 @@
+# This test ensures "package" options use a "literalExpression" in their defaultText
+# I.e. it validates `lib.mkPackageOption` was used to build the package options.
+{
+  evaluatedNixvim,
+  lib,
+  runCommandNoCCLocal,
+}:
+let
+  inherit (builtins)
+    filter
+    head
+    map
+    match
+    ;
+  inherit (lib.strings) concatMapStringsSep removePrefix removeSuffix;
+  inherit (lib.attrsets) isDerivation;
+  inherit (lib.options)
+    isOption
+    renderOptionValue
+    showOption
+    ;
+
+  # This doesn't collect any submodule sub-options,
+  # but that's fine since most of our "package" options are in the top level module eval
+  options = lib.collect isOption evaluatedNixvim.options;
+
+  # All visible non-sub options that default to a derivation
+  drvOptions = filter (
+    {
+      default ? null,
+      visible ? true,
+      internal ? false,
+      ...
+    }:
+    visible && !internal && isDerivation default
+  ) options;
+
+  # Bad options do not use `literalExpression` in their `defaultText`,
+  # or have a `defaultText` that doesn't start with "pkgs."
+  badOptions = filter (
+    opt:
+    opt.defaultText._type or null != "literalExpression"
+    || match ''pkgs[.].*'' (opt.defaultText.text or "") == null
+  ) drvOptions;
+in
+runCommandNoCCLocal "validate-package-options"
+  {
+    # Use structuredAttrs to avoid "Argument List Too Long" errors
+    # and get proper bash array support.
+    __structuredAttrs = true;
+
+    # Passthroughs for debugging purposes
+    passthru = {
+      inherit evaluatedNixvim drvOptions badOptions;
+    };
+
+    # Error strings to print
+    errors =
+      let
+        # A little hack to get the flake's source in the nix store
+        # We will use this to make the option declaration sources more readable
+        src = removeSuffix "modules/top-level/output.nix" (
+          head evaluatedNixvim.options.package.declarations
+        );
+      in
+      map (
+        opt:
+        let
+          # The default, as rendered in documentation. Will always be a literalExpression.
+          default = builtins.addErrorContext "while evaluating the default text for `${showOption opt.loc}`" (
+            renderOptionValue (opt.defaultText or opt.default)
+          );
+        in
+        ''
+          - ${showOption opt.loc} (${default.text}), declared in:
+          ${concatMapStringsSep "\n" (file: "  - ${removePrefix src file}") opt.declarations}
+        ''
+      ) badOptions;
+  }
+  ''
+    if [ -n "$errors" ]; then
+      echo "Found ''${#errors[@]} errors:"
+      for err in "''${errors[@]}"; do
+        echo "$err"
+      done
+      echo "(''${#errors[@]} options with errors)"
+      exit 1
+    fi
+    touch $out
+  ''

--- a/tests/test-sources/extended-lib.nix
+++ b/tests/test-sources/extended-lib.nix
@@ -8,7 +8,7 @@ let
           message = "lib.nixvim should be defined";
         }
         {
-          assertion = lib.nixvim == helpers;
+          assertion = builtins.attrNames lib.nixvim == builtins.attrNames helpers;
           message = "lib.nixvim and helpers should be aliases";
         }
       ];


### PR DESCRIPTION
[Adds a test](https://github.com/nix-community/nixvim/pull/2150/files#diff-4824391e6ed74ff5dccc7c7e96859742e3054a7a6531351378a9f576d864630c) that ensures "package" options use a "literalExpression" in their defaultText; i.e. it validates `lib.mkPackageOption` was used to build the package options.

All options whose `default` is a derivation are covered by the test, other than submodule sub-options.

This PR completely removes `lib.nixvim.mkPackageOption` and `lib.nixvim.mkPluginPackageOption` in favour of using `lib.mkPackageOption` treewide.

<details><summary>Example build log produced by the test _without_ the other fixes</summary>
<p>

```
structuredAttrs is enabled
Found 433 issues:
- colorschemes.dracula.package (<derivation vimplugin-dracula-vim-2024-07-26>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/colorschemes/dracula.nix

- package (<derivation neovim-unwrapped-0.10.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/modules/top-level/output.nix

- plugins.alpha.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/alpha.nix

- plugins.alpha.package (<derivation vimplugin-alpha-nvim-2024-02-25>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/alpha.nix

- plugins.auto-session.package (<derivation vimplugin-auto-session-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/auto-session.nix

- plugins.autoclose.package (<derivation vimplugin-autoclose.nvim-2024-07-21>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/autoclose.nix

- plugins.barbar.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/bufferlines/barbar.nix

- plugins.barbecue.package (<derivation vimplugin-barbecue.nvim-2023-09-13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/bufferlines/barbecue.nix

- plugins.bufferline.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/bufferlines/bufferline.nix

- plugins.chadtree.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/chadtree.nix

- plugins.chadtree.package (<derivation vimplugin-chadtree-2024-07-25>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/chadtree.nix

- plugins.chatgpt.curlPackage (<derivation curl-8.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/ai/chatgpt.nix

- plugins.clangd-extensions.package (<derivation vimplugin-clangd_extensions.nvim-2024-06-06>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/clangd-extensions.nix

- plugins.clipboard-image.package (<derivation vimplugin-clipboard-image.nvim-2022-11-10>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/clipboard-image.nix

- plugins.cmp-fish.fishPackage (<derivation fish-3.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/completion/cmp/sources/cmp-fish.nix

- plugins.commentary.package (<derivation vimplugin-vim-commentary-2024-04-08>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/commentary.nix

- plugins.committia.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/committia.nix

- plugins.conjure.package (<derivation vimplugin-conjure-2024-07-19>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/conjure.nix

- plugins.copilot-lua.package (<derivation vimplugin-copilot.lua-2024-06-15>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/completion/copilot-lua.nix

- plugins.coq-nvim.artifactsPackage (<derivation vimplugin-coq.artifacts-2024-03-01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/completion/coq.nix

- plugins.coq-thirdparty.package (<derivation vimplugin-coq.thirdparty-2024-07-25>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/completion/coq-thirdparty.nix

- plugins.coverage.package (<derivation vimplugin-nvim-coverage-2024-03-24>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/coverage.nix

- plugins.cursorline.package (<derivation vimplugin-nvim-cursorline-2022-04-15>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/cursorline.nix

- plugins.dap.extensions.dap-go.package (<derivation vimplugin-nvim-dap-go-2024-07-19>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/dap/dap-go.nix

- plugins.dap.extensions.dap-python.package (<derivation vimplugin-nvim-dap-python-2024-06-26>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/dap/dap-python.nix

- plugins.dap.extensions.dap-ui.package (<derivation vimplugin-nvim-dap-ui-2024-07-13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/dap/dap-ui.nix

- plugins.dap.extensions.dap-virtual-text.package (<derivation vimplugin-nvim-dap-virtual-text-2024-07-02>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/dap/dap-virtual-text.nix

- plugins.dap.package (<derivation vimplugin-nvim-dap-2024-08-01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/dap

- plugins.diffview.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/diffview.nix

- plugins.diffview.package (<derivation vimplugin-diffview.nvim-2024-06-13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/diffview.nix

- plugins.easyescape.package (<derivation vimplugin-vim-easyescape-2020-11-22>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/easyescape.nix

- plugins.efmls-configs.package (<derivation vimplugin-efmls-configs-nvim-2024-07-31>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.actionlint (<derivation actionlint-1.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.alejandra (<derivation alejandra-3.0.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.alex (<derivation alex-11.0.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.ameba (<derivation ameba-1.6.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.ansible_lint (<derivation ansible-lint-24.7.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.astyle (<derivation astyle-3.5.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.autopep8 (<derivation python3.12-autopep8-2.0.4-unstable-2023-10-27>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.bashate (<derivation bashate-2.1.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.beautysh (<derivation beautysh-6.2.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.biome (<derivation biome-1.8.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.black (<derivation black-24.4.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.buf (<derivation buf-1.37.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.cbfmt (<derivation cbfmt-0.2.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.checkmake (<derivation checkmake-0.2.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.chktex (<derivation texlive-2023-env>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.clang_format (<derivation clang-tools-18.1.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.clang_tidy (<derivation clang-tools-18.1.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.clazy (<derivation clazy-1.12>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.clj_kondo (<derivation clj-kondo-2024.08.01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.cmake_lint (<derivation cmake-format-0.6.13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.codespell (<derivation codespell-2.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.cppcheck (<derivation cppcheck-2.14.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.cpplint (<derivation cpplint-1.6.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.dartfmt (<derivation dart-3.5.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.dfmt (<derivation dfmt-1.2.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.djlint (<derivation djlint-1.34.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.dmd (<derivation dmd-2.109.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.dotnet_format (<derivation dotnet-runtime-6.0.33>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.dprint (<derivation dprint-0.47.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.eslint (<derivation eslint-9.7.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.eslint_d (<derivation eslint_d-14.0.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.fish (<derivation fish-3.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.fish_indent (<derivation fish-3.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.flake8 (<derivation python3.12-flake8-7.1.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.flawfinder (<derivation flawfinder-2.0.19>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.fnlfmt (<derivation fnlfmt-0.3.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.fourmolu (<derivation fourmolu-0.14.0.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.gcc (<derivation gcc-wrapper-13.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.gitlint (<derivation gitlint-0.19.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.go_revive (<derivation revive-1.3.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.gofmt (<derivation go-1.22.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.gofumpt (<derivation gofumpt-0.7.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.goimports (<derivation go-tools-2024.1.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.golangci_lint (<derivation golangci-lint-1.60.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.golines (<derivation golines-0.12.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.golint (<derivation golint-unstable-2020-12-08>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.google_java_format (<derivation google-java-format-1.23.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.hadolint (<derivation hadolint-2.12.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.isort (<derivation isort-5.13.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.joker (<derivation joker-1.4.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.jq (<derivation jq-1.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.languagetool (<derivation LanguageTool-6.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.latexindent (<derivation texlive-2023-env>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.lua_format (<derivation luaformatter-1.3.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.luacheck (<derivation lua5.2-luacheck-1.2.0-1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.markdownlint (<derivation markdownlint-cli-0.41.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.mcs (<derivation mono-6.12.0.182>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.mdformat (<derivation python3.12-mdformat-0.7.17>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.mypy (<derivation mypy-1.10.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.nixfmt (<derivation nixfmt-0.6.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.phan (<derivation phan-5.4.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.php (<derivation php-with-extensions-8.2.22>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.php_cs_fixer (<derivation php-cs-fixer-3.58.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.phpcbf (<derivation php-codesniffer-3.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.phpcs (<derivation php-codesniffer-3.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.phpstan (<derivation phpstan-1.11.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.prettier (<derivation prettier-3.3.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.prettier_d (<derivation fsouza-prettierd-0.25.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.prettypst (<derivation prettypst-unstable-2023-12-06>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.proselint (<derivation proselint-0.13.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.protolint (<derivation protolint-0.50.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.psalm (<derivation psalm-5.25.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.pylint (<derivation pylint-3.2.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.rubocop (<derivation ruby3.1-rubocop-1.62.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.ruff (<derivation ruff-0.6.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.rustfmt (<derivation rustfmt-1.80.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.scalafmt (<derivation scalafmt-3.7.17>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.selene (<derivation selene-0.27.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.shellcheck (<derivation shellcheck-0.10.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.shellharden (<derivation shellharden-4.3.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.shfmt (<derivation shfmt-3.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.slither (<derivation slither-analyzer-0.10.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.smlfmt (<derivation smlfmt-1.1.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.sql-formatter (<derivation sql-formatter-15.3.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.sqlfluff (<derivation sqlfluff-3.1.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.staticcheck (<derivation go-tools-2024.1.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.statix (<derivation statix-0.5.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.stylelint (<derivation stylelint-16.8.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.stylua (<derivation stylua-0.20.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.taplo (<derivation taplo-0.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.terraform_fmt (<derivation terraform-1.9.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.textlint (<derivation textlint-14.2.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.typstfmt (<derivation typstfmt-0.2.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.typstyle (<derivation typstyle-0.11.32>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.uncrustify (<derivation uncrustify-0.79.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.vale (<derivation vale-3.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.vint (<derivation vim-vint-0.3.21>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.vulture (<derivation python3.12-vulture-2.11>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.write_good (<derivation write-good-1.0.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.yamllint (<derivation yamllint-1.35.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.yapf (<derivation yapf-0.40.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.efmls-configs.toolPackages.yq (<derivation yq-go-4.44.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/efmls-configs.nix

- plugins.fidget.package (<derivation vimplugin-lua5.1-fidget.nvim-1.4.1-1-unstable-2024-07-13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/fidget.nix

- plugins.floaterm.package (<derivation vimplugin-vim-floaterm-2024-04-08>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/floaterm.nix

- plugins.friendly-snippets.package (<derivation vimplugin-friendly-snippets-2024-07-15>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/snippets/friendly-snippets.nix

- plugins.fugitive.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/fugitive.nix

- plugins.fzf-lua.fzfPackage (<derivation fzf-0.54.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/fzf-lua.nix

- plugins.fzf-lua.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/fzf-lua.nix

- plugins.git-conflict.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/git-conflict.nix

- plugins.git-worktree.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/git-worktree.nix

- plugins.git-worktree.package (<derivation vimplugin-git-worktree.nvim-2023-11-07>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/git-worktree.nix

- plugins.gitblame.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/gitblame.nix

- plugins.gitgutter.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/gitgutter.nix

- plugins.gitgutter.package (<derivation vimplugin-vim-gitgutter-2024-07-16>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/gitgutter.nix

- plugins.gitlinker.package (<derivation vimplugin-gitlinker.nvim-2023-02-03>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/gitlinker.nix

- plugins.gitmessenger.package (<derivation vimplugin-git-messenger.vim-2022-08-30>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/gitmessenger.nix

- plugins.gitsigns.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/gitsigns

- plugins.godot.godotPackage (<derivation godot4-4.3-stable>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/godot.nix

- plugins.hardtime.package (<derivation vimplugin-hardtime.nvim-2024-07-26>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/hardtime.nix

- plugins.harpoon.package (<derivation vimplugin-harpoon-2023-12-26>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/harpoon.nix

- plugins.helm.package (<derivation vimplugin-vim-helm-2024-05-31>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/helm.nix

- plugins.hmts.package (<derivation vimplugin-hmts.nvim-2024-05-07>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/treesitter/hmts.nix

- plugins.illuminate.package (<derivation vimplugin-vim-illuminate-2024-05-17>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/illuminate.nix

- plugins.image.package (<derivation vimplugin-lua5.1-image.nvim-1.3.0-1-unstable-2024-08-02>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/ui/image.nix

- plugins.inc-rename.package (<derivation vimplugin-inc-rename.nvim-2024-07-03>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/inc-rename.nix

- plugins.intellitab.package (<derivation vimplugin-intellitab.nvim-2024-02-05>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/intellitab.nix

- plugins.lastplace.package (<derivation vimplugin-nvim-lastplace-2023-07-27>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/lastplace.nix

- plugins.lazy.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/pluginmanagers/lazy.nix

- plugins.lazygit.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/lazygit.nix

- plugins.lazygit.lazygitPackage (<derivation lazygit-0.43.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/lazygit.nix

- plugins.lean.leanPackage (<derivation lean4-4.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/lean.nix

- plugins.lean.package (<derivation vimplugin-lean.nvim-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/lean.nix

- plugins.leap.package (<derivation vimplugin-leap.nvim-2024-07-30>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/leap.nix

- plugins.ledger.ledgerPackage (<derivation ledger-3.3.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/ledger.nix

- plugins.lint.package (<derivation vimplugin-nvim-lint-2024-06-26>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/lint.nix

- plugins.lsp.servers.pylsp.pythonPackage (<derivation python3-3.12.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/pylsp.nix

- plugins.lsp.servers.rust-analyzer.cargoPackage (<derivation cargo-1.80.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/rust-analyzer.nix

- plugins.lsp.servers.rust-analyzer.rustcPackage (<derivation rustc-wrapper-1.80.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/language-servers/rust-analyzer.nix

- plugins.lsp-format.package (<derivation vimplugin-lsp-format.nvim-2024-08-05>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/lsp-format.nix

- plugins.lspkind.package (<derivation vimplugin-lspkind-nvim-2024-07-25>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/completion/lspkind.nix

- plugins.lspsaga.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/lspsaga.nix

- plugins.lspsaga.package (<derivation vimplugin-lspsaga.nvim-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/lspsaga.nix

- plugins.lualine.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/statuslines/lualine.nix

- plugins.lualine.package (<derivation vimplugin-lualine.nvim-2024-07-15>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/statuslines/lualine.nix

- plugins.luasnip.package (<derivation vimplugin-lua5.1-luasnip-2.3.0-1-unstable-2024-08-01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/snippets/luasnip

- plugins.mark-radar.package (<derivation vimplugin-mark-radar.nvim-2024-06-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/mark-radar.nix

- plugins.marks.package (<derivation vimplugin-marks.nvim-2024-01-07>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/marks.nix

- plugins.mini.package (<derivation vimplugin-mini.nvim-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/mini.nix

- plugins.mkdnflow.package (<derivation vimplugin-mkdnflow.nvim-2024-07-29>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/mkdnflow.nix

- plugins.multicursors.package (<derivation vimplugin-multicursors.nvim-2024-06-25>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/multicursors.nix

- plugins.navbuddy.package (<derivation vimplugin-nvim-navbuddy-2024-05-19>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/navbuddy.nix

- plugins.navic.package (<derivation vimplugin-nvim-navic-2023-11-30>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/bufferlines/navic.nix

- plugins.neo-tree.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/neo-tree.nix

- plugins.neo-tree.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/neo-tree.nix

- plugins.neo-tree.package (<derivation vimplugin-neo-tree.nvim-2024-06-11>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/neo-tree.nix

- plugins.neogen.package (<derivation vimplugin-neogen-2024-08-02>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/neogen.nix

- plugins.neogit.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/git/neogit

- plugins.neorg.package (<derivation vimplugin-neorg-2024-07-28>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/neorg.nix

- plugins.neotest.adapters.bash.package (<derivation vimplugin-neotest-bash-2024-05-06>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.dart.package (<derivation vimplugin-neotest-dart-2024-02-28>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.deno.package (<derivation vimplugin-neotest-deno-2022-12-09>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.dotnet.package (<derivation vimplugin-neotest-dotnet-2024-07-24>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.elixir.package (<derivation vimplugin-neotest-elixir-2024-06-21>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.foundry.package (<derivation vimplugin-neotest-foundry-2024-02-03>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.go.package (<derivation vimplugin-neotest-go-2024-05-19>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.golang.package (<derivation vimplugin-neotest-golang-2024-08-01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.gradle.package (<derivation vimplugin-neotest-gradle-2023-12-05>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.gtest.package (<derivation vimplugin-neotest-gtest-2024-06-12>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.hardhat.package (<derivation vimplugin-hardhat.nvim-2024-07-28>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.haskell.package (<derivation vimplugin-neotest-haskell-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.java.package (<derivation vimplugin-neotest-java-2024-07-11>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.jest.package (<derivation vimplugin-neotest-jest-2024-03-21>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.minitest.package (<derivation vimplugin-neotest-minitest-2024-04-29>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.pest.package (<derivation vimplugin-neotest-pest-2024-02-16>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.phpunit.package (<derivation vimplugin-neotest-phpunit-2024-05-05>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.playwright.package (<derivation vimplugin-neotest-playwright-2024-07-08>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.plenary.package (<derivation vimplugin-neotest-plenary-2023-09-29>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.python.package (<derivation vimplugin-neotest-python-2024-01-15>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.rspec.package (<derivation vimplugin-neotest-rspec-2024-05-15>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.rust.package (<derivation vimplugin-neotest-rust-2024-04-08>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.scala.package (<derivation vimplugin-neotest-scala-2022-10-15>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.testthat.package (<derivation vimplugin-neotest-testthat-2022-07-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.vitest.package (<derivation vimplugin-neotest-vitest-2024-06-22>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.neotest.adapters.zig.package (<derivation vimplugin-neotest-zig-2024-07-28>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/neotest/adapters.nix

- plugins.netman.package (<derivation vimplugin-netman.nvim-2024-04-21>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/netman.nix

- plugins.nix-develop.package (<derivation vimplugin-nix-develop.nvim-2023-07-23>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/nix-develop.nix

- plugins.noice.package (<derivation vimplugin-noice.nvim-2024-07-25>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/ui/noice.nix

- plugins.none-ls.sources.code_actions.gitsigns.package (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.code_actions.proselint.package (<derivation proselint-0.13.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.code_actions.statix.package (<derivation statix-0.5.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.actionlint.package (<derivation actionlint-1.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.alex.package (<derivation alex-11.0.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.ansiblelint.package (<derivation ansible-lint-24.7.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.bean_check.package (<derivation beancount-2.3.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.buf.package (<derivation buf-1.37.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.buildifier.package (<derivation bazel-buildtools-7.1.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.cfn_lint.package (<derivation python3.12-cfn-lint-0.87.7>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.checkmake.package (<derivation checkmake-0.2.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.checkstyle.package (<derivation checkstyle-10.17.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.clazy.package (<derivation clazy-1.12>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.clj_kondo.package (<derivation clj-kondo-2024.08.01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.cmake_lint.package (<derivation cmake-format-0.6.13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.codespell.package (<derivation codespell-2.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.commitlint.package (<derivation _at_commitlint_slash_cli-19.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.cppcheck.package (<derivation cppcheck-2.14.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.credo.package (<derivation elixir-1.16.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.cue_fmt.package (<derivation cue-0.10.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.deadnix.package (<derivation deadnix-1.2.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.djlint.package (<derivation djlint-1.34.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.dotenv_linter.package (<derivation dotenv-linter-3.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.editorconfig_checker.package (<derivation editorconfig-checker-3.0.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.fish.package (<derivation fish-3.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.gdlint.package (<derivation gdtoolkit-4.2.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.gitlint.package (<derivation gitlint-0.19.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.glslc.package (<derivation shaderc-2024.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.golangci_lint.package (<derivation golangci-lint-1.60.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.hadolint.package (<derivation hadolint-2.12.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.haml_lint.package (<derivation mastodon-4.2.12>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.ktlint.package (<derivation ktlint-1.3.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.ltrs.package (<derivation languagetool-rust-2.1.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.markdownlint.package (<derivation markdownlint-cli-0.41.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.markdownlint_cli2.package (<derivation markdownlint-cli2-0.13.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.mdl.package (<derivation mdl-0.13.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.mypy.package (<derivation mypy-1.10.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.opacheck.package (<derivation open-policy-agent-0.66.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.phpcs.package (<derivation php-codesniffer-3.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.phpmd.package (<derivation phpmd-2.15.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.phpstan.package (<derivation phpstan-1.11.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.pmd.package (<derivation pmd-6.55.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.proselint.package (<derivation proselint-0.13.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.protolint.package (<derivation protolint-0.50.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.puppet_lint.package (<derivation puppet-lint-4.2.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.pylint.package (<derivation pylint-3.2.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.qmllint.package (<derivation qtdeclarative-6.7.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.revive.package (<derivation revive-1.3.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.rpmspec.package (<derivation rpm-4.18.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.rstcheck.package (<derivation rstcheck-6.2.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.rubocop.package (<derivation ruby3.1-rubocop-1.62.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.selene.package (<derivation selene-0.27.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.semgrep.package (<derivation semgrep-1.74.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.sqlfluff.package (<derivation sqlfluff-3.1.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.staticcheck.package (<derivation go-tools-2024.1.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.statix.package (<derivation statix-0.5.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.stylelint.package (<derivation stylelint-16.8.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.teal.package (<derivation lua5.2-tl-0.15.3-1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.terraform_validate.package (<derivation terraform-1.9.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.terragrunt_validate.package (<derivation terragrunt-0.66.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.tfsec.package (<derivation tfsec-1.28.10>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.tidy.package (<derivation html-tidy-5.8.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.trivy.package (<derivation trivy-0.54.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.vale.package (<derivation vale-3.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.verilator.package (<derivation verilator-5.026>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.vint.package (<derivation vim-vint-0.3.21>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.write_good.package (<derivation write-good-1.0.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.yamllint.package (<derivation yamllint-1.35.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.diagnostics.zsh.package (<derivation zsh-5.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.alejandra.package (<derivation alejandra-3.0.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.asmfmt.package (<derivation asmfmt-1.3.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.astyle.package (<derivation astyle-3.5.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.bean_format.package (<derivation beancount-2.3.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.bibclean.package (<derivation bibclean-3.07>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.biome.package (<derivation biome-1.8.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.black.package (<derivation python3.12-black-24.4.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.blackd.package (<derivation black-24.4.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.buf.package (<derivation buf-1.37.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.buildifier.package (<derivation bazel-buildtools-7.1.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.cbfmt.package (<derivation cbfmt-0.2.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.clang_format.package (<derivation clang-tools-18.1.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.cmake_format.package (<derivation cmake-format-0.6.13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.codespell.package (<derivation codespell-2.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.crystal_format.package (<derivation crystal-1.11.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.csharpier.package (<derivation csharpier-0.28.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.cue_fmt.package (<derivation cue-0.10.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.d2_fmt.package (<derivation d2-0.6.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.dart_format.package (<derivation dart-3.5.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.dfmt.package (<derivation dfmt-1.2.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.djhtml.package (<derivation djhtml-3.0.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.djlint.package (<derivation djlint-1.34.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.dxfmt.package (<derivation dioxus-cli-0.5.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.elm_format.package (<derivation elm-format-0.8.7>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.emacs_scheme_mode.package (<derivation emacs-29.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.emacs_vhdl_mode.package (<derivation emacs-29.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.erb_format.package (<derivation ruby3.1-erb-formatter-0.7.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.erlfmt.package (<derivation erlfmt-1.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.fantomas.package (<derivation fantomas-6.3.10>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.fish_indent.package (<derivation fish-3.7.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.fnlfmt.package (<derivation fnlfmt-0.3.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.format_r.package (<derivation R-4.4.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.fprettify.package (<derivation fprettify-0.3.7>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.gdformat.package (<derivation gdtoolkit-4.2.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.gleam_format.package (<derivation gleam-1.4.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.gn_format.package (<derivation gn-unstable-2020-03-09>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.gofmt.package (<derivation go-1.22.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.gofumpt.package (<derivation gofumpt-0.7.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.goimports.package (<derivation gotools-0.22.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.goimports_reviser.package (<derivation goimports-reviser-3.6.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.golines.package (<derivation golines-0.12.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.google_java_format.package (<derivation google-java-format-1.23.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.haxe_formatter.package (<derivation haxe-4.3.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.hclfmt.package (<derivation hclfmt-2.22.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.htmlbeautifier.package (<derivation ruby3.1-htmlbeautifier-1.4.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.isort.package (<derivation isort-5.13.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.isortd.package (<derivation isort-5.13.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.joker.package (<derivation joker-1.4.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.just.package (<derivation just-1.34.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.ktlint.package (<derivation ktlint-1.3.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.leptosfmt.package (<derivation leptosfmt-0.1.18>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.markdownlint.package (<derivation markdownlint-cli-0.41.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.mdformat.package (<derivation mdformat-wrapped>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.mix.package (<derivation elixir-1.16.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.nimpretty.package (<derivation x86_64-unknown-linux-gnu-nim-wrapper-2.0.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.nixfmt.package (<derivation nixfmt-0.6.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.nixpkgs_fmt.package (<derivation nixpkgs-fmt-1.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.ocamlformat.package (<derivation ocaml5.1.1-ocamlformat-0.26.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.opentofu_fmt.package (<derivation opentofu-1.8.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.pg_format.package (<derivation perl5.38.2-pgformatter-5.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.phpcbf.package (<derivation php-codesniffer-3.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.phpcsfixer.package (<derivation php-cs-fixer-3.58.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.prettier.package (<derivation prettier-3.3.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.prettierd.package (<derivation fsouza-prettierd-0.25.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.prisma_format.package (<derivation prisma-5.16.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.protolint.package (<derivation protolint-0.50.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.ptop.package (<derivation fpc-3.2.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.puppet_lint.package (<derivation puppet-lint-4.2.4>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.qmlformat.package (<derivation qtdeclarative-6.7.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.racket_fixw.package (<derivation racket-8.14>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.raco_fmt.package (<derivation racket-8.14>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.rego.package (<derivation open-policy-agent-0.66.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.rubocop.package (<derivation ruby3.1-rubocop-1.62.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.rubyfmt.package (<derivation rubyfmt-0.10.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.rufo.package (<derivation rufo-0.17.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.rustywind.package (<derivation rustywind-0.22.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.scalafmt.package (<derivation scalafmt-3.7.17>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.shellharden.package (<derivation shellharden-4.3.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.shfmt.package (<derivation shfmt-3.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.smlfmt.package (<derivation smlfmt-1.1.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.sqlfluff.package (<derivation sqlfluff-3.1.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.sqlformat.package (<derivation python3.12-sqlparse-0.5.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.stylelint.package (<derivation stylelint-16.8.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.stylua.package (<derivation stylua-0.20.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.surface.package (<derivation elixir-1.16.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.swift_format.package (<derivation swift-format-5.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.terraform_fmt.package (<derivation terraform-1.9.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.terragrunt_fmt.package (<derivation terragrunt-0.66.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.tidy.package (<derivation html-tidy-5.8.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.topiary.package (<derivation topiary-0.3.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.treefmt.package (<derivation treefmt-2.0.5>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.typstfmt.package (<derivation typstfmt-0.2.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.typstyle.package (<derivation typstyle-0.11.32>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.uncrustify.package (<derivation uncrustify-0.79.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.usort.package (<derivation usort-1.0.8>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.verible_verilog_format.package (<derivation verible-0.0.3747>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.xmllint.package (<derivation libxml2-2.13.3>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.yamlfix.package (<derivation yamlfix-1.16.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.yamlfmt.package (<derivation yamlfmt-0.13.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.yapf.package (<derivation yapf-0.40.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.formatting.zprint.package (<derivation zprint-1.2.9>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.none-ls.sources.hover.dictionary.package (<derivation curl-8.9.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/none-ls/sources.nix

- plugins.notify.package (<derivation vimplugin-nvim-notify-2024-05-17>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/notify.nix

- plugins.nvim-bqf.package (<derivation vimplugin-nvim-bqf-2024-06-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/nvim-bqf.nix

- plugins.nvim-colorizer.package (<derivation vimplugin-nvim-colorizer.lua-2024-07-24>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/nvim-colorizer.nix

- plugins.nvim-jdtls.package (<derivation vimplugin-nvim-jdtls-2024-08-01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/nvim-jdtls.nix

- plugins.nvim-osc52.package (<derivation vimplugin-nvim-osc52-2024-05-24>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/nvim-osc52.nix

- plugins.nvim-tree.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/nvim-tree.nix

- plugins.nvim-tree.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/nvim-tree.nix

- plugins.nvim-tree.package (<derivation vimplugin-nvim-tree.lua-2024-07-28>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/filetrees/nvim-tree.nix

- plugins.nvim-ufo.package (<derivation vimplugin-nvim-ufo-2024-08-01>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/nvim-ufo.nix

- plugins.ollama.package (<derivation vimplugin-ollama.nvim-2024-06-09>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/ollama.nix

- plugins.openscad.package (<derivation vimplugin-openscad.nvim-2024-04-13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/openscad.nix

- plugins.packer.gitPackage (<derivation git-2.45.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/pluginmanagers/packer.nix

- plugins.persistence.package (<derivation vimplugin-persistence.nvim-2024-07-22>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/persistence.nix

- plugins.plantuml-syntax.package (<derivation vimplugin-plantuml-syntax-2024-07-25>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/plantuml-syntax.nix

- plugins.presence-nvim.package (<derivation vimplugin-presence.nvim-2023-01-29>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/presence-nvim.nix

- plugins.project-nvim.package (<derivation vimplugin-project.nvim-2023-04-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/project-nvim.nix

- plugins.quickmath.package (<derivation vimplugin-quickmath.nvim-2024-02-12>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/quickmath.nix

- plugins.rainbow-delimiters.package (<derivation vimplugin-rainbow-delimiters.nvim-2024-07-29>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/treesitter/rainbow-delimiters.nix

- plugins.rust-tools.package (<derivation vimplugin-rust-tools.nvim-2024-01-03>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/rust/rust-tools.nix

- plugins.rust-tools.serverPackage (<derivation rust-analyzer-2024-08-19>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/rust/rust-tools.nix

- plugins.rustaceanvim.rustAnalyzerPackage (<derivation rust-analyzer-2024-08-19>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/rust/rustaceanvim

- plugins.spider.package (<derivation vimplugin-nvim-spider-2024-07-21>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/spider.nix

- plugins.startup.package (<derivation vimplugin-startup.nvim-2023-12-20>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/startup.nix

- plugins.telescope.extensions.media-files.dependencies.chafa.package (<derivation chafa-1.14.2>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/telescope/extensions/media-files.nix

- plugins.telescope.extensions.media-files.dependencies.epub-thumbnailer.package (<derivation epub-thumbnailer-0-unstable-2024-03-26>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/telescope/extensions/media-files.nix

- plugins.telescope.extensions.media-files.dependencies.ffmpegthumbnailer.package (<derivation ffmpegthumbnailer-unstable-2024-01-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/telescope/extensions/media-files.nix

- plugins.telescope.extensions.media-files.dependencies.fontpreview.package (<derivation fontpreview-1.0.6>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/telescope/extensions/media-files.nix

- plugins.telescope.extensions.media-files.dependencies.imageMagick.package (<derivation imagemagick-7.1.1-37>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/telescope/extensions/media-files.nix

- plugins.telescope.extensions.media-files.dependencies.pdftoppm.package (<derivation poppler-utils-24.02.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/telescope/extensions/media-files.nix

- plugins.telescope.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/telescope

- plugins.texpresso.texpressoPackage (<derivation texpresso-0-unstable-2024-07-02>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/texpresso.nix

- plugins.todo-comments.ripgrepPackage (<derivation ripgrep-14.1.0>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/todo-comments.nix

- plugins.treesitter-refactor.package (<derivation vimplugin-nvim-treesitter-refactor-2023-04-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/treesitter/treesitter-refactor.nix

- plugins.treesitter-textobjects.package (<derivation vimplugin-nvim-treesitter-textobjects-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/treesitter/treesitter-textobjects.nix

- plugins.trouble.iconsPackage (<derivation vimplugin-nvim-web-devicons-2024-08-04>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/trouble.nix

- plugins.ts-context-commentstring.package (<derivation vimplugin-nvim-ts-context-commentstring-2024-07-10>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/treesitter/ts-context-commentstring.nix

- plugins.typescript-tools.package (<derivation vimplugin-typescript-tools.nvim-2024-07-18>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/typescript-tools.nix

- plugins.vim-bbye.package (<derivation vimplugin-vim-bbye-2018-03-03>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/vim-bbye.nix

- plugins.vim-matchup.package (<derivation vimplugin-vim-matchup-2024-05-29>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/vim-matchup.nix

- plugins.vimtex.texlivePackage (<derivation texlive-combined-medium-2023-final>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/languages/vimtex.nix

- plugins.wilder.package (<derivation vimplugin-wilder.nvim-2022-08-13>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/wilder.nix

- plugins.wtf.package (<derivation vimplugin-wtf.nvim-2024-07-10>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/lsp/wtf.nix

- plugins.zk.zkPackage (<derivation zk-0.14.1>), declared in:
  - /nix/store/56ri0qrf22klkh6nnpqhmzv7z8jdvcwd-source/plugins/utils/zk.nix

(433 options with issues)
```

</p>
</details> 

- [x] #2139 
- [x] #2160 
