### PR TITLE
lib/modules: assert that `specialArgs` has a valid `lib`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -23,6 +23,11 @@ in
     # NOTE: this argument was always marked as experimental
     assert lib.assertMsg (!args ? "check")
       "`evalNixvim`: passing `check` is no longer supported. Checks are now done when evaluating `config.build.package` and can be avoided by using `config.build.packageUnchecked` instead.";
+    # Ensure a suitable `lib` is used
+    # TODO: offer a lib overlay that end-users could use to apply nixvim's extensions to their own `lib`
+    assert lib.assertMsg (extraSpecialArgs ? lib -> extraSpecialArgs.lib ? nixvim) ''
+      Nixvim requires a lib that includes some custom extensions, however the `lib` from `specialArgs` does not have a `nixvim` attr.
+      Remove `lib` from nixvim's `specialArgs` or ensure you apply nixvim's extensions to your `lib`.'';
     lib.evalModules {
       modules = [ ../modules/top-level ] ++ modules;
       specialArgs = {


### PR DESCRIPTION
End-users have ran into issues before when attempting to re-use a `lib` from elsewhere in nixvim's configuration.

If a `lib` without the `nixvim` extension is used, the new assertion will explain that this isn't supported.

```
Nixvim requires a lib that includes some custom extensions, however the `lib` specialArg does not have a `nixvim` attr.
Remove `lib` from nixvim's specialArgs or ensure you apply nixvim's extensions to your lib.
```

In the future we can also provide better ways for end-users to overlay their own lib with nixvim's [extensions](https://github.com/nix-community/nixvim/blob/main/lib/extend-lib.nix), but this is not yet implemented. Draft #2328
