### PR TITLE
plugins/idris2: init

### DIFF
--- a/plugins/by-name/idris2/default.nix
+++ b/plugins/by-name/idris2/default.nix
@@ -1,0 +1,11 @@
+{
+  helpers,
+  lib,
+  ...
+}:
+helpers.neovim-plugin.mkNeovimPlugin {
+  name = "idris2";
+  originalName = "idris2";
+  package = "idris2-nvim";
+  maintainers = [ lib.maintainers.mitchmindtree ];
+}

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -256,12 +256,20 @@ let
     }
     {
       name = "idris2-lsp";
-      description = "Idris 2 Language Server";
+      description = ''
+        Idris 2 Language Server.
+        Enabling this also enables the required `idris2` plugin.
+      '';
       serverName = "idris2_lsp";
       package = [
         "idris2Packages"
         "idris2Lsp"
       ];
+      extraConfig =
+        cfg:
+        mkIf cfg.enable {
+          plugins.idris2.enable = lib.mkDefault true;
+        };
     }
     {
       name = "intelephense";

--- a/tests/test-sources/plugins/by-name/idris2/default.nix
+++ b/tests/test-sources/plugins/by-name/idris2/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.idris2.enable = true;
+  };
+}


### PR DESCRIPTION
Adds the `idris2` neovim plugin.

Also changes `idris2-lsp` to enable this new `idris2` plugin when enabled, as it's required for `idris2-lsp` to work at all. I'm not 100% sure this is the best way to achieve this - let me know if you'd prefer this was done another way!