### PR TITLE
lib/types: make `strLua` coerce strings to rawLua

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -90,48 +90,18 @@ rec {
   mkNullOrStr' = args: mkNullOrOption' (args // { type = with types; maybeRaw str; });
   mkNullOrStr = description: mkNullOrStr' { inherit description; };
 
-  mkNullOrLua' =
-    args:
-    mkNullOrOption' (
-      args
-      // {
-        type = types.strLua;
-        apply = lib.nixvim.mkRaw;
-      }
-    );
+  mkNullOrLua' = args: mkNullOrOption' (args // { type = types.strLua; });
   mkNullOrLua = description: mkNullOrLua' { inherit description; };
 
-  mkNullOrLuaFn' =
-    args:
-    mkNullOrOption' (
-      args
-      // {
-        type = types.strLuaFn;
-        apply = lib.nixvim.mkRaw;
-      }
-    );
+  mkNullOrLuaFn' = args: mkNullOrOption' (args // { type = types.strLuaFn; });
   mkNullOrLuaFn = description: mkNullOrLua' { inherit description; };
 
   mkNullOrStrLuaOr' =
-    { type, ... }@args:
-    mkNullOrOption' (
-      args
-      // {
-        type = with types; either strLua type;
-        apply = v: if lib.isString v then lib.nixvim.mkRaw v else v;
-      }
-    );
+    { type, ... }@args: mkNullOrOption' (args // { type = with types; either strLua type; });
   mkNullOrStrLuaOr = type: description: mkNullOrStrLuaOr' { inherit type description; };
 
   mkNullOrStrLuaFnOr' =
-    { type, ... }@args:
-    mkNullOrOption' (
-      args
-      // {
-        type = with types; either strLuaFn type;
-        apply = v: if lib.isString v then lib.nixvim.mkRaw v else v;
-      }
-    );
+    { type, ... }@args: mkNullOrOption' (args // { type = with types; either strLuaFn type; });
   mkNullOrStrLuaFnOr = type: description: mkNullOrStrLuaFnOr' { inherit type description; };
 
   defaultNullOpts =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -32,7 +32,22 @@ rec {
     check = v: (isRawType v) || (v ? __empty);
   };
 
-  maybeRaw = type: types.either type rawLua;
+  maybeRaw =
+    elemType:
+    let
+      luaFirst = types.either rawLua elemType;
+      elemFirst = types.either elemType rawLua;
+    in
+    luaFirst
+    // {
+      name = "maybeRaw";
+      inherit (elemFirst) description;
+      nestedTypes = {
+        left = lib.warn "maybeRaw.nestedTypes: `left` is a deprecated alias for `elemType`." elemType;
+        right = lib.warn "maybeRaw.nestedTypes: `right` is a deprecated alias for `rawLua`." rawLua;
+        inherit rawLua elemType;
+      };
+    };
 
   # Describes an boolean-like integer flag that is either 0 or 1
   # Has legacy support for boolean definitions, added 2024-09-08

--- a/plugins/by-name/conform-nvim/default.nix
+++ b/plugins/by-name/conform-nvim/default.nix
@@ -125,7 +125,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
           See `:help conform.format` for details.
         '';
-        apply = v: if lib.isString v then mkRaw v else v;
       };
 
       default_format_opts = defaultNullOpts.mkNullable defaultFormatSubmodule { } ''
@@ -143,7 +142,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
           See `:help conform.format` for details.
         '';
-        apply = v: if lib.isString v then mkRaw v else v;
       };
 
       log_level = defaultNullOpts.mkLogLevel "error" ''

--- a/plugins/by-name/edgy/default.nix
+++ b/plugins/by-name/edgy/default.nix
@@ -151,7 +151,6 @@ helpers.neovim-plugin.mkNeovimPlugin {
               });
             default = null;
             example = "require('noice.util.spinners').spinners.circleFull";
