### PR TITLE
tests: set `_file` to avoid `<unknown-file>` messages

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -5,7 +5,7 @@
   pkgsUnfree,
 }:
 let
-  fetchTests = import ./fetch-tests.nix;
+  fetchTests = import ./fetch-tests.nix { inherit lib pkgs helpers; };
   test-derivation = import ../lib/tests.nix { inherit pkgs lib; };
   inherit (test-derivation) mkTestDerivationFromNixvimModule;
 
@@ -17,10 +17,7 @@ let
     };
 
   # List of files containing configurations
-  testFiles = fetchTests {
-    inherit lib pkgs helpers;
-    root = ./test-sources;
-  };
+  testFiles = fetchTests ./test-sources;
 
   exampleFiles = {
     name = "examples";

--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -1,5 +1,4 @@
 {
-  root,
   lib,
   pkgs,
   helpers,
@@ -49,4 +48,4 @@ let
       builtins.concatLists
     ];
 in
-fetchTests root [ ]
+root: fetchTests root [ ]


### PR DESCRIPTION
Set `_file` in test-case modules, to avoid `<unknown-file>` messages.

Since the module system is importing an anonymous fnOrAttr module, instead of a `path` type module, it doesn't have enough context to figure out the module's file automatically.

Usually such non-path modules would just inherit their importer's `_file`, however this doesn't apply when passing modules directly to `lib.evalModules` since there is no importer to inherit from.

## Example test failurues

Adding `foo = ""` to a test case in `tests/test-sources/examples.nix` produces the following errors:


Without the change:
```
error: The option `foo' does not exist. Definition values:
- In `<unknown-file>': ""
```

With the change:
```
error: The option `foo' does not exist. Definition values:
- In `/nix/store/ss06gh6ig3nk0pvh1a7n5x1a3g47x91j-test-sources/examples.nix': ""
```

