### PR TITLE
wrappers: define `pkgs` default within type declaration

### DIFF
--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,4 +1,6 @@
 {
+  # Extra args for the `evalNixvim` call that produces the type for `programs.nixvim`
+  evalArgs ? { },
   # Option path where extraFiles should go
   filesOpt ? null,
   # Filepath prefix to apply to extraFiles
@@ -26,10 +28,16 @@ let
     setAttrByPath
     ;
   cfg = config.programs.nixvim;
+  nixvimConfiguration = config.lib.nixvim.modules.evalNixvim evalArgs;
   extraFiles = lib.filter (file: file.enable) (lib.attrValues cfg.extraFiles);
 in
 {
   _file = ./_shared.nix;
+
+  options.programs.nixvim = lib.mkOption {
+    inherit (nixvimConfiguration) type;
+    default = { };
+  };
 
   # TODO: Added 2024-07-24; remove after 24.11
   imports = [

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -16,7 +16,7 @@ let
     types
     ;
   cfg = config.programs.nixvim;
-  nixvimConfig = config.lib.nixvim.modules.evalNixvim {
+  evalArgs = {
     extraSpecialArgs = {
       darwinConfig = config;
     };
@@ -28,14 +28,7 @@ in
 {
   _file = ./darwin.nix;
 
-  options = {
-    programs.nixvim = mkOption {
-      inherit (nixvimConfig) type;
-      default = { };
-    };
-  };
-
-  imports = [ (import ./_shared.nix { }) ];
+  imports = [ (import ./_shared.nix { inherit evalArgs; }) ];
 
   config = mkIf cfg.enable {
     environment.systemPackages = [

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -15,7 +15,7 @@ let
     types
     ;
   cfg = config.programs.nixvim;
-  nixvimConfig = config.lib.nixvim.modules.evalNixvim {
+  evalArgs = {
     extraSpecialArgs = {
       hmConfig = config;
     };
@@ -27,15 +27,9 @@ in
 {
   _file = ./hm.nix;
 
-  options = {
-    programs.nixvim = mkOption {
-      inherit (nixvimConfig) type;
-      default = { };
-    };
-  };
-
   imports = [
     (import ./_shared.nix {
+      inherit evalArgs;
       filesOpt = [
         "xdg"
         "configFile"

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -16,7 +16,7 @@ let
     types
     ;
   cfg = config.programs.nixvim;
-  nixvimConfig = config.lib.nixvim.modules.evalNixvim {
+  evalArgs = {
     extraSpecialArgs = {
       nixosConfig = config;
     };
@@ -28,15 +28,9 @@ in
 {
   _file = ./nixos.nix;
 
-  options = {
-    programs.nixvim = mkOption {
-      inherit (nixvimConfig) type;
-      default = { };
-    };
-  };
-
   imports = [
     (import ./_shared.nix {
+      inherit evalArgs;
       filesOpt = [
         "environment"
         "etc"


### PR DESCRIPTION
- **wrappers: move `programs.nixvim` declaration to `_shared.nix`**
- **wrappers: define `pkgs` default within type declaration**

The first commit refactors the `programs.nixvim` option declaration so that it can be centralised to `wrappers/_shared.nix`, the second commit then moves the `nixpkgs.pkgs = pkgs` definition into the `evalNixvim` call.

This means `nixpkgs.pkgs` is defined in a module that is considered part of `programs.nixvim`'s type. Config definitions are not part of the type, and therefore are not part of `type.getSubModules` or `type.getSubOptions`.

Fixes #2378
