### PR TITLE
modules/output: move outputs to `build` scope

### DIFF
--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -30,7 +30,7 @@ let
           );
       };
     in
-    result.config.test.derivation;
+    result.config.build.test;
 
   # Create a nix derivation from a nixvim configuration.
   # The build phase simply consists in running neovim with the given configuration.
@@ -71,7 +71,7 @@ let
         check = false;
       };
     in
-    result.config.test.derivation;
+    result.config.build.test;
 in
 # NOTE: this is exported publicly in the flake outputs as `lib.<system>.check`
 {

--- a/modules/top-level/default.nix
+++ b/modules/top-level/default.nix
@@ -8,6 +8,7 @@
     ../.
     ./files
     ./output.nix
+    ./readonly-renames.nix
     ./test.nix
   ];
 

--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -36,7 +36,7 @@ in
       };
     };
 
-    filesPlugin = lib.mkOption {
+    build.extraFiles = lib.mkOption {
       type = types.package;
       description = "A derivation with all the files inside.";
       internal = true;
@@ -68,7 +68,7 @@ in
 
       # A directory with all the files in it
       # Implementation based on NixOS's /etc module
-      filesPlugin = pkgs.runCommandLocal "nvim-config" { } ''
+      build.extraFiles = pkgs.runCommandLocal "nvim-config" { } ''
         set -euo pipefail
 
         makeEntry() {
@@ -91,6 +91,6 @@ in
       '';
 
       # Never combine user files with the rest of the plugins
-      performance.combinePlugins.standalonePlugins = [ config.filesPlugin ];
+      performance.combinePlugins.standalonePlugins = [ config.build.extraFiles ];
     };
 }

--- a/modules/top-level/readonly-renames.nix
+++ b/modules/top-level/readonly-renames.nix
@@ -1,0 +1,41 @@
+{ lib, options, ... }:
+let
+  # Recursively maps an attrset of option-refs into an attrset of option alias declarations.
+  #
+  # NOTE: `mkRenameOptionModule` is not appropriate for readOnly options, and we don't need a full two-way alias anyway (since it is read only).
+  toReadOnlyRenameOptions =
+    let
+      mkAlias =
+        from: toOpt:
+        assert lib.assertMsg toOpt.readOnly
+          "toReadOnlyRenameOptions used on non-readOnly option `${lib.showOption toOpt.loc}'.";
+        assert lib.assertMsg toOpt.isDefined
+          "toReadOnlyRenameOptions used on undefined option `${lib.showOption toOpt.loc}'.";
+        lib.mkOption {
+          inherit (toOpt) type;
+          default = toOpt.value;
+          apply = lib.warn "Obsolete option `${lib.showOption from}' is used. It was renamed to `${lib.showOption toOpt.loc}'.";
+          description = "Alias of {option}`${lib.showOption toOpt.loc}`.";
+          readOnly = true;
+          visible = false;
+        };
+
+      go =
+        path: name: opt:
+        let
+          loc = path ++ lib.singleton name;
+        in
+        if lib.isOption opt then mkAlias loc opt else lib.mapAttrs (go loc) opt;
+    in
+    lib.mapAttrs (go [ ]);
+in
+{
+  # TODO: Added 2024-09-24; remove after 24.11
+  options = toReadOnlyRenameOptions {
+    inherit (options.build) printInitPackage;
+    finalPackage = options.build.package;
+    initPath = options.build.initFile;
+    filesPlugin = options.build.extraFiles;
+    test.derivation = options.build.test;
+  };
+}

--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -36,9 +36,10 @@ in
       description = "Whether to check `config.assertions` in the test.";
       default = true;
     };
+  };
 
