### PR TITLE
lib: remove `helpers` from internal usage

### DIFF
--- a/lib/autocmd-helpers.nix
+++ b/lib/autocmd-helpers.nix
@@ -1,6 +1,7 @@
-{ lib, helpers }:
+{ lib }:
 let
   inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
 in
 rec {
   autoGroupOption = types.submodule {
@@ -14,34 +15,34 @@ rec {
   };
 
   autoCmdOptions = {
-    event = helpers.mkNullOrOption (with types; either str (listOf str)) ''
+    event = lib.nixvim.mkNullOrOption (with types; either str (listOf str)) ''
       The event or events to register this autocommand.
     '';
 
-    group = helpers.mkNullOrOption (with types; either str int) ''
+    group = lib.nixvim.mkNullOrOption (with types; either str int) ''
       The autocommand group name or id to match against.
     '';
 
-    pattern = helpers.mkNullOrOption (with types; either str (listOf str)) ''
+    pattern = lib.nixvim.mkNullOrOption (with types; either str (listOf str)) ''
       Pattern or patterns to match literally against.
     '';
 
-    buffer = helpers.mkNullOrOption types.int ''
+    buffer = lib.nixvim.mkNullOrOption types.int ''
       Buffer number for buffer local autocommands |autocmd-buflocal|.
       Cannot be used with `pattern`.
     '';
 
     # Introduced early October 2023.
     # TODO remove in early December 2023.
-    description = helpers.mkNullOrOption types.str ''
+    description = lib.nixvim.mkNullOrOption types.str ''
       DEPRECATED, please use `desc`.
     '';
 
-    desc = helpers.mkNullOrOption types.str ''
+    desc = lib.nixvim.mkNullOrOption types.str ''
       A textual description of this autocommand.
     '';
 
-    callback = helpers.mkNullOrOption (with types; either str rawLua) ''
+    callback = lib.nixvim.mkNullOrOption (with types; either str rawLua) ''
       A function or a string.
       - if a string, the name of a Vimscript function to call when this autocommand is triggered.
       - Otherwise, a Lua function which is called when this autocommand is triggered.
@@ -65,13 +66,13 @@ rec {
         }
     '';
 
-    command = helpers.defaultNullOpts.mkStr "" ''
+    command = defaultNullOpts.mkStr "" ''
       Vim command to execute on event. Cannot be used with `callback`.
     '';
 
-    once = helpers.defaultNullOpts.mkBool false "Run the autocommand only once.";
+    once = defaultNullOpts.mkBool false "Run the autocommand only once.";
 
-    nested = helpers.defaultNullOpts.mkBool false "Run nested autocommands.";
+    nested = defaultNullOpts.mkBool false "Run nested autocommands.";
   };
 
   autoCmdOption = types.submodule { options = autoCmdOptions; };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,14 +4,12 @@
   _nixvimTests ? false,
   ...
 }:
-# Build helpers recursively
 lib.fix (
   self:
   let
-    # Used when importing parts of helpers
+    # Used when importing parts of our lib
     call = lib.callPackageWith {
       inherit call pkgs self;
-      helpers = self; # TODO: stop using `helpers` in the subsections
       lib = self.extendedLib;
     };
 

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -1,27 +1,28 @@
-{ lib, helpers }:
+{ lib }:
 let
   inherit (lib) optionalAttrs isAttrs types;
+  inherit (lib.nixvim) defaultNullOpts;
 in
 rec {
   # These are the configuration options that change the behavior of each mapping.
   mapConfigOptions = {
-    silent = helpers.defaultNullOpts.mkBool false "Whether this mapping should be silent. Equivalent to adding `<silent>` to a map.";
+    silent = defaultNullOpts.mkBool false "Whether this mapping should be silent. Equivalent to adding `<silent>` to a map.";
 
-    nowait = helpers.defaultNullOpts.mkBool false "Whether to wait for extra input on ambiguous mappings. Equivalent to adding `<nowait>` to a map.";
+    nowait = defaultNullOpts.mkBool false "Whether to wait for extra input on ambiguous mappings. Equivalent to adding `<nowait>` to a map.";
 
-    script = helpers.defaultNullOpts.mkBool false "Equivalent to adding `<script>` to a map.";
+    script = defaultNullOpts.mkBool false "Equivalent to adding `<script>` to a map.";
 
-    expr = helpers.defaultNullOpts.mkBool false "Means that the action is actually an expression. Equivalent to adding `<expr>` to a map.";
+    expr = defaultNullOpts.mkBool false "Means that the action is actually an expression. Equivalent to adding `<expr>` to a map.";
 
-    unique = helpers.defaultNullOpts.mkBool false "Whether to fail if the map is already defined. Equivalent to adding `<unique>` to a map.";
+    unique = defaultNullOpts.mkBool false "Whether to fail if the map is already defined. Equivalent to adding `<unique>` to a map.";
 
-    noremap = helpers.defaultNullOpts.mkBool true "Whether to use the `noremap` variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
+    noremap = defaultNullOpts.mkBool true "Whether to use the `noremap` variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
 
-    remap = helpers.defaultNullOpts.mkBool false "Make the mapping recursive. Inverses `noremap`.";
+    remap = defaultNullOpts.mkBool false "Make the mapping recursive. Inverses `noremap`.";
 
-    desc = helpers.mkNullOrOption lib.types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
+    desc = lib.nixvim.mkNullOrOption lib.types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
 
-    buffer = helpers.defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
+    buffer = defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
   };
 
   modes = {
@@ -120,7 +121,7 @@ rec {
               {
                 type = types.maybeRaw types.str;
                 description = "The action to execute.";
-                apply = v: if options.lua.isDefined or false && config.lua then helpers.mkRaw v else v;
+                apply = v: if options.lua.isDefined or false && config.lua then lib.nixvim.mkRaw v else v;
               }
               // (optionalAttrs (isAttrs action) action)
               // (optionalAttrs (defaults ? action) { default = defaults.action; })

--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -1,4 +1,4 @@
-{ lib, helpers }:
+{ lib }:
 {
   # TODO: DEPRECATED: use the `settings` option instead
   extraOptionsOptions = {
@@ -68,7 +68,7 @@
 
           setupCode = ''
             require('${luaName}')${setup}(${
-              lib.optionalString (cfg ? settings) (helpers.toLuaObject cfg.settings)
+              lib.optionalString (cfg ? settings) (lib.nixvim.toLuaObject cfg.settings)
             })
           '';
 
@@ -106,7 +106,7 @@
                   };
             }
             // lib.optionalAttrs hasSettings {
-              settings = helpers.mkSettingsOption {
+              settings = lib.nixvim.mkSettingsOption {
                 description = settingsDescription;
                 options = settingsOptions;
                 example = settingsExample;

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -1,4 +1,4 @@
-{ lib, helpers }:
+{ lib }:
 let
   inherit (lib) types;
 
@@ -96,7 +96,7 @@ rec {
       args
       // {
         type = types.strLua;
-        apply = helpers.mkRaw;
+        apply = lib.nixvim.mkRaw;
       }
     );
   mkNullOrLua = description: mkNullOrLua' { inherit description; };
@@ -107,7 +107,7 @@ rec {
       args
       // {
         type = types.strLuaFn;
-        apply = helpers.mkRaw;
+        apply = lib.nixvim.mkRaw;
       }
     );
   mkNullOrLuaFn = description: mkNullOrLua' { inherit description; };
@@ -118,7 +118,7 @@ rec {
       args
       // {
         type = with types; either strLua type;
-        apply = v: if lib.isString v then helpers.mkRaw v else v;
+        apply = v: if lib.isString v then lib.nixvim.mkRaw v else v;
       }
     );
   mkNullOrStrLuaOr = type: description: mkNullOrStrLuaOr' { inherit type description; };
@@ -129,7 +129,7 @@ rec {
       args
       // {
         type = with types; either strLuaFn type;
-        apply = v: if lib.isString v then helpers.mkRaw v else v;
+        apply = v: if lib.isString v then lib.nixvim.mkRaw v else v;
       }
     );
   mkNullOrStrLuaFnOr = type: description: mkNullOrStrLuaFnOr' { inherit type description; };
@@ -149,7 +149,7 @@ rec {
     in
     rec {
       # TODO: removed 2024-06-14; remove stub 2024-09-01
-      mkDesc = abort "mkDesc has been removed. Use the `pluginDefault` argument or `helpers.pluginDefaultText`.";
+      mkDesc = abort "mkDesc has been removed. Use the `pluginDefault` argument or `lib.nixvim.pluginDefaultText`.";
 
       mkNullable' = args: mkNullOrOption' (processDefaultNullArgs args);
       mkNullable =
@@ -277,7 +277,7 @@ rec {
               if lib.isInt value then
                 value
               else
-                helpers.mkRaw "vim.diagnostic.severity.${lib.strings.toUpper value}"
+                lib.nixvim.mkRaw "vim.diagnostic.severity.${lib.strings.toUpper value}"
             );
           }
         );
@@ -291,7 +291,7 @@ rec {
             type = with types; either ints.unsigned logLevel;
             apply = lib.mapNullable (
               value:
-              if lib.isInt value then value else helpers.mkRaw "vim.log.levels.${lib.strings.toUpper value}"
+              if lib.isInt value then value else lib.nixvim.mkRaw "vim.log.levels.${lib.strings.toUpper value}"
             );
           }
         );

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  helpers,
   _nixvimTests,
 }:
 rec {

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -1,4 +1,4 @@
-{ lib, helpers }:
+{ lib }:
 {
   mkVimPlugin =
     {
@@ -36,7 +36,7 @@
       createSettingsOption = (lib.isString globalPrefix) && (globalPrefix != "");
 
       settingsOption = lib.optionalAttrs createSettingsOption {
-        settings = helpers.mkSettingsOption {
+        settings = lib.nixvim.mkSettingsOption {
           options = settingsOptions;
           example = settingsExample;
           description = ''


### PR DESCRIPTION
Simply removes all usage of `helpers` from the internals of `lib.nixvim`. It is also dropped from the available attrs in `call`.
