### PR TITLE
TEST: reformat with latest nixfmt

### DIFF
--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -75,33 +75,36 @@
             };
           };
 
-          options.${namespace}.${name} = {
-            enable = lib.mkEnableOption originalName;
-            package =
-              if lib.isOption package then
-                package
-              else
-                lib.mkPackageOption pkgs originalName {
-                  default =
-                    if builtins.isList package then
-                      package
-                    else
-                      [
-                        "vimPlugins"
+          options.${namespace}.${name} =
+            {
+              enable = lib.mkEnableOption originalName;
+              package =
+                if lib.isOption package then
+                  package
+                else
+                  lib.mkPackageOption pkgs originalName {
+                    default =
+                      if builtins.isList package then
                         package
-                      ];
-                };
-            packageDecorator = lib.mkOption {
-              type = lib.types.functionTo lib.types.package;
-              default = lib.id;
-              defaultText = lib.literalExpression "x: x";
-              description = ''
-                Additional transformations to apply to the final installed package.
-                The result of these transformations is **not** visible in the `package` option's value.
-              '';
-              internal = true;
-            };
-          } // settingsOption // extraOptions;
+                      else
+                        [
+                          "vimPlugins"
+                          package
+                        ];
+                  };
+              packageDecorator = lib.mkOption {
+                type = lib.types.functionTo lib.types.package;
+                default = lib.id;
+                defaultText = lib.literalExpression "x: x";
+                description = ''
+                  Additional transformations to apply to the final installed package.
+                  The result of these transformations is **not** visible in the `package` option's value.
+                '';
+                internal = true;
+              };
+            }
+            // settingsOption
+            // extraOptions;
 
           config = lib.mkIf cfg.enable (
             lib.mkMerge [

--- a/plugins/by-name/clipboard-image/default.nix
+++ b/plugins/by-name/clipboard-image/default.nix
@@ -145,9 +145,12 @@ in
 
     extraConfigLua =
       let
-        setupOptions = {
-          default = processPluginOptions cfg.default;
-        } // cfg.filetypes // cfg.extraOptions;
+        setupOptions =
+          {
+            default = processPluginOptions cfg.default;
+          }
+          // cfg.filetypes
+          // cfg.extraOptions;
       in
       ''
         require('clipboard-image').setup(${helpers.toLuaObject setupOptions})

--- a/plugins/by-name/coverage/default.nix
+++ b/plugins/by-name/coverage/default.nix
@@ -183,13 +183,13 @@ in
     '';
 
     summary = {
-      widthPercentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
-        1.0
-      ) 0.7 "Width of the pop-up window.";
+      widthPercentage =
+        helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.7
+          "Width of the pop-up window.";
 
-      heightPercentage = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
-        1.0
-      ) 0.5 "Height of the pop-up window.";
+      heightPercentage =
+        helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.5
+          "Height of the pop-up window.";
 
       borders = mapAttrs (optionName: default: helpers.defaultNullOpts.mkStr default "") {
         topleft = "╭";

--- a/plugins/by-name/dap/dap-go.nix
+++ b/plugins/by-name/dap/dap-go.nix
@@ -29,9 +29,7 @@ in
     delve = {
       path = helpers.defaultNullOpts.mkStr "dlv" "The path to the executable dlv which will be used for debugging.";
 
-      initializeTimeoutSec =
-        helpers.defaultNullOpts.mkInt 20
-          "Time to wait for delve to initialize the debug session.";
+      initializeTimeoutSec = helpers.defaultNullOpts.mkInt 20 "Time to wait for delve to initialize the debug session.";
 
       port = helpers.defaultNullOpts.mkStr "$\{port}" ''
         A string that defines the port to start delve debugger.

--- a/plugins/by-name/dap/dap-ui.nix
+++ b/plugins/by-name/dap/dap-ui.nix
@@ -192,9 +192,7 @@ in
 
       maxTypeLength = helpers.mkNullOrOption types.int "Maximum number of characters to allow a type name to fill before trimming.";
 
-      maxValueLines =
-        helpers.defaultNullOpts.mkInt 100
-          "Maximum number of lines to allow a value to fill before trimming.";
+      maxValueLines = helpers.defaultNullOpts.mkInt 100 "Maximum number of lines to allow a value to fill before trimming.";
     };
 
     selectWindow = helpers.defaultNullOpts.mkLuaFn null ''

--- a/plugins/by-name/indent-o-matic/default.nix
+++ b/plugins/by-name/indent-o-matic/default.nix
@@ -7,9 +7,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "indent-o-matic";
   maintainers = [ lib.maintainers.alisonjenkins ];
   settingsOptions = {
-    max_lines =
-      defaultNullOpts.mkInt 2048
-        "Number of lines without indentation before giving up (use -1 for infinite)";
+    max_lines = defaultNullOpts.mkInt 2048 "Number of lines without indentation before giving up (use -1 for infinite)";
     skip_multiline = defaultNullOpts.mkBool false "Skip multi-line comments and strings (more accurate detection but less performant)";
     standard_widths = defaultNullOpts.mkListOf types.ints.unsigned [
       2

--- a/plugins/by-name/lspsaga/default.nix
+++ b/plugins/by-name/lspsaga/default.nix
@@ -317,13 +317,13 @@ in
           Auto save file when the rename is done.
         '';
 
-        projectMaxWidth = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
-          1.0
-        ) 0.5 "Width for the `project_replace` float window.";
+        projectMaxWidth =
+          helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.5
+            "Width for the `project_replace` float window.";
 
-        projectMaxHeight = helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0
-          1.0
-        ) 0.5 "Height for the `project_replace` float window.";
+        projectMaxHeight =
+          helpers.defaultNullOpts.mkNullable (types.numbers.between 0.0 1.0) 0.5
+            "Height for the `project_replace` float window.";
 
         keys = {
           quit = mkKeymapOption "<C-k>" "Quit rename window or `project_replace` window.";

--- a/plugins/by-name/markdown-preview/default.nix
+++ b/plugins/by-name/markdown-preview/default.nix
@@ -33,30 +33,12 @@ mkVimPlugin {
   ];
   imports = [
     (mkRenamedOptionModule
-      [
-        "plugins"
-        "markdown-preview"
-        "fileTypes"
-      ]
-      [
-        "plugins"
-        "markdown-preview"
-        "settings"
-        "filetypes"
-      ]
+      [ "plugins" "markdown-preview" "fileTypes" ]
+      [ "plugins" "markdown-preview" "settings" "filetypes" ]
     )
     (mkRenamedOptionModule
-      [
-        "plugins"
-        "markdown-preview"
-        "browserFunc"
-      ]
-      [
-        "plugins"
-        "markdown-preview"
-        "settings"
-        "browserfunc"
-      ]
+      [ "plugins" "markdown-preview" "browserFunc" ]
+      [ "plugins" "markdown-preview" "settings" "browserfunc" ]
     )
   ];
 

--- a/plugins/by-name/mini/default.nix
+++ b/plugins/by-name/mini/default.nix
@@ -72,13 +72,15 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           evaluate_single = true;
           items = {
             "__unkeyed-1.buildtin_actions".__raw = "require('mini.starter').sections.builtin_actions()";
-            "__unkeyed-2.recent_files_current_directory".__raw = "require('mini.starter').sections.recent_files(10, false)";
+            "__unkeyed-2.recent_files_current_directory".__raw =
+              "require('mini.starter').sections.recent_files(10, false)";
             "__unkeyed-3.recent_files".__raw = "require('mini.starter').sections.recent_files(10, true)";
             "__unkeyed-4.sessions".__raw = "require('mini.starter').sections.sessions(5, true)";
           };
           content_hooks = {
             "__unkeyed-1.adding_bullet".__raw = "require('mini.starter').gen_hook.adding_bullet()";
-            "__unkeyed-2.indexing".__raw = "require('mini.starter').gen_hook.indexing('all', { 'Builtin actions' })";
+            "__unkeyed-2.indexing".__raw =
+              "require('mini.starter').gen_hook.indexing('all', { 'Builtin actions' })";
             "__unkeyed-3.padding".__raw = "require('mini.starter').gen_hook.aligning('center', 'center')";
           };
         };

--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -104,13 +104,9 @@ in
       gitStatusAsync = helpers.defaultNullOpts.mkBool true "";
 
       gitStatusAsyncOptions = {
-        batchSize =
-          helpers.defaultNullOpts.mkInt 1000
-            "How many lines of git status results to process at a time";
+        batchSize = helpers.defaultNullOpts.mkInt 1000 "How many lines of git status results to process at a time";
 
-        batchDelay =
-          helpers.defaultNullOpts.mkInt 10
-            "delay in ms between batches. Spreads out the workload to let other processes run.";
+        batchDelay = helpers.defaultNullOpts.mkInt 10 "delay in ms between batches. Spreads out the workload to let other processes run.";
 
         maxLines = helpers.defaultNullOpts.mkInt 10000 ''
           How many lines of git status results to process. Anything after this will be dropped.

--- a/plugins/by-name/neogit/options.nix
+++ b/plugins/by-name/neogit/options.nix
@@ -44,8 +44,10 @@ in
 
   git_services = helpers.defaultNullOpts.mkAttrsOf types.str {
     "github.com" = "https://github.com/$\{owner}/$\{repository}/compare/$\{branch_name}?expand=1";
-    "bitbucket.org" = "https://bitbucket.org/$\{owner}/$\{repository}/pull-requests/new?source=$\{branch_name}&t=1";
-    "gitlab.com" = "https://gitlab.com/$\{owner}/$\{repository}/merge_requests/new?merge_request[source_branch]=$\{branch_name}";
+    "bitbucket.org" =
+      "https://bitbucket.org/$\{owner}/$\{repository}/pull-requests/new?source=$\{branch_name}&t=1";
+    "gitlab.com" =
+      "https://gitlab.com/$\{owner}/$\{repository}/merge_requests/new?merge_request[source_branch]=$\{branch_name}";
   } "Used to generate URL's for branch popup action 'pull request'.";
 
   fetch_after_checkout = helpers.defaultNullOpts.mkBool false ''

--- a/plugins/by-name/rust-tools/default.nix
+++ b/plugins/by-name/rust-tools/default.nix
@@ -48,15 +48,11 @@ in
 
       maxLenAlign = lib.nixvim.defaultNullOpts.mkBool false "whether to align to the length of the longest line in the file";
 
-      maxLenAlignPadding =
-        lib.nixvim.defaultNullOpts.mkUnsignedInt 1
-          "padding from the left if max_len_align is true";
+      maxLenAlignPadding = lib.nixvim.defaultNullOpts.mkUnsignedInt 1 "padding from the left if max_len_align is true";
 
       rightAlign = lib.nixvim.defaultNullOpts.mkBool false "whether to align to the extreme right or not";
 
-      rightAlignPadding =
-        lib.nixvim.defaultNullOpts.mkInt 7
-          "padding from the right if right_align is true";
+      rightAlignPadding = lib.nixvim.defaultNullOpts.mkInt 7 "padding from the right if right_align is true";
 
       highlight = lib.nixvim.defaultNullOpts.mkStr "Comment" "The color of the hints";
     };

--- a/plugins/by-name/telescope/extensions/live-greps-args.nix
+++ b/plugins/by-name/telescope/extensions/live-greps-args.nix
@@ -48,7 +48,8 @@ mkExtension {
     mappings = {
       i = {
         "<C-k>".__raw = ''require("telescope-live-grep-args.actions").quote_prompt()'';
-        "<C-i>".__raw = ''require("telescope-live-grep-args.actions").quote_prompt({ postfix = " --iglob " })'';
+        "<C-i>".__raw =
+          ''require("telescope-live-grep-args.actions").quote_prompt({ postfix = " --iglob " })'';
         "<C-space>".__raw = ''require("telescope.actions").to_fuzzy_refine'';
       };
     };

--- a/plugins/by-name/vim-matchup/default.nix
+++ b/plugins/by-name/vim-matchup/default.nix
@@ -77,13 +77,9 @@ with lib;
         Set this conservatively since high values may cause performance issues.
       '';
 
-      timeout =
-        helpers.defaultNullOpts.mkInt 300
-          "Adjust timeouts in milliseconds for matchparen highlighting";
+      timeout = helpers.defaultNullOpts.mkInt 300 "Adjust timeouts in milliseconds for matchparen highlighting";
 
-      insertTimeout =
-        helpers.defaultNullOpts.mkInt 60
-          "Adjust timeouts in milliseconds for matchparen highlighting";
+      insertTimeout = helpers.defaultNullOpts.mkInt 60 "Adjust timeouts in milliseconds for matchparen highlighting";
 
       deferred = {
         enable = helpers.defaultNullOpts.mkBool false ''

--- a/plugins/by-name/which-key/default.nix
+++ b/plugins/by-name/which-key/default.nix
@@ -377,9 +377,9 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       zindex = defaultNullOpts.mkUnsignedInt 1000 "Layer depth on the popup window.";
 
       wo = {
-        winblend = defaultNullOpts.mkNullableWithRaw (types.ints.between 0
-          100
-        ) 0 "`0` for fully opaque and `100` for fully transparent.";
+        winblend =
+          defaultNullOpts.mkNullableWithRaw (types.ints.between 0 100) 0
+            "`0` for fully opaque and `100` for fully transparent.";
       };
     };
 

--- a/plugins/by-name/yazi/default.nix
+++ b/plugins/by-name/yazi/default.nix
@@ -138,9 +138,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       NOTE: this only works if `use_ya_for_events_reading` is enabled, etc.
     '';
 
-    floating_window_scaling_factor =
-      defaultNullOpts.mkNum 0.9
-        "The floating window scaling factor. 1 means 100%, 0.9 means 90%, etc.";
+    floating_window_scaling_factor = defaultNullOpts.mkNum 0.9 "The floating window scaling factor. 1 means 100%, 0.9 means 90%, etc.";
 
     yazi_floating_window_winblend = defaultNullOpts.mkNullableWithRaw' {
       type = types.ints.between 0 100;

--- a/plugins/deprecation.nix
+++ b/plugins/deprecation.nix
@@ -48,28 +48,13 @@ in
       ]
     ) removed)
     ++ (lib.mapAttrsToList (
-      old: new:
-      lib.mkRenamedOptionModule
-        [
-          "plugins"
-          old
-        ]
-        [
-          "plugins"
-          new
-        ]
+      old: new: lib.mkRenamedOptionModule [ "plugins" old ] [ "plugins" new ]
     ) renamed)
     ++ builtins.map (
       name:
-      lib.mkRemovedOptionModule
-        [
-          "plugins"
-          name
-          "iconsPackage"
-        ]
-        ''
-          Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-        ''
+      lib.mkRemovedOptionModule [ "plugins" name "iconsPackage" ] ''
+        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+      ''
     ) iconsPackagePlugins
     ++ [
       (

--- a/tests/test-sources/plugins/by-name/neogit/default.nix
+++ b/tests/test-sources/plugins/by-name/neogit/default.nix
@@ -22,8 +22,10 @@
         disable_signs = false;
         git_services = {
           "github.com" = "https://github.com/$\{owner}/$\{repository}/compare/$\{branch_name}?expand=1";
-          "bitbucket.org" = "https://bitbucket.org/$\{owner}/$\{repository}/pull-requests/new?source=$\{branch_name}&t=1";
-          "gitlab.com" = "https://gitlab.com/$\{owner}/$\{repository}/merge_requests/new?merge_request[source_branch]=$\{branch_name}";
+          "bitbucket.org" =
+            "https://bitbucket.org/$\{owner}/$\{repository}/pull-requests/new?source=$\{branch_name}&t=1";
+          "gitlab.com" =
+            "https://gitlab.com/$\{owner}/$\{repository}/merge_requests/new?merge_request[source_branch]=$\{branch_name}";
         };
         telescope_sorter = null;
         disable_insert_on_commit = "auto";

--- a/tests/test-sources/plugins/by-name/telescope/live-grep-args.nix
+++ b/tests/test-sources/plugins/by-name/telescope/live-grep-args.nix
@@ -36,7 +36,8 @@
           mappings = {
             i = {
               "<C-k>".__raw = ''require("telescope-live-grep-args.actions").quote_prompt()'';
-              "<C-i>".__raw = ''require("telescope-live-grep-args.actions").quote_prompt({ postfix = " --iglob " })'';
+              "<C-i>".__raw =
+                ''require("telescope-live-grep-args.actions").quote_prompt({ postfix = " --iglob " })'';
               "<C-space>".__raw = ''require("telescope-live-grep-args.actions").to_fuzzy_refine'';
             };
           };


### PR DESCRIPTION
Just to satisfy my curiosity, this is what the repo looks like when running
```
nix run github:nixos/nixfmt -- **/*.nix
```

Note: some of the new formatting uses input-formatting-based heuristics, so if you (for example) wanted to reformat the following, it may require manual intervention.
```nix
# from
mkRenamedOptionModule
  [
    "plugins"
    "hello"
    "foo"
  ]
  [
    "plugins"
    "goodbye"
    "bar"
  ]
# to
mkRenamedOptionModule [ "plugins" "hello" "foo" ] [ "plugins" "goodbye" "bar" ]
# or
mkRenamedOptionModule
  [ "plugins" "hello" "foo" ]
  [ "plugins" "goodbye" "bar" ]
```

We can experiment with additional commits on this branch, manually modifying input formatting and re-running nixfmt to see what it now permits.
