### PR TITLE
plugins/luasnip: fix function name `extend_filetypes` to `filetype_extend`

### DIFF
--- a/plugins/by-name/luasnip/default.nix
+++ b/plugins/by-name/luasnip/default.nix
@@ -192,7 +192,7 @@ in
           ];
 
       filetypeExtendConfig = mapAttrsToList (n: v: ''
-        require("luasnip").extend_filetypes("${n}", ${helpers.toLuaObject v})
+        require("luasnip").filetype_extend("${n}", ${helpers.toLuaObject v})
       '') cfg.filetypeExtend;
 
       extraConfig = [


### PR DESCRIPTION
Follow up to #1987, fixes #2303 