-            apply = v: if isString v then helpers.mkRaw v else v;
             description = "Spinner for pinned views that are loading.";
             pluginDefault = {
               frames = defaultFrames;
@@ -182,7 +181,6 @@ helpers.neovim-plugin.mkNeovimPlugin {
       # Hence, we convert the string to raw lua in `apply`.
       keys = helpers.defaultNullOpts.mkAttrsOf' {
         type = with lib.types; either strLuaFn (enum [ false ]);
-        apply = x: if x == null then null else mapAttrs (_: v: if isString v then helpers.mkRaw v else v) x;
         description = ''
           Buffer-local keymaps to be added to edgebar buffers.
           Existing buffer-local keymaps will never be overridden.

--- a/plugins/by-name/hydra/settings-options.nix
+++ b/plugins/by-name/hydra/settings-options.nix
@@ -156,7 +156,6 @@ with lib;
                 end
               '';
             };
-            apply = mapAttrs (_: helpers.mkRaw);
           };
         };
       };

--- a/plugins/by-name/lint/default.nix
+++ b/plugins/by-name/lint/default.nix
@@ -91,7 +91,6 @@ let
       example = ''
         require('lint.parser').from_pattern(pattern, groups, severity_map, defaults, opts)
       '';
-      apply = helpers.mkRaw;
       mandatory = true;
     };
   };

--- a/plugins/by-name/neotest/default.nix
+++ b/plugins/by-name/neotest/default.nix
@@ -17,7 +17,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     adapters = mkOption {
       type = with types; listOf strLua;
       default = [ ];
-      apply = map mkRaw;
       # NOTE: We hide this option from the documentation as users should use the top-level
       # `adapters` option.
       # They can still directly append raw lua code to this `settings.adapters` option.

--- a/plugins/by-name/nvim-surround/default.nix
+++ b/plugins/by-name/nvim-surround/default.nix
@@ -55,7 +55,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
                 For "static" delimiter pairs it can be a list of strings representing the value
                 of the delimiter pair.
               '';
-              apply = v: if lib.isString v then lib.nixvim.mkRaw v else v;
               example = [
                 "( "
                 " )"

--- a/plugins/by-name/obsidian/options.nix
+++ b/plugins/by-name/obsidian/options.nix
@@ -226,7 +226,6 @@ with lib;
             action = mkOption {
               type = lib.types.strLua;
               description = "The lua code for this keymap action.";
-              apply = helpers.mkRaw;
             };
             opts = helpers.keymaps.mapConfigOptions // {
               buffer = helpers.defaultNullOpts.mkBool false ''

--- a/plugins/by-name/startify/options.nix
+++ b/plugins/by-name/startify/options.nix
@@ -30,7 +30,6 @@ with lib;
           };
         })
       );
-    apply = v: map (listElem: if isString listElem then helpers.mkRaw listElem else listElem) v;
     default = [ ];
     description = ''
       Startify displays lists. Each list consists of a `type` and optionally a `header` and

