### PR TITLE
lib/types: simplify `eitherRecursive` by defining it only once

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -15,18 +15,6 @@ let
           };
 
         eitherRecursive = t1: t2: (final.types.either t1 t2) // { getSubOptions = _: { }; };
-
-        oneOfRecursive =
-          ts:
-          let
-            head' =
-              if ts == [ ] then
-                throw "types.oneOfRecursive needs to get at least one type in its argument"
-              else
-                builtins.head ts;
-            tail' = builtins.tail ts;
-          in
-          builtins.foldl' final.types.eitherRecursive head' tail';
       };
     }
   );

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -13,8 +13,6 @@ let
           // {
             getSubOptions = prefix: (t1.getSubOptions prefix) // (t2.getSubOptions prefix);
           };
-
-        eitherRecursive = t1: t2: (final.types.either t1 t2) // { getSubOptions = _: { }; };
       };
     }
   );

--- a/lib/extend-lib.nix
+++ b/lib/extend-lib.nix
@@ -13,6 +13,6 @@ lib.extend (
     maintainers = prev.maintainers // import ./maintainers.nix;
 
     # Merge in our custom types
-    types = call ./types.nix { } // prev.types;
+    types = prev.types // call ./types.nix { };
   }
 )

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -95,8 +95,15 @@ rec {
   strLua = strLikeType "lua code string";
   strLuaFn = strLikeType "lua function string";
 
-  # Overridden when building the documentation
-  eitherRecursive = types.either;
+  # When building the documentation `either` is extended to return the nestedType's sub-options
+  # This type can be used to avoid infinite recursion when evaluating the docs
+  # TODO: consider deprecating this in favor of using `config.isDocs` in option declarations
+  eitherRecursive =
+    t1: t2:
+    types.either t1 t2
+    // {
+      getSubOptions = _: { };
+    };
 
   listOfLen =
     elemType: len:


### PR DESCRIPTION
- **docs: remove unused `oneOfRecursive`**

This function is not used anywhere in nixvim, and was never even included in our `lib/types.nix`.

- **lib/types: simplify `eitherRecursive` by defining it only once**

Overriding the implementation in the docs is redundant. We can do the same thing directly in `lib/types.nix`.
