### PR TITLE
treewide: iconsPackage -> plugins enabled

### DIFF
--- a/plugins/by-name/alpha/default.nix
+++ b/plugins/by-name/alpha/default.nix
@@ -51,20 +51,6 @@ let
   };
 in
 {
-  # TODO: added 2024-09-20 remove after 24.11
-  imports = [
-    (lib.mkRemovedOptionModule
-      [
-        "plugins"
-        "alpha"
-        "iconsPackage"
-      ]
-      ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      ''
-    )
-  ];
-
   options = {
     plugins.alpha = {
       enable = lib.mkEnableOption "alpha-nvim";
@@ -167,23 +153,11 @@ in
     lib.mkIf cfg.enable {
 
       # TODO: added 2024-09-20 remove after 24.11
-      warnings = lib.optionals opt.iconsEnabled.isDefined (
-        [
-          ''
-            The option definition `plugins.alpha.iconsEnabled' in ${lib.showFiles opt.iconsEnabled.files} has been deprecated; please remove it.
-          ''
-        ]
-        ++
-          lib.optional
-            (
-              (opt.iconsEnabled.isDefined -> cfg.iconsEnabled)
-              && options.plugins.web-devicons.enable.highestPrio == 1490
-            )
-            ''
-              Nixvim (plugins.alpha) `web-devicons` automatic installation is deprecated.
-              Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-            ''
-      );
+      warnings = lib.optionals opt.iconsEnabled.isDefined [
+        ''
+          The option definition `plugins.alpha.iconsEnabled' in ${lib.showFiles opt.iconsEnabled.files} has been deprecated; please remove it.
+        ''
+      ];
       plugins.web-devicons =
         lib.mkIf
           (

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -1,6 +1,7 @@
 {
+  config,
   lib,
-  pkgs,
+  options,
   ...
 }:
 with lib;
@@ -172,6 +173,17 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           ]
         )
       )
+      # TODO: added 2024-09-20 remove after 24.11
+      (lib.mkRemovedOptionModule
+        [
+          "plugins"
+          "barbar"
+          "iconsPackage"
+        ]
+        ''
+          Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+        ''
+      )
     ]
     ++ (map
       (
@@ -195,11 +207,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     );
 
   extraOptions = {
-    iconsPackage = lib.mkPackageOption pkgs [
-      "vimPlugins"
-      "nvim-web-devicons"
-    ] { nullable = true; };
-
     keymaps = mapAttrs (
       optionName: funcName:
       mkNullOrOption' {
@@ -217,7 +224,18 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    extraPlugins = mkIf (cfg.iconsPackage != null) [ cfg.iconsPackage ];
+    # TODO: added 2024-09-20 remove after 24.11
+    plugins.web-devicons = mkIf (
+      !(
+        config.plugins.mini.enable
+        && config.plugins.mini.modules ? icons
+        && config.plugins.mini.mockDevIcons
+      )
+    ) { enable = mkOverride 1490 true; };
+    warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
+      Nixvim (plugins.barbar) `web-devicons` automatic installation is deprecated.
+      Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+    '';
 
     keymaps = filter (keymap: keymap != null) (
       # TODO: switch to `attrValues cfg.keymaps` when removing the deprecation warnings above:

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -173,17 +173,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           ]
         )
       )
-      # TODO: added 2024-09-20 remove after 24.11
-      (lib.mkRemovedOptionModule
-        [
-          "plugins"
-          "barbar"
-          "iconsPackage"
-        ]
-        ''
-          Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-        ''
-      )
     ]
     ++ (map
       (
@@ -232,10 +221,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         && config.plugins.mini.mockDevIcons
       )
     ) { enable = mkOverride 1490 true; };
-    warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
-      Nixvim (plugins.barbar) `web-devicons` automatic installation is deprecated.
-      Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-    '';
 
     keymaps = filter (keymap: keymap != null) (
       # TODO: switch to `attrValues cfg.keymaps` when removing the deprecation warnings above:

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -162,9 +162,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       (lib.mkRenamedOptionModule (oldHighlightsPath ++ [ "trunkMarker" ]) (
         newHighlightsPath ++ [ "trunc_marker" ]
       ))
-      (lib.mkRemovedOptionModule (basePluginPath ++ [ "iconsPackage" ]) ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      '')
     ]
     ++ mkSettingsRenamedOptionModules basePluginPath optionsPath oldOptions
     ++ mkSettingsRenamedOptionModules oldHighlightsPath newHighlightsPath oldHighlightOptions;
@@ -666,10 +663,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         && config.plugins.mini.mockDevIcons
       )
     ) { enable = lib.mkOverride 1490 true; };
-    warnings = lib.optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
-      Nixvim (plugins.bufferline) `web-devicons` automatic installation is deprecated.
-      Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-    '';
+
     opts.termguicolors = true;
   };
 }

