### PR TITLE
lib/keymaps: remove `lua` attr in type's `merge` fn

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -81,7 +81,7 @@
     extraConfigLua = lib.mkIf (config.keymaps != [ ]) ''
       -- Set up keybinds {{{
       do
-        local __nixvim_binds = ${helpers.toLuaObject (map helpers.keymaps.removeDeprecatedMapAttrs config.keymaps)}
+        local __nixvim_binds = ${helpers.toLuaObject config.keymaps}
         for i, map in ipairs(__nixvim_binds) do
           vim.keymap.set(map.mode, map.key, map.action, map.options)
         end
@@ -99,7 +99,7 @@
       callback = helpers.mkRaw ''
         function()
           do
-            local __nixvim_binds = ${helpers.toLuaObject (map helpers.keymaps.removeDeprecatedMapAttrs mappings)}
+            local __nixvim_binds = ${helpers.toLuaObject mappings}
             for i, map in ipairs(__nixvim_binds) do
               vim.keymap.set(map.mode, map.key, map.action, map.options)
             end

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -206,7 +206,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           };
           lua = true;
         };
-        apply = v: if v == null then null else keymaps.removeDeprecatedMapAttrs v;
         description = "Keymap for function Buffer${funcName}";
       }
     ) keymapsActions;

--- a/plugins/by-name/tmux-navigator/default.nix
+++ b/plugins/by-name/tmux-navigator/default.nix
@@ -180,7 +180,6 @@ helpers.vim-plugin.mkVimPlugin {
           lua = true;
         }
       );
-      apply = map helpers.keymaps.removeDeprecatedMapAttrs;
     };
   };
 

--- a/plugins/by-name/wtf/default.nix
+++ b/plugins/by-name/wtf/default.nix
@@ -61,7 +61,6 @@ in
                 lua = true;
               }
             );
-          apply = v: if v == null then null else helpers.keymaps.removeDeprecatedMapAttrs v;
           description = "Keymap for the ${action} action.";
         }
       ) defaultKeymaps;

--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -53,7 +53,6 @@ in
 
         extra = mkOption {
           type = with types; listOf helpers.keymaps.deprecatedMapOptionSubmodule;
-          apply = map helpers.keymaps.removeDeprecatedMapAttrs;
           description = ''
             Extra keymaps to register when an LSP is attached.
             This can be used to customise LSP behaviour, for example with "telescope" or the "Lspsaga" plugin, as seen in the examples.


### PR DESCRIPTION
Rather than having each option remove `lua` in their `apply` function, we can do this in the submodule type's `merge` function.

Yes, it's a little annoying that we have to indent the submodule definition in order to override it's `merge` attr.
