### PR TITLE
lib/types/pluginLuaConfig: only merge `pre` and `post` when defined

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -116,19 +116,23 @@ rec {
 
   pluginLuaConfig = types.submodule (
     { config, ... }:
+    let
+      inherit (builtins) toString;
+      inherit (lib.nixvim.utils) mkBeforeSection mkAfterSection;
+    in
     {
       options = {
         pre = lib.mkOption {
-          type = types.lines;
-          default = "";
+          type = with types; nullOr lines;
+          default = null;
           description = ''
             Lua code inserted at the start of the plugin's configuration.
             This is the same as using `lib.nixvim.utils.mkBeforeSection` when defining `content`.
           '';
         };
         post = lib.mkOption {
-          type = types.lines;
-          default = "";
+          type = with types; nullOr lines;
+          default = null;
           description = ''
             Lua code inserted at the end of the plugin's configuration.
             This is the same as using `lib.nixvim.utils.mkAfterSection` when defining `content`.
@@ -137,13 +141,19 @@ rec {
         content = lib.mkOption {
           type = types.lines;
           default = "";
-          description = "Configuration of the plugin";
+          description = ''
+            Configuration of the plugin.
+
+            If `pre` and/or `post` are non-null, they will be merged using the order priorities
+            ${toString (mkBeforeSection null).priority} and ${toString (mkBeforeSection null).priority}
+            respectively.
+          '';
         };
       };
 
       config.content = lib.mkMerge [
-        (lib.nixvim.utils.mkBeforeSection config.pre)
-        (lib.nixvim.utils.mkAfterSection config.post)
+        (lib.mkIf (config.pre != null) (mkBeforeSection config.pre))
+        (lib.mkIf (config.post != null) (mkAfterSection config.post))
       ];
     }
   );


### PR DESCRIPTION
Follow up to https://github.com/nix-community/nixvim/pull/1876#discussion_r1770586071

- Have `pre` and `post` default to `null`
- Only merge them into `content` when non-null
- Mention this in `content`'s description

cc @traxys
