### PR TITLE
plugins/tokyonight: add moon style to settings

### DIFF
--- a/plugins/colorschemes/tokyonight.nix
+++ b/plugins/colorschemes/tokyonight.nix
@@ -55,12 +55,13 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     style =
       defaultNullOpts.mkEnumFirstDefault
         [
+          "moon"
           "storm"
           "night"
           "day"
         ]
         ''
-          The theme comes in three styles, `storm`, a darker variant `night` and `day`.
+          The theme comes in four styles, `moon`, `storm`, a darker variant `night`, and `day`.
         '';
 
     light_style = defaultNullOpts.mkStr "day" ''


### PR DESCRIPTION
Default style since tokyonight v4.0.0. See https://github.com/folke/tokyonight.nvim/commit/766be08803922a5761551500c09d4be4c3366b71#diff-2118ce7f3d4c28292bfec01fd0828fa01ea8b5505df921c874452e35997939c5R9