### PR TITLE
modules/output: check warnings+assertions on `build.package` option

### DIFF
--- a/flake-modules/legacy-packages.nix
+++ b/flake-modules/legacy-packages.nix
@@ -15,7 +15,6 @@
           extraSpecialArgs = {
             defaultPkgs = pkgs;
           };
-          check = false;
         };
       };
     };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -20,32 +20,17 @@ rec {
     {
       modules ? [ ],
       extraSpecialArgs ? { },
-      # Set to false to disable warnings and assertions
-      # Intended to aid accessing config.test.derivation
-      # WARNING: This argument may be removed without notice:
-      check ? true,
-    }:
-    let
-      result = lib.evalModules {
-        modules = [ ../modules/top-level ] ++ modules;
-        specialArgs = specialArgsWith extraSpecialArgs;
-      };
+      check ? null, # TODO: Remove stub
+    }@args:
+    # TODO: `check` argument removed 2024-09-24
+    # NOTE: this argument was always marked as experimental
+    assert lib.assertMsg (!args ? "check")
+      "`evalNixvim`: passing `check` is no longer supported. Checks are now done when evaluating `config.build.package` and can be avoided by using `config.build.packageUnchecked` instead.";
+    lib.evalModules {
+      modules = [ ../modules/top-level ] ++ modules;
+      specialArgs = specialArgsWith extraSpecialArgs;
+    };
 
-      failedAssertions = getAssertionMessages result.config.assertions;
-
-      checked =
-        if failedAssertions != [ ] then
-          throw "\nFailed assertions:\n${lib.concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
-        else
-          lib.showWarnings result.config.warnings result;
-    in
-    if check then checked else result;
-
-  # Return the messages for all assertions that failed
-  getAssertionMessages =
-    assertions:
-    lib.pipe assertions [
-      (lib.filter (x: !x.assertion))
-      (lib.map (x: x.message))
-    ];
+  # TODO: Removed 2024-09-24
+  getAssertionMessages = throw "`modules.getAssertionMessages` has been removed.";
 }

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -66,9 +66,6 @@ let
         extraSpecialArgs = {
           defaultPkgs = pkgs;
         } // extraSpecialArgs;
-        # Don't check assertions/warnings while evaluating nixvim config
-        # We'll let the test derivation handle that
-        check = false;
       };
     in
     result.config.build.test;

--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -9,7 +9,7 @@ let
   cfg = config.test;
 
   inherit (config) warnings;
-  assertions = lib.nixvim.modules.getAssertionMessages config.assertions;
+  assertions = builtins.concatMap (x: lib.optional (!x.assertion) x.message) config.assertions;
 in
 {
   options.test = {
@@ -70,7 +70,7 @@ in
       build.test =
         pkgs.runCommandNoCCLocal cfg.name
           {
-            nativeBuildInputs = [ config.build.package ];
+            nativeBuildInputs = [ config.build.packageUnchecked ];
 
             # Allow inspecting the test's module a little from the repl
             # e.g.

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -33,7 +33,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs, expected one plugin pack.";
         }
       ];
@@ -50,7 +50,7 @@ in
       ];
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" >= 2;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" >= 2;
           message = "Only one plugin is defined in packpathDirs, expected at least two.";
         }
       ];
@@ -77,7 +77,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -105,7 +105,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -132,7 +132,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -186,11 +186,11 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "opt" == 2;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "opt" == 2;
           message = "Less than two opt plugins are defined in packpathDirs";
         }
       ];
@@ -233,7 +233,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
       ];
@@ -303,7 +303,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
       ];
@@ -369,7 +369,7 @@ in
       assertions = [
         {
           # plugin-pack, nvim-treesitter, nvim-lspconfig, telescope-nvim, nvim-cmp
-          assertion = pluginCount config.build.package config.build.extraFiles "start" == 5;
+          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 5;
           message = "Wrong number of plugins in packpathDirs";
         }
       ];

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -24,7 +24,6 @@ let
     modules = [
       ./modules/darwin.nix
     ];
-    check = false;
   };
 in
 {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -31,7 +31,6 @@ let
         };
       }
     ];
-    check = false;
   };
 in
 {

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -24,7 +24,6 @@ let
     modules = [
       ./modules/nixos.nix
     ];
-    check = false;
   };
 in
 {


### PR DESCRIPTION
Instead of `evalNixvim` checking `config.assertions` and `config.warnings`, this can be done when reading the `config.build.package` option.

This is intended to simplify `evalNixvim`, the wrappers, and the test derivation

This is similar to the approach used by NixOS, where assertions are [checked](https://github.com/NixOS/nixpkgs/blob/2af19cfb6aa40768c4bbefd801a136270e099191/nixos/modules/system/activation/top-level.nix#L62-L68) while evaluating its `config.system.build.toplevel` [option value](https://github.com/NixOS/nixpkgs/blob/2af19cfb6aa40768c4bbefd801a136270e099191/nixos/modules/system/activation/top-level.nix#L357).

The previously incubating `check = false` argument is now replaced with an "unchecked" package option. This is used by `config.build.test` and by wrapper modules that prefer to pass nixvim's assertions up to the host config.

<details><summary>Notes regarding 2306</summary>
<p>

This was originally part of #2306 ~~and is blocked by that PR~~.

I've pushed up the original version (based on #2306) to [`build_opt_checks_warnings_on_2306`](https://github.com/mattsturgeon/nixvim/tree/build_opt_checks_warnings_on_2306), for reference when resolving the inevitable merge conflicts :cold_sweat: 

</p>
</details> 