### PR TITLE
wrappers: use `(evalModules {}).type` for nixvim submodule

### DIFF
--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -10,7 +10,6 @@ let
   inherit (lib) types;
 
   fileModuleType = types.submoduleWith {
-    shorthandOnlyDefinesConfig = true;
     inherit specialArgs;
     # Don't include the modules in the docs, as that'd be redundant
     modules = lib.optionals (!config.isDocs) [

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -16,22 +16,22 @@ let
     types
     ;
   cfg = config.programs.nixvim;
+  nixvimConfig = config.lib.nixvim.modules.evalNixvim {
+    extraSpecialArgs = {
+      defaultPkgs = pkgs;
+      darwinConfig = config;
+    };
+    modules = [
+      ./modules/darwin.nix
+    ];
+    check = false;
+  };
 in
 {
   options = {
     programs.nixvim = mkOption {
+      inherit (nixvimConfig) type;
       default = { };
-      type = types.submoduleWith {
-        shorthandOnlyDefinesConfig = true;
-        specialArgs = config.lib.nixvim.modules.specialArgsWith {
-          defaultPkgs = pkgs;
-          darwinConfig = config;
-        };
-        modules = [
-          ./modules/darwin.nix
-          ../modules/top-level
-        ];
-      };
     };
   };
 

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -15,22 +15,22 @@ let
     types
     ;
   cfg = config.programs.nixvim;
+  nixvimConfig = config.lib.nixvim.modules.evalNixvim {
+    extraSpecialArgs = {
+      defaultPkgs = pkgs;
+      hmConfig = config;
+    };
+    modules = [
+      ./modules/hm.nix
+    ];
+    check = false;
+  };
 in
 {
   options = {
     programs.nixvim = mkOption {
+      inherit (nixvimConfig) type;
       default = { };
-      type = types.submoduleWith {
-        shorthandOnlyDefinesConfig = true;
-        specialArgs = config.lib.nixvim.modules.specialArgsWith {
-          defaultPkgs = pkgs;
-          hmConfig = config;
-        };
-        modules = [
-          ./modules/hm.nix
-          ../modules/top-level
-        ];
-      };
     };
   };
 

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -16,22 +16,22 @@ let
     types
     ;
   cfg = config.programs.nixvim;
+  nixvimConfig = config.lib.nixvim.modules.evalNixvim {
+    extraSpecialArgs = {
+      defaultPkgs = pkgs;
+      nixosConfig = config;
+    };
+    modules = [
+      ./modules/nixos.nix
+    ];
+    check = false;
+  };
 in
 {
   options = {
     programs.nixvim = mkOption {
+      inherit (nixvimConfig) type;
       default = { };
-      type = types.submoduleWith {
-        shorthandOnlyDefinesConfig = true;
-        specialArgs = config.lib.nixvim.modules.specialArgsWith {
-          defaultPkgs = pkgs;
-          nixosConfig = config;
-        };
-        modules = [
-          ./modules/nixos.nix
-          ../modules/top-level
-        ];
-      };
     };
   };
 

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -15,7 +15,7 @@ let
   mkNvim =
     mod:
     let
-      evaledModule = evalNixvim {
+      nixvimConfig = evalNixvim {
         modules = [
           mod
           ./modules/standalone.nix
@@ -24,7 +24,7 @@ let
           defaultPkgs = pkgs;
         } // extraSpecialArgs;
       };
-      inherit (evaledModule.config) enableMan finalPackage printInitPackage;
+      inherit (nixvimConfig.config) enableMan finalPackage printInitPackage;
     in
     (pkgs.symlinkJoin {
       name = "nixvim";
@@ -35,7 +35,7 @@ let
       meta.mainProgram = "nvim";
     })
     // rec {
-      inherit (evaledModule) config options;
+      inherit (nixvimConfig) config options;
       extend =
         extension:
         mkNvim {


### PR DESCRIPTION
This simplifies the wrapper modules, adding a little consistency.

Rather than passing all the same stuff to `types.submoduleWith` that we do internally in `evalNixvim`, we can just use `evalNixvim` itself and then inherit its [`type`](https://github.com/NixOS/nixpkgs/blob/b4cde4d7f1fc84f6ff41ad165dab793dedaedfa0/lib/modules.nix#L327-L329) output.

This also means `modules.specialArgsWith` is now entirely internal and could be removed from out public API before we branch off 24.11.

This also fixes #2305 because we no longer enable `shorthandOnlyDefinesConfig`. We added that a while ago because we had an `options` option, however we renamed that to `opts` in #1342 so we no longer benefit from it.