-    # Output
-    derivation = lib.mkOption {
+  options.build = {
+    test = lib.mkOption {
       type = lib.types.package;
       description = ''
         A derivation that tests the config by running neovim.
@@ -66,10 +67,10 @@ in
       ) "" toCheck;
     in
     {
-      test.derivation =
+      build.test =
         pkgs.runCommandNoCCLocal cfg.name
           {
-            nativeBuildInputs = [ config.finalPackage ];
+            nativeBuildInputs = [ config.build.package ];
 
             # Allow inspecting the test's module a little from the repl
             # e.g.

--- a/tests/extra-files.nix
+++ b/tests/extra-files.nix
@@ -14,7 +14,7 @@ let
 in
 pkgs.runCommand "extra-files-test"
   {
-    root = build.config.filesPlugin;
+    root = build.config.build.extraFiles;
     files = builtins.attrNames extraFiles;
   }
   ''

--- a/tests/test-sources/modules/performance/byte-compile-lua.nix
+++ b/tests/test-sources/modules/performance/byte-compile-lua.nix
@@ -90,7 +90,7 @@ in
         assert(is_byte_compiled(init), "MYVIMRC is expected to be byte compiled, but it's not")
 
         -- nixvim-print-init prints text
-        local init_content = vim.fn.system("${config.printInitPackage}/bin/nixvim-print-init")
+        local init_content = vim.fn.system("${lib.getExe config.build.printInitPackage}")
         assert(init_content:find("VALIDATING_STRING"), "nixvim-print-init's output is byte compiled")
 
         -- lua extraFiles are byte compiled
@@ -116,7 +116,11 @@ in
     };
 
   disabled =
-    { config, ... }:
+    {
+      config,
+      lib,
+      ...
+    }:
     {
       performance.byteCompileLua.enable = false;
 
@@ -140,7 +144,7 @@ in
         assert(not is_byte_compiled(init), "MYVIMRC is not expected to be byte compiled, but it is")
 
         -- nixvim-print-init prints text
-        local init_content = vim.fn.system("${config.printInitPackage}/bin/nixvim-print-init")
+        local init_content = vim.fn.system("${lib.getExe config.build.printInitPackage}")
         assert(init_content:find("VALIDATING_STRING"), "nixvim-print-init's output is byte compiled")
 
         -- Nothing is byte compiled

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -2,10 +2,10 @@
 let
   inherit (pkgs) lib;
 
-  # Count plugins of given type excluding 'filesPlugin'
+  # Count plugins of given type excluding 'build.extraFiles'
   pluginCount =
-    pkg: filesPlugin: type:
-    builtins.length (builtins.filter (p: p != filesPlugin) pkg.packpathDirs.myNeovimPackages.${type});
+    pkg: files: type:
+    builtins.length (builtins.filter (p: p != files) pkg.packpathDirs.myNeovimPackages.${type});
 in
 {
   # Test basic functionality
@@ -33,7 +33,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 1;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs, expected one plugin pack.";
         }
       ];
@@ -50,7 +50,7 @@ in
       ];
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" >= 2;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" >= 2;
           message = "Only one plugin is defined in packpathDirs, expected at least two.";
         }
       ];
@@ -77,7 +77,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 1;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -105,7 +105,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 1;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -132,7 +132,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 1;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -186,11 +186,11 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 1;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "opt" == 2;
+          assertion = pluginCount config.build.package config.build.extraFiles "opt" == 2;
           message = "Less than two opt plugins are defined in packpathDirs";
         }
       ];
@@ -233,13 +233,13 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 1;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
       ];
     };
 
-  # Test that config.filesPlugin is not combined
+  # Test that config.build.extraFiles is not combined
   files-plugin =
     { config, ... }:
     {
@@ -248,7 +248,7 @@ in
         nvim-treesitter
         vim-nix
       ];
