### PR TITLE
plugins/cord-nvim: init

### DIFF
--- a/plugins/by-name/cord-nvim/default.nix
+++ b/plugins/by-name/cord-nvim/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  helpers,
+  ...
+}:
+with lib;
+helpers.neovim-plugin.mkNeovimPlugin {
+  name = "cord-nvim";
+  originalName = "cord.nvim";
+  package = "cord-nvim";
+  maintainers = [ ];
+
+  settingsOptions = {
+    usercmds = helpers.defaultNullOpts.mkBool false ''
+      	Enables user commands
+    '';
+    log_level =
+      helpers.defaultNullOpts.mkEnum
+        [
+          "trace"
+          "debug"
+          "info"
+          "warn"
+          "off"
+        ]
+        null
+        ''
+          	Log messages at or above this level.
+        '';
+  };
+
+  settingsExample = {
+    usercmds = false;
+    log_level = null;
+  };
+}

--- a/tests/test-sources/plugins/by-name/cord-nvim/default.nix
+++ b/tests/test-sources/plugins/by-name/cord-nvim/default.nix
@@ -1,0 +1,30 @@
+{
+	empty = {
+		# don't run tests as they try to access the network.
+		test.runNvim = false;
+		plugins.cord-nvim.enable = true;
+	};
+
+	defaults = {
+		# don't run tests as they try to access the network.
+		test.runNvim = true;
+		plugins.cord-nvim = {
+			enable = true;
+			settings = {
+				usercmd = false;
+				log_level = null;
+			};
+		};
+	};
+
+	example = {
+		# don't run tests as they try to access the network.
+		test.runNvim = false;
+		plugins.cord-nvim = {
+			enable = true;
+			settings = {
+				usercmd = false;
+			};
+		};
+	};
+}


### PR DESCRIPTION
Adds the `cord-nvim` plugin.
For more info view the plugin homepage: https://github.com/vyfor/cord.nvim.

fixes: #2373

**Note: It's work in progress as I need to do most of the options**