### PR TITLE
flake: add an empty `nixvimConfiguration` to the `legacyPackages` output

### DIFF
--- a/flake-modules/legacy-packages.nix
+++ b/flake-modules/legacy-packages.nix
@@ -2,7 +2,7 @@
   perSystem =
     {
       pkgs,
-      config,
+      helpers,
       makeNixvimWithModule,
       ...
     }:
@@ -10,6 +10,13 @@
       legacyPackages = rec {
         inherit makeNixvimWithModule;
         makeNixvim = module: makeNixvimWithModule { inherit module; };
+
+        nixvimConfiguration = helpers.modules.evalNixvim {
+          extraSpecialArgs = {
+            defaultPkgs = pkgs;
+          };
+          check = false;
+        };
       };
     };
 }

--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -7,15 +7,11 @@
       system,
       helpers,
       makeNixvimWithModule,
+      self',
       ...
     }:
     let
-      evaluatedNixvim = helpers.modules.evalNixvim {
-        extraSpecialArgs = {
-          defaultPkgs = pkgs;
-        };
-        check = false;
-      };
+      inherit (self'.legacyPackages) nixvimConfiguration;
     in
     {
       checks = {
@@ -50,11 +46,11 @@
 
         maintainers = import ../tests/maintainers.nix { inherit pkgs; };
 
-        plugins-by-name = pkgs.callPackage ../tests/plugins-by-name.nix { inherit evaluatedNixvim; };
+        plugins-by-name = pkgs.callPackage ../tests/plugins-by-name.nix { inherit nixvimConfiguration; };
 
         generated = pkgs.callPackage ../tests/generated.nix { };
 
-        package-options = pkgs.callPackage ../tests/package-options.nix { inherit evaluatedNixvim; };
+        package-options = pkgs.callPackage ../tests/package-options.nix { inherit nixvimConfiguration; };
       } // import ../tests { inherit pkgs pkgsUnfree helpers; };
     };
 }

--- a/tests/package-options.nix
+++ b/tests/package-options.nix
@@ -1,7 +1,7 @@
 # This test ensures "package" options use a "literalExpression" in their defaultText
 # I.e. it validates `lib.mkPackageOption` was used to build the package options.
 {
-  evaluatedNixvim,
+  nixvimConfiguration,
   lib,
   runCommandNoCCLocal,
 }:
@@ -22,7 +22,7 @@ let
 
   # This doesn't collect any submodule sub-options,
   # but that's fine since most of our "package" options are in the top level module eval
-  options = lib.collect isOption evaluatedNixvim.options;
+  options = lib.collect isOption nixvimConfiguration.options;
 
   # All visible non-sub options that default to a derivation
   drvOptions = filter (
@@ -51,7 +51,7 @@ runCommandNoCCLocal "validate-package-options"
 
     # Passthroughs for debugging purposes
     passthru = {
-      inherit evaluatedNixvim drvOptions badOptions;
+      inherit nixvimConfiguration drvOptions badOptions;
     };
 
     # Error strings to print
@@ -60,7 +60,7 @@ runCommandNoCCLocal "validate-package-options"
         # A little hack to get the flake's source in the nix store
         # We will use this to make the option declaration sources more readable
         src = removeSuffix "modules/top-level/output.nix" (
-          head evaluatedNixvim.options.package.declarations
+          head nixvimConfiguration.options.package.declarations
         );
       in
       map (

--- a/tests/plugins-by-name.nix
+++ b/tests/plugins-by-name.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  evaluatedNixvim,
+  nixvimConfiguration,
   linkFarmFromDrvs,
   runCommandNoCCLocal,
 }:
 let
   by-name = ../plugins/by-name;
-  options = lib.collect lib.isOption evaluatedNixvim.options;
+  options = lib.collect lib.isOption nixvimConfiguration.options;
 
   # Option namespaces that we allow by-name plugins to declare
   knownPluginNamespaces = [
@@ -137,7 +137,7 @@ linkFarmFromDrvs "plugins-by-name" [
       ];
 
       passthru = {
-        inherit evaluatedNixvim;
+        inherit nixvimConfiguration;
       };
     }
     ''
@@ -172,7 +172,7 @@ linkFarmFromDrvs "plugins-by-name" [
       ];
 
       passthru = {
-        inherit evaluatedNixvim;
+        inherit nixvimConfiguration;
       };
     }
     ''


### PR DESCRIPTION
This was already used in a couple test cases, however having it as a flake output allows for 

1. easier debugging using `nix repl` or `nix eval` 
2. doing things like `nix eval .#nixvimConfiguration.config.plugins --apply builtins.attrNames --json` to very quickly get a JSON list of all plugins.

This would be useful in a CI task that looks for newly added plugins, for example.

NOTE: it has to go in `legacyPackages` and not `packages` because the latter can only contain derivations. Non-drv attrsets will throw an error when included in `packages`.