### PR TITLE
plugins/efmls: move `eslint` pkg ref to top-level

### DIFF
--- a/plugins/lsp/language-servers/efmls-configs-pkgs.nix
+++ b/plugins/lsp/language-servers/efmls-configs-pkgs.nix
@@ -53,6 +53,7 @@ in
       "djlint"
       "dmd"
       "dprint"
+      "eslint"
       "fish"
       "flawfinder"
       "fnlfmt"
@@ -101,7 +102,6 @@ in
         "vulture"
       ];
       nodePackages = [
-        "eslint" # FIXME: No way to have a transition fallback...
         "eslint_d"
         "prettier"
         "alex"


### PR DESCRIPTION
Fixes #2168

I'm somewhat confused, when testing locally with `tests plugins-lsp-efmls-configs` I get `error: eslint cannot be found in pkgs`. However, when overriding my nixvim config's flake input to use this branch, this indeed fixes #2168...

See also https://github.com/NixOS/nixpkgs/pull/339641 ([tracker](https://nixpk.gs/pr-tracker.html?pr=339641)) and #2128