### PR TITLE
plugins/wtf: add history and grep_history keymaps

### DIFF
--- a/plugins/by-name/wtf/default.nix
+++ b/plugins/by-name/wtf/default.nix
@@ -24,6 +24,18 @@ let
       mode = "n";
       action.__raw = "require('wtf').search";
     };
+
+    history = {
+      key = "wh";
+      mode = "n";
+      action.__raw = "require('wtf').history";
+    };
+
+    grep_history = {
+      key = "wg";
+      mode = "n";
+      action.__raw = "require('wtf').grep_history";
+    };
   };
 in
 {

--- a/tests/test-sources/plugins/by-name/wtf/default.nix
+++ b/tests/test-sources/plugins/by-name/wtf/default.nix
@@ -8,7 +8,7 @@
       enable = true;
 
       keymaps = {
-        ai = "gw";
+        ai.key = "gw";
         search = {
           mode = [
             "n"


### PR DESCRIPTION
While working on https://github.com/nix-community/nixvim/pull/2235 I found these 2 in the docs for the plugin and they weren't supported. 