--- a/plugins/by-name/chadtree/default.nix
+++ b/plugins/by-name/chadtree/default.nix
@@ -12,20 +12,6 @@ let
   mkListStr = helpers.defaultNullOpts.mkNullable (types.listOf types.str);
 in
 {
-  # TODO: added 2024-09-20 remove after 24.11
-  imports = [
-    (lib.mkRemovedOptionModule
-      [
-        "plugins"
-        "chadtree"
-        "iconsPackage"
-      ]
-      ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      ''
-    )
-  ];
-
   options.plugins.chadtree = helpers.neovim-plugin.extraOptionsOptions // {
     enable = mkEnableOption "chadtree";
 
@@ -526,17 +512,6 @@ in
           {
             enable = lib.mkOverride 1490 false;
           };
-      warnings =
-        optional
-          (
-            (cfg.theme == null || cfg.theme.iconGlyphSet == "devicons")
-
-            && options.plugins.web-devicons.enable.highestPrio == 1490
-          )
-          ''
-            Nixvim (plugins.chadtree) `web-devicons` automatic installation is deprecated.
-            Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-          '';
 
       extraPlugins = [ cfg.package ];
 

--- a/plugins/by-name/diffview/default.nix
+++ b/plugins/by-name/diffview/default.nix
@@ -81,19 +81,6 @@ let
     };
 in
 {
-  # TODO: added 2024-09-20 remove after 24.11
-  imports = [
-    (lib.mkRemovedOptionModule
-      [
-        "plugins"
-        "diffview"
-        "iconsPackage"
-      ]
-      ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      ''
-    )
-  ];
   options.plugins.diffview =
     with helpers.defaultNullOpts;
     helpers.neovim-plugin.extraOptionsOptions
@@ -844,10 +831,6 @@ in
           && config.plugins.mini.mockDevIcons
         )
       ) { enable = mkOverride 1490 true; };
-      warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
-        Nixvim (plugins.diffview) `web-devicons` automatic installation is deprecated.
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      '';
 
       extraPlugins = [ cfg.package ];
 

--- a/plugins/by-name/fzf-lua/default.nix
+++ b/plugins/by-name/fzf-lua/default.nix
@@ -38,20 +38,6 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   inherit settingsOptions settingsExample;
 
-  # TODO: added 2024-09-20 remove after 24.11
-  imports = [
-    (lib.mkRemovedOptionModule
-      [
-        "plugins"
-        "fzf-lua"
-        "iconsPackage"
-      ]
-      ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      ''
-    )
-  ];
-
   extraOptions = {
     fzfPackage = lib.mkPackageOption pkgs "fzf" {
       nullable = true;
@@ -122,23 +108,11 @@ helpers.neovim-plugin.mkNeovimPlugin {
     in
     {
       # TODO: deprecated 2024-08-29 remove after 24.11
-      warnings = lib.optionals opt.iconsEnabled.isDefined (
-        [
-          ''
-            The option definition `plugins.fzf-lua.iconsEnabled' in ${lib.showFiles opt.iconsEnabled.files} has been deprecated; please remove it.
-          ''
-        ]
-        ++
-          lib.optional
-            (
-              (opt.iconsEnabled.isDefined -> cfg.iconsEnabled)
-              && options.plugins.web-devicons.enable.highestPrio == 1490
-            )
-            ''
-              Nixvim (plugins.fzf-lua) `web-devicons` automatic installation is deprecated.
-              Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-            ''
-      );
+      warnings = lib.optionals opt.iconsEnabled.isDefined [
+        ''
+          The option definition `plugins.fzf-lua.iconsEnabled' in ${lib.showFiles opt.iconsEnabled.files} has been deprecated; please remove it.
+        ''
+      ];
       # TODO: added 2024-09-20 remove after 24.11
       plugins.web-devicons =
         lib.mkIf

--- a/plugins/by-name/lspsaga/default.nix
+++ b/plugins/by-name/lspsaga/default.nix
@@ -44,20 +44,7 @@ in
         "keys"
         "borderStyle"
         "renamePromptPrefix"
-      ]
-    ++ [
-      # TODO: added 2024-09-20 remove after 24.11
-      (lib.mkRemovedOptionModule
-        [
-          "plugins"
-          "lspsaga"
-          "iconsPackage"
-        ]
-        ''
-          Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-        ''
-      )
-    ];
+      ];
 
   options = {
     plugins.lspsaga = helpers.neovim-plugin.extraOptionsOptions // {
@@ -484,21 +471,11 @@ in
         {
           enable = mkOverride 1490 true;
         };
-    warnings =
-      lib.optional
-        (
-          (cfg.ui.devicon == null || cfg.ui.devicon)
-          && options.plugins.web-devicons.enable.highestPrio == 1490
-        )
-        ''
-          Nixvim (plugins.lspsaga) `web-devicons` automatic installation is deprecated.
-          Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-        ''
-      ++ lib.optional (
-        # https://nvimdev.github.io/lspsaga/implement/#default-options
-        (isBool cfg.implement.enable && cfg.implement.enable)
-        && (isBool cfg.symbolInWinbar.enable && !cfg.symbolInWinbar.enable)
-      ) "You have enabled the `implement` module but it requires `symbolInWinbar` to be enabled.";
+    warnings = lib.optional (
+      # https://nvimdev.github.io/lspsaga/implement/#default-options
+      (isBool cfg.implement.enable && cfg.implement.enable)
+      && (isBool cfg.symbolInWinbar.enable && !cfg.symbolInWinbar.enable)
+    ) "You have enabled the `implement` module but it requires `symbolInWinbar` to be enabled.";
 
     extraPlugins = [ cfg.package ];
     extraConfigLua =

--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -3,6 +3,7 @@
   helpers,
   config,
   pkgs,
+  options,
   ...
 }:
 with lib;
@@ -25,6 +26,17 @@ in
     (mkRemovedOptionModule (
       basePluginPath ++ [ "closeFloatsOnEscapeKey" ]
     ) "This option has been removed from upstream.")
+    # TODO: added 2024-09-20 remove after 24.11
+    (lib.mkRemovedOptionModule
+      [
+        "plugins"
+        "neo-tree"
+        "iconsPackage"
+      ]
+      ''
+        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+      ''
+    )
   ];
   options.plugins.neo-tree =
     let
@@ -61,11 +73,6 @@ in
           "neo-tree-nvim"
         ];
       };
