### PR TITLE
modules/output: obtain plugin configs from wrapped neovim

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -285,8 +285,10 @@ in
         }
       );
 
+      wrappedNeovim' = pkgs.wrapNeovimUnstable package neovimConfig;
+
       customRC = helpers.concatNonEmptyLines [
-        (helpers.wrapVimscriptForLua neovimConfig.neovimRcContent)
+        (helpers.wrapVimscriptForLua wrappedNeovim'.initRc)
         config.content
       ];
 
@@ -330,13 +332,13 @@ in
         else
           config.package;
 
-      wrappedNeovim = pkgs.wrapNeovimUnstable package (
-        neovimConfig
-        // {
-          wrapperArgs = lib.escapeShellArgs neovimConfig.wrapperArgs + " " + extraWrapperArgs;
-          wrapRc = false;
-        }
-      );
+      wrappedNeovim = wrappedNeovim'.override (prev: {
+        wrapperArgs =
+          (if lib.isString prev.wrapperArgs then prev.wrapperArgs else lib.escapeShellArgs prev.wrapperArgs)
+          + " "
+          + extraWrapperArgs;
+        wrapRc = false;
+      });
     in
     {
       build = {

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -7,7 +7,7 @@
 }:
 let
   inherit (lib) types mkOption mkPackageOption;
-  inherit (lib) optional optionalString optionalAttrs;
+  inherit (lib) optional optionalAttrs;
   builders = lib.nixvim.builders.withPkgs pkgs;
 in
 {

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -48,7 +48,7 @@
 
       extraPlugins = [
         {
-          config = "let g:var = 'neovimRcContent5'";
+          config = "let g:var = 'wrappedNeovim.initRc5'";
 
           # Test that final init.lua contains all config sections
           plugin = pkgs.runCommandLocal "init-lua-content-test" { } ''
@@ -63,7 +63,7 @@
             test_content extraConfigLua2 extraConfigLua
             test_content extraConfigLuaPost3 extraConfigLuaPost
             test_content extraConfigVim4 extraConfigVim4
-            test_content neovimRcContent5 neovimRcContent
+            test_content wrappedNeovim.initRc5 wrappedNeovim.initRc
 
             touch $out
           '';

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -46,13 +46,27 @@
         "test.vim" = configs;
       };
 
-      # Plugin configs
-      # TODO: Test this makes it to the nvim configuration
-      # NOTE: config.content currently does not contain extraPlugins config
       extraPlugins = [
         {
-          plugin = pkgs.emptyDirectory;
           config = "let g:var = 'neovimRcContent5'";
+
+          # Test that final init.lua contains all config sections
+          plugin = pkgs.runCommandLocal "init-lua-content-test" { } ''
+            test_content() {
+                if ! grep -qF "$1" "${config.build.initFile}"; then
+                    echo "init.lua should contain $2" >&2
+                    exit 1
+                fi
+            }
+
+            test_content extraConfigLuaPre1 extraConfigLuaPre
+            test_content extraConfigLua2 extraConfigLua
+            test_content extraConfigLuaPost3 extraConfigLuaPost
+            test_content extraConfigVim4 extraConfigVim4
+            test_content neovimRcContent5 neovimRcContent
+
+            touch $out
+          '';
         }
       ];
 


### PR DESCRIPTION
This:
* restores modules/output generated init.lua tests removed in 3d1224a039d70098c78d263b0867352d95f2194b, but without IFD.
* changes where generated plugin configs are obtained. Instead of using the result of `makeNeovimConfig`, generated config is obtained from `wrappedNeovim.initRc`. This should avoid breaking after NixOS/nixpkgs#344541 is merged. See also conversation in #2343.