-      # Ensure that filesPlugin is added extraPlugins
+      # Ensure that build.extraFiles is added extraPlugins
       wrapRc = true;
       # Extra user files colliding with plugins
       extraFiles = {
@@ -287,23 +287,23 @@ in
         assert(#get_paths("ftdetect/nix.vim") == 2, "only one version of ftdetect/nix.vim")
         assert(#get_paths("queries/nix/highlights.scm") == 2, "only one version of queries/nix/highlights.scm")
 
-        -- First found file is from filesPlugin
+        -- First found file is from build.extraFiles
         assert(
-          get_paths("ftplugin/nix.vim")[1]:find("${lib.getName config.filesPlugin}", 1, true),
-          "first found ftplugin/nix.vim isn't in filesPlugin runtime path"
+          get_paths("ftplugin/nix.vim")[1]:find("${lib.getName config.build.extraFiles}", 1, true),
+          "first found ftplugin/nix.vim isn't in build.extraFiles runtime path"
         )
         assert(
-          get_paths("queries/nix/highlights.scm")[1]:find("${lib.getName config.filesPlugin}", 1, true),
-          "first found queries/nix/highlights.scm isn't in filesPlugin runtime path"
+          get_paths("queries/nix/highlights.scm")[1]:find("${lib.getName config.build.extraFiles}", 1, true),
+          "first found queries/nix/highlights.scm isn't in build.extraFiles runtime path"
         )
         assert(
-          get_paths("queries/nix/highlights.scm")[1]:find("${lib.getName config.filesPlugin}", 1, true),
-          "first found queries/nix/highlights.scm isn't in filesPlugin runtime path"
+          get_paths("queries/nix/highlights.scm")[1]:find("${lib.getName config.build.extraFiles}", 1, true),
+          "first found queries/nix/highlights.scm isn't in build.extraFiles runtime path"
         )
       '';
       assertions = [
         {
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 1;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
       ];
@@ -369,7 +369,7 @@ in
       assertions = [
         {
           # plugin-pack, nvim-treesitter, nvim-lspconfig, telescope-nvim, nvim-cmp
-          assertion = pluginCount config.finalPackage config.filesPlugin "start" == 5;
+          assertion = pluginCount config.build.package config.build.extraFiles "start" == 5;
           message = "Wrong number of plugins in packpathDirs";
         }
       ];

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -74,7 +74,7 @@ in
             ) extraFiles
           )
           // {
-            ${filesPrefix + initName}.source = cfg.initPath;
+            ${filesPrefix + initName}.source = cfg.build.initFile;
           }
         )
       )

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -41,8 +41,8 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [
-      cfg.finalPackage
-      cfg.printInitPackage
+      cfg.build.package
+      cfg.build.printInitPackage
     ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
   };
 }

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -55,8 +55,8 @@ in
 
   config = mkIf cfg.enable {
     home.packages = [
-      cfg.finalPackage
-      cfg.printInitPackage
+      cfg.build.package
+      cfg.build.printInitPackage
     ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
 
     home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -49,8 +49,8 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [
-      cfg.finalPackage
-      cfg.printInitPackage
+      cfg.build.package
+      cfg.build.printInitPackage
     ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
 
     environment.variables = {

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -23,13 +23,13 @@ let
           defaultPkgs = pkgs;
         } // extraSpecialArgs;
       };
-      inherit (nixvimConfig.config) enableMan finalPackage printInitPackage;
+      inherit (nixvimConfig.config) enableMan build;
     in
     (pkgs.symlinkJoin {
       name = "nixvim";
       paths = [
-        finalPackage
-        printInitPackage
+        build.package
+        build.printInitPackage
       ] ++ pkgs.lib.optional enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
       meta.mainProgram = "nvim";
     })


### PR DESCRIPTION
- **modules/output: move outputs to `build` scope**
- **modules/output: add `build.initSource` option**

This PR refactors our output options by moving anything we're "building" to `config.build.*`. This is also used as an opportunity to rename some of the options. Feedback on the names chosen is appreciated!

The intention is adding some structure to our output options, allowing for growth without things getting too messy..

#2313 is also based on this, since otherwise I'd have to re-write it to resolve merge conflicts.