### PR TITLE
lib: fix escaping bugs in wrapVimscriptForLua and wrapLuaForVimscript

### DIFF
--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -374,6 +374,41 @@ let
         ];
       };
     };
+
+    testEscapeStringForLua = {
+      expr = lib.mapAttrs (_: helpers.utils.toLuaLongLiteral) {
+        simple = "simple";
+        depth-one = " ]] ";
+        depth-two = " ]] ]=] ";
+      };
+      expected = {
+        simple = "[[simple]]";
+        depth-one = "[=[ ]] ]=]";
+        depth-two = "[==[ ]] ]=] ]==]";
+      };
+    };
+
+    testEscapeStringForVimscript = {
+      expr = lib.mapAttrs (_: helpers.utils.toVimscriptHeredoc) {
+        simple = "simple";
+        depth-one = "EOF";
+        depth-two = "EOF EOFF";
+      };
+      expected = {
+        simple = ''
+          << EOF
+          simple
+          EOF'';
+        depth-one = ''
+          << EOFF
+          EOF
+          EOFF'';
+        depth-two = ''
+          << EOFFF
+          EOF EOFF
+          EOFFF'';
+      };
+    };
   };
 in
 if results == [ ] then


### PR DESCRIPTION
These functions had very similar bugs: they didn't check if their chosen "close token" was already present in the string they're escaping.

I went ahead and did the work implied by the TODOs: search for a "close token" that is *not* in the original string. Pretty simple concept, but it turned into an annoying amount of code. I couldn't find anything in upstream nixpkgs lib, or some clever insight about lua/vimscript that makes this work unecessary, but I'll be thrilled (and a little bummed about a wasted afternoon) to learn about something.