### PR TITLE
Revert "Remove config"

### DIFF
--- a/plugins/colorschemes/dracula-nvim.nix
+++ b/plugins/colorschemes/dracula-nvim.nix
@@ -1,9 +1,10 @@
 {
   lib,
+  config,
   pkgs,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.neovim-plugin.mkNeovimPlugin config {
   name = "dracula";
   originalName = "dracula.nvim ";
   defaultPackage = pkgs.vimPlugins.dracula-nvim;


### PR DESCRIPTION
This reverts commit 3f9cf9f961ba734d85021248c01b38cd8f2aa173.

The original change (https://github.com/nix-community/nixvim/pull/2153) was wrong in several aspects:
- colorscheme is not declared as such and is then under `plugins.dracula` instead of being `colorschemes.dracula`
- the latter already exists and is based on
