### PR TITLE
plugins/alpha: rawLua support; remove helpers and with lib; fix terminal type

### DIFF
--- a/plugins/by-name/alpha/default.nix
+++ b/plugins/by-name/alpha/default.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  helpers,
   config,
   options,
   pkgs,
   ...
 }:
-with lib;
 let
+  inherit (lib) types mkOption;
+
   cfg = config.plugins.alpha;
 
   sectionType = types.submodule {
@@ -24,8 +24,8 @@ let
         description = "Type of section";
       };
 
-      val = helpers.mkNullOrOption (
-        with helpers.nixvimTypes;
+      val = lib.nixvim.mkNullOrOption (
+        with types;
         nullOr (oneOf [
 
           # "button", "text"
@@ -53,7 +53,7 @@ in
 {
   options = {
     plugins.alpha = {
-      enable = mkEnableOption "alpha-nvim";
+      enable = lib.mkEnableOption "alpha-nvim";
 
       package = lib.mkPackageOption pkgs "alpha-nvim" {
         default = [
@@ -75,8 +75,8 @@ in
       ] { nullable = true; };
 
       theme = mkOption {
-        type = with helpers.nixvimTypes; nullOr (maybeRaw str);
-        apply = v: if isString v then helpers.mkRaw "require'alpha.themes.${v}'.config" else v;
+        type = with types; nullOr (maybeRaw str);
+        apply = v: if lib.isString v then lib.nixvim.mkRaw "require'alpha.themes.${v}'.config" else v;
         default = null;
         example = "dashboard";
         description = "You can directly use a pre-defined theme.";
@@ -142,7 +142,7 @@ in
         ];
       };
 
-      opts = helpers.mkNullOrOption (with types; attrsOf anything) ''
+      opts = lib.nixvim.mkNullOrOption (with types; attrsOf anything) ''
         Optional global options.
       '';
     };
@@ -155,12 +155,12 @@ in
 
       opt = options.plugins.alpha;
     in
-    mkIf cfg.enable {
+    lib.mkIf cfg.enable {
       # TODO: deprecated 2024-08-29 remove after 24.11
       warnings = lib.mkIf opt.iconsEnabled.isDefined [
         ''
           nixvim (plugins.alpha):
-          The option definition `plugins.alpha.iconsEnabled' in ${showFiles opt.iconsEnabled.files} has been deprecated; please remove it.
+          The option definition `plugins.alpha.iconsEnabled' in ${lib.showFiles opt.iconsEnabled.files} has been deprecated; please remove it.
           You should use `plugins.alpha.iconsPackage' instead.
         ''
       ];
@@ -198,7 +198,7 @@ in
               });
         in
         ''
-          require('alpha').setup(${helpers.toLuaObject setupOptions})
+          require('alpha').setup(${lib.nixvim.toLuaObject setupOptions})
         '';
     };
 }

--- a/plugins/by-name/alpha/default.nix
+++ b/plugins/by-name/alpha/default.nix
@@ -199,6 +199,7 @@ in
         in
         ''
           require('alpha').setup(${lib.nixvim.toLuaObject setupOptions})
+          require('alpha.term')
         '';
     };
 }

--- a/plugins/by-name/alpha/default.nix
+++ b/plugins/by-name/alpha/default.nix
@@ -27,8 +27,9 @@ let
       val = helpers.mkNullOrOption (
         with helpers.nixvimTypes;
         nullOr (oneOf [
+
           # "button", "text"
-          str
+          (maybeRaw str)
           # "padding"
           int
           (listOf (
@@ -82,7 +83,7 @@ in
       };
 
       layout = mkOption {
-        type = types.listOf sectionType;
+        type = with types; either (maybeRaw str) (listOf sectionType);
         default = [ ];
         description = "List of sections to layout for the dashboard";
         example = [

--- a/tests/test-sources/plugins/by-name/alpha/default.nix
+++ b/tests/test-sources/plugins/by-name/alpha/default.nix
@@ -19,7 +19,7 @@
       layout = [
         {
           type = "terminal";
-          command = "thisisfine";
+          command = "echo 'Welcome to Nixvim!'";
           width = 46;
           height = 25;
           opts = {


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/2273
Resolves https://github.com/nix-community/nixvim/issues/1382

Documentation states that we need to call require('alpha.term') to support a terminal type. Tested without using a terminal type and didn't see any negative side effects to just including it without having to parse through a user's layout configuration. But, in the rewrite it might be nice to properly check if it's even needed. 