### PR TITLE
plugins/otter: remove myself as maintainer

### DIFF
--- a/plugins/by-name/otter/default.nix
+++ b/plugins/by-name/otter/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "otter.nvim";
   package = "otter-nvim";
 
-  maintainers = [ lib.maintainers.perchun ];
+  maintainers = [ ];
 
   imports = [
     # TODO: introduced 2024-06-29; remove after 24.11


### PR DESCRIPTION
I no longer use nixvim

BTW otter no longer requires CMP; see https://github.com/nix-community/nixvim/discussions/2243