### PR TITLE
plugins/{efmls,none-ls}: use `mkPackageOption` and/or `defaultText`

### DIFF
--- a/lib/pkg-lists.nix
+++ b/lib/pkg-lists.nix
@@ -1,0 +1,23 @@
+# This file isn't (currently) part of `lib.nixvim`, but is used directly by `efmls` and `none-ls` pkg lists
+lib: rec {
+  # Produces an attrset of { ${name} = name; }
+  topLevel = names: lib.genAttrs names lib.id;
+
+  # Produces an attrset of { ${name} = null; }
+  nullAttrs = names: lib.genAttrs names (_: null);
+
+  # Produces an attrset of { ${name} = [ scope name ]; }
+  # Where the "scope" is the (nested) attr names,
+  # and "name" is the value.
+  # If the name value is a list, it will be expanded into multiple attrs.
+  scoped = lib.concatMapAttrs (
+    scope: v:
+    if builtins.isAttrs v then
+      lib.mapAttrs (_: loc: [ scope ] ++ loc) (scoped v)
+    else
+      lib.genAttrs (lib.toList v) (name: [
+        scope
+        name
+      ])
+  );
+}

--- a/plugins/lsp/language-servers/efmls-configs-pkgs.nix
+++ b/plugins/lsp/language-servers/efmls-configs-pkgs.nix
@@ -1,4 +1,8 @@
-lib: {
+lib:
+let
+  inherit (import ../../../lib/pkg-lists.nix lib) topLevel scoped;
+in
+{
   # efmls-configs tools that have no corresponding nixpkgs package
   unpackaged = [
     "blade_formatter"
@@ -28,20 +32,6 @@ lib: {
 
   # Mapping from a efmls-configs tool name to the corresponding nixpkgs package
   packaged =
-    let
-      # TODO: move these helpers to a shared location so that none-ls can also use them
-      topLevel = names: lib.genAttrs names lib.id;
-      scoped = lib.concatMapAttrs (
-        scope: v:
-        if builtins.isAttrs v then
-          lib.mapAttrs (_: loc: [ scope ] ++ loc) (scoped v)
-        else
-          lib.genAttrs (lib.toList v) (name: [
-            scope
-            name
-          ])
-      );
-    in
     # Top-level packages
     topLevel [
       "actionlint"

--- a/plugins/lsp/language-servers/efmls-configs-pkgs.nix
+++ b/plugins/lsp/language-servers/efmls-configs-pkgs.nix
@@ -1,4 +1,4 @@
-pkgs: {
+lib: {
   # efmls-configs tools that have no corresponding nixpkgs package
   unpackaged = [
     "blade_formatter"
@@ -27,115 +27,149 @@ pkgs: {
   ];
 
   # Mapping from a efmls-configs tool name to the corresponding nixpkgs package
-  packaged = with pkgs; {
-    inherit
-      actionlint
-      alejandra
-      ameba
-      astyle
-      bashate
-      beautysh
-      biome
-      black
-      buf
-      cbfmt
-      checkmake
-      clazy
-      codespell
-      cppcheck
-      cpplint
-      dfmt
-      djlint
-      dmd
-      dprint
-      fish
-      flawfinder
-      fnlfmt
-      gcc
-      gitlint
-      gofumpt
-      golines
-      golint
-      hadolint
-      isort
-      joker
-      jq
-      languagetool
-      mypy
-      php
-      prettypst
-      proselint
-      protolint
-      pylint
-      rubocop
-      ruff
-      rustfmt
-      scalafmt
-      selene
-      shellcheck
-      shellharden
-      shfmt
-      smlfmt
-      sqlfluff
-      statix
-      stylua
-      taplo
-      typstfmt
-      typstyle
-      uncrustify
-      vale
-      yamllint
-      yapf
-      ;
-    inherit (python3.pkgs)
-      autopep8
-      flake8
-      mdformat
-      vulture
-      ;
-    inherit (nodePackages)
-      eslint_d
-      prettier
-      alex
-      sql-formatter
-      stylelint
-      textlint
-      ;
-    inherit (phpPackages) phan phpstan psalm;
-    inherit (luaPackages) luacheck;
-    inherit (haskellPackages) fourmolu;
-    ansible_lint = ansible-lint;
-    chktex = texliveMedium;
-    clang_format = clang-tools;
-    clang_tidy = clang-tools;
-    clj_kondo = clj-kondo;
-    cmake_lint = cmake-format;
-    dartfmt = dart;
-    dotnet_format = dotnet-runtime;
-    # TODO: Added 2024-08-31; remove 2024-11-31
-    # eslint was moved out of nodePackages set without alias
-    # Using fallback as a transition period
-    eslint = pkgs.eslint or pkgs.nodePackages.eslint;
-    fish_indent = fish;
-    gofmt = go;
-    goimports = go-tools;
-    golangci_lint = golangci-lint;
-    google_java_format = google-java-format;
-    go_revive = revive;
-    latexindent = texliveMedium;
-    lua_format = luaformatter;
-    markdownlint = markdownlint-cli;
-    mcs = mono;
-    nixfmt = nixfmt-classic;
-    phpcbf = phpPackages.php-codesniffer;
-    php_cs_fixer = phpPackages.php-cs-fixer;
-    phpcs = phpPackages.php-codesniffer;
-    prettier_d = prettierd;
-    slither = slither-analyzer;
-    staticcheck = go-tools;
-    terraform_fmt = terraform;
-    vint = vim-vint;
-    write_good = write-good;
-    yq = yq-go;
-  };
+  packaged =
+    let
+      # TODO: move these helpers to a shared location so that none-ls can also use them
+      topLevel = names: lib.genAttrs names lib.id;
+      scoped = lib.concatMapAttrs (
+        scope: v:
+        if builtins.isAttrs v then
+          lib.mapAttrs (_: loc: [ scope ] ++ loc) (scoped v)
+        else
+          lib.genAttrs (lib.toList v) (name: [
+            scope
+            name
+          ])
+      );
+    in
+    # Top-level packages
+    topLevel [
+      "actionlint"
+      "alejandra"
+      "ameba"
+      "astyle"
+      "bashate"
+      "beautysh"
+      "biome"
+      "black"
+      "buf"
+      "cbfmt"
+      "checkmake"
+      "clazy"
+      "codespell"
+      "cppcheck"
+      "cpplint"
+      "dfmt"
+      "djlint"
+      "dmd"
+      "dprint"
+      "fish"
+      "flawfinder"
+      "fnlfmt"
+      "gcc"
+      "gitlint"
+      "gofumpt"
+      "golines"
+      "golint"
+      "hadolint"
+      "isort"
+      "joker"
+      "jq"
+      "languagetool"
+      "mypy"
+      "php"
+      "prettypst"
+      "proselint"
+      "protolint"
+      "pylint"
+      "rubocop"
+      "ruff"
+      "rustfmt"
+      "scalafmt"
+      "selene"
+      "shellcheck"
+      "shellharden"
+      "shfmt"
+      "smlfmt"
+      "sqlfluff"
+      "statix"
+      "stylua"
+      "taplo"
+      "typstfmt"
+      "typstyle"
+      "uncrustify"
+      "vale"
+      "yamllint"
+      "yapf"
+    ]
+    # Scoped packages
+    // scoped {
+      python3.pkgs = [
+        "autopep8"
+        "flake8"
+        "mdformat"
+        "vulture"
+      ];
+      nodePackages = [
+        "eslint" # FIXME: No way to have a transition fallback...
+        "eslint_d"
+        "prettier"
+        "alex"
+        "sql-formatter"
+        "stylelint"
+        "textlint"
+      ];
+      phpPackages = [
+        "phan"
+        "phpstan"
+        "psalm"
+      ];
+      luaPackages = [
+        "luacheck"
+      ];
+      haskellPackages = [
+        "fourmolu"
+      ];
+    }
+    # Packages where the name is different
+    // {
+      ansible_lint = "ansible-lint";
+      chktex = "texliveMedium";
+      clang_format = "clang-tools";
+      clang_tidy = "clang-tools";
+      clj_kondo = "clj-kondo";
+      cmake_lint = "cmake-format";
+      dartfmt = "dart";
+      dotnet_format = "dotnet-runtime";
+      fish_indent = "fish";
+      gofmt = "go";
+      goimports = "go-tools";
+      golangci_lint = "golangci-lint";
+      google_java_format = "google-java-format";
+      go_revive = "revive";
+      latexindent = "texliveMedium";
+      lua_format = "luaformatter";
+      markdownlint = "markdownlint-cli";
+      mcs = "mono";
+      nixfmt = "nixfmt-classic";
+      phpcbf = [
+        "phpPackages"
+        "php-codesniffer"
+      ];
+      php_cs_fixer = [
+        "phpPackages"
+        "php-cs-fixer"
+      ];
+      phpcs = [
+        "phpPackages"
+        "php-codesniffer"
+      ];
+      prettier_d = "prettierd";
+      slither = "slither-analyzer";
+      staticcheck = "go-tools";
+      terraform_fmt = "terraform";
+      vint = "vim-vint";
+      write_good = "write-good";
+      yq = "yq-go";
+    };
 }

--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -7,7 +7,7 @@
 }:
 let
   tools = import ../../../generated/efmls-configs.nix;
-  inherit (import ./efmls-configs-pkgs.nix pkgs) packaged;
+  inherit (import ./efmls-configs-pkgs.nix lib) packaged;
 in
 {
   options.plugins.efmls-configs = {
@@ -26,10 +26,10 @@ in
     toolPackages = lib.pipe packaged [
       # Produce package a option for each tool
       (lib.attrsets.mapAttrs (
-        tool: pkg:
-        helpers.mkPackageOption {
-          name = tool;
-          default = pkg;
+        name: loc:
+        lib.mkPackageOption pkgs name {
+          nullable = true;
+          default = loc;
         }
       ))
       # Filter package defaults that are not compatible with the current platform
@@ -38,7 +38,7 @@ in
         if lib.meta.availableOn pkgs.stdenv.hostPlatform opt.default then
           opt
         else
-          opt // { default = null; }
+          builtins.removeAttrs opt [ "defaultText" ] // { default = null; }
       ))
     ];
 

--- a/plugins/none-ls/_mk-source-plugin.nix
+++ b/plugins/none-ls/_mk-source-plugin.nix
@@ -8,8 +8,9 @@ sourceType: sourceName:
   ...
 }:
 let
-  inherit (import ./packages.nix pkgs) packaged;
+  inherit (import ./packages.nix lib) packaged;
   pkg = packaged.${sourceName};
+  loc = lib.toList pkg;
 
   cfg = config.plugins.none-ls;
   cfg' = config.plugins.none-ls.sources.${sourceType}.${sourceName};
@@ -55,7 +56,12 @@ in
               ''
             ));
         }
-        // lib.optionalAttrs (pkg != null) { default = pkg; }
+        // lib.optionalAttrs (pkg != null) {
+          default =
+            lib.attrByPath loc (lib.warn "${lib.concatStringsSep "." loc} cannot be found in pkgs!" null)
+              pkgs;
+          defaultText = lib.literalExpression "pkgs.${lib.concatStringsSep "." loc}";
+        }
       );
     };
 

