### PR TITLE
plugins/lsp-status: add undocumented options

### DIFF
--- a/plugins/by-name/lsp-status/default.nix
+++ b/plugins/by-name/lsp-status/default.nix
@@ -58,6 +58,30 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       diagnostics = defaultNullOpts.mkBool true ''
         If false, the default statusline component does not display LSP diagnostics.
       '';
+
+      spinner_frames =
+        defaultNullOpts.mkListOf types.str
+          [
+            "⣾"
+            "⣽"
+            "⣻"
+            "⢿"
+            "⡿"
+            "⣟"
+            "⣯"
+            "⣷"
+          ]
+          ''
+            Animation frames of the spinner displayed while lsp is processing.
+          '';
+
+      status_symbol = defaultNullOpts.mkStr " 🇻" ''
+        Symbol displayed at the beginning of the status message.
+      '';
+
+      update_interval = defaultNullOpts.mkInt 100 ''
+        The interval, in milliseconds, to update the status message.
+      '';
     };
 
   callSetup = false;


### PR DESCRIPTION
added options to lsp-status that aren't documented in the packages readme
options in plugin [source](https://github.com/nvim-lua/lsp-status.nvim/blob/54f48eb5017632d81d0fd40112065f1d062d0629/lua/lsp-status.lua#L1)