### PR TITLE
nixvimInfo: access `package.default` using `tryEval`

### DIFF
--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -49,6 +49,7 @@
     }@args:
     let
       namespace = if isColorscheme then "colorschemes" else "plugins";
+      extraConfigNamespace = if isColorscheme then "extraConfigLuaPre" else "extraConfigLua";
 
       module =
         {
@@ -60,14 +61,15 @@
         let
           cfg = config.${namespace}.${name};
           opt = options.${namespace}.${name};
-          extraConfigNamespace = if isColorscheme then "extraConfigLuaPre" else "extraConfigLua";
+          # `package.default` will throw "not found in pkgs" if the nixpkgs channel is mismatched
+          pkg = (builtins.tryEval opt.package.default).value;
+          url = args.url or pkg.meta.homepage or null;
         in
         {
           meta = {
             inherit maintainers;
             nixvimInfo = {
-              inherit description;
-              url = args.url or opt.package.default.meta.homepage;
+              inherit url description;
               path = [
                 namespace
                 name

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -61,13 +61,15 @@
         let
           cfg = config.${namespace}.${name};
           opt = options.${namespace}.${name};
+          # `package.default` will throw "not found in pkgs" if the nixpkgs channel is mismatched
+          pkg = (builtins.tryEval opt.package.default).value;
+          url = args.url or pkg.meta.homepage or null;
         in
         {
           meta = {
             inherit maintainers;
             nixvimInfo = {
-              inherit description;
-              url = args.url or opt.package.default.meta.homepage;
+              inherit url description;
               path = [
                 namespace
                 name

--- a/plugins/lsp/language-servers/_mk-lsp.nix
+++ b/plugins/lsp/language-servers/_mk-lsp.nix
@@ -30,11 +30,14 @@ with lib;
 let
   cfg = config.plugins.lsp.servers.${name};
   opt = options.plugins.lsp.servers.${name};
+  # `package.default` will throw "not found in pkgs" if the nixpkgs channel is mismatched
+  pkg = (builtins.tryEval opt.package.default).value;
+  url = args.url or pkg.meta.homepage or null;
 in
 {
   meta.nixvimInfo = {
     # TODO: description
-    url = args.url or opt.package.default.meta.homepage or null;
+    inherit url;
     path = [
       "plugins"
       "lsp"


### PR DESCRIPTION
Allow getting `meta.homepage` from the default package to fail gracefully when the nixpkgs channel lock is out-of-sync with ours.

This is a draft because we still need to:
- [ ] see if this fixes (or at least helps with) end-user mismatched/out-of-sync nixpkgs lock errors
- [ ] add a test to ensure plugin maintainers set a valid URL (or use a package that has `meta.homepage`)
