### PR TITLE
treewide: avoid passing `pkgs` to our lib

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -33,12 +33,11 @@ let
       ) opt.declarations;
     };
 
-  evaledModules = lib.evalModules {
-    specialArgs = helpers.modules.specialArgsWith {
+  evaledModules = helpers.modules.evalNixvim {
+    extraSpecialArgs = {
       defaultPkgs = pkgs;
     };
     modules = [
-      ../modules/top-level
       { isDocs = true; }
     ];
   };

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -7,7 +7,7 @@ let
   # We overlay a few tweaks into pkgs, for use in the docs
   pkgs = import ./pkgs.nix { inherit system nixpkgs; };
   inherit (pkgs) lib;
-  helpers = import ../lib { inherit lib pkgs; };
+  helpers = import ../lib { inherit lib; };
 
   nixvimPath = toString ./..;
 
@@ -34,7 +34,9 @@ let
     };
 
   evaledModules = lib.evalModules {
-    inherit (helpers.modules) specialArgs;
+    specialArgs = helpers.modules.specialArgsWith {
+      defaultPkgs = pkgs;
+    };
     modules = [
       ../modules/top-level
       { isDocs = true; }

--- a/flake-modules/legacy-packages.nix
+++ b/flake-modules/legacy-packages.nix
@@ -1,8 +1,8 @@
+{ helpers, ... }:
 {
   perSystem =
     {
       pkgs,
-      helpers,
       makeNixvimWithModule,
       ...
     }:

--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -5,11 +5,7 @@
   ...
 }:
 {
-  perSystem =
-    { pkgs, ... }:
-    {
-      _module.args.helpers = import ../lib { inherit lib pkgs; };
-    };
+  _module.args.helpers = import ../lib { inherit lib; };
 
   # TODO: output lib without pkgs at the top-level
   flake.lib = lib.genAttrs config.systems (
@@ -18,6 +14,7 @@
       {
         # NOTE: this is the publicly documented flake output we've had for a while
         check = import ../lib/tests.nix { inherit lib pkgs; };
+        # NOTE: user-facing so we must include the legacy `pkgs` argument
         helpers = import ../lib { inherit lib pkgs; };
       }
     )

--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -1,11 +1,10 @@
-{ self, ... }:
+{ self, helpers, ... }:
 {
   perSystem =
     {
       pkgs,
       pkgsUnfree,
       system,
-      helpers,
       makeNixvimWithModule,
       self',
       ...

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -45,6 +45,7 @@ let
     }@args:
     let
       helpers = import ../lib {
+        # NOTE: must match the user-facing functions, so we still include the `pkgs` argument
         inherit pkgs lib;
         # TODO: deprecate helpers.enableExceptInTests,
         # add a context option e.g. `config.isTest`?

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -46,6 +46,7 @@ in
   config = mkMerge [
     {
       # Make our lib available to the host modules
+      # NOTE: user-facing so we must include the legacy `pkgs` argument
       lib.nixvim = lib.mkDefault (import ../lib { inherit pkgs lib; });
 
       # Make nixvim's "extended" lib available to the host's module args

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -7,6 +7,7 @@ default_pkgs: self:
   module,
 }:
 let
+  # NOTE: user-facing so we must include the legacy `pkgs` argument
   helpers = import ../lib { inherit pkgs lib _nixvimTests; };
 
   inherit (helpers.modules) evalNixvim;


### PR DESCRIPTION
In the two places where our "helpers" lib is exclusively internal (flake module args and building the docs), we no longer supply `pkgs`.

In the other 4 locations, we now note why we still provide a `pkgs` in a comment.

Additionally, this refactors the work done in #2231 by _always_ including the deprecated functions.

When `pkgs` is provided they are wrapped in `lib.warn`; when `pkgs` is missing, they are stubs that `throw` a deprecation message instead.

## Future work

For the `nixpkgs` module, I'm thinking we'll need to supply either a `pkgsPath` (`inputs.nixpkgs`) or our flake `inputs`. This could be optional, but `evalNixvim` may not work as intended when it isn't provided.

If we ever get to the point where the "standalone" wrapper is fully part of our lib, then we may also need to provide the flake outputs (`self`), or at least provide access to the `man-docs` package somehow. Alternatively, the modules could build their own copy of the man-docs.

After 24.11 is stabilised, I plan to drop `pkgs` from our lib, so any uses that currently have a note will also be able to get helpers without first needing a pkgs instance.
