### PR TITLE
plugins/hardtime: add missing rename for `settings.enabled`

### DIFF
--- a/plugins/by-name/hardtime/default.nix
+++ b/plugins/by-name/hardtime/default.nix
@@ -16,6 +16,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   # TODO: Added 2024-09-07; remove after 24.11
   deprecateExtraOptions = true;
   optionsRenamedToSettings = [
+    "enabled"
     "hint"
     "notification"
     "hints"


### PR DESCRIPTION
Was omitted from #2193 due to confusion with our `enable` option.

See https://github.com/m4xshen/hardtime.nvim#options

Fixes #2203