-
-      iconsPackage = lib.mkPackageOption pkgs [
-        "vimPlugins"
-        "nvim-web-devicons"
-      ] { nullable = true; };
 
       gitPackage = lib.mkPackageOption pkgs "git" {
         nullable = true;
@@ -1130,9 +1137,22 @@ in
         // cfg.extraOptions;
     in
     mkIf cfg.enable {
+      # TODO: added 2024-09-20 remove after 24.11
+      plugins.web-devicons = mkIf (
+        !(
+          config.plugins.mini.enable
+          && config.plugins.mini.modules ? icons
+          && config.plugins.mini.mockDevIcons
+        )
+      ) { enable = mkOverride 1490 true; };
+      warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
+        Nixvim (plugins.neo-tree) `web-devicons` automatic installation is deprecated.
+        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+      '';
+
       extraPlugins = [
         cfg.package
-      ] ++ lib.optional (cfg.iconsPackage != null) cfg.iconsPackage;
+      ];
 
       extraConfigLua = ''
         require('neo-tree').setup(${helpers.toLuaObject setupOptions})

--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -26,17 +26,6 @@ in
     (mkRemovedOptionModule (
       basePluginPath ++ [ "closeFloatsOnEscapeKey" ]
     ) "This option has been removed from upstream.")
-    # TODO: added 2024-09-20 remove after 24.11
-    (lib.mkRemovedOptionModule
-      [
-        "plugins"
-        "neo-tree"
-        "iconsPackage"
-      ]
-      ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      ''
-    )
   ];
   options.plugins.neo-tree =
     let
@@ -1145,10 +1134,6 @@ in
           && config.plugins.mini.mockDevIcons
         )
       ) { enable = mkOverride 1490 true; };
-      warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
-        Nixvim (plugins.neo-tree) `web-devicons` automatic installation is deprecated.
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      '';
 
       extraPlugins = [
         cfg.package

--- a/plugins/by-name/nvim-tree/default.nix
+++ b/plugins/by-name/nvim-tree/default.nix
@@ -1171,10 +1171,6 @@ in
           && config.plugins.mini.mockDevIcons
         )
       ) { enable = mkOverride 1490 true; };
-      warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
-        Nixvim (plugins.nvim-tree) `web-devicons` automatic installation is deprecated.
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      '';
 
       extraPlugins = [
         cfg.package

--- a/plugins/by-name/telescope/default.nix
+++ b/plugins/by-name/telescope/default.nix
@@ -37,17 +37,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       ]
       "This option no longer has any effect now that the `plugin.telescope.keymaps` implementation uses `<cmd>`."
     )
-    # TODO: added 2024-09-20 remove after 24.11
-    (lib.mkRemovedOptionModule
-      [
-        "plugins"
-        "telescope"
-        "iconsPackage"
-      ]
-      ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      ''
-    )
   ];
 
   extraOptions = {
@@ -115,10 +104,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         && config.plugins.mini.mockDevIcons
       )
     ) { enable = mkOverride 1490 true; };
-    warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
-      Nixvim (plugins.telescope) `web-devicons` automatic installation is deprecated.
-      Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-    '';
 
     extraConfigVim = mkIf (cfg.highlightTheme != null) ''
       let $BAT_THEME = '${cfg.highlightTheme}'

--- a/plugins/by-name/trouble/default.nix
+++ b/plugins/by-name/trouble/default.nix
@@ -13,20 +13,6 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   maintainers = [ maintainers.loicreynier ];
 
-  # TODO: added 2024-09-20 remove after 24.11
-  imports = [
-    (lib.mkRemovedOptionModule
-      [
-        "plugins"
-        "trouble"
-        "iconsPackage"
-      ]
-      ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-      ''
-    )
-  ];
-
   # TODO introduced 2024-03-15: remove 2024-05-15
   optionsRenamedToSettings = [
     "autoClose"
@@ -324,9 +310,5 @@ helpers.neovim-plugin.mkNeovimPlugin {
         && config.plugins.mini.mockDevIcons
       )
     ) { enable = mkOverride 1490 true; };
-    warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
-      Nixvim (plugins.trouble) `web-devicons` automatic installation is deprecated.
-      Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
-    '';
   };
 }

