### PR TITLE
wrappers: move assertion propagation to `_shared.nix` & only propagate files when nixvim is enabled

### DIFF
--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -58,7 +58,7 @@ in
 
     # Propagate extraFiles to the host modules
     (optionalAttrs (filesOpt != null) (
-      mkIf (!cfg.wrapRc) (
+      mkIf (cfg.enable && !cfg.wrapRc) (
         setAttrByPath filesOpt (
           listToAttrs (
             map (

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -53,6 +53,9 @@ in
       _module.args.nixvimLib = lib.mkDefault config.lib.nixvim.extendedLib;
     }
 
+    # Propagate nixvim's assertions to the host modules
+    (lib.mkIf cfg.enable { inherit (cfg) warnings assertions; })
+
     # Propagate extraFiles to the host modules
     (optionalAttrs (filesOpt != null) (
       mkIf (!cfg.wrapRc) (

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -37,13 +37,10 @@ in
 
   imports = [ (import ./_shared.nix { }) ];
 
-  config = mkIf cfg.enable (mkMerge [
-    {
-      environment.systemPackages = [
-        cfg.finalPackage
-        cfg.printInitPackage
-      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs);
-    }
-    { inherit (cfg) warnings assertions; }
-  ]);
+  config = mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.finalPackage
+      cfg.printInitPackage
+    ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
+  };
 }

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -43,21 +43,18 @@ in
     })
   ];
 
-  config = mkIf cfg.enable (mkMerge [
-    {
-      home.packages = [
-        cfg.finalPackage
-        cfg.printInitPackage
-      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs);
-    }
-    {
-      inherit (cfg) warnings assertions;
-      home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
-    }
-    {
-      programs.bash.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
-      programs.fish.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
-      programs.zsh.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
-    }
-  ]);
+  config = mkIf cfg.enable {
+    home.packages = [
+      cfg.finalPackage
+      cfg.printInitPackage
+    ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
+
+    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
+
+    programs = mkIf cfg.vimdiffAlias {
+      bash.shellAliases.vimdiff = "nvim -d";
+      fish.shellAliases.vimdiff = "nvim -d";
+      zsh.shellAliases.vimdiff = "nvim -d";
+    };
+  };
 }

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -45,20 +45,17 @@ in
     })
   ];
 
-  config = mkIf cfg.enable (mkMerge [
-    {
-      environment.systemPackages = [
-        cfg.finalPackage
-        cfg.printInitPackage
-      ] ++ (lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs);
-    }
-    {
-      inherit (cfg) warnings assertions;
-      programs.neovim.defaultEditor = cfg.defaultEditor;
-      environment.variables = {
-        VIM = mkIf (!cfg.wrapRc) "/etc/nvim";
-        EDITOR = mkIf cfg.defaultEditor (lib.mkOverride 900 "nvim");
-      };
-    }
-  ]);
+  config = mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.finalPackage
+      cfg.printInitPackage
+    ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
+
+    environment.variables = {
+      VIM = mkIf (!cfg.wrapRc) "/etc/nvim";
+      EDITOR = mkIf cfg.defaultEditor (lib.mkOverride 900 "nvim");
+    };
+
+    programs.neovim.defaultEditor = cfg.defaultEditor;
+  };
 }


### PR DESCRIPTION
- **wrappers: move assertion propagation to `_shared.nix`**
These options were propagated to the host modules in all wrappers (other than standalone), so we can move the implementation to `_shared.nix`.

- **wrappers/shared: only propagate files when nixvim is enabled**
These files should only be defined when nixvim is enabled. Currently the files are always created if `wrapRc` is false.


