### PR TITLE
plugins/none-ls: fix pkg names

### DIFF
--- a/plugins/none-ls/packages.nix
+++ b/plugins/none-ls/packages.nix
@@ -124,7 +124,11 @@ in
       ];
       blackd = "black";
       buildifier = "bazel-buildtools";
-      cfn_lint = "python3.pkgs.cfn-lint";
+      cfn_lint = [
+        "python3"
+        "pkgs"
+        "cfn-lint"
+      ];
       clang_format = "clang-tools";
       clj_kondo = "clj-kondo";
       cmake_format = "cmake-format";
@@ -188,7 +192,12 @@ in
         "php-codesniffer"
       ];
       # FIXME: Can't have transition fallbacks anymore
-      prisma_format = "prisma";
+      # TODO: replace after flake.lock update
+      # prisma_format = "prisma";
+      prisma_format = [
+        "nodePackages"
+        "prisma"
+      ];
       ptop = "fpc";
       puppet_lint = "puppet-lint";
       qmlformat = [
@@ -211,7 +220,10 @@ in
       staticcheck = "go-tools";
       surface = "elixir";
       swift_format = "swift-format";
-      teal = "luaPackages.tl";
+      teal = [
+        "luaPackages"
+        "tl"
+      ];
       terraform_fmt = "terraform";
       terraform_validate = "terraform";
       terragrunt_fmt = "terragrunt";


### PR DESCRIPTION
Follow up to https://github.com/nix-community/nixvim/pull/2198 and finishes fixing the naming issues in https://github.com/nix-community/nixvim/issues/2197