### PR TITLE
tests/package-options: allow option defaults to throw

### DIFF
--- a/tests/package-options.nix
+++ b/tests/package-options.nix
@@ -32,7 +32,11 @@ let
       internal ? false,
       ...
     }:
-    visible && !internal && isDerivation default
+    let
+      # Some options have defaults that throw when evaluated
+      default' = (builtins.tryEval default).value;
+    in
+    visible && !internal && isDerivation default'
   ) options;
 
   # Bad options do not use `literalExpression` in their `defaultText`,


### PR DESCRIPTION
This is often an intended behaviour, so just assume any option whose default throws is not a package-type option

Extracted from #2022