--- a/plugins/by-name/trouble/default.nix
+++ b/plugins/by-name/trouble/default.nix
@@ -1,7 +1,8 @@
 {
+  config,
   lib,
   helpers,
-  pkgs,
+  options,
   ...
 }:
 with lib;
@@ -11,6 +12,20 @@ helpers.neovim-plugin.mkNeovimPlugin {
   package = "trouble-nvim";
 
   maintainers = [ maintainers.loicreynier ];
+
+  # TODO: added 2024-09-20 remove after 24.11
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "plugins"
+        "trouble"
+        "iconsPackage"
+      ]
+      ''
+        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+      ''
+    )
+  ];
 
   # TODO introduced 2024-03-15: remove 2024-05-15
   optionsRenamedToSettings = [
@@ -300,14 +315,18 @@ helpers.neovim-plugin.mkNeovimPlugin {
     '';
   };
 
-  extraOptions = {
-    iconsPackage = lib.mkPackageOption pkgs [
-      "vimPlugins"
-      "nvim-web-devicons"
-    ] { nullable = true; };
-  };
-
   extraConfig = cfg: {
-    extraPlugins = mkIf (cfg.iconsPackage != null) [ cfg.iconsPackage ];
+    # TODO: added 2024-09-20 remove after 24.11
+    plugins.web-devicons = mkIf (
+      !(
+        config.plugins.mini.enable
+        && config.plugins.mini.modules ? icons
+        && config.plugins.mini.mockDevIcons
+      )
+    ) { enable = mkOverride 1490 true; };
+    warnings = optional (options.plugins.web-devicons.enable.highestPrio == 1490) ''
+      Nixvim (plugins.trouble) `web-devicons` automatic installation is deprecated.
+      Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+    '';
   };
 }

--- a/plugins/deprecation.nix
+++ b/plugins/deprecation.nix
@@ -14,6 +14,21 @@ let
     # Added 2024-09-17
     surround = "vim-surround";
   };
+  # Added 2024-09-21; remove after 24.11
+  # `iconsPackage` options were briefly available in the following plugins for ~3 weeks
+  iconsPackagePlugins = [
+    "telescope"
+    "lspsaga"
+    "nvim-tree"
+    "neo-tree"
+    "trouble"
+    "alpha"
+    "diffview"
+    "fzf-lua"
+    "bufferline"
+    "barbar"
+    "chadtree"
+  ];
 in
 {
 
@@ -36,5 +51,36 @@ in
           "plugins"
           new
         ]