--- a/plugins/none-ls/packages.nix
+++ b/plugins/none-ls/packages.nix
@@ -1,4 +1,8 @@
-lib: {
+lib:
+let
+  inherit (import ../../lib/pkg-lists.nix lib) topLevel scoped nullAttrs;
+in
+{
   # builtin sources that don't require a package
   noPackage = [
     "gitrebase"
@@ -20,7 +24,7 @@ lib: {
   # nixpkgs packages for a given source
   packaged =
     # Top-level packages
-    lib.genAttrs [
+    topLevel [
       "actionlint"
       "alejandra"
       "asmfmt"
@@ -94,29 +98,20 @@ lib: {
       "yapf"
       "zprint"
       "zsh"
-    ] lib.id
+    ]
     # Scoped packages
-    //
-      lib.concatMapAttrs
-        (
-          scope: names:
-          lib.genAttrs names (name: [
-            scope
-            name
-          ])
-        )
-        {
-          nodePackages = [
-            "alex"
-            "prettier"
-          ];
-          phpPackages = [
-            "phpmd"
-            "phpstan"
-          ];
-          rubyPackages = [ "htmlbeautifier" ];
-          ocamlPackages = [ "ocamlformat" ];
-        }
+    // scoped {
+      nodePackages = [
+        "alex"
+        "prettier"
+      ];
+      phpPackages = [
+        "phpmd"
+        "phpstan"
+      ];
+      rubyPackages = "htmlbeautifier";
+      ocamlPackages = "ocamlformat";
+    }
     # Packages where the name is different
     // {
       ansiblelint = "ansible-lint";
@@ -229,7 +224,7 @@ lib: {
       xmllint = "libxml2";
     }
     # builtin sources that are not packaged in nixpkgs
-    // lib.genAttrs [
+    // nullAttrs [
       "blade_formatter"
       "bsfmt"
       "bslint"
@@ -268,5 +263,5 @@ lib: {
       "textlint"
       "twigcs"
       "vacuum"
-    ] (_: null);
+    ];
 }

--- a/plugins/none-ls/packages.nix
+++ b/plugins/none-ls/packages.nix
@@ -1,4 +1,4 @@
-pkgs: {
+lib: {
   # builtin sources that don't require a package
   noPackage = [
     "gitrebase"
@@ -19,172 +19,217 @@ pkgs: {
 
   # nixpkgs packages for a given source
   packaged =
-    {
-      inherit (pkgs)
-        actionlint
-        alejandra
-        asmfmt
-        astyle
-        bibclean
-        biome
-        buf
-        cbfmt
-        checkmake
-        checkstyle
-        clazy
-        codespell
-        commitlint
-        cppcheck
-        csharpier
-        deadnix
-        dfmt
-        djhtml
-        djlint
-        erlfmt
-        fantomas
-        fish
-        fnlfmt
-        fprettify
-        gitlint
-        gofumpt
-        golines
-        hadolint
-        hclfmt
-        isort
-        joker
-        just
-        ktlint
-        leptosfmt
-        mdformat
-        mdl
-        mypy
-        pmd
-        prettierd
-        proselint
-        protolint
-        pylint
-        revive
-        rstcheck
-        rubocop
-        rubyfmt
-        rufo
-        rustywind
-        scalafmt
-        selene
-        semgrep
-        shellharden
-        shfmt
-        smlfmt
-        sqlfluff
-        statix
-        stylelint
-        stylua
-        tfsec
-        topiary
-        trivy
-        typstfmt
-        typstyle
-        uncrustify
-        usort
-        vale
-        verilator
-        yamlfix
-        yamlfmt
-        yamllint
-        yapf
-        zprint
-        zsh
-        ;
-      inherit (pkgs.nodePackages) alex prettier;
-      inherit (pkgs.python3.pkgs) black;
-      inherit (pkgs.phpPackages) phpmd phpstan;
-      inherit (pkgs.rubyPackages) htmlbeautifier;
-      inherit (pkgs.ocamlPackages) ocamlformat;
-      ansiblelint = pkgs.ansible-lint;
-      bean_check = pkgs.beancount;
-      bean_format = pkgs.beancount;
-      blackd = pkgs.black;
-      buildifier = pkgs.bazel-buildtools;
-      cfn_lint = pkgs.python3.pkgs.cfn-lint;
-      clang_format = pkgs.clang-tools;
-      clj_kondo = pkgs.clj-kondo;
-      cmake_format = pkgs.cmake-format;
-      cmake_lint = pkgs.cmake-format;
-      credo = pkgs.elixir;
-      crystal_format = pkgs.crystal;
-      cue_fmt = pkgs.cue;
-      d2_fmt = pkgs.d2;
-      dart_format = pkgs.dart;
-      dictionary = pkgs.curl;
-      dotenv_linter = pkgs.dotenv-linter;
-      dxfmt = pkgs.dioxus-cli;
-      editorconfig_checker = pkgs.editorconfig-checker;
-      elm_format = pkgs.elmPackages.elm-format;
-      emacs_scheme_mode = pkgs.emacs;
-      emacs_vhdl_mode = pkgs.emacs;
-      erb_format = pkgs.rubyPackages.erb-formatter;
-      fish_indent = pkgs.fish;
-      format_r = pkgs.R;
-      # TODO: Added 2024-06-13; remove 2024-09-13
-      # Nixpkgs renamed to _3 & _4 without maintaining an alias
-      # Out of sync lock files could be using either attr name...
-      gdformat = pkgs.gdtoolkit_4 or pkgs.gdtoolkit;
-      gdlint = pkgs.gdtoolkit_4 or pkgs.gdtoolkit;
-      gitsigns = pkgs.git;
-      gleam_format = pkgs.gleam;
-      glslc = pkgs.shaderc;
-      gn_format = pkgs.gn;
-      gofmt = pkgs.go;
-      goimports = pkgs.gotools;
-      goimports_reviser = pkgs.goimports-reviser;
-      golangci_lint = pkgs.golangci-lint;
-      google_java_format = pkgs.google-java-format;
-      haml_lint = pkgs.mastodon;
-      haxe_formatter = pkgs.haxe;
-      isortd = pkgs.isort;
-      ltrs = pkgs.languagetool-rust;
-      markdownlint_cli2 = pkgs.markdownlint-cli2;
-      markdownlint = pkgs.markdownlint-cli;
-      mix = pkgs.elixir;
-      nimpretty = pkgs.nim;
-      nixfmt = pkgs.nixfmt-classic;
-      nixpkgs_fmt = pkgs.nixpkgs-fmt;
-      opacheck = pkgs.open-policy-agent;
-      opentofu_fmt = pkgs.opentofu;
-      pg_format = pkgs.pgformatter;
-      phpcbf = pkgs.phpPackages.php-codesniffer;
-      phpcsfixer = pkgs.phpPackages.php-cs-fixer;
-      phpcs = pkgs.phpPackages.php-codesniffer;
-      # TODO: Added 2024-08-31; remove 2024-11-31
-      # prisma was moved out of nodePackages set without alias
-      # Using fallback as a transition period
-      prisma_format = pkgs.prisma or pkgs.nodePackages.prisma;
-      ptop = pkgs.fpc;
-      puppet_lint = pkgs.puppet-lint;
-      qmlformat = pkgs.qt6.qtdeclarative;
-      qmllint = pkgs.qt6.qtdeclarative;
-      racket_fixw = pkgs.racket;
-      raco_fmt = pkgs.racket;
-      rego = pkgs.open-policy-agent;
-      rpmspec = pkgs.rpm;
-      sqlformat = pkgs.python3.pkgs.sqlparse;
-      staticcheck = pkgs.go-tools;
-      surface = pkgs.elixir;
-      swift_format = pkgs.swift-format;
-      teal = pkgs.luaPackages.tl;
-      terraform_fmt = pkgs.terraform;
-      terraform_validate = pkgs.terraform;
-      terragrunt_fmt = pkgs.terragrunt;
-      terragrunt_validate = pkgs.terragrunt;
-      tidy = pkgs.html-tidy;
-      treefmt = pkgs.treefmt2;
-      verible_verilog_format = pkgs.verible;
-      vint = pkgs.vim-vint;
-      write_good = pkgs.write-good;
-      xmllint = pkgs.libxml2;
+    # Top-level packages
+    lib.genAttrs [
+      "actionlint"
+      "alejandra"
+      "asmfmt"
+      "astyle"
+      "bibclean"
+      "biome"
+      "buf"
+      "cbfmt"
+      "checkmake"
+      "checkstyle"
+      "clazy"
+      "codespell"
+      "commitlint"
+      "cppcheck"
+      "csharpier"
+      "deadnix"
+      "dfmt"
+      "djhtml"
+      "djlint"
+      "erlfmt"
+      "fantomas"
+      "fish"
+      "fnlfmt"
+      "fprettify"
+      "gitlint"
+      "gofumpt"
+      "golines"
+      "hadolint"
+      "hclfmt"
+      "isort"
+      "joker"
+      "just"
+      "ktlint"
+      "leptosfmt"
+      "mdformat"
+      "mdl"
+      "mypy"
+      "pmd"
+      "prettierd"
+      "proselint"
+      "protolint"
+      "pylint"
+      "revive"
+      "rstcheck"
+      "rubocop"
+      "rubyfmt"
+      "rufo"
+      "rustywind"
+      "scalafmt"
+      "selene"
+      "semgrep"
+      "shellharden"
+      "shfmt"
+      "smlfmt"
+      "sqlfluff"
+      "statix"
+      "stylelint"
+      "stylua"
+      "tfsec"
+      "topiary"
+      "trivy"
+      "typstfmt"
+      "typstyle"
+      "uncrustify"
+      "usort"
+      "vale"
+      "verilator"
+      "yamlfix"
+      "yamlfmt"
+      "yamllint"
+      "yapf"
+      "zprint"
+      "zsh"
+    ] lib.id
+    # Scoped packages
+    //
+      lib.concatMapAttrs
+        (
+          scope: names:
+          lib.genAttrs names (name: [
+            scope
+            name
+          ])
+        )
+        {
+          nodePackages = [
+            "alex"
+            "prettier"
+          ];
+          phpPackages = [
+            "phpmd"
+            "phpstan"
+          ];
+          rubyPackages = [ "htmlbeautifier" ];
+          ocamlPackages = [ "ocamlformat" ];
+        }
+    # Packages where the name is different
+    // {
+      ansiblelint = "ansible-lint";
+      bean_check = "beancount";
+      bean_format = "beancount";
+      black = [
+        "python3"
+        "pkgs"
+        "black"
+      ];
+      blackd = "black";
+      buildifier = "bazel-buildtools";
+      cfn_lint = "python3.pkgs.cfn-lint";
+      clang_format = "clang-tools";
+      clj_kondo = "clj-kondo";
+      cmake_format = "cmake-format";
+      cmake_lint = "cmake-format";
+      credo = "elixir";
+      crystal_format = "crystal";
+      cue_fmt = "cue";
+      d2_fmt = "d2";
+      dart_format = "dart";
+      dictionary = "curl";
+      dotenv_linter = "dotenv-linter";
+      dxfmt = "dioxus-cli";
+      editorconfig_checker = "editorconfig-checker";
+      elm_format = [
+        "elmPackages"
+        "elm-format"
+      ];
+      emacs_scheme_mode = "emacs";
+      emacs_vhdl_mode = "emacs";
+      erb_format = [
+        "rubyPackages"
+        "erb-formatterpkgs"
+      ];
+      fish_indent = "fish";
+      format_r = "R";
+      # FIXME: Can't have transition fallbacks anymore
+      gdformat = "gdtoolkit_4";
+      gdlint = "gdtoolkit_4";
+      gitsigns = "git";
+      gleam_format = "gleam";
+      glslc = "shaderc";
+      gn_format = "gn";
+      gofmt = "go";
+      goimports = "gotools";
+      goimports_reviser = "goimports-reviser";
+      golangci_lint = "golangci-lint";
+      google_java_format = "google-java-format";
+      haml_lint = "mastodon";
+      haxe_formatter = "haxe";
+      isortd = "isort";
+      ltrs = "languagetool-rust";
+      markdownlint_cli2 = "markdownlint-cli2";
+      markdownlint = "markdownlint-cli";
+      mix = "elixir";
+      nimpretty = "nim";
+      nixfmt = "nixfmt-classic";
+      nixpkgs_fmt = "nixpkgs-fmt";
+      opacheck = "open-policy-agent";
+      opentofu_fmt = "opentofu";
+      pg_format = "pgformatter";
+      phpcbf = [
+        "phpPackages"
+        "php-codesnifferpkgs"
+      ];
+      phpcsfixer = [
+        "phpPackages"
+        "php-cs-fixerpkgs"
+      ];
+      phpcs = [
+        "phpPackages"
+        "php-codesnifferpkgs"
+      ];
+      # FIXME: Can't have transition fallbacks anymore
+      prisma_format = "prisma";
+      ptop = "fpc";
+      puppet_lint = "puppet-lint";
+      qmlformat = [
+        "qt6"
+        "qtdeclarativepkgs"
+      ];
+      qmllint = [
+        "qt6"
+        "qtdeclarativepkgs"
+      ];
+      racket_fixw = "racket";
+      raco_fmt = "racket";
+      rego = "open-policy-agent";
+      rpmspec = "rpm";
+      sqlformat = [
+        "python3"
+        "pkgs"
+        "sqlparse"
+      ];
+      staticcheck = "go-tools";
+      surface = "elixir";
+      swift_format = "swift-format";
+      teal = "luaPackages.tl";
+      terraform_fmt = "terraform";
+      terraform_validate = "terraform";
+      terragrunt_fmt = "terragrunt";
+      terragrunt_validate = "terragrunt";
+      tidy = "html-tidy";
+      treefmt = "treefmt2";
+      verible_verilog_format = "verible";
+      vint = "vim-vint";
+      write_good = "write-good";
+      xmllint = "libxml2";
     }
     # builtin sources that are not packaged in nixpkgs
-    // pkgs.lib.genAttrs [
+    // lib.genAttrs [
       "blade_formatter"
       "bsfmt"
       "bslint"

--- a/tests/generated.nix
+++ b/tests/generated.nix
@@ -37,7 +37,7 @@ let
 
       declared =
         let
-          inherit (import ../plugins/none-ls/packages.nix pkgs) noPackage packaged;
+          inherit (import ../plugins/none-ls/packages.nix lib) noPackage packaged;
         in
         noPackage ++ lib.attrsets.attrNames packaged;
 

--- a/tests/generated.nix
+++ b/tests/generated.nix
@@ -54,7 +54,7 @@ let
 
       declared =
         let
-          inherit (import ../plugins/lsp/language-servers/efmls-configs-pkgs.nix pkgs) packaged unpackaged;
+          inherit (import ../plugins/lsp/language-servers/efmls-configs-pkgs.nix lib) packaged unpackaged;
         in
         unpackaged ++ lib.attrsets.attrNames packaged;
 


### PR DESCRIPTION
- **plugins/efmls: use `mkPackageOption`**
- **plugins/none-ls: use `defaultText` in package options**

Extracted from #2150 to reduce its scope.

This PR refactors the efmls and none-ls package list files to use package names/paths instead of _actual_ package derivations. This then allows us to show a useful `defaultText` in the resulting package options.

