### PR TITLE
modules/output: add `impureRtp` option & don't remove "site" dir

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -56,6 +56,18 @@ in
       '';
     };
 
+    impureRtp = mkOption {
+      type = types.bool;
+      description = ''
+        Whether to keep the (impure) nvim config directory in the runtimepath.
+
+        If disabled, the XDG config dirs `nvim` and `nvim/after` will be removed from the runtimepath.
+      '';
+      defaultText = lib.literalMD ''
+        Configured by your installation method: `true` when using the home-manager module, `false` otherwise.
+      '';
+    };
+
     finalPackage = mkOption {
       type = types.package;
       description = "Wrapped Neovim.";
@@ -290,12 +302,13 @@ in
         '';
       };
 
-      # Set `wrapRc`s option default with even lower priority than `mkOptionDefault`
+      # Set `wrapRc` and `impureRtp`s option defaults with even lower priority than `mkOptionDefault`
       wrapRc = lib.mkOverride 1501 true;
+      impureRtp = lib.mkOverride 1501 false;
 
       extraConfigLuaPre = lib.mkOrder 100 (
         lib.concatStringsSep "\n" (
-          lib.optional config.wrapRc ''
+          lib.optional (!config.impureRtp) ''
             -- Ignore the user lua configuration
             vim.opt.runtimepath:remove(vim.fn.stdpath('config'))              -- ~/.config/nvim
             vim.opt.runtimepath:remove(vim.fn.stdpath('config') .. "/after")  -- ~/.config/nvim/after

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -312,7 +312,6 @@ in
             -- Ignore the user lua configuration
             vim.opt.runtimepath:remove(vim.fn.stdpath('config'))              -- ~/.config/nvim
             vim.opt.runtimepath:remove(vim.fn.stdpath('config') .. "/after")  -- ~/.config/nvim/after
-            vim.opt.runtimepath:remove(vim.fn.stdpath('data') .. "/site")     -- ~/.local/share/nvim/site
           ''
           # Add a global table at start of init
           ++ lib.singleton ''

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -22,6 +22,13 @@ let
     };
     modules = [
       ./modules/hm.nix
+      # FIXME: this can't go in ./modules/hm.nix because we eval that module in the docs _without_ nixvim's modules
+      {
+        _file = ./hm.nix;
+        config = {
+          wrapRc = lib.mkOptionDefault false;
+        };
+      }
     ];
     check = false;
   };

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -27,6 +27,7 @@ let
         _file = ./hm.nix;
         config = {
           wrapRc = lib.mkOptionDefault false;
+          impureRtp = lib.mkOptionDefault true;
         };
       }
     ];

--- a/wrappers/modules/darwin.nix
+++ b/wrappers/modules/darwin.nix
@@ -1,8 +1,3 @@
-{ lib, ... }:
 {
   imports = [ ./enable.nix ];
-
-  config = {
-    wrapRc = lib.mkForce true;
-  };
 }

--- a/wrappers/modules/nixos.nix
+++ b/wrappers/modules/nixos.nix
@@ -5,8 +5,4 @@
   };
 
   imports = [ ./enable.nix ];
-
-  config = {
-    wrapRc = lib.mkForce true;
-  };
 }

--- a/wrappers/modules/standalone.nix
+++ b/wrappers/modules/standalone.nix
@@ -1,6 +1,0 @@
-{ lib, ... }:
-{
-  config = {
-    wrapRc = lib.mkForce true;
-  };
-}

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -18,7 +18,6 @@ let
       nixvimConfig = evalNixvim {
         modules = [
           mod
-          ./modules/standalone.nix
         ];
         extraSpecialArgs = {
           defaultPkgs = pkgs;


### PR DESCRIPTION
- **modules/output: clarify `wrapRc` default**
- **modules/output: add `impureRtp` option**
- **modules/output: don't remove "site" dir when `impureRtp` is disabled**

Instead of assuming `wrapRc` implies we don't want impurities, configure this separately.

Additionally, the "site" dir is required for storing the state of several things, such as spell files.
Fixes #2297
