### PR TITLE
wrappers: explicitly set `_file` for wrapper modules

### DIFF
--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -29,6 +29,8 @@ let
   extraFiles = lib.filter (file: file.enable) (lib.attrValues cfg.extraFiles);
 in
 {
+  _file = ./_shared.nix;
+
   # TODO: Added 2024-07-24; remove after 24.11
   imports = [
     (lib.mkRenamedOptionModule

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -28,6 +28,8 @@ let
   };
 in
 {
+  _file = ./darwin.nix;
+
   options = {
     programs.nixvim = mkOption {
       inherit (nixvimConfig) type;

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -27,6 +27,8 @@ let
   };
 in
 {
+  _file = ./hm.nix;
+
   options = {
     programs.nixvim = mkOption {
       inherit (nixvimConfig) type;

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -28,6 +28,8 @@ let
   };
 in
 {
+  _file = ./nixos.nix;
+
   options = {
     programs.nixvim = mkOption {
       inherit (nixvimConfig) type;


### PR DESCRIPTION
This won't be detected automatically, since the modules are all returned from function calls instead of being path references.
