### PR TITLE
flake/pre-commit: check maintainers when modified

### DIFF
--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -18,6 +18,7 @@
     lib.optionalAttrs (inputs.treefmt-nix ? flakeModule) {
       treefmt.config = {
         projectRootFile = "flake.nix";
+        flakeCheck = true;
 
         programs = {
           isort.enable = true;
@@ -58,6 +59,9 @@
     }
     // lib.optionalAttrs (inputs.git-hooks ? flakeModule) {
       pre-commit = {
+        # We have a treefmt check already, so this is redundant.
+        check.enable = false;
+
         settings.hooks = {
           treefmt.enable = true;
           typos.enable = true;

--- a/flake-modules/dev/default.nix
+++ b/flake-modules/dev/default.nix
@@ -9,7 +9,7 @@
     {
       lib,
       pkgs,
-      config,
+      system,
       ...
     }:
     let
@@ -60,11 +60,23 @@
     // lib.optionalAttrs (inputs.git-hooks ? flakeModule) {
       pre-commit = {
         # We have a treefmt check already, so this is redundant.
+        # We also can't run the test if it includes running `nix build`,
+        # since the nix CLI can't build within a derivation builder.
         check.enable = false;
 
         settings.hooks = {
           treefmt.enable = true;
           typos.enable = true;
+          maintainers = {
+            enable = true;
+            name = "maintainers";
+            description = "Check maintainers when it is modified.";
+            files = "^lib/maintainers[.]nix$";
+            package = pkgs.nix;
+            entry = "nix build --no-link --print-build-logs";
+            args = [ ".#checks.${system}.maintainers" ];
+            pass_filenames = false;
+          };
         };
       };
     };


### PR DESCRIPTION
Follow up to #1846, which added the test. Currently the test only checks that nixpkgs maintainers don't redundantly add themselves to nixvim's maintainer list.

This PR adds a custom `pre-commit` hook that runs the test whenever `lib/maintainers.nix` has changes staged for commit.

> [!NOTE]
> This was developed in parallel with a similar hook in #2164, that one runs the `plugins-by-name` test when `plugins/by-name` or `tests/test-sources/plugins/by-name` is staged for commit.

## Usage

E.g. if I attempt to revert 497ce4759383d72a028b720468ebed78520c1012 and then commit, I get the following:
```nix
$ git commit
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/matt/.cache/pre-commit/patch1725667052-916231.
deadnix..................................................................Passed
flake-checker........................................(no files to check)Skipped
maintainers..............................................................Failed
- hook id: maintainers
- exit code: 1

warning: Git tree '/home/matt/nixvim/maintainers-hook' is dirty
warning: ignoring untrusted substituter 'https://nix-community.cachix.org', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
error: builder for '/nix/store/sizwppcwrmcwsxxb1kx59sxmm194sbq6-maintainers-test.drv' failed with exit code 1;
       last 2 log lines:
       > 1 nixvim maintainers are also nixpkgs maintainers:
       > - MattSturgeon
       For full logs, run 'nix log /nix/store/sizwppcwrmcwsxxb1kx59sxmm194sbq6-maintainers-test.drv'.

treefmt..................................................................Passed
typos....................................................................Passed
[INFO] Restored changes from /home/matt/.cache/pre-commit/patch1725667052-916231.
```

However, when `lib/maintainers.nix` is untouched, I get output like this:
```
$ git commit
deadnix..................................................................Passed
flake-checker........................................(no files to check)Skipped
maintainers..........................................(no files to check)Skipped
treefmt..................................................................Passed
typos....................................................................Passed
[maintainers-hook 871a3bb8] flake/pre-commit: check maintainers when modified
 1 file changed, 11 insertions(+)
```


## Additional changes

I also removed the pre-commit "check" derivation, since it's mostly redundant when we already enforce our formatting via the treefmt check.
If we're also explicitly running flake checks _in_ our git hooks, it seems kinda silly to then also run the git hooks in our flake checks...

It turns out that running nix builds within the pre-commit hooks also means that the pre-commit hooks themselves _cannot_ be tested under flake checks. So this is an additional reason to drop them from flake checks.

