### PR TITLE
plugins/web-devicons: support custom icons and default icon

### DIFF
--- a/plugins/by-name/web-devicons/default.nix
+++ b/plugins/by-name/web-devicons/default.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 let
-  inherit (lib.nixvim) defaultNullOpts;
+  inherit (lib.nixvim) defaultNullOpts mkNullOrOption toLuaObject;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "web-devicons";
@@ -13,5 +13,37 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   settingsExample = {
     color_icons = true;
     strict = true;
+  };
+
+  extraOptions = {
+    customIcons = defaultNullOpts.mkAttrsOf (lib.types.submodule {
+      freeformType = lib.types.anything;
+
+      options = {
+        icon = defaultNullOpts.mkStr null "Icon to use.";
+        color = defaultNullOpts.mkStr null "Color of the icon.";
+        cterm_color = defaultNullOpts.mkStr null "Cterm color of the icon.";
+        name = defaultNullOpts.mkStr null "Name to replace with icon.";
+      };
+    }) { } ''Custom overrides for icons.'';
+
+    defaultIcon = mkNullOrOption (lib.types.submodule {
+      options = {
+        icon = defaultNullOpts.mkStr null "Icon to use.";
+        color = defaultNullOpts.mkStr null "Color of the icon.";
+        cterm_color = defaultNullOpts.mkStr null "Cterm color of the icon.";
+      };
+    }) ''Set the default icon when none is found.'';
+  };
+
+  extraConfig = cfg: {
+    plugins.web-devicons.luaConfig.post =
+      lib.optionalString (cfg.customIcons != null) ''
+        require('nvim-web-devicons').set_icon(${toLuaObject cfg.customIcons})
+      ''
+      + lib.optionalString (cfg.defaultIcon != null) ''
+        require('nvim-web-devicons').set_default_icon(
+          ${toLuaObject cfg.defaultIcon.icon}, ${toLuaObject cfg.defaultIcon.color}, ${toLuaObject cfg.defaultIcon.cterm_color})
+      '';
   };
 }

--- a/tests/test-sources/plugins/by-name/web-devicons/default.nix
+++ b/tests/test-sources/plugins/by-name/web-devicons/default.nix
@@ -2,4 +2,46 @@
   empty = {
     plugins.web-devicons.enable = true;
   };
+
+  custom-icons = {
+    plugins.web-devicons = {
+      enable = true;
+
+      customIcons = {
+        lir_folder_icon = {
+          icon = "";
+          color = "#7ebae4";
+          name = "LirFolderNode";
+        };
+        zsh = {
+          icon = "";
+          color = "#428850";
+          cterm_color = "65";
+          name = "Zsh";
+        };
+      };
+    };
+  };
+
+  default-icon = {
+    plugins.web-devicons = {
+      enable = true;
+
+      defaultIcon = {
+        icon = "";
+        color = "#7ebae4";
+        cterm_color = "65";
+      };
+    };
+  };
+
+  default-icon-no-color = {
+    plugins.web-devicons = {
+      enable = true;
+
+      defaultIcon = {
+        icon = "";
+      };
+    };
+  };
 }


### PR DESCRIPTION
Support configuring icon overrides and the default icon easier.
<img width="609" alt="image" src="https://github.com/user-attachments/assets/4ae86181-547a-4ac1-afbd-f195c157abed">
