### PR TITLE
lib: segregate and deprecate functions that need `pkgs`

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -10,7 +10,12 @@
       ...
     }:
     let
-      evaluatedNixvim = helpers.modules.evalNixvim { check = false; };
+      evaluatedNixvim = helpers.modules.evalNixvim {
+        extraSpecialArgs = {
+          defaultPkgs = pkgs;
+        };
+        check = false;
+      };
     in
     {
       checks = {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1,19 +1,17 @@
 {
-  pkgs,
   lib,
-  helpers,
+  self,
 }:
 rec {
-  # Minimal specialArgs required to evaluate nixvim modules
-  specialArgs = specialArgsWith { };
-
   # Build specialArgs for evaluating nixvim modules
   specialArgsWith =
-    extraSpecialArgs:
+    # TODO: switch defaultPkgs -> pkgsPath (i.e. pkgs.path or inputs.nixvim)
+    # FIXME: Ideally, we should not require callers to pass in _anything_ specific
+    { defaultPkgs, ... }@extraSpecialArgs:
     {
+      inherit lib defaultPkgs;
       # TODO: deprecate `helpers`
-      inherit lib helpers;
-      defaultPkgs = pkgs;
+      helpers = self;
     }
     // extraSpecialArgs;
 

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -6,6 +6,8 @@
   ...
 }:
 let
+  builders = lib.nixvim.builders.withPkgs pkgs;
+
   fileTypeModule =
     {
       name,
@@ -73,10 +75,10 @@ let
             then
               if lib.isDerivation config.source then
                 # Source is a derivation
-                helpers.byteCompileLuaDrv config.source
+                builders.byteCompileLuaDrv config.source
               else
                 # Source is a path or string
-                helpers.byteCompileLuaFile derivationName config.source
+                builders.byteCompileLuaFile derivationName config.source
             else
               config.source;
         };

--- a/modules/top-level/files/submodule.nix
+++ b/modules/top-level/files/submodule.nix
@@ -3,7 +3,6 @@
   config,
   lib,
   pkgs,
-  helpers,
   ...
 }:
 {
@@ -18,7 +17,8 @@
   config =
     let
       derivationName = "nvim-" + lib.replaceStrings [ "/" ] [ "-" ] name;
-      writeContent = if config.type == "lua" then helpers.writeLua else pkgs.writeText;
+      writeContent =
+        if config.type == "lua" then lib.nixvim.builders.writeLuaWith pkgs else pkgs.writeText;
     in
     {
       path = lib.mkDefault name;

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -8,6 +8,7 @@
 let
   inherit (lib) types mkOption mkPackageOption;
   inherit (lib) optional optionalString optionalAttrs;
+  builders = lib.nixvim.builders.withPkgs pkgs;
 in
 {
   options = {
@@ -91,7 +92,7 @@ in
         let
           byteCompile =
             p:
-            (helpers.byteCompileLuaDrv p).overrideAttrs (
+            (builders.byteCompileLuaDrv p).overrideAttrs (
               prev: lib.optionalAttrs (prev ? dependencies) { dependencies = map byteCompile prev.dependencies; }
             );
         in
@@ -223,8 +224,8 @@ in
         config.content
       ];
 
-      textInit = helpers.writeLua "init.lua" customRC;
-      byteCompiledInit = helpers.writeByteCompiledLua "init.lua" customRC;
+      textInit = builders.writeLua "init.lua" customRC;
+      byteCompiledInit = builders.writeByteCompiledLua "init.lua" customRC;
       init =
         if
           config.type == "lua"
@@ -250,7 +251,7 @@ in
             paths = [ config.package ];
             # Required attributes from original neovim package
             inherit (config.package) lua meta;
-            nativeBuildInputs = [ helpers.byteCompileLuaHook ];
+            nativeBuildInputs = [ builders.byteCompileLuaHook ];
             postBuild = ''
               # Replace Nvim's binary symlink with a regular file,
               # or Nvim will use original runtime directory

--- a/tests/test-sources/modules/performance/byte-compile-lua.nix
+++ b/tests/test-sources/modules/performance/byte-compile-lua.nix
@@ -1,4 +1,4 @@
-{ pkgs, helpers, ... }:
+{ pkgs, ... }:
 let
   isByteCompiledFun = ''
     local function is_byte_compiled(filename)
@@ -25,7 +25,15 @@ let
 in
 {
   default =
-    { config, ... }:
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      writeLua = lib.nixvim.builders.writeLuaWith pkgs;
+    in
     {
       performance.byteCompileLua.enable = true;
 
@@ -33,7 +41,7 @@ in
         # By text
         "plugin/file_text.lua".text = "vim.opt.tabstop = 2";
         # By simple source derivation using buildCommand
-        "plugin/file_source.lua".source = helpers.writeLua "file_source.lua" "vim.opt.tabstop = 2";
+        "plugin/file_source.lua".source = writeLua "file_source.lua" "vim.opt.tabstop = 2";
         # By standard derivation, it needs to execute fixupPhase
         "plugin/file_drv.lua".source = pkgs.stdenvNoCC.mkDerivation {
           name = "file_drv.lua";
@@ -48,13 +56,13 @@ in
         "plugin/file_string.lua".source = builtins.toFile "file_path.lua" "vim.opt.tabstop = 2";
         # By derivation converted to string
         "plugin/file_drv_string.lua".source = toString (
-          helpers.writeLua "file_drv_string.lua" "vim.opt.tabstop = 2"
+          writeLua "file_drv_string.lua" "vim.opt.tabstop = 2"
         );
         # Non-lua files
         "plugin/test.vim".text = "set tabstop=2";
         "plugin/test.json".text = builtins.toJSON { a = 1; };
         # Lua file with txt extension won't be byte compiled
-        "test.txt".source = helpers.writeLua "test.txt" "vim.opt.tabstop = 2";
+        "test.txt".source = writeLua "test.txt" "vim.opt.tabstop = 2";
       };
 
       files = {

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -23,7 +23,10 @@ in
       default = { };
       type = types.submoduleWith {
         shorthandOnlyDefinesConfig = true;
-        specialArgs = config.lib.nixvim.modules.specialArgsWith { darwinConfig = config; };
+        specialArgs = config.lib.nixvim.modules.specialArgsWith {
+          defaultPkgs = pkgs;
+          darwinConfig = config;
+        };
         modules = [
           ./modules/darwin.nix
           ../modules/top-level

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -22,7 +22,10 @@ in
       default = { };
       type = types.submoduleWith {
         shorthandOnlyDefinesConfig = true;
-        specialArgs = config.lib.nixvim.modules.specialArgsWith { hmConfig = config; };
+        specialArgs = config.lib.nixvim.modules.specialArgsWith {
+          defaultPkgs = pkgs;
+          hmConfig = config;
+        };
         modules = [
           ./modules/hm.nix
           ../modules/top-level

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -23,7 +23,10 @@ in
       default = { };
       type = types.submoduleWith {
         shorthandOnlyDefinesConfig = true;
-        specialArgs = config.lib.nixvim.modules.specialArgsWith { nixosConfig = config; };
+        specialArgs = config.lib.nixvim.modules.specialArgsWith {
+          defaultPkgs = pkgs;
+          nixosConfig = config;
+        };
         modules = [
           ./modules/nixos.nix
           ../modules/top-level

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -19,7 +19,9 @@ let
           mod
           ./modules/standalone.nix
         ];
-        inherit extraSpecialArgs;
+        extraSpecialArgs = {
+          defaultPkgs = pkgs;
+        } // extraSpecialArgs;
       };
       inherit (evaledModule.config) enableMan finalPackage printInitPackage;
     in


### PR DESCRIPTION
Splits everything that depends on a `pkgs` instance into an `optionalAttrs`, allowing `helpers.nix` to be bootstrapped without `pkgs`. The separated functions may be deprecated later, depending on how other refactoring pans out.

This required some refactoring:
- `modules.specialArgs` is only available when `pkgs` is used
- `modules.specialArgsWith` now requires `defaultPkgs` be provided
- `builders.*` now have `*With` variants that take `pkgs` as an argument

This is the first small step towards https://github.com/nix-community/nixvim/discussions/2186, #2210, and related refactoring.
