### PR TITLE
plugins/lsp/idris2-lsp: init

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -247,6 +247,15 @@ let
       package = "htmx-lsp";
     }
     {
+      name = "idris2-lsp";
+      description = "Idris 2 Language Server";
+      serverName = "idris2_lsp";
+      package = [
+        "idris2Packages"
+        "idris2Lsp"
+      ];
+    }
+    {
       name = "intelephense";
       description = "intelephense for PHP";
       package = [

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -144,6 +144,7 @@
             hls.enable = true;
             html.enable = true;
             htmx.enable = true;
+            idris2-lsp.enable = true;
             java-language-server.enable = true;
             jdt-language-server.enable = true;
             jsonls.enable = true;


### PR DESCRIPTION
Adds the Idris 2 LSP implementation. Tested successfully locally.