### PR TITLE
mergify: update config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,8 +17,15 @@ queue_rules:
           # Allow queuing PRs that have been approved
           - "#approved-reviews-by >= 1"
 
-          # Allow queuing flake.lock updates without approval
+          # Allow queuing update PRs without approval
           - and:
-              - "#files = 1"
-              - files = flake.lock
-              - author = GaetanLepage
+              # We need a double-negative, because mergify only has "any" conditions on list types...
+              #
+              # So we check if "any file does not match the regex", using the `-` prefix operator.
+              # The regex matches anything except `flake.lock` and `generated`, using a negative lookahead `(?!)`
+              #
+              # After canceling out the double-negative, the condition below is true when
+              # _all_ files match either `^flake\.lock$` or `^generated/`
+              - "-files ~= ^(?!flake[.]lock$|generated/)"
+              # Also check the PR was opened by the github-actions bot
+              - author = github-actions

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ queue_rules:
     # Account used for pushing rebased updates. Default is {{author}},
     # but that doesn't work when they haven't logged into Mergify Dashboard:
     # https://github.com/Mergifyio/mergify/issues/5075
-    update_bot_account: GaetanLepage
+    update_bot_account: nix-infra-bot
     update_method: rebase
     merge_method: fast-forward
     merge_conditions:


### PR DESCRIPTION
- **mergify: use @nix-infra-bot to update queued PRs**

As per this discussion https://github.com/Mergifyio/mergify/discussions/5117, using a regular user for updating PRs feels wrong; we are essentially lying about who made the rebased commits.

After [raising this on matrix](https://matrix.to/#/!PbtOpdWBSRFbEZRLIf:numtide.com/$jwKmsz34yobKlwQHl7a0Qy71uVBIFpdcwlJu-m6JBBk?via=blad.is&via=matrix.org&via=nixos.dev), @nix-infra-bot was logged into mergify dashboard and granted write access to nixvim. Thanks @zowoq!

- **mergify: fix "update PR" logic**

We can no longer simply check the files list matches `[ flake.lock ]`, since we now also touch `generated/` files.

Mergify conditions cannot be checked against "all" list items; checks are always applied against "any" item. Therefore we need some double-negatives to check that "any item does not match a regex that does not match `(flake.lock|generated/.*)`".

Note: mergify conditions support python-syntax regexes.

Yes, this is horrible.

If it is _too_ horrible, perhaps we drop the "allow merging update PRs without approval" condition? We can't use it _anyway_ all the while we _also_ require approval in github's branch protection rules.
