### PR TITLE
tests/lsp-servers: de-couple from grouped tests

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -50,6 +50,8 @@
         generated = pkgs.callPackage ../tests/generated.nix { };
 
         package-options = pkgs.callPackage ../tests/package-options.nix { inherit nixvimConfiguration; };
+
+        lsp-all-servers = pkgs.callPackage ../tests/lsp-servers.nix { inherit nixvimConfiguration; };
       } // import ../tests { inherit pkgs pkgsUnfree helpers; };
     };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -42,37 +42,24 @@ let
   };
 in
 # We attempt to build & execute all configurations
-(lib.pipe
-  (
-    testFiles
-    ++ [
-      exampleFiles
-    ]
-  )
-  [
-    (builtins.map (
-      {
-        name,
-        file,
-        cases,
-      }:
-      {
-        inherit name;
-        path = pkgs.linkFarm name (builtins.mapAttrs (moduleToTest file) cases);
-      }
-    ))
-    (helpers.groupListBySize 10)
-    (lib.imap1 (
-      i: group: rec {
-        name = "test-${toString i}";
-        value = pkgs.linkFarm name group;
-      }
-    ))
-    builtins.listToAttrs
-  ]
-)
-// {
-  all-lsp-servers = moduleToTest ./lsp-servers.nix "all-lsp-servers" (
-    import ./lsp-servers.nix { inherit pkgs; }
-  );
-}
+lib.pipe (testFiles ++ [ exampleFiles ]) [
+  (builtins.map (
+    {
+      name,
+      file,
+      cases,
+    }:
+    {
+      inherit name;
+      path = pkgs.linkFarm name (builtins.mapAttrs (moduleToTest file) cases);
+    }
+  ))
+  (helpers.groupListBySize 10)
+  (lib.imap1 (
+    i: group: rec {
+      name = "test-${toString i}";
+      value = pkgs.linkFarm name group;
+    }
+  ))
+  builtins.listToAttrs
+]

--- a/tests/lsp-servers.nix
+++ b/tests/lsp-servers.nix
@@ -1,53 +1,83 @@
-{ pkgs, ... }:
-{ lib, options, ... }:
-pkgs.lib.optionalAttrs
-  # This fails on darwin
-  # See https://github.com/NixOS/nix/issues/4119
-  (!pkgs.stdenv.isDarwin)
-  {
+{
+  lib,
+  nixvimConfiguration,
+  stdenv,
+  runCommandNoCCLocal,
+  name ? "lsp-all-servers",
+}:
+let
+  _file = ./lsp-servers.nix;
+
+  renamed = builtins.attrNames (import ../plugins/lsp/language-servers/_renamed.nix);
+
+  enable-lsp-module = {
+    inherit _file;
+
     plugins.lsp = {
       enable = true;
 
-      servers =
-        let
-          disabled =
-            (lib.optionals pkgs.stdenv.isDarwin [
-              "fsautocomplete"
-            ])
-            ++ (lib.optionals pkgs.stdenv.isAarch64 [
-              # Broken
-              "scheme_langserver"
-            ])
-            ++ (lib.optionals (pkgs.stdenv.hostPlatform.system == "aarch64-linux") [
-              # Binary package not available for this architecture
-              "starpls"
-              # TODO: 2024-10-05 build failure
-              "fstar"
-            ])
-            ++ (lib.optionals (pkgs.stdenv.hostPlatform.system == "x86_64-darwin") [
-              # Binary package not available for this architecture
-              "starpls"
-            ]);
-
-          renamed = lib.attrNames (import ../plugins/lsp/language-servers/_renamed.nix);
-        in
-        lib.mkMerge [
-          (lib.pipe options.plugins.lsp.servers [
-            (lib.mapAttrs (
-              server: opts:
-              {
-                enable = !(lib.elem server disabled);
-              }
-              // lib.optionalAttrs (opts ? package && !(opts.package ? default)) { package = null; }
-            ))
-            (lib.filterAttrs (server: _: !(lib.elem server renamed)))
-          ])
-          {
-            rust_analyzer = {
-              installCargo = true;
-              installRustc = true;
-            };
-          }
-        ];
+      servers.rust_analyzer = {
+        installCargo = true;
+        installRustc = true;
+      };
     };
-  }
+  };
+
+  enable-servers-module =
+    {
+      lib,
+      options,
+      pkgs,
+      ...
+    }:
+    let
+      disabled =
+        lib.optionals pkgs.stdenv.isDarwin [
+          "fsautocomplete"
+        ]
+        ++ lib.optionals pkgs.stdenv.isAarch64 [
+          # Broken
+          "scheme_langserver"
+        ]
+        ++ lib.optionals (pkgs.stdenv.hostPlatform.system == "aarch64-linux") [
+          # Binary package not available for this architecture
+          "starpls"
+          # TODO: 2024-10-05 build failure
+          "fstar"
+        ]
+        ++ lib.optionals (pkgs.stdenv.hostPlatform.system == "x86_64-darwin") [
+          # Binary package not available for this architecture
+          "starpls"
+        ];
+    in
+    {
+      inherit _file;
+
+      plugins.lsp.servers = lib.pipe options.plugins.lsp.servers [
+        (lib.mapAttrs (
+          server: opts:
+          {
+            enable = !(lib.elem server disabled);
+          }
+          // lib.optionalAttrs (opts ? package && !(opts.package ? default)) { package = null; }
+        ))
+        (lib.filterAttrs (server: _: !(lib.elem server renamed)))
+      ];
+    };
+
+  result = nixvimConfiguration.extendModules {
+    modules = [
+      enable-lsp-module
+      enable-servers-module
+      { test.name = name; }
+    ];
+  };
+in
+# This fails on darwin
+# See https://github.com/NixOS/nix/issues/4119
+if stdenv.isDarwin then
+  runCommandNoCCLocal name { } ''
+    touch $out
+  ''
+else
+  result.config.build.test


### PR DESCRIPTION
Follow up to cab6b0c9febfecd96e4cda3dfe4ec8675f6d9ddb from #2365, which intended to ungroup the "all servers" lsp test for performance reasons. This does that more explicitly, by handling the test in the same way as other "loose" tests outside of `tests/test-sources`.
