### PR TITLE
plugins/lsp: add basedpyright

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -34,6 +34,10 @@ let
       ];
     }
     {
+      name = "basedpyright";
+      description = "basedpyright, a static type checker and language server for python";
+    }
+    {
       name = "bashls";
       description = "bashls for bash";
       package = "bash-language-server";

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -108,6 +108,7 @@
             ansiblels.enable = true;
             ast-grep.enable = true;
             astro.enable = true;
+            basedpyright.enable = true;
             bashls.enable = true;
             beancount.enable = true;
             biome.enable = true;


### PR DESCRIPTION
Adds the [basedpyright](https://detachhead.github.io/basedpyright) language server for Python.

Fixes #2180
