### PR TITLE
modules/misc: include `assertions` and `meta` modules in the repo

### DIFF
--- a/modules/misc/assertions.nix
+++ b/modules/misc/assertions.nix
@@ -1,0 +1,34 @@
+{ lib, ... }:
+# Based on https://github.com/NixOS/nixpkgs/blob/814a4e48/nixos/modules/misc/assertions.nix
+{
+  options = {
+    assertions = lib.mkOption {
+      type = with lib.types; listOf unspecified;
+      internal = true;
+      default = [ ];
+      example = [
+        {
+          assertion = false;
+          message = "you can't enable this for that reason";
+        }
+      ];
+      description = ''
+        This option allows modules to express conditions that must
+        hold for the evaluation of the system configuration to
+        succeed, along with associated error messages for the user.
+      '';
+    };
+
+    warnings = lib.mkOption {
+      internal = true;
+      default = [ ];
+      type = with lib.types; listOf str;
+      example = [ "The `foo' service is deprecated and will go away soon!" ];
+      description = ''
+        This option allows modules to show warnings to users during
+        the evaluation of the system configuration.
+      '';
+    };
+  };
+  # implementation of assertions is in lib/modules.nix
+}

--- a/modules/misc/default.nix
+++ b/modules/misc/default.nix
@@ -1,15 +1,9 @@
-{ defaultPkgs, ... }:
-let
-  # We can't use config._module.args to define imports,
-  # so we're forced to use specialArgs.defaultPkgs's path
-  nixosModules = defaultPkgs.path + "/nixos/modules/";
-in
 {
   imports = [
+    ./assertions.nix
     ./context.nix
+    ./meta.nix
     ./nixpkgs.nix
     ./nixvim-info.nix
-    (nixosModules + "/misc/assertions.nix")
-    (nixosModules + "/misc/meta.nix")
   ];
 }

--- a/modules/misc/meta.nix
+++ b/modules/misc/meta.nix
@@ -1,0 +1,56 @@
+{ lib, ... }:
+# Based on https://github.com/NixOS/nixpkgs/blob/814a4e48/nixos/modules/misc/meta.nix
+let
+  maintainer = lib.mkOptionType {
+    name = "maintainer";
+    check = m: lib.elem m (lib.attrValues lib.maintainers);
+    merge =
+      loc: defs:
+      let
+        def = lib.last defs;
+      in
+      {
+        ${def.file} = def.value;
+      };
+  };
+
+  listOfMaintainers = lib.types.listOf maintainer // {
+    # Returns attrset of
+    #   { "module-file" = [
+    #        "maintainer1 <first@nixos.org>"
+    #        "maintainer2 <second@nixos.org>" ];
+    #   }
+    merge =
+      loc: defs:
+      lib.pipe defs [
+        (lib.imap1 (
+          n: def:
+          lib.imap1 (
+            m: value:
+            maintainer.merge (loc ++ [ "[${toString n}-${toString m}]" ]) [
+              {
+                inherit (def) file;
+                inherit value;
+              }
+            ]
+          ) def.value
+        ))
+        lib.flatten
+        lib.zipAttrs
+      ];
+  };
+in
+{
+  options.meta = {
+    maintainers = lib.mkOption {
+      type = listOfMaintainers;
+      internal = true;
+      default = [ ];
+      example = lib.literalExpression "[ lib.maintainers.all ]";
+      description = ''
+        List of maintainers of each module.  This option should be defined at
+        most once per module.
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Based on the modules we previously imported from NixOS. I've re-formatted the files, removed `with lib` and re-wrote a couple things to better fit the code-style in nixvim. You can view the upstream files for comparison:
- https://github.com/NixOS/nixpkgs/blob/814a4e48/nixos/modules/misc/assertions.nix
- https://github.com/NixOS/nixpkgs/blob/814a4e48/nixos/modules/misc/meta.nix

This will allow us to drop the `defaultPkgs` specialArg and avoids needing the proposed `pkgsPath` specialArg.

It could also lead to future divergence from upstream (intended or otherwise), for example as suggested in #2309.