### PR TITLE
lib: remove `nixvimTypes` alias

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -120,13 +120,18 @@ lib.fix (
       wrapVimscriptForLua
       ;
 
-    # TODO: Removed 2024-09-27
-    maintainers = throw "The `maintainers` alias has been removed. Use `lib.maintainers` on a lib with nixvim's extensions.";
-
-    # TODO: Deprecate the old `nixvimTypes` alias?
-    nixvimTypes = self.extendedLib.types;
-
     toLuaObject = self.lua.toLua;
     mkLuaInline = self.lua.mkInline;
   }
+  //
+    # TODO: Removed 2024-09-27; remove after 24.11
+    lib.mapAttrs
+      (
+        old: new:
+        throw "The `${old}` alias has been removed. Use `${new}` on a lib with nixvim's extensions."
+      )
+      {
+        maintainers = "lib.maintainers";
+        nixvimTypes = "lib.types";
+      }
 )

--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -114,7 +114,7 @@
             }
             // lib.optionalAttrs hasConfigAttrs {
               luaConfig = lib.mkOption {
-                type = lib.nixvim.nixvimTypes.pluginLuaConfig;
+                type = lib.types.pluginLuaConfig;
                 default = { };
                 description = "The plugin's lua configuration";
               };

--- a/modules/commands.nix
+++ b/modules/commands.nix
@@ -8,7 +8,7 @@ let
   commandAttributes = lib.types.submodule {
     options = {
       command = lib.mkOption {
-        type = with helpers.nixvimTypes; either str rawLua;
+        type = with lib.types; either str rawLua;
         description = "The command to run.";
       };
 
@@ -24,7 +24,7 @@ let
           ''
             The number of arguments to expect, see :h command-nargs.
           '';
-      complete = helpers.mkNullOrOption (with lib.types; either str helpers.nixvimTypes.rawLua) ''
+      complete = helpers.mkNullOrOption (with lib.types; either str rawLua) ''
         Tab-completion behaviour, see :h command-complete.
       '';
       range =

--- a/modules/filetype.nix
+++ b/modules/filetype.nix
@@ -15,7 +15,7 @@ let
       # Raw filetype
       str
       # Function to set the filetype
-      helpers.nixvimTypes.rawLua
+      rawLua
       # ["filetype" {priority = xx;}]
       (listOf (
         either str (submodule {

--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -7,7 +7,7 @@
 {
   options = {
     highlight = lib.mkOption {
-      type = lib.types.attrsOf helpers.nixvimTypes.highlight;
+      type = lib.types.attrsOf lib.types.highlight;
       default = { };
       description = "Define new highlight groups";
       example = {
@@ -16,7 +16,7 @@
     };
 
     highlightOverride = lib.mkOption {
-      type = lib.types.attrsOf helpers.nixvimTypes.highlight;
+      type = lib.types.attrsOf lib.types.highlight;
       default = { };
       description = "Define highlight groups to override existing highlight";
       example = {

--- a/plugins/by-name/airline/default.nix
+++ b/plugins/by-name/airline/default.nix
@@ -59,7 +59,7 @@ mkVimPlugin {
           name:
           nameValuePair "section_${name}" (
             helpers.mkNullOrOption (
-              with helpers.nixvimTypes;
+              with lib.types;
               oneOf [
                 rawLua
                 str
@@ -111,7 +111,7 @@ mkVimPlugin {
       detect_spelllang =
         helpers.defaultNullOpts.mkNullable
           (
-            with helpers.nixvimTypes;
+            with lib.types;
             oneOf [
               rawLua
               intFlag
@@ -179,47 +179,45 @@ mkVimPlugin {
         If you want to use plain ascii symbols, set this variable: >
       '';
 
-      mode_map = helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (attrsOf str)) ''
+      mode_map = helpers.mkNullOrOption (with lib.types; maybeRaw (attrsOf str)) ''
         Define the set of text to display for each mode.
 
         Default: see source
       '';
 
-      exclude_filenames = helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (listOf str)) ''
+      exclude_filenames = helpers.mkNullOrOption (with lib.types; maybeRaw (listOf str)) ''
         Define the set of filename match queries which excludes a window from having its
         statusline modified.
 
         Default: see source for current list
       '';
 
-      exclude_filetypes = helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (listOf str)) ''
+      exclude_filetypes = helpers.mkNullOrOption (with lib.types; maybeRaw (listOf str)) ''
         Define the set of filetypes which are excluded from having its window statusline modified.
 
         Default: see source for current list
       '';
 
-      filetype_overrides =
-        helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (attrsOf (listOf str)))
-          ''
-            Define the set of names to be displayed instead of a specific filetypes.
+      filetype_overrides = helpers.mkNullOrOption (with lib.types; maybeRaw (attrsOf (listOf str))) ''
+        Define the set of names to be displayed instead of a specific filetypes.
 
-            Example:
-            ```nix
-              {
-                coc-explorer =  ["CoC Explorer" ""];
-                defx = ["defx" "%{b:defx.paths[0]}"];
-                fugitive = ["fugitive" "%{airline#util#wrap(airline#extensions#branch#get_head(),80)}"];
-                gundo = ["Gundo" "" ];
-                help = ["Help" "%f"];
-                minibufexpl = ["MiniBufExplorer" ""];
-                startify = ["startify" ""];
-                vim-plug = ["Plugins" ""];
-                vimfiler = ["vimfiler" "%{vimfiler#get_status_string()}"];
-                vimshell = ["vimshell" "%{vimshell#get_status_string()}"];
-                vaffle = ["Vaffle" "%{b:vaffle.dir}"];
-              }
-            ```
-          '';
+        Example:
+        ```nix
+          {
+            coc-explorer =  ["CoC Explorer" ""];
+            defx = ["defx" "%{b:defx.paths[0]}"];
+            fugitive = ["fugitive" "%{airline#util#wrap(airline#extensions#branch#get_head(),80)}"];
+            gundo = ["Gundo" "" ];
+            help = ["Help" "%f"];
+            minibufexpl = ["MiniBufExplorer" ""];
+            startify = ["startify" ""];
+            vim-plug = ["Plugins" ""];
+            vimfiler = ["vimfiler" "%{vimfiler#get_status_string()}"];
+            vimshell = ["vimshell" "%{vimshell#get_status_string()}"];
+            vaffle = ["Vaffle" "%{b:vaffle.dir}"];
+          }
+        ```
+      '';
 
       exclude_preview = helpers.defaultNullOpts.mkFlagInt 0 ''
         Defines whether the preview window should be excluded from having its window statusline

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -5,8 +5,8 @@
   ...
 }:
 let
-  inherit (lib.nixvim) defaultNullOpts nixvimTypes mkSettingsRenamedOptionModules;
-  types = nixvimTypes;
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts mkSettingsRenamedOptionModules;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "bufferline";

--- a/plugins/by-name/clipboard-image/default.nix
+++ b/plugins/by-name/clipboard-image/default.nix
@@ -13,7 +13,7 @@ let
     imgDir =
       helpers.defaultNullOpts.mkNullable
         (
-          with helpers.nixvimTypes;
+          with lib.types;
           oneOf [
             str
             (listOf str)
@@ -29,7 +29,7 @@ let
         '';
 
     imgDirTxt = helpers.defaultNullOpts.mkNullable (
-      with helpers.nixvimTypes;
+      with lib.types;
       oneOf [
         str
         (listOf str)

--- a/plugins/by-name/dap/dap-python.nix
+++ b/plugins/by-name/dap/dap-python.nix
@@ -42,13 +42,13 @@ in
       By default the `VIRTUAL_ENV` and `CONDA_PREFIX` environment variables are used if present.
     '';
 
-    testRunner = helpers.mkNullOrOption (types.either types.str helpers.nixvimTypes.rawLua) ''
+    testRunner = helpers.mkNullOrOption (types.either types.str types.rawLua) ''
       The name of test runner to use by default.
       The default value is dynamic and depends on `pytest.ini` or `manage.py` markers.
       If neither is found "unittest" is used.
     '';
 
-    testRunners = helpers.mkNullOrOption (with helpers.nixvimTypes; attrsOf strLuaFn) ''
+    testRunners = helpers.mkNullOrOption (with lib.types; attrsOf strLuaFn) ''
       Set to register test runners.
       Built-in are test runners for unittest, pytest and django.
       The key is the test runner name, the value a function to generate the

--- a/plugins/by-name/debugprint/default.nix
+++ b/plugins/by-name/debugprint/default.nix
@@ -44,7 +44,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   settingsOptions = {
     keymaps =
-      helpers.defaultNullOpts.mkAttrsOf (with helpers.nixvimTypes; attrsOf (either str rawLua))
+      helpers.defaultNullOpts.mkAttrsOf (with lib.types; attrsOf (either str rawLua))
         {
           normal = {
             plain_below = "g?p";

--- a/plugins/by-name/edgy/default.nix
+++ b/plugins/by-name/edgy/default.nix
@@ -136,7 +136,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
           in
           helpers.mkNullOrOption' {
             type =
-              with helpers.nixvimTypes;
+              with lib.types;
               either strLua (submodule {
                 freeformType = attrsOf anything;
                 options = {
@@ -181,7 +181,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       # This option accepts an attrs or a lua string.
       # Hence, we convert the string to raw lua in `apply`.
       keys = helpers.defaultNullOpts.mkAttrsOf' {
-        type = with helpers.nixvimTypes; either strLuaFn (enum [ false ]);
+        type = with lib.types; either strLuaFn (enum [ false ]);
         apply = x: if x == null then null else mapAttrs (_: v: if isString v then helpers.mkRaw v else v) x;
         description = ''
           Buffer-local keymaps to be added to edgebar buffers.

--- a/plugins/by-name/fidget/default.nix
+++ b/plugins/by-name/fidget/default.nix
@@ -16,7 +16,7 @@ let
         with types;
         oneOf [
           str
-          helpers.nixvimTypes.rawLua
+          rawLua
           (listOf str)
           (attrsOf (either str ints.unsigned))
         ]

--- a/plugins/by-name/firenvim/default.nix
+++ b/plugins/by-name/firenvim/default.nix
@@ -5,8 +5,8 @@
   ...
 }:
 let
+  inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
-  types = lib.nixvim.nixvimTypes;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "firenvim";

--- a/plugins/by-name/gitblame/default.nix
+++ b/plugins/by-name/gitblame/default.nix
@@ -4,8 +4,8 @@
   ...
 }:
 let
+  inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
-  types = lib.nixvim.nixvimTypes;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "gitblame";

--- a/plugins/by-name/gitlinker/default.nix
+++ b/plugins/by-name/gitlinker/default.nix
@@ -24,8 +24,7 @@ with lib;
     '';
 
     actionCallback =
-      helpers.defaultNullOpts.mkNullable (with types; either str helpers.nixvimTypes.rawLua)
-        "copy_to_clipboard"
+      helpers.defaultNullOpts.mkNullable (with types; either str rawLua) "copy_to_clipboard"
         ''
           Callback for what to do with the url.
 

--- a/plugins/by-name/gitsigns/options.nix
+++ b/plugins/by-name/gitsigns/options.nix
@@ -58,14 +58,14 @@ with lib;
         freeformType = with types; attrsOf anything;
         options = {
           toplevel = mkOption {
-            type = with helpers.nixvimTypes; maybeRaw str;
+            type = with lib.types; maybeRaw str;
             description = ''
               Path to the top-level of the parent git repository.
             '';
           };
 
           gitdir = mkOption {
-            type = with helpers.nixvimTypes; maybeRaw str;
+            type = with lib.types; maybeRaw str;
             description = ''
               Path to the git directory of the parent git repository (typically the `.git/` directory).
             '';

--- a/plugins/by-name/hydra/hydras-option.nix
+++ b/plugins/by-name/hydra/hydras-option.nix
@@ -10,7 +10,7 @@ let
       '';
 
       mode = helpers.defaultNullOpts.mkNullable (
-        with helpers.nixvimTypes; either helpers.keymaps.modeEnum (listOf helpers.keymaps.modeEnum)
+        with lib.types; either helpers.keymaps.modeEnum (listOf helpers.keymaps.modeEnum)
       ) "n" "Modes where the hydra exists, same as `vim.keymap.set()` accepts.";
 
       body = helpers.mkNullOrStr ''
@@ -75,12 +75,12 @@ let
               '';
 
               mode = helpers.mkNullOrOption (
-                with helpers.nixvimTypes; either helpers.keymaps.modeEnum (listOf helpers.keymaps.modeEnum)
+                with lib.types; either helpers.keymaps.modeEnum (listOf helpers.keymaps.modeEnum)
               ) "Override `mode` for this head.";
             };
           };
           headType =
-            with helpers.nixvimTypes;
+            with lib.types;
             # More precisely, a tuple: [head action opts]
             listOf (
               nullOr (

--- a/plugins/by-name/hydra/settings-options.nix
+++ b/plugins/by-name/hydra/settings-options.nix
@@ -129,7 +129,7 @@ with lib;
           '';
 
           funcs = mkOption {
-            type = with helpers.nixvimTypes; attrsOf strLuaFn;
+            type = with lib.types; attrsOf strLuaFn;
             description = ''
               Table from function names to function.
               Functions should return a string.

--- a/plugins/by-name/improved-search/default.nix
+++ b/plugins/by-name/improved-search/default.nix
@@ -21,7 +21,7 @@ helpers.vim-plugin.mkVimPlugin {
         See [here](https://github.com/backdround/improved-search.nvim?tab=readme-ov-file#functions-and-operators) for the list of available callbacks.
       '';
       type =
-        with helpers.nixvimTypes;
+        with lib.types;
         listOf (submodule {
           options = {
             key = mkOption {
@@ -34,7 +34,7 @@ helpers.vim-plugin.mkVimPlugin {
 
             action = mkOption {
               type =
-                with helpers.nixvimTypes;
+                with lib.types;
                 maybeRaw (
                   # https://github.com/backdround/improved-search.nvim?tab=readme-ov-file#functions-and-operators
                   enum [

--- a/plugins/by-name/leap/default.nix
+++ b/plugins/by-name/leap/default.nix
@@ -90,7 +90,7 @@ in
     };
 
     safeLabels =
-      helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; maybeRaw (listOf str))
+      helpers.defaultNullOpts.mkNullable (with lib.types; maybeRaw (listOf str))
         (stringToCharacters "sfnut/SFNLHMUGT?Z")
         ''
           When the number of matches does not exceed the number of these "safe" labels plus one, the

--- a/plugins/by-name/lint/default.nix
+++ b/plugins/by-name/lint/default.nix
@@ -41,7 +41,7 @@ let
     };
 
     args = {
-      type = listOf (either str helpers.nixvimTypes.rawLua);
+      type = listOf (either str rawLua);
       description = ''
         List of arguments.
         Can contain functions with zero arguments that will be evaluated once the linter is used.
@@ -86,7 +86,7 @@ let
     };
 
     parser = {
-      type = helpers.nixvimTypes.strLuaFn;
+      type = lib.types.strLuaFn;
       description = "The code for your parser function.";
       example = ''
         require('lint.parser').from_pattern(pattern, groups, severity_map, defaults, opts)
@@ -211,7 +211,7 @@ in
               };
 
               callback = mkOption {
-                type = with types; nullOr (either str helpers.nixvimTypes.rawLua);
+                type = with types; nullOr (either str rawLua);
                 default = defaultCallback;
                 description = "What action to perform for linting";
               };

--- a/plugins/by-name/luasnip/default.nix
+++ b/plugins/by-name/luasnip/default.nix
@@ -23,7 +23,7 @@ let
       paths =
         helpers.mkNullOrOption
           (
-            with helpers.nixvimTypes;
+            with lib.types;
             oneOf [
               str
               path
@@ -39,11 +39,11 @@ let
             List of paths to load.
           '';
 
-      exclude = helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (listOf (maybeRaw str))) ''
+      exclude = helpers.mkNullOrOption (with lib.types; maybeRaw (listOf (maybeRaw str))) ''
         List of languages to exclude, by default is empty.
       '';
 
-      include = helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (listOf (maybeRaw str))) ''
+      include = helpers.mkNullOrOption (with lib.types; maybeRaw (listOf (maybeRaw str))) ''
         List of languages to include, by default is not set.
       '';
     };

--- a/plugins/by-name/neoclip/default.nix
+++ b/plugins/by-name/neoclip/default.nix
@@ -75,7 +75,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     '';
 
     default_register =
-      helpers.defaultNullOpts.mkNullable (with helpers.nixvimTypes; either str (listOf str)) "\""
+      helpers.defaultNullOpts.mkNullable (with lib.types; either str (listOf str)) "\""
         ''
           What register to use by default when not specified (e.g. `Telescope neoclip`).
           Can be a string such as `"\""` (single register) or a table of strings such as

--- a/plugins/by-name/notify/default.nix
+++ b/plugins/by-name/notify/default.nix
@@ -26,11 +26,11 @@ in
 
     timeout = helpers.defaultNullOpts.mkUnsignedInt 5000 "Default timeout for notification.";
 
-    maxWidth = helpers.mkNullOrOption (with types; either ints.unsigned helpers.nixvimTypes.rawLua) ''
+    maxWidth = helpers.mkNullOrOption (with types; either ints.unsigned rawLua) ''
       Max number of columns for messages.
     '';
 
-    maxHeight = helpers.mkNullOrOption (with types; either ints.unsigned helpers.nixvimTypes.rawLua) ''
+    maxHeight = helpers.mkNullOrOption (with types; either ints.unsigned rawLua) ''
       Max number of lines for a message.
     '';
 

--- a/plugins/by-name/nvim-jdtls/default.nix
+++ b/plugins/by-name/nvim-jdtls/default.nix
@@ -53,7 +53,7 @@ in
     '';
 
     data = mkOption {
-      type = helpers.nixvimTypes.maybeRaw (with types; nullOr str);
+      type = with types; nullOr (maybeRaw str);
       default = null;
       example = "/home/YOUR_USERNAME/.cache/jdtls/workspace";
       description = ''
@@ -64,7 +64,7 @@ in
     };
 
     configuration = mkOption {
-      type = helpers.nixvimTypes.maybeRaw (with types; nullOr str);
+      type = with types; nullOr (maybeRaw str);
       default = null;
       example = "/home/YOUR_USERNAME/.cache/jdtls/config";
       description = "Path to the configuration file.";

--- a/plugins/by-name/nvim-tree/default.nix
+++ b/plugins/by-name/nvim-tree/default.nix
@@ -323,9 +323,7 @@ in
     };
 
     onAttach =
-      helpers.defaultNullOpts.mkNullable
-        (with types; either (enum [ "default" ]) helpers.nixvimTypes.rawLua)
-        "default"
+      helpers.defaultNullOpts.mkNullable (with types; either (enum [ "default" ]) rawLua) "default"
         ''
           Function ran when creating the nvim-tree buffer.
           This can be used to attach keybindings to the tree buffer.
@@ -387,7 +385,7 @@ in
                     '';
 
                     padding =
-                      helpers.defaultNullOpts.mkNullable (either ints.unsigned helpers.nixvimTypes.rawLua) "1"
+                      helpers.defaultNullOpts.mkNullable (either ints.unsigned rawLua) "1"
                         "Extra padding to the right.";
                   };
               })
@@ -503,7 +501,7 @@ in
             oneOf [
               str
               bool
-              helpers.nixvimTypes.rawLua
+              rawLua
             ]
           )
           # Default

--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -214,12 +214,12 @@ helpers.neovim-plugin.mkNeovimPlugin {
               types.submodule {
                 options = {
                   name = mkOption {
-                    type = with helpers.nixvimTypes; maybeRaw str;
+                    type = with lib.types; maybeRaw str;
                     description = "The name for this workspace";
                   };
 
                   path = mkOption {
-                    type = with helpers.nixvimTypes; maybeRaw str;
+                    type = with lib.types; maybeRaw str;
                     description = "The of the workspace.";
                   };
 

--- a/plugins/by-name/obsidian/options.nix
+++ b/plugins/by-name/obsidian/options.nix
@@ -31,7 +31,7 @@ with lib;
     '';
 
     substitutions = helpers.defaultNullOpts.mkAttrsOf (
-      with helpers.nixvimTypes; either str rawLua
+      with lib.types; either str rawLua
     ) { } "A map for custom variables, the key should be the variable and the value a function.";
   };
 
@@ -224,7 +224,7 @@ with lib;
         attrsOf (submodule {
           options = {
             action = mkOption {
-              type = helpers.nixvimTypes.strLua;
+              type = lib.types.strLua;
               description = "The lua code for this keymap action.";
               apply = helpers.mkRaw;
             };
@@ -372,12 +372,12 @@ with lib;
           submodule {
             options = {
               char = mkOption {
-                type = with helpers.nixvimTypes; maybeRaw str;
+                type = with lib.types; maybeRaw str;
                 description = "The character to use for this checkbox.";
               };
 
               hl_group = mkOption {
-                type = with helpers.nixvimTypes; maybeRaw str;
+                type = with lib.types; maybeRaw str;
                 description = "The name of the highlight group to use for this checkbox.";
               };
             };
@@ -447,7 +447,7 @@ with lib;
       '';
     };
 
-    hl_groups = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight {
+    hl_groups = helpers.defaultNullOpts.mkAttrsOf lib.types.highlight {
       ObsidianTodo = {
         bold = true;
         fg = "#f78c6c";

--- a/plugins/by-name/oil/default.nix
+++ b/plugins/by-name/oil/default.nix
@@ -210,7 +210,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
       columns = mkOption {
         type =
-          with helpers.nixvimTypes;
+          with lib.types;
           listOf (oneOf [
             str
             (attrsOf anything)

--- a/plugins/by-name/ollama/default.nix
+++ b/plugins/by-name/ollama/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.ollama;
 
   actionOptionType =
-    with helpers.nixvimTypes;
+    with lib.types;
     oneOf [
       rawLua
       (enum [
@@ -78,7 +78,7 @@ in
       let
         promptOptions = {
           prompt = mkOption {
-            type = with helpers.nixvimTypes; maybeRaw str;
+            type = with lib.types; maybeRaw str;
             description = ''
               The prompt to send to the model.
 
@@ -112,8 +112,7 @@ in
           '';
 
           extract =
-            helpers.defaultNullOpts.mkNullable
-              (with helpers.nixvimTypes; maybeRaw (either str (enum [ false ])))
+            helpers.defaultNullOpts.mkNullable (with lib.types; maybeRaw (either str (enum [ false ])))
               "```$ftype\n(.-)```"
               ''
                 A `string.match` pattern to use for an Action to extract the output from the response

--- a/plugins/by-name/presence-nvim/default.nix
+++ b/plugins/by-name/presence-nvim/default.nix
@@ -119,7 +119,7 @@ in
 
       # Rich presence text options.
       editingText =
-        helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Editing %s"
+        helpers.defaultNullOpts.mkNullable (types.either types.str types.rawLua) "Editing %s"
           ''
             String rendered when an editable file is loaded in the buffer.
 
@@ -128,7 +128,7 @@ in
           '';
 
       fileExplorerText =
-        helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Browsing %s"
+        helpers.defaultNullOpts.mkNullable (types.either types.str types.rawLua) "Browsing %s"
           ''
             String rendered when browsing a file explorer.
 
@@ -137,8 +137,7 @@ in
           '';
 
       gitCommitText =
-        helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua)
-          "Committing changes"
+        helpers.defaultNullOpts.mkNullable (types.either types.str types.rawLua) "Committing changes"
           ''
             String rendered when committing changes in git.
 
@@ -147,8 +146,7 @@ in
           '';
 
       pluginManagerText =
-        helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua)
-          "Managing plugins"
+        helpers.defaultNullOpts.mkNullable (types.either types.str types.rawLua) "Managing plugins"
           ''
             String rendered when managing plugins.
 
@@ -157,7 +155,7 @@ in
           '';
 
       readingText =
-        helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua) "Reading %s"
+        helpers.defaultNullOpts.mkNullable (types.either types.str types.rawLua) "Reading %s"
           ''
             String rendered when a read-only/unmodifiable file is loaded into the buffer.
 
@@ -166,8 +164,7 @@ in
           '';
 
       workspaceText =
-        helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua)
-          "Working on %s"
+        helpers.defaultNullOpts.mkNullable (types.either types.str types.rawLua) "Working on %s"
           ''
             String rendered when in a git repository.
 
@@ -176,8 +173,7 @@ in
           '';
 
       lineNumberText =
-        helpers.defaultNullOpts.mkNullable (types.either types.str helpers.nixvimTypes.rawLua)
-          "Line %s out of %s"
+        helpers.defaultNullOpts.mkNullable (types.either types.str types.rawLua) "Line %s out of %s"
           ''
             String rendered when `enableLineNumber` is set to `true` to display the current line number.
 

--- a/plugins/by-name/refactoring/default.nix
+++ b/plugins/by-name/refactoring/default.nix
@@ -39,7 +39,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     plugins.telescope.enabledExtensions = mkIf cfg.enableTelescope [ "refactoring" ];
   };
 
-  settingsOptions = with helpers.nixvimTypes; {
+  settingsOptions = with lib.types; {
     prompt_func_return_type =
       helpers.defaultNullOpts.mkAttrsOf bool
         {

--- a/plugins/by-name/rustaceanvim/settings-options.nix
+++ b/plugins/by-name/rustaceanvim/settings-options.nix
@@ -327,7 +327,7 @@ with lib;
             executable = {
               command = helpers.mkNullOrStr "The command for the executable.";
 
-              args = helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (listOf str)) ''
+              args = helpers.mkNullOrOption (with lib.types; maybeRaw (listOf str)) ''
                 Its arguments.
               '';
             };

--- a/plugins/by-name/schemastore/default.nix
+++ b/plugins/by-name/schemastore/default.nix
@@ -18,20 +18,20 @@ helpers.vim-plugin.mkVimPlugin {
         freeformType = with types; attrsOf anything;
         options = {
           name = mkOption {
-            type = with helpers.nixvimTypes; maybeRaw str;
+            type = with lib.types; maybeRaw str;
             description = "The name of the schema.";
           };
 
           description = helpers.mkNullOrStr "A description for this schema.";
 
           fileMatch =
-            helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (either str (listOf (maybeRaw str))))
+            helpers.mkNullOrOption (with lib.types; maybeRaw (either str (listOf (maybeRaw str))))
               ''
                 Which filename to match against for this schema.
               '';
 
           url = mkOption {
-            type = with helpers.nixvimTypes; maybeRaw str;
+            type = with lib.types; maybeRaw str;
             description = "The URL of this schema.";
           };
         };

--- a/plugins/by-name/startify/options.nix
+++ b/plugins/by-name/startify/options.nix
@@ -7,7 +7,7 @@ with lib;
 
   lists = mkOption {
     type =
-      with helpers.nixvimTypes;
+      with lib.types;
       listOf (
         either strLua (submodule {
           freeformType = with types; attrsOf anything;
@@ -18,12 +18,12 @@ with lib;
               example = "files";
             };
 
-            header = helpers.mkNullOrOption (with helpers.nixvimTypes; listOf (maybeRaw str)) ''
+            header = helpers.mkNullOrOption (with lib.types; listOf (maybeRaw str)) ''
               The 'header' is a list of strings, whereas each string will be put on its own
               line in the header.
             '';
 
-            indices = helpers.mkNullOrOption (with helpers.nixvimTypes; listOf (maybeRaw str)) ''
+            indices = helpers.mkNullOrOption (with lib.types; listOf (maybeRaw str)) ''
               The 'indices' is a list of strings, which act as indices for the current list.
               Opposed to the global `custom_indices`, this is limited to the current list.
             '';
@@ -67,7 +67,7 @@ with lib;
   bookmarks =
     helpers.defaultNullOpts.mkListOf
       (
-        with helpers.nixvimTypes;
+        with lib.types;
         oneOf [
           str
           rawLua
@@ -227,7 +227,7 @@ with lib;
     The number of spaces used for left padding.
   '';
 
-  skiplist_server = helpers.defaultNullOpts.mkListOf (with helpers.nixvimTypes; maybeRaw str) [ ] ''
+  skiplist_server = helpers.defaultNullOpts.mkListOf (with lib.types; maybeRaw str) [ ] ''
     Do not create the startify buffer, if this is a Vim server instance with a name contained in
     this list.
 

--- a/plugins/by-name/startup/default.nix
+++ b/plugins/by-name/startup/default.nix
@@ -84,7 +84,7 @@ in
                     oneOf [
                       # for "text" "mapping"
                       (listOf (either str (listOf str)))
-                      helpers.nixvimTypes.rawLua
+                      rawLua
                       # for "oldfiles" sections
                       (enum [ "" ])
                     ]

--- a/plugins/by-name/statuscol/default.nix
+++ b/plugins/by-name/statuscol/default.nix
@@ -41,7 +41,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
           freeformType = with types; attrsOf anything;
           options = {
             text = mkOption {
-              type = with helpers.nixvimTypes; nullOr (listOf (either str rawLua));
+              type = with lib.types; nullOr (listOf (either str rawLua));
               default = null;
               description = "Segment text.";
               example = [ "%C" ];
@@ -56,7 +56,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
             '';
 
             condition = helpers.mkNullOrOption (
-              with helpers.nixvimTypes; listOf (either bool rawLua)
+              with lib.types; listOf (either bool rawLua)
             ) "Table of booleans or functions returning a boolean.";
 
             sign = {
@@ -124,7 +124,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     '';
 
     clickhandlers = mkOption {
-      type = with helpers.nixvimTypes; attrsOf strLuaFn;
+      type = with lib.types; attrsOf strLuaFn;
       default = { };
       description = ''
         Builtin click handlers.

--- a/plugins/by-name/todo-comments/default.nix
+++ b/plugins/by-name/todo-comments/default.nix
@@ -6,13 +6,13 @@
 }:
 with lib;
 let
+  inherit (lib) types;
   inherit (lib.nixvim)
     defaultNullOpts
     keymaps
     mkNullOrOption'
     transitionType
     ;
-  types = lib.nixvim.nixvimTypes;
 
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {

--- a/plugins/by-name/toggleterm/default.nix
+++ b/plugins/by-name/toggleterm/default.nix
@@ -156,7 +156,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       opened.
     '';
 
-    highlights = helpers.defaultNullOpts.mkAttrsOf helpers.nixvimTypes.highlight {
+    highlights = helpers.defaultNullOpts.mkAttrsOf lib.types.highlight {
       NormalFloat.link = "Normal";
       FloatBorder.link = "Normal";
       StatusLine.gui = "NONE";
@@ -217,7 +217,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     '';
 
     float_opts = {
-      border = helpers.mkNullOrOption helpers.nixvimTypes.border ''
+      border = helpers.mkNullOrOption lib.types.border ''
         `border` = "single" | "double" | "shadow" | "curved" | ... other options supported by
         `win open`.
         The border key is *almost* the same as 'nvim_open_win'.

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -233,8 +233,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
     highlight = {
       additional_vim_regex_highlighting =
-        helpers.defaultNullOpts.mkNullableWithRaw
-          (with helpers.nixvimTypes; either bool (listOf (maybeRaw str)))
+        helpers.defaultNullOpts.mkNullableWithRaw (with lib.types; either bool (listOf (maybeRaw str)))
           false
           ''
             Setting this to true will run `syntax` and tree-sitter at the same time. \
@@ -249,12 +248,10 @@ helpers.neovim-plugin.mkNeovimPlugin {
         Whether to enable treesitter highlighting.
       '';
 
-      disable =
-        helpers.defaultNullOpts.mkStrLuaFnOr (with helpers.nixvimTypes; listOf (maybeRaw str)) null
-          ''
-            Can either be a list of the names of parsers you wish to disable or
-            a lua function that returns a boolean indicating the parser should be disabled.
-          '';
+      disable = helpers.defaultNullOpts.mkStrLuaFnOr (with lib.types; listOf (maybeRaw str)) null ''
+        Can either be a list of the names of parsers you wish to disable or
+        a lua function that returns a boolean indicating the parser should be disabled.
+      '';
 
       custom_captures = helpers.defaultNullOpts.mkAttrsOf types.str { } ''
         Custom capture group highlighting.
@@ -290,7 +287,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
     ensure_installed = helpers.defaultNullOpts.mkNullable' {
       type =
-        with helpers.nixvimTypes;
+        with lib.types;
         oneOf [
           (enum [ "all" ])
           (listOf (maybeRaw str))
@@ -307,7 +304,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     '';
 
     parser_install_dir = helpers.mkNullOrOption' {
-      type = with helpers.nixvimTypes; maybeRaw str;
+      type = with lib.types; maybeRaw str;
       # Backport the default from nvim-treesitter 1.0
       # The current default doesn't work on nix, as it is readonly
       default.__raw = "vim.fs.joinpath(vim.fn.stdpath('data'), 'site')";

--- a/plugins/by-name/trim/default.nix
+++ b/plugins/by-name/trim/default.nix
@@ -17,7 +17,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     '';
 
     patterns = mkOption {
-      type = with helpers.nixvimTypes; listOf strLua;
+      type = with lib.types; listOf strLua;
       apply = map helpers.mkRaw;
       default = [ ];
       example = [ "[[%s/\(\n\n\)\n\+/\1/]]" ];

--- a/plugins/by-name/typescript-tools/default.nix
+++ b/plugins/by-name/typescript-tools/default.nix
@@ -21,7 +21,7 @@ in
 
     onAttach = helpers.defaultNullOpts.mkLuaFn "__lspOnAttach" "Lua code to run when tsserver attaches to a buffer.";
     handlers = mkOption {
-      type = with helpers.nixvimTypes; nullOr (attrsOf strLuaFn);
+      type = with lib.types; nullOr (attrsOf strLuaFn);
       apply = v: helpers.ifNonNull' v (mapAttrs (_: helpers.mkRaw) v);
       default = null;
       description = "How tsserver should respond to LSP requests";
@@ -72,14 +72,14 @@ in
       '';
 
       tsserverPlugins =
-        with helpers.nixvimTypes;
+        with lib.types;
         helpers.mkNullOrOption (listOf (maybeRaw str)) ''
           List of plugins for tsserver to load. See this plugins's README
           at https://github.com/pmizio/typescript-tools.nvim/#-styled-components-support
         '';
 
       tsserverMaxMemory =
-        helpers.mkNullOrOption (with helpers.nixvimTypes; maybeRaw (either ints.unsigned (enum [ "auto" ])))
+        helpers.mkNullOrOption (with lib.types; maybeRaw (either ints.unsigned (enum [ "auto" ])))
           ''
             This value is passed to: https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
             Memory limit in megabytes or "auto"(basically no limit)

--- a/plugins/by-name/vim-slime/default.nix
+++ b/plugins/by-name/vim-slime/default.nix
@@ -56,7 +56,7 @@ mkVimPlugin {
       Whether to preserve cursor position when sending a line or paragraph.
     '';
 
-    default_config = helpers.mkNullOrOption (with helpers.nixvimTypes; attrsOf (either str rawLua)) ''
+    default_config = helpers.mkNullOrOption (with lib.types; attrsOf (either str rawLua)) ''
       Pre-filled prompt answer.
 
       Examples:

--- a/plugins/by-name/which-key/default.nix
+++ b/plugins/by-name/which-key/default.nix
@@ -5,8 +5,8 @@
 }:
 with lib;
 let
+  inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts mkRaw toLuaObject;
-  types = lib.nixvim.nixvimTypes;
 
   opt = options.plugins.which-key;
 

--- a/plugins/by-name/wilder/default.nix
+++ b/plugins/by-name/wilder/default.nix
@@ -156,7 +156,7 @@ in
       Setting the option after the first run has no effect.
     '';
 
-    pipeline = helpers.mkNullOrOption (with helpers.nixvimTypes; listOf strLua) ''
+    pipeline = helpers.mkNullOrOption (with lib.types; listOf strLua) ''
       Sets the pipeline to use to get completions.
       See `|wilder-pipeline|`.
 

--- a/plugins/by-name/yanky/default.nix
+++ b/plugins/by-name/yanky/default.nix
@@ -216,7 +216,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
         '';
 
         mappings = helpers.defaultNullOpts.mkAttrsOf' {
-          type = with helpers.nixvimTypes; either strLuaFn (attrsOf strLuaFn);
+          type = with lib.types; either strLuaFn (attrsOf strLuaFn);
           apply =
             mappings:
             helpers.ifNonNull' mappings (

--- a/plugins/by-name/yazi/default.nix
+++ b/plugins/by-name/yazi/default.nix
@@ -3,8 +3,8 @@
   ...
 }:
 let
+  inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
-  types = lib.nixvim.nixvimTypes;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "yazi";

--- a/plugins/by-name/zen-mode/default.nix
+++ b/plugins/by-name/zen-mode/default.nix
@@ -22,7 +22,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       width =
         helpers.defaultNullOpts.mkNullable
           (
-            with helpers.nixvimTypes;
+            with lib.types;
             oneOf [
               ints.positive
               (numbers.between 0.0 1.0)
@@ -42,7 +42,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       height =
         helpers.defaultNullOpts.mkNullable
           (
-            with helpers.nixvimTypes;
+            with lib.types;
             oneOf [
               ints.positive
               (numbers.between 0.0 1.0)

--- a/plugins/cmp/auto-enable.nix
+++ b/plugins/cmp/auto-enable.nix
@@ -61,7 +61,7 @@ in
     {
       warnings =
         # TODO: expand this warning to ft & cmd sources lists and `showDefs` the offending definitions
-        optional (helpers.nixvimTypes.isRawType cfg.settings.sources) ''
+        optional (lib.types.isRawType cfg.settings.sources) ''
           Nixvim (plugins.cmp): You have enabled `autoEnableSources` that tells Nixvim to automatically
           enable the source plugins with respect to the list of sources provided in `settings.sources`.
           However, the latter is proveded as a raw lua string which is not parseable by Nixvim.

--- a/plugins/cmp/options/settings-options.nix
+++ b/plugins/cmp/options/settings-options.nix
@@ -38,7 +38,7 @@ with lib;
 
   mapping = mkOption {
     default = { };
-    type = with helpers.nixvimTypes; maybeRaw (attrsOf strLua);
+    type = with lib.types; maybeRaw (attrsOf strLua);
     description = ''
       cmp mappings declaration.
       See `:h cmp-mapping` for more information.
@@ -46,7 +46,7 @@ with lib;
     apply =
       v:
       # Handle the raw case first
-      if helpers.nixvimTypes.isRawType v then
+      if lib.types.isRawType v then
         v
       # When v is an attrs **but not {__raw = ...}**
       else
@@ -64,7 +64,7 @@ with lib;
 
   snippet = {
     expand = mkOption {
-      type = with helpers.nixvimTypes; nullOr strLuaFn;
+      type = with lib.types; nullOr strLuaFn;
       default = null;
       description = ''
         The snippet expansion function. That's how nvim-cmp interacts with a particular snippet
@@ -115,8 +115,7 @@ with lib;
     keyword_pattern = helpers.defaultNullOpts.mkLua ''[[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%(-\w*\)*\)]]'' "The default keyword pattern.";
 
     autocomplete =
-      helpers.defaultNullOpts.mkNullable
-        (with helpers.nixvimTypes; either (enum [ false ]) (listOf strLua))
+      helpers.defaultNullOpts.mkNullable (with lib.types; either (enum [ false ]) (listOf strLua))
         [ "require('cmp.types').cmp.TriggerEvent.TextChanged" ]
         ''
           The event to trigger autocompletion.
@@ -210,7 +209,7 @@ with lib;
     '';
 
     comparators = mkOption {
-      type = with helpers.nixvimTypes; nullOr (listOf strLuaFn);
+      type = with lib.types; nullOr (listOf strLuaFn);
       apply = v: helpers.ifNonNull' v (map helpers.mkRaw v);
       default = null;
       description = ''

--- a/plugins/cmp/options/sources-option.nix
+++ b/plugins/cmp/options/sources-option.nix
@@ -81,7 +81,7 @@ let
 in
 mkOption {
   default = [ ];
-  type = with helpers.nixvimTypes; maybeRaw (listOf sourceType);
+  type = with lib.types; maybeRaw (listOf sourceType);
   description = ''
     The sources to use.
     Can either be a list of `sourceConfigs` which will be made directly to a Lua object.

--- a/plugins/cmp/sources/cmp-git.nix
+++ b/plugins/cmp/sources/cmp-git.nix
@@ -161,7 +161,7 @@ in
               };
 
               action = mkOption {
-                type = helpers.nixvimTypes.strLuaFn;
+                type = lib.types.strLuaFn;
                 apply = helpers.mkRaw;
                 description = ''
                   The parameters to the action function are the different sources (currently `git`,

--- a/plugins/lsp/language-servers/efmls-configs.nix
+++ b/plugins/lsp/language-servers/efmls-configs.nix
@@ -74,7 +74,7 @@ in
             kind:
             { lang, possible }:
             let
-              toolType = helpers.nixvimTypes.maybeRaw (lib.types.enum possible);
+              toolType = lib.types.maybeRaw (lib.types.enum possible);
             in
             lib.mkOption {
               type = lib.types.either toolType (lib.types.listOf toolType);

--- a/plugins/lsp/language-servers/ltex-settings.nix
+++ b/plugins/lsp/language-servers/ltex-settings.nix
@@ -2,8 +2,7 @@
 with lib;
 {
   enabled =
-    helpers.defaultNullOpts.mkNullableWithRaw
-      (with helpers.nixvimTypes; either bool (listOf (maybeRaw str)))
+    helpers.defaultNullOpts.mkNullableWithRaw (with lib.types; either bool (listOf (maybeRaw str)))
       [
         "bibtex"
         "context"
@@ -102,125 +101,119 @@ with lib;
     - "zh-CN": Chinese
   '';
 
-  dictionary =
-    helpers.defaultNullOpts.mkAttrsOf (with helpers.nixvimTypes; listOf (maybeRaw str)) { }
-      ''
-        Lists of additional words that should not be counted as spelling errors.
-        This setting is language-specific, so use an attrs of the format
-        ```nix
-          {
-            "<LANGUAGE1>" = [
-              "<WORD1>"
-              "<WORD2>"
-              ...
-            ];
-            "<LANGUAGE2>" = [
-              "<WORD1>"
-              "<WORD2>"
-            ];
-            ...
-          };
-        ```
-        where <LANGUAGE> denotes the language code in `settings.language`.
+  dictionary = helpers.defaultNullOpts.mkAttrsOf (with lib.types; listOf (maybeRaw str)) { } ''
+    Lists of additional words that should not be counted as spelling errors.
+    This setting is language-specific, so use an attrs of the format
+    ```nix
+      {
+        "<LANGUAGE1>" = [
+          "<WORD1>"
+          "<WORD2>"
+          ...
+        ];
+        "<LANGUAGE2>" = [
+          "<WORD1>"
+          "<WORD2>"
+        ];
+        ...
+      };
+    ```
+    where <LANGUAGE> denotes the language code in `settings.language`.
 
-        This setting is a multi-scope setting. See the documentation for details.
-        This setting supports external files. See the documentation for details.
-        By default, no additional spelling errors will be ignored.
+    This setting is a multi-scope setting. See the documentation for details.
+    This setting supports external files. See the documentation for details.
+    By default, no additional spelling errors will be ignored.
 
-        Example:
-        ```nix
-        {
-          "en-US" = [
-            "adaptivity"
-            "precomputed"
-            "subproblem"
-          ];
-          "de-DE" = [
-            "B-Splines"
-            ":/path/to/externalFile.txt"
-          ];
-        }
-        ```
-      '';
+    Example:
+    ```nix
+    {
+      "en-US" = [
+        "adaptivity"
+        "precomputed"
+        "subproblem"
+      ];
+      "de-DE" = [
+        "B-Splines"
+        ":/path/to/externalFile.txt"
+      ];
+    }
+    ```
+  '';
 
-  disabledRules =
-    helpers.defaultNullOpts.mkAttrsOf (with helpers.nixvimTypes; listOf (maybeRaw str)) { }
-      ''
-        Lists of rules that should be disabled (if enabled by default by LanguageTool).
-        This setting is language-specific, so use an attrs of the format
-        ```nix
-          {
-            "<LANGUAGE1>" = [
-              "<WORD1>"
-              "<WORD2>"
-              ...
-            ];
-            "<LANGUAGE2>" = [
-              "<WORD1>"
-              "<WORD2>"
-            ];
-            ...
-          };
-        ```
-        where `<LANGUAGE>` denotes the language code in `settings.language` and `<RULE>` the ID of
-        the LanguageTool rule.
+  disabledRules = helpers.defaultNullOpts.mkAttrsOf (with lib.types; listOf (maybeRaw str)) { } ''
+    Lists of rules that should be disabled (if enabled by default by LanguageTool).
+    This setting is language-specific, so use an attrs of the format
+    ```nix
+      {
+        "<LANGUAGE1>" = [
+          "<WORD1>"
+          "<WORD2>"
+          ...
+        ];
+        "<LANGUAGE2>" = [
+          "<WORD1>"
+          "<WORD2>"
+        ];
+        ...
+      };
+    ```
+    where `<LANGUAGE>` denotes the language code in `settings.language` and `<RULE>` the ID of
+    the LanguageTool rule.
 
-        This setting is a multi-scope setting. See the documentation for details.
-        This setting supports external files. See the documentation for details.
-        By default, no additional rules will be disabled.
+    This setting is a multi-scope setting. See the documentation for details.
+    This setting supports external files. See the documentation for details.
+    By default, no additional rules will be disabled.
 
-        Example:
-        ```nix
-        {
-          "en-US" = [
-            "EN_QUOTES"
-            "UPPERCASE_SENTENCE_START"
-            ":/path/to/externalFile.txt"
-          ];
-        }
-        ```
-      '';
+    Example:
+    ```nix
+    {
+      "en-US" = [
+        "EN_QUOTES"
+        "UPPERCASE_SENTENCE_START"
+        ":/path/to/externalFile.txt"
+      ];
+    }
+    ```
+  '';
 
-  enabledRules =
-    helpers.defaultNullOpts.mkAttrsOf (with helpers.nixvimTypes; listOf (maybeRaw str)) { }
-      ''
-        Lists of rules that should be enabled (if disabled by default by LanguageTool).
-        This setting is language-specific, so use an attrs of the format
-        ```nix
-          {
-            "<LANGUAGE1>" = [
-              "<WORD1>"
-              "<WORD2>"
-              ...
-            ];
-            "<LANGUAGE2>" = [
-              "<WORD1>"
-              "<WORD2>"
-            ];
-            ...
-          };
-        ```
-        where `<LANGUAGE>` denotes the language code in `settings.language` and `<RULE>` the ID of
-        the LanguageTool rule.
+  enabledRules = helpers.defaultNullOpts.mkAttrsOf (with lib.types; listOf (maybeRaw str)) { } ''
+    Lists of rules that should be enabled (if disabled by default by LanguageTool).
+    This setting is language-specific, so use an attrs of the format
+    ```nix
+      {
+        "<LANGUAGE1>" = [
+          "<WORD1>"
+          "<WORD2>"
+          ...
+        ];
+        "<LANGUAGE2>" = [
+          "<WORD1>"
+          "<WORD2>"
+        ];
+        ...
+      };
+    ```
+    where `<LANGUAGE>` denotes the language code in `settings.language` and `<RULE>` the ID of
+    the LanguageTool rule.
 
-        This setting is a multi-scope setting. See the documentation for details.
-        This setting supports external files. See the documentation for details.
-        By default, no additional rules will be enabled.
+    This setting is a multi-scope setting. See the documentation for details.
+    This setting supports external files. See the documentation for details.
+    By default, no additional rules will be enabled.
 
-        Example:
-        ```nix
-          {
-            "en-GB" = [
-              "PASSIVE_VOICE"
-              "OXFORD_SPELLING_NOUNS"
-              ":/path/to/externalFile.txt"
-            ];
-          }
-        ```
-      '';
+    Example:
+    ```nix
+      {
+        "en-GB" = [
+          "PASSIVE_VOICE"
+          "OXFORD_SPELLING_NOUNS"
+          ":/path/to/externalFile.txt"
+        ];
+      }
+    ```
+  '';
 
   hiddenFalsePositives =
-    helpers.defaultNullOpts.mkAttrsOf (with helpers.nixvimTypes; listOf (maybeRaw str)) { }
+    helpers.defaultNullOpts.mkAttrsOf (with lib.types; listOf (maybeRaw str)) { }
       ''
         Lists of false-positive diagnostics to hide (by hiding all diagnostics of a specific rule
         within a specific sentence).
@@ -571,8 +564,7 @@ with lib;
   '';
 
   diagnosticSeverity =
-    helpers.defaultNullOpts.mkNullableWithRaw
-      (with helpers.nixvimTypes; either str (attrsOf (maybeRaw str)))
+    helpers.defaultNullOpts.mkNullableWithRaw (with lib.types; either str (attrsOf (maybeRaw str)))
       "information"
       ''
         Severity of the diagnostics corresponding to the grammar and spelling errors.

--- a/plugins/lsp/language-servers/nixd-settings.nix
+++ b/plugins/lsp/language-servers/nixd-settings.nix
@@ -38,7 +38,7 @@ with lib;
         };
       };
     in
-    helpers.mkNullOrOption (with helpers.nixvimTypes; attrsOf (maybeRaw provider)) ''
+    helpers.mkNullOrOption (with lib.types; attrsOf (maybeRaw provider)) ''
       Tell the language server your desired option set, for completion.
       This is lazily evaluated.
     '';
@@ -54,7 +54,7 @@ with lib;
         };
       };
     in
-    helpers.mkNullOrOption (helpers.nixvimTypes.maybeRaw provider) ''
+    helpers.mkNullOrOption (lib.types.maybeRaw provider) ''
       This expression will be interpreted as "nixpkgs" toplevel
       Nixd provides package, lib completion/information from it.
     '';

--- a/plugins/none-ls/default.nix
+++ b/plugins/none-ls/default.nix
@@ -92,7 +92,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
     update_in_insert = false;
   };
 
-  settingsOptions = import ./settings.nix { inherit helpers; };
+  settingsOptions = import ./settings.nix lib;
 
   extraOptions = {
     enableLspFormat = mkOption {

--- a/plugins/none-ls/settings.nix
+++ b/plugins/none-ls/settings.nix
@@ -1,10 +1,11 @@
-{ helpers }:
+lib:
 let
-  types = helpers.nixvimTypes;
-  applyListOfLua = x: map (v: if builtins.isString v then helpers.mkRaw v else v) x;
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+  applyListOfLua = x: map (v: if builtins.isString v then lib.nixvim.mkRaw v else v) x;
 in
 {
-  border = helpers.defaultNullOpts.mkNullable' {
+  border = defaultNullOpts.mkNullable' {
     type =
       with types;
       oneOf [
@@ -23,13 +24,13 @@ in
     '';
   };
 
-  cmd = helpers.defaultNullOpts.mkListOf types.str [ "nvim" ] ''
+  cmd = defaultNullOpts.mkListOf types.str [ "nvim" ] ''
     Defines the command used to start the null-ls server.
     If you do not have an `nvim` binary available on your `$PATH`,
     you should change this to an absolute path to the binary.
   '';
 
-  debounce = helpers.defaultNullOpts.mkUnsignedInt 250 ''
+  debounce = defaultNullOpts.mkUnsignedInt 250 ''
     The `debounce` setting controls the amount of time between the last change to a
     buffer and the next `textDocument/didChange` notification. These notifications
     cause null-ls to generate diagnostics, so this setting indirectly controls the
@@ -41,7 +42,7 @@ in
     without unnecessary resource usage.
   '';
 
-  debug = helpers.defaultNullOpts.mkBool false ''
+  debug = defaultNullOpts.mkBool false ''
     Displays all possible log messages and writes them to the null-ls log, which you
     can view with the command `:NullLsLog`. This option can slow down Neovim, so
     it's strongly recommended to disable it for normal use.
@@ -49,7 +50,7 @@ in
     `debug = true` is the same as setting `log_level` to `"trace"`.
   '';
 
-  default_timeout = helpers.defaultNullOpts.mkUnsignedInt 5000 ''
+  default_timeout = defaultNullOpts.mkUnsignedInt 5000 ''
     Sets the amount of time (in milliseconds) after which built-in sources will time out.
     Note that built-in sources can define their own timeout period and that users can override the
     timeout period on a per-source basis, too
@@ -58,7 +59,7 @@ in
     Specifying a timeout with a value less than zero will prevent commands from timing out.
   '';
 
-  diagnostic_config = helpers.defaultNullOpts.mkNullable' {
+  diagnostic_config = defaultNullOpts.mkNullable' {
     type =
       with types;
       oneOf [
@@ -78,7 +79,7 @@ in
     '';
   };
 
-  diagnostics_format = helpers.defaultNullOpts.mkStr "#{m}" ''
+  diagnostics_format = defaultNullOpts.mkStr "#{m}" ''
     Sets the default format used for diagnostics. The plugin will replace the following special
     components with the relevant diagnostic information:
 
@@ -102,15 +103,13 @@ in
       method, described in [BUILTIN_CONFIG](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md).
   '';
 
-  fallback_severity =
-    helpers.defaultNullOpts.mkUnsignedInt { __raw = "vim.diagnostic.severity.ERROR"; }
-      ''
-        Defines the severity used when a diagnostic source does not explicitly define a severity.
-        See `:help diagnostic-severity` for available values.
-      '';
+  fallback_severity = defaultNullOpts.mkUnsignedInt { __raw = "vim.diagnostic.severity.ERROR"; } ''
+    Defines the severity used when a diagnostic source does not explicitly define a severity.
+    See `:help diagnostic-severity` for available values.
+  '';
 
   log_level =
-    helpers.defaultNullOpts.mkEnum
+    defaultNullOpts.mkEnum
       [
         "off"
         "error"
@@ -128,29 +127,29 @@ in
         - neovim's notification area.
       '';
 
-  notify_format = helpers.defaultNullOpts.mkStr "[null-ls] %s" ''
+  notify_format = defaultNullOpts.mkStr "[null-ls] %s" ''
     Sets the default format for `vim.notify()` messages.
     Can be used to customize 3rd party notification plugins like
     [nvim-notify](https://github.com/rcarriga/nvim-notify).
   '';
 
-  on_attach = helpers.defaultNullOpts.mkLuaFn null ''
+  on_attach = defaultNullOpts.mkLuaFn null ''
     Defines an `on_attach` callback to run whenever null-ls attaches to a buffer.
     If you have a common `on_attach` you're using for LSP servers, you can reuse that here,
     use a custom callback for null-ls, or leave this undefined.
   '';
 
-  on_init = helpers.defaultNullOpts.mkLuaFn null ''
+  on_init = defaultNullOpts.mkLuaFn null ''
     Defines an `on_init` callback to run when null-ls initializes.
     From here, you can make changes to the client (the first argument)
     or `initialize_result` (the second argument, which as of now is not used).
   '';
 
-  on_exit = helpers.defaultNullOpts.mkLuaFn null ''
+  on_exit = defaultNullOpts.mkLuaFn null ''
     Defines an `on_exit` callback to run when the null-ls client exits.
   '';
 
-  root_dir = helpers.defaultNullOpts.mkLuaFn' {
+  root_dir = defaultNullOpts.mkLuaFn' {
     pluginDefault = "require('null-ls.utils').root_pattern('.null-ls-root', 'Makefile', '.git')";
     description = ''
       Determines the root of the null-ls server. On startup, null-ls will call
@@ -165,7 +164,7 @@ in
     '';
   };
 
-  root_dir_async = helpers.defaultNullOpts.mkLuaFn' {
+  root_dir_async = defaultNullOpts.mkLuaFn' {
     pluginDefault = null;
     description = ''
       Like `root_dir` but also accepts a callback parameter allowing it to be
@@ -180,7 +179,7 @@ in
     '';
   };
 
-  should_attach = helpers.defaultNullOpts.mkLuaFn' {
+  should_attach = defaultNullOpts.mkLuaFn' {
     pluginDefault = null;
     description = ''
       A user-defined function that controls whether to enable null-ls for a given
@@ -197,7 +196,7 @@ in
   };
 
   # Not using mkListOf because I want `strLua` instead of `rawLua`
-  sources = helpers.defaultNullOpts.mkNullable' {
+  sources = defaultNullOpts.mkNullable' {
     # TODO: support custom & third-party sources.
     # Need a "source" submodule type:
     # https://github.com/nvimtools/none-ls.nvim/blob/main/doc/MAIN.md#sources
@@ -225,7 +224,7 @@ in
     visible = false;
   };
 
-  temp_dir = helpers.defaultNullOpts.mkStr null ''
+  temp_dir = defaultNullOpts.mkStr null ''
     Defines the directory used to create temporary files for sources that rely on
     them (a workaround used for command-based sources that do not support `stdio`).
 
@@ -241,7 +240,7 @@ in
     described in [BUILTIN_CONFIG](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md).
   '';
 
-  update_in_insert = helpers.defaultNullOpts.mkBool false ''
+  update_in_insert = defaultNullOpts.mkBool false ''
     Controls whether diagnostic sources run in insert mode. If set to `false`,
     diagnostic sources will run upon exiting insert mode, which greatly improves
     performance but can create a slight delay before diagnostics show up. Set this

--- a/plugins/pluginmanagers/lazy.nix
+++ b/plugins/pluginmanagers/lazy.nix
@@ -85,7 +85,7 @@ in
                 or firenvim for example. (accepts fun(LazyPlugin):boolean)
               '';
 
-              dependencies = helpers.mkNullOrOption (helpers.nixvimTypes.eitherRecursive str listOfPlugins) "Plugin dependencies";
+              dependencies = helpers.mkNullOrOption (eitherRecursive str listOfPlugins) "Plugin dependencies";
 
               init = helpers.mkNullOrLuaFn "init functions are always executed during startup";
 
@@ -107,19 +107,19 @@ in
               '';
 
               event =
-                with helpers.nixvimTypes;
+                with lib.types;
                 helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on event. Events can be specified as BufEnter or with a pattern like BufEnter *.lua";
 
               cmd =
-                with helpers.nixvimTypes;
+                with lib.types;
                 helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on command";
 
               ft =
-                with helpers.nixvimTypes;
+                with lib.types;
                 helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on filetype";
 
               keys =
-                with helpers.nixvimTypes;
+                with lib.types;
                 helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on key mapping";
 
               module = helpers.mkNullOrOption (enum [ false ]) ''
@@ -139,7 +139,7 @@ in
               '';
 
               opts =
-                with helpers.nixvimTypes;
+                with lib.types;
                 helpers.mkNullOrOption (maybeRaw (attrsOf anything)) ''
                   opts should be a table (will be merged with parent specs),
                   return a table (replaces parent specs) or should change a table.

--- a/plugins/pluginmanagers/lz-n.nix
+++ b/plugins/pluginmanagers/lz-n.nix
@@ -131,7 +131,7 @@ nixvim.neovim-plugin.mkNeovimPlugin {
       plugins = mkOption {
         description = ''
           List of plugin specs provided to the `require('lz.n').load` function.
-          Plugin specs can be ${nixvim.nixvimTypes.rawLua.description}.
+          Plugin specs can be ${types.rawLua.description}.
         '';
         default = [ ];
         type = types.listOf lzPluginType;

--- a/plugins/pluginmanagers/packer.nix
+++ b/plugins/pluginmanagers/packer.nix
@@ -57,17 +57,17 @@ in
 
               run = helpers.mkNullOrOption (oneOf [
                 str
-                helpers.nixvimTypes.rawLua
-                (listOf (either str helpers.nixvimTypes.rawLua))
+                rawLua
+                (listOf (either str rawLua))
               ]) "Post-install hook";
 
-              requires = helpers.mkNullOrOption (helpers.nixvimTypes.eitherRecursive str listOfPlugins) "Plugin dependencies";
+              requires = helpers.mkNullOrOption (eitherRecursive str listOfPlugins) "Plugin dependencies";
 
               rocks = helpers.mkNullOrOption (either str (listOf (either str attrs))) "Luarocks dependencies";
 
-              config = helpers.mkNullOrOption (either str helpers.nixvimTypes.rawLua) "Code to run after this plugin is loaded";
+              config = helpers.mkNullOrOption (either str rawLua) "Code to run after this plugin is loaded";
 
-              setup = helpers.mkNullOrOption (either str helpers.nixvimTypes.rawLua) "Code to be run before this plugin is loaded";
+              setup = helpers.mkNullOrOption (either str rawLua) "Code to be run before this plugin is loaded";
 
               cmd = helpers.mkNullOrOption (either str (listOf str)) "Commands which load this plugin";
 
@@ -81,8 +81,8 @@ in
 
               cond = helpers.mkNullOrOption (oneOf [
                 str
-                helpers.nixvimTypes.rawLua
-                (listOf (either str helpers.nixvimTypes.rawLua))
+                rawLua
+                (listOf (either str rawLua))
               ]) "Conditional test to load this plugin";
 
               module = helpers.mkNullOrOption (either str (listOf str)) "Patterns of module names which load this plugin";

--- a/tests/test-sources/plugins/lsp/efmls-configs.nix
+++ b/tests/test-sources/plugins/lsp/efmls-configs.nix
@@ -90,7 +90,7 @@
           # tool options are a `either toolType (listOf toolType)`
           # Look into `nestedTypes.left` to get a `toolType` option.
           toolType = opt.type.nestedTypes.left;
-          # toolType is a `either (enum possible) helpers.nixvimTypes.rawLua
+          # toolType is a `either (enum possible) rawLua
           # Look into `nestedTypes.left` for the enum
           possible = toolType.nestedTypes.left;
           # possible is an enum, look into functor.payload for the variants


### PR DESCRIPTION
Remove the `nixvimTypes` alias. Follow up to #2324.
