### PR TITLE
lib/types/pluginLuaConfig: use `lib.optional` instead of `lib.mkIf`

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -151,10 +151,10 @@ rec {
         };
       };
 
-      config.content = lib.mkMerge [
-        (lib.mkIf (config.pre != null) (mkBeforeSection config.pre))
-        (lib.mkIf (config.post != null) (mkAfterSection config.post))
-      ];
+      config.content = lib.mkMerge (
+        lib.optional (config.pre != null) (mkBeforeSection config.pre)
+        ++ lib.optional (config.post != null) (mkAfterSection config.post)
+      );
     }
   );
 }


### PR DESCRIPTION
This may slightly increase performance by reducing work done by the module system.

Recommended by @stasjok in https://github.com/nix-community/nixvim/pull/2294#issuecomment-2369115145

I don't really know a good way to test performance here though. I guess I'll re-read [Nix Evaluation Performance](https://nixos.wiki/wiki/Nix_Evaluation_Performance) and skim over https://www.youtube.com/watch?v=LXhYWEuwigo again...