-    ) renamed);
+    ) renamed)
+    ++ builtins.map (
+      name:
+      lib.mkRemovedOptionModule
+        [
+          "plugins"
+          name
+          "iconsPackage"
+        ]
+        ''
+          Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons` instead.
+        ''
+    ) iconsPackagePlugins
+    # Show a warning when web-devicons is auto-enabled
+    ++ [
+      (
+        { config, options, ... }:
+        {
+          config = lib.mkIf (options.plugins.web-devicons.enable.highestPrio == 1490) {
+            warnings = [
+              ''
+                Nixvim: `plugins.web-devicons` was enabled automatically because the following plugins are enabled.
+                This behaviour is deprecated. Please explicitly define `plugins.web-devicons.enable` or alternatively enable `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons`.
+                ${lib.concatMapStringsSep "\n" (name: "plugins.${name}") (
+                  builtins.filter (name: config.plugins.${name}.enable) iconsPackagePlugins
+                )}
+              ''
+            ];
+          };
+        }
+      )
+    ];
 }

--- a/templates/simple/config/bufferline.nix
+++ b/templates/simple/config/bufferline.nix
@@ -1,5 +1,6 @@
 {
-  plugins.bufferline = {
-    enable = true;
+  plugins = {
+    bufferline.enable = true;
+    web-devicons.enable = true;
   };
 }

--- a/tests/test-sources/example-configurations/issues.nix
+++ b/tests/test-sources/example-configurations/issues.nix
@@ -139,6 +139,7 @@
         };
       };
       barbar.enable = true;
+      web-devicons.enable = true;
     };
 
     globals.mapleader = " ";

--- a/tests/test-sources/plugins/by-name/alpha/default.nix
+++ b/tests/test-sources/plugins/by-name/alpha/default.nix
@@ -100,11 +100,11 @@
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = false;
     plugins.alpha = {
       enable = true;
       theme = "dashboard";
-      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/barbar/default.nix
+++ b/tests/test-sources/plugins/by-name/barbar/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.barbar.enable = true;
   };
 
   keymappings = {
+    plugins.web-devicons.enable = true;
     plugins.barbar = {
       enable = true;
 
@@ -20,6 +22,7 @@
   };
 
   defaults = {
+    plugins.web-devicons.enable = true;
     plugins.barbar = {
       enable = true;
 
@@ -113,6 +116,7 @@
   };
 
   readme-example = {
+    plugins.web-devicons.enable = true;
     plugins.barbar = {
       enable = true;
 
@@ -220,10 +224,10 @@
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = false;
     plugins.barbar = {
       enable = true;
-      iconsPackage = null;
       settings.icons.filetype.enabled = false;
     };
   };

--- a/tests/test-sources/plugins/by-name/bufferline/default.nix
+++ b/tests/test-sources/plugins/by-name/bufferline/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.bufferline.enable = true;
   };
 
   example = {
+    plugins.web-devicons.enable = true;
     plugins.bufferline = {
       enable = true;
       settings = {
@@ -58,6 +60,7 @@
   };
 
   defaults = {
+    plugins.web-devicons.enable = true;
     plugins.bufferline = {
       enable = true;
       settings = {
@@ -124,10 +127,10 @@
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = false;
     plugins.bufferline = {
       enable = true;
-      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/chadtree/default.nix
+++ b/tests/test-sources/plugins/by-name/chadtree/default.nix
@@ -4,139 +4,142 @@
   };
 
   example = {
-    plugins.chadtree = {
-      enable = true;
+    plugins = {
+      web-devicons.enable = true;
+      chadtree = {
+        enable = true;
 
-      options = {
-        follow = true;
-        mimetypes = {
-          warn = [
-            "audio"
-            "font"
-            "image"
-            "video"
+        options = {
+          follow = true;
+          mimetypes = {
+            warn = [
+              "audio"
+              "font"
+              "image"
+              "video"
+            ];
+            allowExts = [ ".ts" ];
+          };
+          pageIncrement = 5;
+          pollingRate = 2.0;
+          session = true;
+          showHidden = false;
+          versionControl = true;
+          ignore = {
+            nameExact = [
+              ".DS_Store"
+              ".directory"
+              "thumbs.db"
+              ".git"
+            ];
+            nameGlob = [ ];
+            pathGlob = [ ];
+          };
+        };
+        view = {
+          openDirection = "left";
+          sortBy = [
+            "is_folder"
+            "ext"
+            "file_name"
           ];
-          allowExts = [ ".ts" ];
+          width = 40;
+          windowOptions = {
+            cursorline = true;
+            number = false;
+            relativenumber = false;
+            signcolumn = "no";
+            winfixwidth = true;
+            wrap = false;
+          };
         };
-        pageIncrement = 5;
-        pollingRate = 2.0;
-        session = true;
-        showHidden = false;
-        versionControl = true;
-        ignore = {
-          nameExact = [
-            ".DS_Store"
-            ".directory"
-            "thumbs.db"
-            ".git"
-          ];
-          nameGlob = [ ];
-          pathGlob = [ ];
+        theme = {
+          highlights = {
+            ignored = "Comment";
+            bookmarks = "Title";
+            quickfix = "Label";
+            versionControl = "Comment";
+          };
+          iconGlyphSet = "devicons";
+          textColourSet = "env";
+          iconColourSet = "github";
         };
-      };
-      view = {
-        openDirection = "left";
-        sortBy = [
-          "is_folder"
-          "ext"
-          "file_name"
-        ];
-        width = 40;
-        windowOptions = {
-          cursorline = true;
-          number = false;
-          relativenumber = false;
-          signcolumn = "no";
-          winfixwidth = true;
-          wrap = false;
-        };
-      };
-      theme = {
-        highlights = {
-          ignored = "Comment";
-          bookmarks = "Title";
-          quickfix = "Label";
-          versionControl = "Comment";
-        };
-        iconGlyphSet = "devicons";
-        textColourSet = "env";
-        iconColourSet = "github";
-      };
-      keymap = {
-        windowManagement = {
-          quit = [ "q" ];
-          bigger = [
-            "+"
-            "="
-          ];
-          smaller = [
-            "-"
-            "_"
-          ];
-          refresh = [ "<c-r>" ];
-        };
-        rerooting = {
-          changeDir = [ "b" ];
-          changeFocus = [ "c" ];
-          changeFocusUp = [ "C" ];
-        };
-        openFileFolder = {
-          primary = [ "<enter>" ];
-          secondary = [
-            "<tab>"
-            "<2-leftmouse>"
-          ];
-          tertiary = [
-            "<m-enter>"
-            "<middlemouse>"
-          ];
-          vSplit = [ "w" ];
-          hSplit = [ "W" ];
-          openSys = [ "o" ];
-          collapse = [ "o" ];
-        };
-        cursor = {
-          refocus = [ "~" ];
-          jumpToCurrent = [ "J" ];
-          stat = [ "K" ];
-          copyName = [ "y" ];
-          copyBasename = [ "Y" ];
-          copyRelname = [ "<c-y>" ];
-        };
-        filtering = {
-          filter = [ "f" ];
-          clearFilter = [ "F" ];
-        };
-        bookmarks = {
-          bookmarkGoto = [ "m" ];
-        };
-        selecting = {
-          select = [ "s" ];
-          clearSelection = [ "S" ];
-        };
-        fileOperations = {
-          new = [ "a" ];
-          link = [ "A" ];
-          rename = [ "r" ];
-          toggleExec = [ "X" ];
-          copy = [ "p" ];
-          cut = [ "x" ];
-          delete = [ "d" ];
-          trash = [ "t" ];
-        };
-        toggles = {
-          toggleHidden = [ "." ];
-          toggleFollow = [ "u" ];
-          toggleVersionControl = [ "i" ];
+        keymap = {
+          windowManagement = {
+            quit = [ "q" ];
+            bigger = [
+              "+"
+              "="
+            ];
+            smaller = [
+              "-"
+              "_"
+            ];
+            refresh = [ "<c-r>" ];
+          };
+          rerooting = {
+            changeDir = [ "b" ];
+            changeFocus = [ "c" ];
+            changeFocusUp = [ "C" ];
+          };
+          openFileFolder = {
+            primary = [ "<enter>" ];
+            secondary = [
+              "<tab>"
+              "<2-leftmouse>"
+            ];
+            tertiary = [
+              "<m-enter>"
+              "<middlemouse>"
+            ];
+            vSplit = [ "w" ];
+            hSplit = [ "W" ];
+            openSys = [ "o" ];
+            collapse = [ "o" ];
+          };
+          cursor = {
+            refocus = [ "~" ];
+            jumpToCurrent = [ "J" ];
+            stat = [ "K" ];
+            copyName = [ "y" ];
+            copyBasename = [ "Y" ];
+            copyRelname = [ "<c-y>" ];
+          };
+          filtering = {
+            filter = [ "f" ];
+            clearFilter = [ "F" ];
+          };
+          bookmarks = {
+            bookmarkGoto = [ "m" ];
+          };
+          selecting = {
+            select = [ "s" ];
+            clearSelection = [ "S" ];
+          };
+          fileOperations = {
+            new = [ "a" ];
+            link = [ "A" ];
+            rename = [ "r" ];
+            toggleExec = [ "X" ];
+            copy = [ "p" ];
+            cut = [ "x" ];
+            delete = [ "d" ];
+            trash = [ "t" ];
+          };
+          toggles = {
+            toggleHidden = [ "." ];
+            toggleFollow = [ "u" ];
+            toggleVersionControl = [ "i" ];
+          };
         };
       };
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = false;
     plugins.chadtree = {
       enable = true;
-      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/diffview/default.nix
+++ b/tests/test-sources/plugins/by-name/diffview/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.diffview.enable = true;
   };
 
   example = {
+    plugins.web-devicons.enable = true;
     plugins.diffview = {
       enable = true;
 
@@ -162,10 +164,10 @@
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = false;
     plugins.diffview = {
       enable = true;
-      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/fidget/default.nix
+++ b/tests/test-sources/plugins/by-name/fidget/default.nix
@@ -104,6 +104,7 @@
           nvim-tree.enable = true;
         };
       };
+      web-devicons.enable = true;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/fzf-lua/default.nix
+++ b/tests/test-sources/plugins/by-name/fzf-lua/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.fzf-lua.enable = true;
   };
 
   example = {
+    plugins.web-devicons.enable = true;
     plugins.fzf-lua = {
       enable = true;
 
@@ -55,10 +57,10 @@
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = true;
     plugins.fzf-lua = {
       enable = true;
-      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/git-worktree/default.nix
+++ b/tests/test-sources/plugins/by-name/git-worktree/default.nix
@@ -17,6 +17,8 @@
       updateOnChangeCommand = "e .";
       clearJumpsOnChange = true;
     };
+
+    plugins.web-devicons.enable = true;
   };
 
   telescopeDisabled = {

--- a/tests/test-sources/plugins/by-name/harpoon/default.nix
+++ b/tests/test-sources/plugins/by-name/harpoon/default.nix
@@ -70,6 +70,8 @@
         ];
       };
     };
+
+    plugins.web-devicons.enable = true;
   };
 
   telescopeDisabled = {

--- a/tests/test-sources/plugins/by-name/lspsaga/default.nix
+++ b/tests/test-sources/plugins/by-name/lspsaga/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.lspsaga.enable = true;
   };
 
   defaults = {
+    plugins.web-devicons.enable = true;
     plugins.lspsaga = {
       enable = true;
 
@@ -171,10 +173,10 @@
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = false;
     plugins.lspsaga = {
       enable = true;
-      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/neo-tree/default.nix
+++ b/tests/test-sources/plugins/by-name/neo-tree/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.neo-tree.enable = true;
   };
 
   defaults = {
+    plugins.web-devicons.enable = true;
     plugins.neo-tree = {
       enable = true;
 
@@ -439,10 +441,17 @@
   };
 
   no-packages = {
+    plugins.web-devicons.enable = false;
     plugins.neo-tree = {
       enable = true;
-      iconsPackage = null;
       gitPackage = null;
+    };
+  };
+
+  no-icons = {
+    plugins = {
+      web-devicons.enable = false;
+      neo-tree.enable = true;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/neorg/default.nix
+++ b/tests/test-sources/plugins/by-name/neorg/default.nix
@@ -84,6 +84,8 @@
         enable = true;
         modules."core.integrations.telescope".__empty = null;
       };
+
+      web-devicons.enable = true;
     };
   };
 

--- a/tests/test-sources/plugins/by-name/netman/default.nix
+++ b/tests/test-sources/plugins/by-name/netman/default.nix
@@ -12,5 +12,6 @@ pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
       enable = true;
       neoTreeIntegration = true;
     };
+    plugins.web-devicons.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/nvim-tree/default.nix
+++ b/tests/test-sources/plugins/by-name/nvim-tree/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.nvim-tree.enable = true;
   };
 
   defaults = {
+    plugins.web-devicons.enable = true;
     plugins.nvim-tree = {
       enable = true;
 
@@ -258,9 +260,9 @@
   };
 
   no-packages = {
+    plugins.web-devicons.enable = true;
     plugins.nvim-tree = {
       enable = true;
-      iconsPackage = null;
       gitPackage = null;
     };
   };

--- a/tests/test-sources/plugins/by-name/octo/default.nix
+++ b/tests/test-sources/plugins/by-name/octo/default.nix
@@ -3,6 +3,7 @@
     # This test is flaky and fails non-deterministically
     test.runNvim = false;
 
+    plugins.web-devicons.enable = true;
     plugins.octo.enable = true;
   };
 
@@ -10,6 +11,7 @@
     # This test is flaky and fails non-deterministically
     test.runNvim = false;
 
+    plugins.web-devicons.enable = true;
     plugins.octo = {
       enable = true;
 
@@ -30,12 +32,10 @@
     # This test is flaky and fails non-deterministically
     test.runNvim = false;
 
-    plugins = {
-      octo = {
-        enable = true;
-        settings.picker = "fzf-lua";
-      };
-      web-devicons.enable = true;
+    plugins.web-devicons.enable = true;
+    plugins.octo = {
+      enable = true;
+      settings.picker = "fzf-lua";
     };
   };
 
@@ -43,6 +43,7 @@
     # This test is flaky and fails non-deterministically
     test.runNvim = false;
 
+    plugins.web-devicons.enable = true;
     plugins.octo = {
       enable = true;
 
@@ -91,6 +92,7 @@
   no-packages = {
     # Need to add gh executable to runtime path for plugin
     test.runNvim = false;
+    plugins.web-devicons.enable = false;
     plugins.octo = {
       enable = true;
       ghPackage = null;

--- a/tests/test-sources/plugins/by-name/octo/default.nix
+++ b/tests/test-sources/plugins/by-name/octo/default.nix
@@ -1,4 +1,3 @@
-{ pkgs, ... }:
 {
   empty = {
     # This test is flaky and fails non-deterministically
@@ -31,9 +30,12 @@
     # This test is flaky and fails non-deterministically
     test.runNvim = false;
 
-    plugins.octo = {
-      enable = true;
-      settings.picker = "fzf-lua";
+    plugins = {
+      octo = {
+        enable = true;
+        settings.picker = "fzf-lua";
+      };
+      web-devicons.enable = true;
     };
   };
 

--- a/tests/test-sources/plugins/by-name/package-info/default.nix
+++ b/tests/test-sources/plugins/by-name/package-info/default.nix
@@ -37,6 +37,8 @@
         enable = true;
         enableTelescope = true;
       };
+
+      web-devicons.enable = true;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/project-nvim/default.nix
+++ b/tests/test-sources/plugins/by-name/project-nvim/default.nix
@@ -11,6 +11,7 @@
       enable = true;
       enableTelescope = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   defaults = {

--- a/tests/test-sources/plugins/by-name/refactoring/default.nix
+++ b/tests/test-sources/plugins/by-name/refactoring/default.nix
@@ -35,6 +35,8 @@
       enable = true;
       enableTelescope = true;
     };
+
+    plugins.web-devicons.enable = true;
   };
 
   defaults = {

--- a/tests/test-sources/plugins/by-name/telescope/default.nix
+++ b/tests/test-sources/plugins/by-name/telescope/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.telescope.enable = true;
   };
 
   example = {
+    plugins.web-devicons.enable = true;
     plugins.telescope = {
       enable = true;
 
@@ -19,6 +21,7 @@
   };
 
   combine-plugins = {
+    plugins.web-devicons.enable = true;
     plugins.telescope.enable = true;
 
     performance.combinePlugins.enable = true;
@@ -32,10 +35,19 @@
   };
 
   no-packages = {
+    plugins.web-devicons.enable = false;
     plugins.telescope = {
       enable = true;
       batPackage = null;
-      iconsPackage = null;
     };
+  };
+
+  mini-icons = {
+    plugins.mini = {
+      enable = true;
+      mockDevIcons = true;
+      modules.icons = { };
+    };
+    plugins.telescope.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/file-browser.nix
+++ b/tests/test-sources/plugins/by-name/telescope/file-browser.nix
@@ -4,6 +4,7 @@
       enable = true;
       extensions.file-browser.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   defaults = {
@@ -82,5 +83,6 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/frecency.nix
+++ b/tests/test-sources/plugins/by-name/telescope/frecency.nix
@@ -7,6 +7,7 @@
       enable = true;
       extensions.frecency.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   defaults = {
@@ -42,6 +43,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   example = {
@@ -72,5 +74,6 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/fzf-native.nix
+++ b/tests/test-sources/plugins/by-name/telescope/fzf-native.nix
@@ -4,6 +4,7 @@
       enable = true;
       extensions.fzf-native.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   defaults = {
@@ -21,6 +22,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   combine-plugins = {
@@ -28,6 +30,7 @@
       enable = true;
       extensions.fzf-native.enable = true;
     };
+    plugins.web-devicons.enable = true;
 
     performance.combinePlugins.enable = true;
   };

--- a/tests/test-sources/plugins/by-name/telescope/fzy-native.nix
+++ b/tests/test-sources/plugins/by-name/telescope/fzy-native.nix
@@ -4,6 +4,7 @@
       enable = true;
       extensions.fzy-native.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   example = {
@@ -19,6 +20,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   combine-plugins = {
@@ -27,6 +29,7 @@
       extensions.fzy-native.enable = true;
     };
 
+    plugins.web-devicons.enable = true;
     performance.combinePlugins.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/live-grep-args.nix
+++ b/tests/test-sources/plugins/by-name/telescope/live-grep-args.nix
@@ -5,6 +5,7 @@
       enable = true;
       extensions.live-grep-args.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   default = {
@@ -20,6 +21,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   example = {
@@ -42,6 +44,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   custom-packages = {
@@ -53,6 +56,7 @@
         grepPackage = pkgs.gnugrep;
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   no-packages = {
@@ -64,5 +68,6 @@
         grepPackage = null;
       };
     };
+    plugins.web-devicons.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/manix.nix
+++ b/tests/test-sources/plugins/by-name/telescope/manix.nix
@@ -4,6 +4,7 @@
       enable = true;
       extensions.manix.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   default = {
@@ -19,6 +20,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   example = {
@@ -34,6 +36,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   no-packages = {
@@ -45,5 +48,6 @@
         manixPackage = null;
       };
     };
+    plugins.web-devicons.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/media-files.nix
+++ b/tests/test-sources/plugins/by-name/telescope/media-files.nix
@@ -5,6 +5,7 @@
       enable = true;
       extensions.media-files.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   defaults = {
@@ -28,6 +29,7 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 
   dependencies = {
@@ -47,5 +49,6 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/ui-select.nix
+++ b/tests/test-sources/plugins/by-name/telescope/ui-select.nix
@@ -4,6 +4,7 @@
       enable = true;
       extensions.ui-select.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   example = {
@@ -18,5 +19,6 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/undo.nix
+++ b/tests/test-sources/plugins/by-name/telescope/undo.nix
@@ -4,6 +4,7 @@
       enable = true;
       extensions.undo.enable = true;
     };
+    plugins.web-devicons.enable = true;
   };
 
   example = {
@@ -39,5 +40,6 @@
         };
       };
     };
+    plugins.web-devicons.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/todo-comments/default.nix
+++ b/tests/test-sources/plugins/by-name/todo-comments/default.nix
@@ -164,6 +164,7 @@
           };
         };
       };
+      web-devicons.enable = true;
     };
   };
 

--- a/tests/test-sources/plugins/by-name/todo-comments/default.nix
+++ b/tests/test-sources/plugins/by-name/todo-comments/default.nix
@@ -187,6 +187,7 @@
           };
         };
       };
+      plugins.web-devicons.enable = true;
     };
 
   without-ripgrep = {

--- a/tests/test-sources/plugins/by-name/trouble/default.nix
+++ b/tests/test-sources/plugins/by-name/trouble/default.nix
@@ -1,9 +1,11 @@
 {
   empty = {
+    plugins.web-devicons.enable = true;
     plugins.trouble.enable = true;
   };
 
   lsp = {
+    plugins.web-devicons.enable = true;
     plugins.lsp = {
       enable = true;
       servers.clangd.enable = true;
@@ -13,6 +15,7 @@
   };
 
   defaults = {
+    plugins.web-devicons.enable = true;
     plugins.trouble = {
       enable = true;
 
@@ -78,10 +81,10 @@
     };
   };
 
-  no-packages = {
+  no-icons = {
+    plugins.web-devicons.enable = false;
     plugins.trouble = {
       enable = true;
-      iconsPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/yanky/default.nix
+++ b/tests/test-sources/plugins/by-name/yanky/default.nix
@@ -11,6 +11,8 @@
         enable = true;
         enableTelescope = true;
       };
+
+      web-devicons.enable = true;
     };
   };
 
@@ -66,6 +68,7 @@
       sqlite-lua.enable = true;
       telescope.enable = true;
 
+      web-devicons.enable = true;
       yanky = {
         enable = true;
 

--- a/tests/test-sources/plugins/utils/rest.nix
+++ b/tests/test-sources/plugins/utils/rest.nix
@@ -109,6 +109,7 @@
       };
       treesitter.enable = true;
       telescope.enable = true;
+      web-devicons.enable = true;
     };
   };
 }


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/2119

Just wanted to double check if we wanted to do something like this that we did for sqlite-lua transition before I implement this in all the packages that I added iconsPackage to in https://github.com/nix-community/nixvim/pull/2112

With this approach, we will make it easier for a user to toggle between `nvim-web-devicons` and `mini.icons` since they can explicitly enable/disable either plugin. The default is still to use `nvim-web-devicons` to be a transition period of the old behavior. A user can explicitly disable the plugin and enable mini.icons and it will switch to using that instead. 