### PR TITLE
lib/types: `maybeRaw` should propagate `elemType`'s sub-options

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -54,6 +54,11 @@ rec {
         right = lib.warn "maybeRaw.nestedTypes: `right` is a deprecated alias for `rawLua`." rawLua;
         inherit rawLua elemType;
       };
+      inherit (elemType)
+        getSubModules
+        getSubOptions
+        substSubModules
+        ;
     };
 
   # Describes an boolean-like integer flag that is either 0 or 1


### PR DESCRIPTION
This is _technically_ redundant, because we patch `either` to be recursive. But I think it is best if `maybeRaw` does this explicitly, without relying on that behaviour.
