### PR TITLE
lib: remove `maintainers` alias

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -120,8 +120,8 @@ lib.fix (
       wrapVimscriptForLua
       ;
 
-    # TODO: Deprecate this `maintainers` alias
-    inherit (self.extendedLib) maintainers;
+    # TODO: Removed 2024-09-27
+    maintainers = throw "The `maintainers` alias has been removed. Use `lib.maintainers` on a lib with nixvim's extensions.";
 
     # TODO: Deprecate the old `nixvimTypes` alias?
     nixvimTypes = self.extendedLib.types;

--- a/plugins/by-name/auto-save/default.nix
+++ b/plugins/by-name/auto-save/default.nix
@@ -1,10 +1,9 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "auto-save";
   originalName = "auto-save.nvim";
   package = "auto-save-nvim";
@@ -40,8 +39,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
       settingsPath = basePluginPath ++ [ "settings" ];
     in
     [
-      (mkRenamedOptionModule (basePluginPath ++ [ "enableAutoSave" ]) (settingsPath ++ [ "enabled" ]))
-      (mkRemovedOptionModule (basePluginPath ++ [ "keymaps" ]) ''
+      (lib.mkRenamedOptionModule (basePluginPath ++ [ "enableAutoSave" ]) (settingsPath ++ [ "enabled" ]))
+      (lib.mkRemovedOptionModule (basePluginPath ++ [ "keymaps" ]) ''
         Use the top-level `keymaps` option to create a keymap that runs :ASToggle
 
         keymaps = [
@@ -51,17 +50,17 @@ helpers.neovim-plugin.mkNeovimPlugin {
     ];
 
   settingsOptions = {
-    enabled = helpers.defaultNullOpts.mkBool true ''
+    enabled = defaultNullOpts.mkBool true ''
       Whether to start auto-save when the plugin is loaded.
     '';
 
     execution_message = {
-      enabled = helpers.defaultNullOpts.mkBool true ''
+      enabled = defaultNullOpts.mkBool true ''
         Show execution message after successful auto-save.
       '';
 
       message =
-        helpers.defaultNullOpts.mkStr
+        defaultNullOpts.mkStr
           {
             __raw = ''
               function()
@@ -74,11 +73,9 @@ helpers.neovim-plugin.mkNeovimPlugin {
             This can be a lua function that returns a string.
           '';
 
-      dim = helpers.defaultNullOpts.mkNullable (types.numbers.between 0
-        1
-      ) 0.18 "Dim the color of `message`.";
+      dim = defaultNullOpts.mkNullable (types.numbers.between 0 1) 0.18 "Dim the color of `message`.";
 
-      cleaning_interval = helpers.defaultNullOpts.mkUnsignedInt 1250 ''
+      cleaning_interval = defaultNullOpts.mkUnsignedInt 1250 ''
         Time (in milliseconds) to wait before automatically cleaning MsgArea after displaying
         `message`.
         See `:h MsgArea`.
@@ -87,7 +84,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
     trigger_events = {
       immediate_save =
-        helpers.defaultNullOpts.mkListOf types.str
+        defaultNullOpts.mkListOf types.str
           [
             "BufLeave"
             "FocusLost"
@@ -98,7 +95,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
           '';
 
       defer_save =
-        helpers.defaultNullOpts.mkListOf types.str
+        defaultNullOpts.mkListOf types.str
           [
             "InsertLeave"
             "TextChanged"
@@ -108,13 +105,13 @@ helpers.neovim-plugin.mkNeovimPlugin {
             See `:h events` for events description.
           '';
 
-      cancel_defered_save = helpers.defaultNullOpts.mkListOf types.str [ "InsertEnter" ] ''
+      cancel_defered_save = defaultNullOpts.mkListOf types.str [ "InsertEnter" ] ''
         Vim events that cancel a pending deferred save.\
         See `:h events` for events description.
       '';
     };
 
-    condition = helpers.defaultNullOpts.mkLuaFn' {
+    condition = defaultNullOpts.mkLuaFn' {
       pluginDefault = null;
       description = ''
         Function that determines whether to save the current buffer or not.
@@ -139,23 +136,23 @@ helpers.neovim-plugin.mkNeovimPlugin {
       '';
     };
 
-    write_all_buffers = helpers.defaultNullOpts.mkBool false ''
+    write_all_buffers = defaultNullOpts.mkBool false ''
       Write all buffers when the current one meets `condition`.
     '';
 
-    noautocmd = helpers.defaultNullOpts.mkBool false ''
+    noautocmd = defaultNullOpts.mkBool false ''
       Do not execute autocmds when saving.
     '';
 
-    lockmarks = helpers.defaultNullOpts.mkBool false ''
+    lockmarks = defaultNullOpts.mkBool false ''
       Lock marks when saving, see `:h lockmarks` for more details.
     '';
 
-    debounce_delay = helpers.defaultNullOpts.mkUnsignedInt 1000 ''
+    debounce_delay = defaultNullOpts.mkUnsignedInt 1000 ''
       Saves the file at most every `debounce_delay` milliseconds.
     '';
 
-    debug = helpers.defaultNullOpts.mkBool false ''
+    debug = defaultNullOpts.mkBool false ''
       Log debug messages to `auto-save.log` file in NeoVim cache directory.
     '';
   };

--- a/plugins/by-name/auto-save/default.nix
+++ b/plugins/by-name/auto-save/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "auto-save.nvim";
   package = "auto-save-nvim";
 
-  maintainers = [ helpers.maintainers.braindefender ];
+  maintainers = [ lib.maintainers.braindefender ];
 
   # TODO: introduced 2024-06-21, remove after 24.11
   deprecateExtraOptions = true;

--- a/plugins/by-name/autosource/default.nix
+++ b/plugins/by-name/autosource/default.nix
@@ -11,7 +11,7 @@ lib.nixvim.vim-plugin.mkVimPlugin {
   package = "vim-autosource";
   globalPrefix = "autosource_";
 
-  maintainers = [ lib.nixvim.maintainers.refaelsh ];
+  maintainers = [ lib.maintainers.refaelsh ];
 
   settingsOptions = {
     prompt_for_new_file = defaultNullOpts.mkFlagInt 1 ''

--- a/plugins/by-name/bacon/default.nix
+++ b/plugins/by-name/bacon/default.nix
@@ -1,20 +1,16 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "bacon";
   package = "nvim-bacon";
   maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
     quickfix = {
-      enabled = helpers.defaultNullOpts.mkBool true ''
+      enabled = lib.nixvim.defaultNullOpts.mkBool true ''
         Whether to populate the quickfix list with bacon errors and warnings.
       '';
 
-      event_trigger = helpers.defaultNullOpts.mkBool true ''
+      event_trigger = lib.nixvim.defaultNullOpts.mkBool true ''
         Triggers the `QuickFixCmdPost` event after populating the quickfix list.
       '';
     };

--- a/plugins/by-name/bacon/default.nix
+++ b/plugins/by-name/bacon/default.nix
@@ -1,11 +1,12 @@
 {
+  lib,
   helpers,
   ...
 }:
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "bacon";
   package = "nvim-bacon";
-  maintainers = [ helpers.maintainers.alisonjenkins ];
+  maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
     quickfix = {

--- a/plugins/by-name/baleia/default.nix
+++ b/plugins/by-name/baleia/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   helpers,
   ...
 }:
@@ -7,7 +8,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "baleia.nvim";
   package = "baleia-nvim";
 
-  maintainers = [ helpers.maintainers.alisonjenkins ];
+  maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
     async = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/by-name/baleia/default.nix
+++ b/plugins/by-name/baleia/default.nix
@@ -1,9 +1,8 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "baleia";
   originalName = "baleia.nvim";
   package = "baleia-nvim";
@@ -11,20 +10,20 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
-    async = helpers.defaultNullOpts.mkBool true ''
+    async = defaultNullOpts.mkBool true ''
       Highlight asynchronously.
     '';
 
-    colors = helpers.defaultNullOpts.mkStr "NR_8" ''
+    colors = defaultNullOpts.mkStr "NR_8" ''
       Table mapping 256 color codes to vim colors.
     '';
 
-    line_starts_at = helpers.defaultNullOpts.mkInt 1 ''
+    line_starts_at = defaultNullOpts.mkInt 1 ''
       At which column start colorizing.
     '';
 
     log =
-      helpers.defaultNullOpts.mkEnum
+      defaultNullOpts.mkEnum
         [
           "ERROR"
           "WARN"
@@ -36,11 +35,11 @@ helpers.neovim-plugin.mkNeovimPlugin {
           Log level, possible values are ERROR, WARN, INFO or DEBUG.
         '';
 
-    name = helpers.defaultNullOpts.mkStr "BaleiaColors" ''
+    name = defaultNullOpts.mkStr "BaleiaColors" ''
       Prefix used to name highlight groups.
     '';
 
-    strip_ansi_codes = helpers.defaultNullOpts.mkBool true ''
+    strip_ansi_codes = defaultNullOpts.mkBool true ''
       Remove ANSI color codes from text.
     '';
   };

--- a/plugins/by-name/ccc/default.nix
+++ b/plugins/by-name/ccc/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "ccc.nvim";
   package = "ccc-nvim";
 
-  maintainers = [ helpers.maintainers.JanKremer ];
+  maintainers = [ lib.maintainers.JanKremer ];
 
   settingsOptions =
     let

--- a/plugins/by-name/ccc/default.nix
+++ b/plugins/by-name/ccc/default.nix
@@ -1,10 +1,9 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "ccc";
   originalName = "ccc.nvim";
   package = "ccc-nvim";
@@ -13,15 +12,15 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   settingsOptions =
     let
-      listOfRawLua = with helpers.nixvimTypes; listOf strLua;
-      mapToRawLua = map helpers.mkRaw;
+      listOfRawLua = with types; listOf strLua;
+      mapToRawLua = map lib.nixvim.mkRaw;
     in
     {
-      default_color = helpers.defaultNullOpts.mkStr "#000000" ''
+      default_color = defaultNullOpts.mkStr "#000000" ''
         The default color used when a color cannot be picked. It must be HEX format.
       '';
 
-      inputs = mkOption {
+      inputs = lib.mkOption {
         type = listOfRawLua;
         apply = mapToRawLua;
         default = [ ];
@@ -57,7 +56,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
         '';
       };
 
-      outputs = mkOption {
+      outputs = lib.mkOption {
         type = listOfRawLua;
         apply = mapToRawLua;
         default = [ ];
@@ -93,7 +92,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
         '';
       };
 
-      pickers = mkOption {
+      pickers = lib.mkOption {
         type = listOfRawLua;
         apply = mapToRawLua;
         default = [ ];
@@ -128,7 +127,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       };
 
       highlight_mode =
-        helpers.defaultNullOpts.mkEnumFirstDefault
+        defaultNullOpts.mkEnumFirstDefault
           [
             "bg"
             "fg"
@@ -140,46 +139,46 @@ helpers.neovim-plugin.mkNeovimPlugin {
             It is used to `output_line` and `highlighter`.
           '';
 
-      lsp = helpers.defaultNullOpts.mkBool true ''
+      lsp = defaultNullOpts.mkBool true ''
         Whether to enable LSP support.
         The color information is updated in the background and the result is used by `:CccPick` and
         highlighter.
       '';
 
       highlighter = {
-        auto_enable = helpers.defaultNullOpts.mkBool false ''
+        auto_enable = defaultNullOpts.mkBool false ''
           Whether to enable automatically on `BufEnter`.
         '';
 
-        filetypes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        filetypes = defaultNullOpts.mkListOf types.str [ ] ''
           File types for which highlighting is enabled.
           It is only used for automatic highlighting by `ccc-option-highlighter-auto-enable`, and is
           ignored for manual activation.
           An empty table means all file types.
         '';
 
-        excludes = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+        excludes = defaultNullOpts.mkListOf types.str [ ] ''
           Used only when `ccc-option-highlighter-filetypes` is empty table.
           You can specify file types to be excludes.
         '';
 
-        lsp = helpers.defaultNullOpts.mkBool true ''
+        lsp = defaultNullOpts.mkBool true ''
           If true, highlight using LSP.
           If language server with the color provider is not attached to a buffer, it falls back to
           highlight with pickers.
           See also `:help ccc-option-lsp`.
         '';
 
-        update_insert = helpers.defaultNullOpts.mkBool true ''
+        update_insert = defaultNullOpts.mkBool true ''
           If true, highlights will be updated during insert mode.
           If false, highlights will not be updated during editing in insert mode, but will be
           updated on `InsertLeave`.
         '';
       };
 
-      convert = mkOption {
+      convert = lib.mkOption {
         type =
-          with helpers.nixvimTypes;
+          with types;
           nullOr (
             maybeRaw (
               listOf
@@ -187,7 +186,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
                 (listOf strLua)
             )
           );
-        apply = map mapToRawLua;
+        apply = builtins.map mapToRawLua;
         default = [ ];
         example = [
           [
@@ -248,7 +247,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
     plugins.ccc.luaConfig.content = ''
       ccc = require('ccc')
-      ccc.setup(${helpers.toLuaObject cfg.settings})
+      ccc.setup(${lib.nixvim.toLuaObject cfg.settings})
     '';
   };
 }

--- a/plugins/by-name/cmake-tools/default.nix
+++ b/plugins/by-name/cmake-tools/default.nix
@@ -8,7 +8,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "cmake-tools.nvim";
   package = "cmake-tools-nvim";
 
-  maintainers = [ helpers.maintainers.NathanFelber ];
+  maintainers = [ lib.maintainers.NathanFelber ];
 
   settingsOptions = {
     cmake_command = helpers.defaultNullOpts.mkStr "cmake" ''

--- a/plugins/by-name/cmake-tools/default.nix
+++ b/plugins/by-name/cmake-tools/default.nix
@@ -1,9 +1,8 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "cmake-tools";
   originalName = "cmake-tools.nvim";
   package = "cmake-tools-nvim";
@@ -11,51 +10,51 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ lib.maintainers.NathanFelber ];
 
   settingsOptions = {
-    cmake_command = helpers.defaultNullOpts.mkStr "cmake" ''
+    cmake_command = defaultNullOpts.mkStr "cmake" ''
       This is used to specify cmake command path.
     '';
 
-    ctest_command = helpers.defaultNullOpts.mkStr "ctest" ''
+    ctest_command = defaultNullOpts.mkStr "ctest" ''
       This is used to specify ctest command path.
     '';
 
-    cmake_regenerate_on_save = helpers.defaultNullOpts.mkBool true ''
+    cmake_regenerate_on_save = defaultNullOpts.mkBool true ''
       Auto generate when save CMakeLists.txt.
     '';
 
     cmake_generate_options =
-      helpers.defaultNullOpts.mkAttrsOf lib.types.anything { "-DCMAKE_EXPORT_COMPILE_COMMANDS" = 1; }
+      defaultNullOpts.mkAttrsOf lib.types.anything { "-DCMAKE_EXPORT_COMPILE_COMMANDS" = 1; }
         ''
           This will be passed when invoke `CMakeGenerate`.
         '';
 
-    cmake_build_options = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { } ''
+    cmake_build_options = defaultNullOpts.mkAttrsOf lib.types.anything { } ''
       This will be passed when invoke `CMakeBuild`.
     '';
 
-    cmake_build_directory = helpers.defaultNullOpts.mkStr "out/\${variant:buildType}" ''
+    cmake_build_directory = defaultNullOpts.mkStr "out/\${variant:buildType}" ''
       This is used to specify generate directory for cmake, allows macro expansion, relative to vim.loop.cwd().
     '';
 
-    cmake_soft_link_compile_commands = helpers.defaultNullOpts.mkBool true ''
+    cmake_soft_link_compile_commands = defaultNullOpts.mkBool true ''
       This will automatically make a soft link from compile commands file to project root dir.
     '';
 
-    cmake_compile_commands_from_lsp = helpers.defaultNullOpts.mkBool false ''
+    cmake_compile_commands_from_lsp = defaultNullOpts.mkBool false ''
       This will automatically set compile commands file location using lsp, to use it, please set `cmake_soft_link_compile_commands` to false.
     '';
 
-    cmake_kits_path = helpers.defaultNullOpts.mkStr null ''
+    cmake_kits_path = defaultNullOpts.mkStr null ''
       This is used to specify global cmake kits path, see CMakeKits for detailed usage.
     '';
 
     cmake_variants_message = {
-      short = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { show = true; } ''
+      short = defaultNullOpts.mkAttrsOf lib.types.anything { show = true; } ''
         Whether to show short message.
       '';
 
       long =
-        helpers.defaultNullOpts.mkAttrsOf lib.types.anything
+        defaultNullOpts.mkAttrsOf lib.types.anything
           {
             show = true;
             max_length = 40;
@@ -66,46 +65,46 @@ helpers.neovim-plugin.mkNeovimPlugin {
     };
 
     cmake_dap_configuration = {
-      name = helpers.defaultNullOpts.mkStr "cpp" ''
+      name = defaultNullOpts.mkStr "cpp" ''
         Name of the launch configuration.
       '';
 
-      type = helpers.defaultNullOpts.mkStr "codelldb" ''
+      type = defaultNullOpts.mkStr "codelldb" ''
         Debug adapter to use.
       '';
 
-      request = helpers.defaultNullOpts.mkStr "launch" ''
+      request = defaultNullOpts.mkStr "launch" ''
         Session initiation method.
       '';
     };
 
     cmake_executor = {
-      name = helpers.defaultNullOpts.mkStr "quickfix" ''
+      name = defaultNullOpts.mkStr "quickfix" ''
         Name of the executor.
       '';
 
-      opts = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { } ''
+      opts = defaultNullOpts.mkAttrsOf lib.types.anything { } ''
         The options the executor will get, possible values depend on the executor type.
       '';
     };
 
     cmake_runner = {
-      name = helpers.defaultNullOpts.mkStr "terminal" ''
+      name = defaultNullOpts.mkStr "terminal" ''
         Name of the runner.
       '';
 
-      opts = helpers.defaultNullOpts.mkAttrsOf lib.types.anything { } ''
+      opts = defaultNullOpts.mkAttrsOf lib.types.anything { } ''
         The options the runner will get, possible values depend on the runner type.
       '';
     };
 
     cmake_notifications = {
-      runner.enabled = helpers.defaultNullOpts.mkBool true "";
+      runner.enabled = defaultNullOpts.mkBool true "";
 
-      executor.enabled = helpers.defaultNullOpts.mkBool true "";
+      executor.enabled = defaultNullOpts.mkBool true "";
 
       spinner =
-        helpers.defaultNullOpts.mkListOf lib.types.str
+        defaultNullOpts.mkListOf lib.types.str
           [
             "⠋"
             "⠙"
@@ -122,7 +121,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
             Icons used for progress display.
           '';
 
-      refresh_rate_ms = helpers.defaultNullOpts.mkPositiveInt 100 ''
+      refresh_rate_ms = defaultNullOpts.mkPositiveInt 100 ''
         How often to iterate icons.
       '';
     };

--- a/plugins/by-name/committia/default.nix
+++ b/plugins/by-name/committia/default.nix
@@ -1,10 +1,12 @@
 {
-  helpers,
   lib,
   pkgs,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin {
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "committia";
   originalName = "committia.vim";
   package = "committia-vim";
@@ -13,36 +15,36 @@ helpers.vim-plugin.mkVimPlugin {
   maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
-    open_only_vim_starting = helpers.defaultNullOpts.mkFlagInt 1 ''
+    open_only_vim_starting = defaultNullOpts.mkFlagInt 1 ''
       If `0`, committia.vim always attempts to open committia's buffer when `COMMIT_EDITMSG` buffer is opened.
       If you use `vim-fugitive`, I recommend to set this value to `1`.
     '';
 
-    use_singlecolumn = helpers.defaultNullOpts.mkStr "always" ''
+    use_singlecolumn = defaultNullOpts.mkStr "always" ''
       If the value is 'always', `committia.vim` always employs single column mode.
     '';
 
-    min_window_width = helpers.defaultNullOpts.mkUnsignedInt 160 ''
+    min_window_width = defaultNullOpts.mkUnsignedInt 160 ''
       If the width of window is narrower than the value, `committia.vim` employs single column mode.
     '';
 
-    status_window_opencmd = helpers.defaultNullOpts.mkStr "belowright split" ''
+    status_window_opencmd = defaultNullOpts.mkStr "belowright split" ''
       Vim command which opens a status window in multi-columns mode.
     '';
 
-    diff_window_opencmd = helpers.defaultNullOpts.mkStr "botright vsplit" ''
+    diff_window_opencmd = defaultNullOpts.mkStr "botright vsplit" ''
       Vim command which opens a diff window in multi-columns mode.
     '';
 
-    singlecolumn_diff_window_opencmd = helpers.defaultNullOpts.mkStr "belowright split" ''
+    singlecolumn_diff_window_opencmd = defaultNullOpts.mkStr "belowright split" ''
       Vim command which opens a diff window in single-column mode.
     '';
 
-    edit_window_width = helpers.defaultNullOpts.mkUnsignedInt 80 ''
+    edit_window_width = defaultNullOpts.mkUnsignedInt 80 ''
       If `committia.vim` is in multi-columns mode, specifies the width of the edit window.
     '';
 
-    status_window_min_height = helpers.defaultNullOpts.mkUnsignedInt 0 ''
+    status_window_min_height = defaultNullOpts.mkUnsignedInt 0 ''
       Minimum height of a status window.
     '';
   };

--- a/plugins/by-name/committia/default.nix
+++ b/plugins/by-name/committia/default.nix
@@ -10,7 +10,7 @@ helpers.vim-plugin.mkVimPlugin {
   package = "committia-vim";
   globalPrefix = "committia_";
 
-  maintainers = [ helpers.maintainers.alisonjenkins ];
+  maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
     open_only_vim_starting = helpers.defaultNullOpts.mkFlagInt 1 ''

--- a/plugins/by-name/competitest/default.nix
+++ b/plugins/by-name/competitest/default.nix
@@ -1,10 +1,9 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "competitest";
   originalName = "competitest.nvim";
   package = "competitest-nvim";
@@ -12,34 +11,34 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ lib.maintainers.svl ];
 
   settingsOptions = {
-    local_config_file_name = helpers.defaultNullOpts.mkStr ".competitest.lua" ''
+    local_config_file_name = defaultNullOpts.mkStr ".competitest.lua" ''
       You can use a different configuration for every different folder.
       See [local configuration](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#local-configuration).
     '';
 
-    save_current_file = helpers.defaultNullOpts.mkBool true ''
+    save_current_file = defaultNullOpts.mkBool true ''
       If true save current file before running testcases.
     '';
 
-    save_all_files = helpers.defaultNullOpts.mkBool false ''
+    save_all_files = defaultNullOpts.mkBool false ''
       If true save all the opened files before running testcases.
     '';
 
-    compile_directory = helpers.defaultNullOpts.mkStr "." ''
+    compile_directory = defaultNullOpts.mkStr "." ''
       Execution directory of compiler, relatively to current file's path.
     '';
 
     compile_command =
-      helpers.mkNullOrOption
+      lib.nixvim.mkNullOrOption
         (
           with types;
           attrsOf (submodule {
             options = {
-              exec = mkOption {
+              exec = lib.mkOption {
                 type = str;
                 description = "Command to execute";
               };
-              args = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+              args = defaultNullOpts.mkListOf types.str [ ] ''
                 Arguments to the command.
               '';
             };
@@ -50,21 +49,21 @@ helpers.neovim-plugin.mkNeovimPlugin {
           [here](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#customize-compile-and-run-commands).
         '';
 
-    running_directory = helpers.defaultNullOpts.mkStr "." ''
+    running_directory = defaultNullOpts.mkStr "." ''
       Execution directory of your solutions, relatively to current file's path.
     '';
 
     run_command =
-      helpers.mkNullOrOption
+      lib.nixvim.mkNullOrOption
         (
           with types;
           attrsOf (submodule {
             options = {
-              exec = mkOption {
+              exec = lib.mkOption {
                 type = str;
                 description = "Command to execute.";
               };
-              args = helpers.defaultNullOpts.mkListOf types.str [ ] ''
+              args = defaultNullOpts.mkListOf types.str [ ] ''
                 Arguments to the command.
               '';
             };
@@ -75,7 +74,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
           [here](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#customize-compile-and-run-commands).
         '';
 
-    multiple_testing = helpers.defaultNullOpts.mkInt (-1) ''
+    multiple_testing = defaultNullOpts.mkInt (-1) ''
       How many testcases to run at the same time
       * Set it to -1 to make the most of the amount of available parallelism.
         Often the number of testcases run at the same time coincides with the number of CPUs.
@@ -83,19 +82,19 @@ helpers.neovim-plugin.mkNeovimPlugin {
       * Set it to any positive integer to run that number of testcases contemporarily.
     '';
 
-    maximum_time = helpers.defaultNullOpts.mkInt 5000 ''
+    maximum_time = defaultNullOpts.mkInt 5000 ''
       Maximum time, in milliseconds, given to processes.
       If it's exceeded process will be killed.
     '';
 
     output_compare_method =
-      helpers.defaultNullOpts.mkNullable
+      defaultNullOpts.mkNullable
         (
           with types;
           either (enum [
             "exact"
             "squish"
-          ]) helpers.nixvimTypes.rawLua
+          ]) rawLua
         )
         "squish"
         ''
@@ -109,52 +108,52 @@ helpers.neovim-plugin.mkNeovimPlugin {
             output is acceptable, false otherwise.
         '';
 
-    view_output_diff = helpers.defaultNullOpts.mkBool false ''
+    view_output_diff = defaultNullOpts.mkBool false ''
       View diff between actual output and expected output in their respective windows.
     '';
 
-    testcases_directory = helpers.defaultNullOpts.mkStr "." ''
+    testcases_directory = defaultNullOpts.mkStr "." ''
       Where testcases files are located, relatively to current file's path.
     '';
 
-    testcases_use_single_file = helpers.defaultNullOpts.mkBool false ''
+    testcases_use_single_file = defaultNullOpts.mkBool false ''
       If true testcases will be stored in a single file instead of using multiple text files.
       If you want to change the way already existing testcases are stored see
       [conversion](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#convert-testcases).
     '';
 
-    testcases_auto_detect_storage = helpers.defaultNullOpts.mkBool true ''
+    testcases_auto_detect_storage = defaultNullOpts.mkBool true ''
       If true testcases storage method will be detected automatically.
       When both text files and single file are available, testcases will be loaded according
       to the preference specified in `testcases_use_single_file`.
     '';
 
-    testcases_single_file_format = helpers.defaultNullOpts.mkStr "$(FNOEXT).testcases" ''
+    testcases_single_file_format = defaultNullOpts.mkStr "$(FNOEXT).testcases" ''
       String representing how single testcases files should be named
       (see [file-format modifiers](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#file-format-modifiers)).
     '';
 
-    testcases_input_file_format = helpers.defaultNullOpts.mkStr "$(FNOEXT)_input$(TCNUM).txt" ''
+    testcases_input_file_format = defaultNullOpts.mkStr "$(FNOEXT)_input$(TCNUM).txt" ''
       String representing how testcases input files should be named
       (see [file-format modifiers](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#file-format-modifiers)).
     '';
 
-    testcases_output_file_format = helpers.defaultNullOpts.mkStr "$(FNOEXT)_output$(TCNUM).txt" ''
+    testcases_output_file_format = defaultNullOpts.mkStr "$(FNOEXT)_output$(TCNUM).txt" ''
       String representing how testcases output files should be named
       (see [file-format modifiers](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#file-format-modifiers)).
     '';
 
-    companion_port = helpers.defaultNullOpts.mkInt 27121 ''
+    companion_port = defaultNullOpts.mkInt 27121 ''
       Competitive companion port number.
     '';
 
-    receive_print_message = helpers.defaultNullOpts.mkBool true ''
+    receive_print_message = defaultNullOpts.mkBool true ''
       If true notify user that plugin is ready to receive testcases, problems and
       contests or that they have just been received.
     '';
 
     template_file =
-      helpers.mkNullOrOption
+      lib.nixvim.mkNullOrOption
         (
           with types;
           oneOf [
@@ -173,24 +172,24 @@ helpers.neovim-plugin.mkNeovimPlugin {
           * table with paths: table associating file extension to template file.
         '';
 
-    evaluate_template_modifiers = helpers.defaultNullOpts.mkBool false ''
+    evaluate_template_modifiers = defaultNullOpts.mkBool false ''
       Whether to evaluate
       [receive modifiers](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#receive-modifiers)
       inside a template file or not.
     '';
 
-    date_format = helpers.defaultNullOpts.mkStr "%c" ''
+    date_format = defaultNullOpts.mkStr "%c" ''
       String used to format `$(DATE)` modifier (see
       [receive modifiers](https://github.com/xeluxee/competitest.nvim?tab=readme-ov-file#receive-modifiers)).
       The string should follow the formatting rules as per Lua's
       `[os.date](https://www.lua.org/pil/22.1.html)` function.
     '';
 
-    received_files_extension = helpers.defaultNullOpts.mkStr "cpp" ''
+    received_files_extension = defaultNullOpts.mkStr "cpp" ''
       Default file extension for received problems.
     '';
 
-    received_problems_path = helpers.defaultNullOpts.mkStr "$(CWD)/$(PROBLEM).$(FEXT)" ''
+    received_problems_path = defaultNullOpts.mkStr "$(CWD)/$(PROBLEM).$(FEXT)" ''
       Path where received problems (not contests) are stored.
       Can be one of the following:
       * string with receive modifiers.
@@ -199,37 +198,37 @@ helpers.neovim-plugin.mkNeovimPlugin {
         to store received problem.
     '';
 
-    received_problems_prompt_path = helpers.defaultNullOpts.mkBool true ''
+    received_problems_prompt_path = defaultNullOpts.mkBool true ''
       Whether to ask user confirmation about path where the received problem is stored or not.
     '';
 
-    received_contests_directory = helpers.defaultNullOpts.mkStr "$(CWD)" ''
+    received_contests_directory = defaultNullOpts.mkStr "$(CWD)" ''
       Directory where received contests are stored. It can be string or function,
       exactly as `received_problems_path`.
     '';
 
-    received_contests_problems_path = helpers.defaultNullOpts.mkStr "$(PROBLEM).$(FEXT)" ''
+    received_contests_problems_path = defaultNullOpts.mkStr "$(PROBLEM).$(FEXT)" ''
       Relative path from contest root directory, each problem of a received contest
       is stored following this option. It can be string or function, exactly as `received_problems_path`.
     '';
 
-    received_contests_prompt_directory = helpers.defaultNullOpts.mkBool true ''
+    received_contests_prompt_directory = defaultNullOpts.mkBool true ''
       Whether to ask user confirmation about the directory where received contests are stored or not.
     '';
 
-    received_contests_prompt_extension = helpers.defaultNullOpts.mkBool true ''
+    received_contests_prompt_extension = defaultNullOpts.mkBool true ''
       Whether to ask user confirmation about what file extension to use when receiving a contest or not.
     '';
 
-    open_received_problems = helpers.defaultNullOpts.mkBool true ''
+    open_received_problems = defaultNullOpts.mkBool true ''
       Automatically open source files when receiving a single problem.
     '';
 
-    open_received_contests = helpers.defaultNullOpts.mkBool true ''
+    open_received_contests = defaultNullOpts.mkBool true ''
       Automatically open source files when receiving a contest.
     '';
 
-    replace_received_testcases = helpers.defaultNullOpts.mkBool false ''
+    replace_received_testcases = defaultNullOpts.mkBool false ''
       This option applies when receiving only testcases. If true replace existing
       testcases with received ones, otherwise ask user what to do.
     '';

--- a/plugins/by-name/competitest/default.nix
+++ b/plugins/by-name/competitest/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "competitest.nvim";
   package = "competitest-nvim";
 
-  maintainers = [ helpers.maintainers.svl ];
+  maintainers = [ lib.maintainers.svl ];
 
   settingsOptions = {
     local_config_file_name = helpers.defaultNullOpts.mkStr ".competitest.lua" ''

--- a/plugins/by-name/coq-nvim/default.nix
+++ b/plugins/by-name/coq-nvim/default.nix
@@ -1,11 +1,13 @@
 {
   lib,
-  helpers,
   pkgs,
   ...
 }:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "coq-nvim";
   originalName = "coq_nvim";
   package = "coq_nvim";
@@ -17,8 +19,8 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   extraOptions = {
     # TODO: should this enable option be replaced with `nullable = true` in the package option?
-    installArtifacts = mkEnableOption "and install coq-artifacts";
-    artifactsPackage = mkPackageOption pkgs "coq-artifacts" {
+    installArtifacts = lib.mkEnableOption "and install coq-artifacts";
+    artifactsPackage = lib.mkPackageOption pkgs "coq-artifacts" {
       extraDescription = "Installed when `installArtifacts` is enabled.";
       default = [
         "vimPlugins"
@@ -41,7 +43,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       settingsPath = basePath ++ [ "settings" ];
     in
     [
-      (mkRenamedOptionModule (basePath ++ [ "recommendedKeymaps" ]) (
+      (lib.mkRenamedOptionModule (basePath ++ [ "recommendedKeymaps" ]) (
         settingsPath
         ++ [
           "keymap"
@@ -49,7 +51,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
         ]
       ))
 
-      (mkRenamedOptionModule (basePath ++ [ "alwaysComplete" ]) (
+      (lib.mkRenamedOptionModule (basePath ++ [ "alwaysComplete" ]) (
         settingsPath
         ++ [
           "completion"
@@ -60,23 +62,23 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   callSetup = false;
   settingsOptions = {
-    auto_start = helpers.mkNullOrOption (
-      with helpers.nixvimTypes; maybeRaw (either bool (enum [ "shut-up" ]))
+    auto_start = lib.nixvim.mkNullOrOption (
+      with types; maybeRaw (either bool (enum [ "shut-up" ]))
     ) "Auto-start or shut up";
 
-    xdg = mkOption {
+    xdg = lib.mkOption {
       type = types.bool;
       default = true;
       description = "Use XDG paths. May be required when installing coq with Nix.";
     };
 
-    keymap.recommended = helpers.defaultNullOpts.mkBool true "Use the recommended keymaps";
+    keymap.recommended = defaultNullOpts.mkBool true "Use the recommended keymaps";
 
-    completion.always = helpers.defaultNullOpts.mkBool true "Always trigger completion on keystroke";
+    completion.always = defaultNullOpts.mkBool true "Always trigger completion on keystroke";
   };
 
   extraConfig = cfg: {
-    extraPlugins = mkIf cfg.installArtifacts [ cfg.artifactsPackage ];
+    extraPlugins = lib.mkIf cfg.installArtifacts [ cfg.artifactsPackage ];
 
     globals = {
       coq_settings = cfg.settings;

--- a/plugins/by-name/coq-nvim/default.nix
+++ b/plugins/by-name/coq-nvim/default.nix
@@ -10,9 +10,9 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "coq_nvim";
   package = "coq_nvim";
 
-  maintainers = [
-    maintainers.traxys
-    helpers.maintainers.Kareem-Medhat
+  maintainers = with lib.maintainers; [
+    traxys
+    Kareem-Medhat
   ];
 
   extraOptions = {

--- a/plugins/by-name/direnv/default.nix
+++ b/plugins/by-name/direnv/default.nix
@@ -1,10 +1,12 @@
 {
-  helpers,
   pkgs,
   lib,
   ...
 }:
-helpers.vim-plugin.mkVimPlugin {
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "direnv";
   originalName = "direnv.vim";
   package = "direnv-vim";
@@ -13,12 +15,12 @@ helpers.vim-plugin.mkVimPlugin {
   maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
-    direnv_auto = helpers.defaultNullOpts.mkFlagInt 1 ''
+    direnv_auto = defaultNullOpts.mkFlagInt 1 ''
       It will not execute `:DirenvExport` automatically if the value is `0`.
     '';
 
     direnv_edit_mode =
-      helpers.defaultNullOpts.mkEnum
+      defaultNullOpts.mkEnum
         [
           "edit"
           "split"
@@ -30,7 +32,7 @@ helpers.vim-plugin.mkVimPlugin {
           Select the command to open buffers to edit. Default: 'edit'.
         '';
 
-    direnv_silent_load = helpers.defaultNullOpts.mkFlagInt 1 ''
+    direnv_silent_load = defaultNullOpts.mkFlagInt 1 ''
       Stop echoing output from Direnv command.
     '';
   };

--- a/plugins/by-name/direnv/default.nix
+++ b/plugins/by-name/direnv/default.nix
@@ -4,14 +4,13 @@
   lib,
   ...
 }:
-with lib;
 helpers.vim-plugin.mkVimPlugin {
   name = "direnv";
   originalName = "direnv.vim";
   package = "direnv-vim";
   globalPrefix = "direnv_";
 
-  maintainers = [ helpers.maintainers.alisonjenkins ];
+  maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
     direnv_auto = helpers.defaultNullOpts.mkFlagInt 1 ''

--- a/plugins/by-name/dressing/default.nix
+++ b/plugins/by-name/dressing/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "dressing.nvim";
   package = "dressing-nvim";
 
-  maintainers = [ helpers.maintainers.AndresBermeoMarinelli ];
+  maintainers = [ lib.maintainers.AndresBermeoMarinelli ];
 
   settingsOptions =
     let

--- a/plugins/by-name/dressing/default.nix
+++ b/plugins/by-name/dressing/default.nix
@@ -1,10 +1,9 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "dressing";
   originalName = "dressing.nvim";
   package = "dressing-nvim";
@@ -17,20 +16,20 @@ helpers.neovim-plugin.mkNeovimPlugin {
     in
     {
       input = {
-        enabled = helpers.defaultNullOpts.mkBool true ''
+        enabled = defaultNullOpts.mkBool true ''
           Enable the `vim.ui.input` implementation.
         '';
 
-        default_prompt = helpers.defaultNullOpts.mkStr "Input" ''
+        default_prompt = defaultNullOpts.mkStr "Input" ''
           Default prompt string for `vim.ui.input`.
         '';
 
-        trim_prompt = helpers.defaultNullOpts.mkBool true ''
+        trim_prompt = defaultNullOpts.mkBool true ''
           Trim trailing `:` from prompt.
         '';
 
         title_pos =
-          helpers.defaultNullOpts.mkEnumFirstDefault
+          defaultNullOpts.mkEnumFirstDefault
             [
               "left"
               "right"
@@ -40,18 +39,18 @@ helpers.neovim-plugin.mkNeovimPlugin {
               Position of title.
             '';
 
-        insert_only = helpers.defaultNullOpts.mkBool true ''
+        insert_only = defaultNullOpts.mkBool true ''
           When true, `<Esc>` will close the modal.
         '';
 
-        start_in_insert = helpers.defaultNullOpts.mkBool true ''
+        start_in_insert = defaultNullOpts.mkBool true ''
           When true, input will start in insert mode.
         '';
 
-        border = helpers.defaultNullOpts.mkBorder "rounded" "the input window" "";
+        border = defaultNullOpts.mkBorder "rounded" "the input window" "";
 
         relative =
-          helpers.defaultNullOpts.mkEnumFirstDefault
+          defaultNullOpts.mkEnumFirstDefault
             [
               "cursor"
               "win"
@@ -62,16 +61,16 @@ helpers.neovim-plugin.mkNeovimPlugin {
               If 'editor' or 'win', will default to being centered.
             '';
 
-        prefer_width = helpers.defaultNullOpts.mkNullable intOrRatio 40 ''
+        prefer_width = defaultNullOpts.mkNullable intOrRatio 40 ''
           Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
         '';
 
-        width = helpers.defaultNullOpts.mkNullable intOrRatio null ''
+        width = defaultNullOpts.mkNullable intOrRatio null ''
           Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
         '';
 
         max_width =
-          helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+          defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
             [
               140
               0.9
@@ -84,7 +83,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
             '';
 
         min_width =
-          helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+          defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
             [
               20
               0.2
@@ -96,11 +95,11 @@ helpers.neovim-plugin.mkNeovimPlugin {
               total."
             '';
 
-        buf_options = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
+        buf_options = defaultNullOpts.mkAttrsOf types.anything { } ''
           An attribute set of neovim buffer options.
         '';
 
-        win_options = helpers.defaultNullOpts.mkAttrsOf types.anything {
+        win_options = defaultNullOpts.mkAttrsOf types.anything {
           wrap = false;
           list = true;
           listchars = "precedes:...,extends:...";
@@ -108,7 +107,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
         } "An attribute set of window options.";
 
         mappings =
-          helpers.defaultNullOpts.mkAttrsOf (with types; attrsOf (either str (enum [ false ])))
+          defaultNullOpts.mkAttrsOf (with types; attrsOf (either str (enum [ false ])))
             {
               n = {
                 "<Esc>" = "Close";
@@ -127,12 +126,12 @@ helpers.neovim-plugin.mkNeovimPlugin {
               To disable a default mapping in a specific mode, set it to `false`.
             '';
 
-        override = helpers.defaultNullOpts.mkLuaFn "function(conf) return conf end" ''
+        override = defaultNullOpts.mkLuaFn "function(conf) return conf end" ''
           Lua function that takes config that is passed to nvim_open_win.
           Used to customize the layout.
         '';
 
-        get_config = helpers.defaultNullOpts.mkLuaFn null ''
+        get_config = defaultNullOpts.mkLuaFn null ''
           This can be a function that accepts the opts parameter that is passed in to 'vim.select'
           or 'vim.input'. It must return either nil or config values to use in place of the global
           config values for that module.
@@ -142,11 +141,11 @@ helpers.neovim-plugin.mkNeovimPlugin {
       };
 
       select = {
-        enabled = helpers.defaultNullOpts.mkBool true ''
+        enabled = defaultNullOpts.mkBool true ''
           Enable the vim.ui.select implementation.
         '';
 
-        backend = helpers.defaultNullOpts.mkListOf types.str [
+        backend = defaultNullOpts.mkListOf types.str [
           "telescope"
           "fzf_lua"
           "fzf"
@@ -154,34 +153,32 @@ helpers.neovim-plugin.mkNeovimPlugin {
           "nui"
         ] "Priority list of preferred vim.select implementations. ";
 
-        trim_prompt = helpers.defaultNullOpts.mkBool true ''
+        trim_prompt = defaultNullOpts.mkBool true ''
           Trim trailing `:` from prompt.
         '';
 
-        telescope =
-          helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; either strLua (attrsOf anything)) null
-            ''
-              Options for telescope selector.
+        telescope = defaultNullOpts.mkNullable (with types; either strLua (attrsOf anything)) null ''
+          Options for telescope selector.
 
-              Can be a raw lua string like:
+          Can be a raw lua string like:
 
-              `telescope = \'\'require("telescope.themes").get_ivy({})\'\'`
+          `telescope = \'\'require("telescope.themes").get_ivy({})\'\'`
 
-              or an attribute set of telescope settings.
-            '';
+          or an attribute set of telescope settings.
+        '';
 
         fzf = {
-          window = helpers.defaultNullOpts.mkAttrsOf types.anything {
+          window = defaultNullOpts.mkAttrsOf types.anything {
             width = 0.5;
             height = 0.4;
           } "Window options for fzf selector. ";
         };
 
-        fzf_lua = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
+        fzf_lua = defaultNullOpts.mkAttrsOf types.anything { } ''
           Options for fzf-lua selector.
         '';
 
-        nui = helpers.defaultNullOpts.mkAttrsOf types.anything {
+        nui = defaultNullOpts.mkAttrsOf types.anything {
           position = "50%";
           size = null;
           relative = "editor";
@@ -202,14 +199,14 @@ helpers.neovim-plugin.mkNeovimPlugin {
         } "Options for nui selector. ";
 
         builtin = {
-          show_numbers = helpers.defaultNullOpts.mkBool true ''
+          show_numbers = defaultNullOpts.mkBool true ''
             Display numbers for options and set up keymaps.
           '';
 
-          border = helpers.defaultNullOpts.mkBorder "rounded" "the select window" "";
+          border = defaultNullOpts.mkBorder "rounded" "the select window" "";
 
           relative =
-            helpers.defaultNullOpts.mkEnumFirstDefault
+            defaultNullOpts.mkEnumFirstDefault
               [
                 "editor"
                 "win"
@@ -220,21 +217,21 @@ helpers.neovim-plugin.mkNeovimPlugin {
                 If 'editor' or 'win', will default to being centered.
               '';
 
-          buf_options = helpers.defaultNullOpts.mkAttrsOf types.anything { } ''
+          buf_options = defaultNullOpts.mkAttrsOf types.anything { } ''
             An attribute set of buffer options.
           '';
 
-          win_options = helpers.defaultNullOpts.mkAttrsOf types.anything {
+          win_options = defaultNullOpts.mkAttrsOf types.anything {
             cursorline = true;
             cursorlineopt = "both";
           } "An attribute set of window options.";
 
-          width = helpers.defaultNullOpts.mkNullable intOrRatio null ''
+          width = defaultNullOpts.mkNullable intOrRatio null ''
             Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
           '';
 
           max_width =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+            defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
               [
                 140
                 0.8
@@ -247,7 +244,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
               '';
 
           min_width =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+            defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
               [
                 40
                 0.2
@@ -259,21 +256,19 @@ helpers.neovim-plugin.mkNeovimPlugin {
                 of total."
               '';
 
-          height = helpers.defaultNullOpts.mkNullable intOrRatio null ''
+          height = defaultNullOpts.mkNullable intOrRatio null ''
             Can be an integer or a float between 0 and 1 (e.g. 0.4 for 40%).
           '';
 
-          max_height =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) 0.9
-              ''
-                Max height of window.
+          max_height = defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio)) 0.9 ''
+            Max height of window.
 
-                Can be a list of mixed types, e.g. `[140 0.8]` means "less than 140 rows or 80%
-                of total."
-              '';
+            Can be a list of mixed types, e.g. `[140 0.8]` means "less than 140 rows or 80%
+            of total."
+          '';
 
           min_height =
-            helpers.defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
+            defaultNullOpts.mkNullable (with types; either intOrRatio (listOf intOrRatio))
               [
                 10
                 0.2
@@ -286,7 +281,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
               '';
 
           mappings =
-            helpers.defaultNullOpts.mkAttrsOf (with types; either str (enum [ false ]))
+            defaultNullOpts.mkAttrsOf (with types; either str (enum [ false ]))
               {
                 "<Esc>" = "Close";
                 "<C-c>" = "Close";
@@ -298,13 +293,13 @@ helpers.neovim-plugin.mkNeovimPlugin {
                 To disable a default mapping in a specific mode, set it to `false`.
               '';
 
-          override = helpers.defaultNullOpts.mkLuaFn "function(conf) return conf end" ''
+          override = defaultNullOpts.mkLuaFn "function(conf) return conf end" ''
             Lua function that takes config that is passed to nvim_open_win.
             Used to customize the layout.
           '';
         };
 
-        format_item_override = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.strLuaFn { } ''
+        format_item_override = defaultNullOpts.mkAttrsOf types.strLuaFn { } ''
           Override the formatting/display for a specific "kind" when using vim.ui.select.
           For example, code actions from vim.lsp.buf.code_action use a kind="codeaction".
           You can override the format function when selecting for that kind, e.g.
@@ -322,7 +317,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
           ```
         '';
 
-        get_config = helpers.defaultNullOpts.mkLuaFn null ''
+        get_config = defaultNullOpts.mkLuaFn null ''
           This can be a function that accepts the opts parameter that is passed in to 'vim.select'
           or 'vim.input'. It must return either nil or config values to use in place of the global
           config values for that module.

--- a/plugins/by-name/guess-indent/default.nix
+++ b/plugins/by-name/guess-indent/default.nix
@@ -1,10 +1,9 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "guess-indent";
   originalName = "guess-indent.nvim";
   package = "guess-indent-nvim";
@@ -12,16 +11,16 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ lib.maintainers.GGORG ];
 
   settingsOptions = {
-    auto_cmd = helpers.defaultNullOpts.mkBool true ''
+    auto_cmd = defaultNullOpts.mkBool true ''
       Whether to create autocommand to automatically detect indentation
     '';
 
-    override_editorconfig = helpers.defaultNullOpts.mkBool false ''
+    override_editorconfig = defaultNullOpts.mkBool false ''
       Whether or not to override indentation set by Editorconfig
     '';
 
     filetype_exclude =
-      helpers.defaultNullOpts.mkListOf types.str
+      defaultNullOpts.mkListOf types.str
         [
           "netrw"
           "tutor"
@@ -31,7 +30,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
         '';
 
     buftype_exclude =
-      helpers.defaultNullOpts.mkListOf types.str
+      defaultNullOpts.mkListOf types.str
         [
           "help"
           "nofile"
@@ -42,12 +41,12 @@ helpers.neovim-plugin.mkNeovimPlugin {
           Buffer types to ignore indentation detection in
         '';
 
-    on_tab_options = helpers.defaultNullOpts.mkAttrsOf types.anything { expandtab = false; } ''
+    on_tab_options = defaultNullOpts.mkAttrsOf types.anything { expandtab = false; } ''
       A table of vim options when tabs are detected
     '';
 
     on_space_options =
-      helpers.defaultNullOpts.mkAttrsOf types.anything
+      defaultNullOpts.mkAttrsOf types.anything
         {
           expandtab = true;
           tabstop = "detected";

--- a/plugins/by-name/guess-indent/default.nix
+++ b/plugins/by-name/guess-indent/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "guess-indent.nvim";
   package = "guess-indent-nvim";
 
-  maintainers = [ helpers.maintainers.GGORG ];
+  maintainers = [ lib.maintainers.GGORG ];
 
   settingsOptions = {
     auto_cmd = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/by-name/indent-o-matic/default.nix
+++ b/plugins/by-name/indent-o-matic/default.nix
@@ -1,18 +1,17 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "indent-o-matic";
   maintainers = [ lib.maintainers.alisonjenkins ];
   settingsOptions = {
     max_lines =
-      helpers.defaultNullOpts.mkInt 2048
+      defaultNullOpts.mkInt 2048
         "Number of lines without indentation before giving up (use -1 for infinite)";
-    skip_multiline = helpers.defaultNullOpts.mkBool false "Skip multi-line comments and strings (more accurate detection but less performant)";
-    standard_widths = helpers.defaultNullOpts.mkListOf types.ints.unsigned [
+    skip_multiline = defaultNullOpts.mkBool false "Skip multi-line comments and strings (more accurate detection but less performant)";
+    standard_widths = defaultNullOpts.mkListOf types.ints.unsigned [
       2
       4
       8

--- a/plugins/by-name/indent-o-matic/default.nix
+++ b/plugins/by-name/indent-o-matic/default.nix
@@ -6,7 +6,7 @@
 with lib;
 helpers.neovim-plugin.mkNeovimPlugin {
   name = "indent-o-matic";
-  maintainers = [ helpers.maintainers.alisonjenkins ];
+  maintainers = [ lib.maintainers.alisonjenkins ];
   settingsOptions = {
     max_lines =
       helpers.defaultNullOpts.mkInt 2048

--- a/plugins/by-name/lazygit/default.nix
+++ b/plugins/by-name/lazygit/default.nix
@@ -1,11 +1,13 @@
 {
   lib,
-  helpers,
   pkgs,
   ...
 }:
-with lib;
-helpers.vim-plugin.mkVimPlugin {
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "lazygit";
   originalName = "lazygit.nvim";
   package = "lazygit-nvim";
@@ -14,15 +16,15 @@ helpers.vim-plugin.mkVimPlugin {
   maintainers = [ lib.maintainers.AndresBermeoMarinelli ];
 
   settingsOptions = {
-    floating_window_winblend = helpers.defaultNullOpts.mkNullable (types.ints.between 0 100) 0 ''
+    floating_window_winblend = defaultNullOpts.mkNullable (types.ints.between 0 100) 0 ''
       Set the transparency of the floating window.
     '';
 
     floating_window_scaling_factor =
-      helpers.defaultNullOpts.mkNullable types.numbers.nonnegative 0.9
+      defaultNullOpts.mkNullable types.numbers.nonnegative 0.9
         "Set the scaling factor for floating window.";
 
-    floating_window_border_chars = helpers.defaultNullOpts.mkListOf types.str [
+    floating_window_border_chars = defaultNullOpts.mkListOf types.str [
       "╭"
       "─"
       "╮"
@@ -33,19 +35,19 @@ helpers.vim-plugin.mkVimPlugin {
       "│"
     ] "Customize lazygit popup window border characters.";
 
-    floating_window_use_plenary = helpers.defaultNullOpts.mkFlagInt 0 ''
+    floating_window_use_plenary = defaultNullOpts.mkFlagInt 0 ''
       Whether to use plenary.nvim to manage floating window if available.
     '';
 
-    use_neovim_remote = helpers.defaultNullOpts.mkFlagInt 1 ''
+    use_neovim_remote = defaultNullOpts.mkFlagInt 1 ''
       Whether to use neovim remote. Will fallback to `0` if neovim-remote is not installed.
     '';
 
-    use_custom_config_file_path = helpers.defaultNullOpts.mkFlagInt 0 ''
+    use_custom_config_file_path = defaultNullOpts.mkFlagInt 0 ''
       Config file path is evaluated if this value is `1`.
     '';
 
-    config_file_path = helpers.defaultNullOpts.mkNullable (
+    config_file_path = defaultNullOpts.mkNullable (
       with types; either str (listOf str)
     ) [ ] "Custom config file path or list of custom config file paths.";
   };

--- a/plugins/by-name/lazygit/default.nix
+++ b/plugins/by-name/lazygit/default.nix
@@ -11,7 +11,7 @@ helpers.vim-plugin.mkVimPlugin {
   package = "lazygit-nvim";
   globalPrefix = "lazygit_";
 
-  maintainers = [ helpers.maintainers.AndresBermeoMarinelli ];
+  maintainers = [ lib.maintainers.AndresBermeoMarinelli ];
 
   settingsOptions = {
     floating_window_winblend = helpers.defaultNullOpts.mkNullable (types.ints.between 0 100) 0 ''

--- a/plugins/by-name/lsp-status/default.nix
+++ b/plugins/by-name/lsp-status/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   name = "lsp-status";
   originalName = "lsp-status.nvim";
   package = "lsp-status-nvim";
-  maintainers = [ helpers.maintainers.b3nb5n ];
+  maintainers = [ lib.maintainers.b3nb5n ];
 
   settingsOptions =
     let

--- a/plugins/by-name/lsp-status/default.nix
+++ b/plugins/by-name/lsp-status/default.nix
@@ -1,11 +1,13 @@
 {
   lib,
-  helpers,
   config,
   ...
 }:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "lsp-status";
   originalName = "lsp-status.nvim";
   package = "lsp-status-nvim";
@@ -15,27 +17,27 @@ helpers.neovim-plugin.mkNeovimPlugin {
     let
       mkIndicatorOption =
         default:
-        helpers.defaultNullOpts.mkStr default ''
+        defaultNullOpts.mkStr default ''
           The string to show as diagnostics.
           If you don't have Nerd/Awesome Fonts you can replace defaults with ASCII chars.
         '';
     in
     {
-      kind_labels = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
+      kind_labels = defaultNullOpts.mkAttrsOf types.str { } ''
         An optional map from LSP symbol kinds to label symbols. Used to decorate the current function name.
       '';
 
-      select_symbol = helpers.defaultNullOpts.mkStr "" ''
+      select_symbol = defaultNullOpts.mkStr "" ''
         An optional handler of the form `function(cursor_pos, document_symbol)` that should return
         `true` if `document_symbol` (a `DocumentSymbol`) should be accepted as the symbol currently
         containing the cursor.
       '';
 
-      current_function = helpers.defaultNullOpts.mkBool true ''
+      current_function = defaultNullOpts.mkBool true ''
         True if the current function should be updated and displayed in the default statusline component.
       '';
 
-      show_filename = helpers.defaultNullOpts.mkBool true ''
+      show_filename = defaultNullOpts.mkBool true ''
         True if the current function should be updated and displayed in the default statusline component.
       '';
 
@@ -45,15 +47,15 @@ helpers.neovim-plugin.mkNeovimPlugin {
       indicator_info = mkIndicatorOption "🛈";
       indicator_hint = mkIndicatorOption "❗";
 
-      indicator_separator = helpers.defaultNullOpts.mkStr " " ''
+      indicator_separator = defaultNullOpts.mkStr " " ''
         A string which goes between each diagnostic group symbol and its count.
       '';
 
-      component_separator = helpers.defaultNullOpts.mkStr " " ''
+      component_separator = defaultNullOpts.mkStr " " ''
         A string which goes between each "chunk" of the statusline component (i.e. different diagnostic groups, messages).
       '';
 
-      diagnostics = helpers.defaultNullOpts.mkBool true ''
+      diagnostics = defaultNullOpts.mkBool true ''
         If false, the default statusline component does not display LSP diagnostics.
       '';
     };
@@ -73,7 +75,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       preConfig = ''
         do
           local lsp_status = require('lsp-status')
-          lsp_status.config(${helpers.toLuaObject cfg.settings})
+          lsp_status.config(${lib.nixvim.toLuaObject cfg.settings})
           lsp_status.register_progress()
         end
       '';

--- a/plugins/by-name/numbertoggle/default.nix
+++ b/plugins/by-name/numbertoggle/default.nix
@@ -7,5 +7,5 @@ lib.nixvim.vim-plugin.mkVimPlugin {
   originalName = "vim-numbertoggle";
   package = "vim-numbertoggle";
 
-  maintainers = [ lib.nixvim.maintainers.refaelsh ];
+  maintainers = [ lib.maintainers.refaelsh ];
 }

--- a/plugins/by-name/octo/default.nix
+++ b/plugins/by-name/octo/default.nix
@@ -10,7 +10,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "octo.nvim";
   package = "octo-nvim";
 
-  maintainers = [ helpers.maintainers.svl ];
+  maintainers = [ lib.maintainers.svl ];
 
   settingsOptions = {
     use_local_fs = helpers.defaultNullOpts.mkBool false ''

--- a/plugins/by-name/octo/default.nix
+++ b/plugins/by-name/octo/default.nix
@@ -1,11 +1,13 @@
 {
   lib,
-  helpers,
   pkgs,
   ...
 }:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "octo";
   originalName = "octo.nvim";
   package = "octo-nvim";
@@ -13,16 +15,16 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ lib.maintainers.svl ];
 
   settingsOptions = {
-    use_local_fs = helpers.defaultNullOpts.mkBool false ''
+    use_local_fs = defaultNullOpts.mkBool false ''
       Use local files on right side of reviews.
     '';
 
-    enable_builtin = helpers.defaultNullOpts.mkBool false ''
+    enable_builtin = defaultNullOpts.mkBool false ''
       Shows a list of builtin actions when no action is provided.
     '';
 
     default_remote =
-      helpers.defaultNullOpts.mkListOf types.str
+      defaultNullOpts.mkListOf types.str
         [
           "upstream"
           "origin"
@@ -31,23 +33,23 @@ helpers.neovim-plugin.mkNeovimPlugin {
           Order to try remotes
         '';
 
-    ssh_aliases = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
+    ssh_aliases = defaultNullOpts.mkAttrsOf types.str { } ''
       SSH aliases.
     '';
 
     picker_config = {
-      use_emojis = helpers.defaultNullOpts.mkBool false ''
+      use_emojis = defaultNullOpts.mkBool false ''
         Use emojis in picker. Only used by "fzf-lua" picker for now.
       '';
 
       mappings =
         let
           mkMappingOption = lhs: desc: {
-            lhs = helpers.defaultNullOpts.mkStr lhs ''
+            lhs = defaultNullOpts.mkStr lhs ''
               Key to map.
             '';
 
-            desc = helpers.defaultNullOpts.mkStr desc ''
+            desc = defaultNullOpts.mkStr desc ''
               Description of the mapping.
             '';
           };
@@ -71,54 +73,54 @@ helpers.neovim-plugin.mkNeovimPlugin {
         };
     };
 
-    reaction_viewer_hint_icon = helpers.defaultNullOpts.mkStr "" ''
+    reaction_viewer_hint_icon = defaultNullOpts.mkStr "" ''
       Marker for user reactions.
     '';
 
-    user_icon = helpers.defaultNullOpts.mkStr " " ''
+    user_icon = defaultNullOpts.mkStr " " ''
       User Icon.
     '';
 
-    timeline_marker = helpers.defaultNullOpts.mkStr "" ''
+    timeline_marker = defaultNullOpts.mkStr "" ''
       Timeline marker.
     '';
 
-    timeline_indent = helpers.defaultNullOpts.mkStr "2" ''
+    timeline_indent = defaultNullOpts.mkStr "2" ''
       Timeline indentation.
     '';
 
-    right_bubble_delimiter = helpers.defaultNullOpts.mkStr "" ''
+    right_bubble_delimiter = defaultNullOpts.mkStr "" ''
       Bubble delimiter.
     '';
 
-    left_bubble_delimiter = helpers.defaultNullOpts.mkStr "" ''
+    left_bubble_delimiter = defaultNullOpts.mkStr "" ''
       Bubble delimiter.
     '';
 
-    github_hostname = helpers.defaultNullOpts.mkStr "" ''
+    github_hostname = defaultNullOpts.mkStr "" ''
       Github Enterprise host.
     '';
 
-    snippet_context_lines = helpers.defaultNullOpts.mkInt 4 ''
+    snippet_context_lines = defaultNullOpts.mkInt 4 ''
       Number of lines around commented lines.
     '';
 
-    gh_env = helpers.defaultNullOpts.mkAttributeSet { } ''
+    gh_env = defaultNullOpts.mkAttributeSet { } ''
       Extra environment variables to pass on to GitHub CLI, can be a table or function returning a table.
     '';
 
-    timeout = helpers.defaultNullOpts.mkInt 5000 ''
+    timeout = defaultNullOpts.mkInt 5000 ''
       Timeout for requests between the remote server.
     '';
 
     ui = {
-      use_sign_column = helpers.defaultNullOpts.mkBool true ''
+      use_sign_column = defaultNullOpts.mkBool true ''
         Show "modified" marks on the sign column.
       '';
     };
 
     picker =
-      helpers.defaultNullOpts.mkEnumFirstDefault
+      defaultNullOpts.mkEnumFirstDefault
         [
           "telescope"
           "fzf-lua"
@@ -130,7 +132,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     issues = {
       order_by = {
         field =
-          helpers.defaultNullOpts.mkEnumFirstDefault
+          defaultNullOpts.mkEnumFirstDefault
             [
               "CREATED_AT"
               "COMMENTS"
@@ -140,7 +142,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
               See GitHub's [`IssueOrderField`](https://docs.github.com/en/graphql/reference/enums#issueorderfield) documentation.
             '';
         direction =
-          helpers.defaultNullOpts.mkEnumFirstDefault
+          defaultNullOpts.mkEnumFirstDefault
             [
               "DESC"
               "ASC"
@@ -174,11 +176,11 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   extraConfig =
     cfg:
-    mkMerge [
+    lib.mkMerge [
       { extraPackages = [ cfg.ghPackage ]; }
-      (mkIf (cfg.settings.picker == null || cfg.settings.picker == "telescope") {
-        plugins.telescope.enable = mkDefault true;
+      (lib.mkIf (cfg.settings.picker == null || cfg.settings.picker == "telescope") {
+        plugins.telescope.enable = lib.mkDefault true;
       })
-      (mkIf (cfg.settings.picker == "fzf-lua") { plugins.fzf-lua.enable = mkDefault true; })
+      (lib.mkIf (cfg.settings.picker == "fzf-lua") { plugins.fzf-lua.enable = lib.mkDefault true; })
     ];
 }

--- a/plugins/by-name/orgmode/default.nix
+++ b/plugins/by-name/orgmode/default.nix
@@ -9,7 +9,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "orgmode";
   originalName = "nvim-orgmode";
 
-  maintainers = [ lib.nixvim.maintainers.refaelsh ];
+  maintainers = [ lib.maintainers.refaelsh ];
 
   settingsOptions = {
     org_agenda_files = defaultNullOpts.mkNullable (with lib.types; either str (listOf str)) "" ''

--- a/plugins/by-name/repeat/default.nix
+++ b/plugins/by-name/repeat/default.nix
@@ -7,5 +7,5 @@ lib.nixvim.vim-plugin.mkVimPlugin {
   originalName = "vim-repeat";
   package = "vim-repeat";
 
-  maintainers = [ lib.nixvim.maintainers.refaelsh ];
+  maintainers = [ lib.maintainers.refaelsh ];
 }

--- a/plugins/by-name/vim-css-color/default.nix
+++ b/plugins/by-name/vim-css-color/default.nix
@@ -1,8 +1,9 @@
 {
+  lib,
   helpers,
   ...
 }:
 helpers.vim-plugin.mkVimPlugin {
   name = "vim-css-color";
-  maintainers = [ helpers.maintainers.DanielLaing ];
+  maintainers = [ lib.maintainers.DanielLaing ];
 }

--- a/plugins/by-name/vim-css-color/default.nix
+++ b/plugins/by-name/vim-css-color/default.nix
@@ -1,9 +1,5 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-helpers.vim-plugin.mkVimPlugin {
+{ lib, ... }:
+lib.nixvim.vim-plugin.mkVimPlugin {
   name = "vim-css-color";
   maintainers = [ lib.maintainers.DanielLaing ];
 }

--- a/plugins/by-name/virt-column/default.nix
+++ b/plugins/by-name/virt-column/default.nix
@@ -1,10 +1,9 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
-helpers.neovim-plugin.mkNeovimPlugin {
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "virt-column";
   originalName = "virt-column.nvim";
   package = "virt-column-nvim";
@@ -12,25 +11,25 @@ helpers.neovim-plugin.mkNeovimPlugin {
   maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
-    enabled = helpers.defaultNullOpts.mkBool true ''
+    enabled = defaultNullOpts.mkBool true ''
       Enables or disables virt-column.
     '';
 
-    char = helpers.defaultNullOpts.mkNullable (with types; either str (listOf str)) [ "┃" ] ''
+    char = defaultNullOpts.mkNullable (with types; either str (listOf str)) [ "┃" ] ''
       Character, or list of characters, that get used to display the virtual column.
       Each character has to have a display width of 0 or 1.
     '';
 
-    virtcolumn = helpers.defaultNullOpts.mkStr "" ''
+    virtcolumn = defaultNullOpts.mkStr "" ''
       Comma-separated list of screen columns same syntax as `:help colorcolumn`.
     '';
 
-    highlight = helpers.defaultNullOpts.mkNullable (with types; either str (listOf str)) "NonText" ''
+    highlight = defaultNullOpts.mkNullable (with types; either str (listOf str)) "NonText" ''
       Highlight group, or list of highlight groups, that get applied to the virtual column.
     '';
 
     exclude = {
-      filetypes = helpers.defaultNullOpts.mkListOf types.str [
+      filetypes = defaultNullOpts.mkListOf types.str [
         "lspinfo"
         "packer"
         "checkhealth"
@@ -40,7 +39,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
         "TelescopeResults"
       ] "List of `filetype`s for which virt-column is disabled.";
 
-      buftypes = helpers.defaultNullOpts.mkListOf types.str [
+      buftypes = defaultNullOpts.mkListOf types.str [
         "nofile"
         "quickfix"
         "terminal"

--- a/plugins/by-name/virt-column/default.nix
+++ b/plugins/by-name/virt-column/default.nix
@@ -9,7 +9,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
   originalName = "virt-column.nvim";
   package = "virt-column-nvim";
 
-  maintainers = [ helpers.maintainers.alisonjenkins ];
+  maintainers = [ lib.maintainers.alisonjenkins ];
 
   settingsOptions = {
     enabled = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/colorschemes/cyberdream.nix
+++ b/plugins/colorschemes/cyberdream.nix
@@ -11,7 +11,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   originalName = "cyberdream.nvim";
   package = "cyberdream-nvim";
 
-  maintainers = [ lib.nixvim.maintainers.AndresBermeoMarinelli ];
+  maintainers = [ lib.maintainers.AndresBermeoMarinelli ];
 
   settingsOptions = {
     transparent = defaultNullOpts.mkBool false ''

--- a/plugins/colorschemes/dracula-nvim.nix
+++ b/plugins/colorschemes/dracula-nvim.nix
@@ -6,7 +6,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   colorscheme = "dracula";
   isColorscheme = true;
 
-  maintainers = [ lib.nixvim.maintainers.refaelsh ];
+  maintainers = [ lib.maintainers.refaelsh ];
 
   settingsExample = {
     italic_comment = true;

--- a/plugins/colorschemes/everforest.nix
+++ b/plugins/colorschemes/everforest.nix
@@ -10,7 +10,7 @@ lib.nixvim.vim-plugin.mkVimPlugin {
   isColorscheme = true;
   globalPrefix = "everforest_";
 
-  maintainers = [ lib.nixvim.maintainers.sheemap ];
+  maintainers = [ lib.maintainers.sheemap ];
 
   settingsOptions = {
     background =

--- a/plugins/colorschemes/modus.nix
+++ b/plugins/colorschemes/modus.nix
@@ -12,7 +12,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   package = "modus-themes-nvim";
   isColorscheme = true;
 
-  maintainers = [ lib.nixvim.maintainers.nwjsmith ];
+  maintainers = [ lib.maintainers.nwjsmith ];
 
   settingsOptions = {
     style =


### PR DESCRIPTION
Remove the `lib.nixvim.maintainers` alias for `lib.maintainers`.

Also cleanup lib usage in several plugins, specifically the plugins that were touched by the main part of the PR:
- removed `with lib`
- migrate `helpers` -> `lib.nixvim`
- remove (most?) `nixvimTypes` usage
