### PR TITLE
docs/home-manager: eval options without checking config definitions

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -42,8 +42,12 @@ let
     ];
   };
 
-  hmOptions = builtins.removeAttrs (lib.evalModules { modules = [ ../wrappers/modules/hm.nix ]; })
-    .options [ "_module" ];
+  hmOptions = builtins.removeAttrs (lib.evalModules {
+    modules = [
+      ../wrappers/modules/hm.nix
+      { _module.check = false; } # Ignore missing option declarations
+    ];
+  }).options [ "_module" ];
 
   options-json =
     (pkgs.nixosOptionsDoc {

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -22,14 +22,6 @@ let
     };
     modules = [
       ./modules/hm.nix
-      # FIXME: this can't go in ./modules/hm.nix because we eval that module in the docs _without_ nixvim's modules
-      {
-        _file = ./hm.nix;
-        config = {
-          wrapRc = lib.mkOptionDefault false;
-          impureRtp = lib.mkOptionDefault true;
-        };
-      }
     ];
   };
 in

--- a/wrappers/modules/hm.nix
+++ b/wrappers/modules/hm.nix
@@ -13,4 +13,9 @@
   };
 
   imports = [ ./enable.nix ];
+
+  config = {
+    wrapRc = lib.mkOptionDefault false;
+    impureRtp = lib.mkOptionDefault true;
+  };
 }


### PR DESCRIPTION
By default `lib.evalModules` will check all config definitions match a declared option, leading to errors like:

```
error: The option `wrapRc' does not exist.
```

Defining a [`freeformType`](https://github.com/NixOS/nixpkgs/blob/de38446996523da09e299aee94ceb73bd83a8bb4/lib/modules.nix#L205-L219) would instead check such definitions match the given type, producing mismatched type errors instead of "does not exist".

[`_module.check`](https://github.com/NixOS/nixpkgs/blob/de38446996523da09e299aee94ceb73bd83a8bb4/lib/modules.nix#L198-L203) can disable definition checking entirely, allowing us to evaluate the option declaration without checking the config definitions.

If `_module.check` is disabled, then definitions for missing options will simply not exist in the final merged `config` attrs.
