### PR TITLE
plugins/earthly: add plugin

### DIFF
--- a/plugins/by-name/earthly/default.nix
+++ b/plugins/by-name/earthly/default.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+lib.nixvim.vim-plugin.mkVimPlugin {
+  name = "earthly";
+  originalName = "earthly.vim";
+  package = "earthly-vim";
+  url = "https://github.com/earthly/earthly.vim";
+  description = "Earthfile syntax highlighting for vim";
+  maintainers = [ lib.maintainers.DataHearth ];
+}

--- a/tests/test-sources/plugins/by-name/earthly/default.nix
+++ b/tests/test-sources/plugins/by-name/earthly/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.earthly.enable = true;
+  };
+}


### PR DESCRIPTION
Added the <https://github.com/earthly/earthly.vim> plugin and its tests. No configuration is required.