### PR TITLE
plugins/treesitter: update description

### DIFF
--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -15,6 +15,12 @@ helpers.neovim-plugin.mkNeovimPlugin {
   description = ''
     Provides an interface to [tree-sitter]
 
+    > [!NOTE]
+    > This plugin defaults to all functionality disabled.
+    >
+    > Please explicitly enable the features you would like to use in `plugins.treesitter.settings`.
+    > For example, to enable syntax highlighting use the `plugins.treesitter.settings.highlight.enable` option.
+
     ### Installing tree-sitter grammars from Nixpkgs
 
     By default, **all** available grammars packaged in the `nvim-treesitter` package are installed.


### PR DESCRIPTION
Added some more upfront details about the plugin's default settings. Lots of people assume just enabling the plugin will give them the behaviors of highlighting they expect, but the plugin does not default this to be the case.

![image](https://github.com/user-attachments/assets/9570b079-dd1a-4982-a54c-6d377520c393)

Resolves https://github.com/nix-community/nixvim/issues/2396