### PR TITLE
plugins/otter: Remove cmp

### DIFF
--- a/plugins/by-name/otter/default.nix
+++ b/plugins/by-name/otter/default.nix
@@ -19,9 +19,17 @@ helpers.neovim-plugin.mkNeovimPlugin {
         "otter"
         "addCmpSources"
       ]
-      "Otter is now supported by `plugins.cmp.autoEnableSources`, adding `otter` to `cmp` sources will enable this plugin."
+      ''
+        You should use the "cmp-nvim-lsp" source instead.
+        To quote upstream's README:
+        > If you previously used the otter nvim-cmp source, you can remove it, as the completion results now come directly via the cmp-nvim-lsp source together with other language servers.
+      ''
     )
+
     # Register nvim-cmp association
+    # TODO: Otter is no longer a cmp-source
+    # Deprecated 2024-09-22; remove after 24.11
+    # Note: a warning is implemented in plugins/cmp/auto-enable.nix
     { cmpSourcePlugins.otter = "otter"; }
   ];
 

--- a/plugins/cmp/auto-enable.nix
+++ b/plugins/cmp/auto-enable.nix
@@ -69,6 +69,11 @@ in
           If you want to keep using raw lua for defining your sources:
           - Ensure you enable the relevant plugins manually in your configuration;
           - Dismiss this warning by explicitly setting `autoEnableSources` to `false`;
+        ''
+        # TODO: Added 2024-09-22; remove after 24.11
+        ++ optional (elem "otter" enabledSources) ''
+          Nixvim (plugins.cmp): "otter" is listed in `settings.sources`, however it is no longer a cmp source.
+          Instead, you should enable `plugins.otter` and use the "cmp-nvim-lsp" completion source.
         '';
 
       # If the user has enabled the `foo` and `bar` sources, then `plugins` will look like:


### PR DESCRIPTION
Cmp integration is no longer needed for this plugin.
Here is a quote from their README:

> If you previously used the otter nvim-cmp source, you can remove it, as the completion results now come directly via the cmp-nvim-lsp source together with other language servers.


Fixes #2243