--- a/plugins/by-name/statuscol/default.nix
+++ b/plugins/by-name/statuscol/default.nix
@@ -129,7 +129,6 @@ helpers.neovim-plugin.mkNeovimPlugin {
       description = ''
         Builtin click handlers.
       '';
-      apply = mapAttrs (_: helpers.mkRaw);
       example = {
         Lnum = "require('statuscol.builtin').lnum_click";
         FoldClose = "require('statuscol.builtin').foldclose_click";

--- a/plugins/by-name/telescope/extensions/_helpers.nix
+++ b/plugins/by-name/telescope/extensions/_helpers.nix
@@ -95,7 +95,6 @@ rec {
           ${defaults}
         ```
       '';
-      apply = lib.mapAttrs (_: lib.nixvim.mkRaw);
     };
 
   mkMappingsOption =

--- a/plugins/by-name/trim/default.nix
+++ b/plugins/by-name/trim/default.nix
@@ -18,7 +18,6 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
     patterns = mkOption {
       type = with lib.types; listOf strLua;
-      apply = map helpers.mkRaw;
       default = [ ];
       example = [ "[[%s/\(\n\n\)\n\+/\1/]]" ];
       description = ''

--- a/plugins/by-name/typescript-tools/default.nix
+++ b/plugins/by-name/typescript-tools/default.nix
@@ -22,7 +22,6 @@ in
     onAttach = helpers.defaultNullOpts.mkLuaFn "__lspOnAttach" "Lua code to run when tsserver attaches to a buffer.";
     handlers = mkOption {
       type = with lib.types; nullOr (attrsOf strLuaFn);
-      apply = v: helpers.ifNonNull' v (mapAttrs (_: helpers.mkRaw) v);
       default = null;
       description = "How tsserver should respond to LSP requests";
       example = {

--- a/plugins/cmp/options/settings-options.nix
+++ b/plugins/cmp/options/settings-options.nix
@@ -43,14 +43,6 @@ with lib;
       cmp mappings declaration.
       See `:h cmp-mapping` for more information.
     '';
-    apply =
-      v:
-      # Handle the raw case first
-      if lib.types.isRawType v then
-        v
-      # When v is an attrs **but not {__raw = ...}**
-      else
-        mapAttrs (_: helpers.mkRaw) v;
     example = {
       "<C-d>" = "cmp.mapping.scroll_docs(-4)";
       "<C-f>" = "cmp.mapping.scroll_docs(4)";
@@ -98,7 +90,6 @@ with lib;
           end
         ```
       '';
-      apply = helpers.mkRaw;
       example = ''
         function(args)
           require('luasnip').lsp_expand(args.body)
@@ -210,7 +201,6 @@ with lib;
 
     comparators = mkOption {
       type = with lib.types; nullOr (listOf strLuaFn);
-      apply = v: helpers.ifNonNull' v (map helpers.mkRaw v);
       default = null;
       description = ''
         The function to customize the sorting behavior.

--- a/plugins/cmp/sources/cmp-git.nix
+++ b/plugins/cmp/sources/cmp-git.nix
@@ -162,7 +162,6 @@ in
 
               action = mkOption {
                 type = lib.types.strLuaFn;
-                apply = helpers.mkRaw;
                 description = ''
                   The parameters to the action function are the different sources (currently `git`,
                   `gitlab` and `github`), the completion callback, the trigger character, the

--- a/plugins/utils/rest.nix
+++ b/plugins/utils/rest.nix
@@ -207,7 +207,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
         default: `{}`
       '';
-      apply = v: if lib.isAttrs v then lib.mapAttrs (_: lib.nixvim.mkRaw) v else v;
     };
 
     request = {

--- a/tests/test-sources/plugins/lsp/efmls-configs.nix
+++ b/tests/test-sources/plugins/lsp/efmls-configs.nix
@@ -92,7 +92,7 @@
           toolType = opt.type.nestedTypes.left;
           # toolType is a `either (enum possible) rawLua
           # Look into `nestedTypes.left` for the enum
-          possible = toolType.nestedTypes.left;
+          possible = toolType.nestedTypes.elemType;
           # possible is an enum, look into functor.payload for the variants
           toolList = possible.functor.payload;
         in


### PR DESCRIPTION
- **lib/types: make `strLua` coerce strings to rawLua**
- **lib/options: remove redundant `mkRaw` `apply` functions**
- **plugins: remove redundant `mkRaw` `apply` functions**

Related to #2003, but does not yet take any steps to deprecate strLua.

This PR simply shifts responsibility for coercing strings to rawLua from the option to the type.

In normal usage, this shouldn't break anything. If an option is also applying `mkRaw` then that is redundant, but idempotent and will do no harm. Also, `apply` happens _after_ the type is merged anyway.

In abnormal usage, this could break things. E.g. if a user is incorrectly using `strLua` in their own option, but **not** expecting the value to be coerced to rawLua... While worth noting, I don't think we need to be concerned about such incorrect usage.
