### PR TITLE
plugins/lsp/hls: handle automatic installation of required GHC

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -220,6 +220,7 @@ in
     ++ [
       ./ccls.nix
       ./efmls-configs.nix
+      ./hls.nix
       ./pylsp.nix
       ./rust-analyzer.nix
       ./svelte.nix

--- a/plugins/lsp/language-servers/hls.nix
+++ b/plugins/lsp/language-servers/hls.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.plugins.lsp.servers.hls;
+in
+{
+  options.plugins.lsp.servers.hls = {
+    installGhc = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = true;
+      description = "Whether to install `ghc`.";
+    };
+
+    ghcPackage = mkPackageOption pkgs "ghc" { };
+  };
+
+  config = mkIf cfg.enable {
+    warnings = optional (cfg.installGhc == null) ''
+      `hls` relies on `ghc` (the Glasgow Haskell Compiler).
+      - Set `plugins.lsp.servers.hls.installGhc = true` to install it automatically with Nixvim.
+        You can customize which package to install by changing `plugins.lsp.servers.hls.ghcPackage`.
+      - Set `plugins.lsp.servers.hls.installGhc = false` to not have it install through Nixvim.
+        By doing so, you will dismiss this warning.
+    '';
+
+    extraPackages = with pkgs; (optional ((isBool cfg.installGhc) && cfg.installGhc) cfg.ghcPackage);
+  };
+}

--- a/tests/lsp-servers.nix
+++ b/tests/lsp-servers.nix
@@ -16,9 +16,14 @@ let
     plugins.lsp = {
       enable = true;
 
-      servers.rust_analyzer = {
-        installCargo = true;
-        installRustc = true;
+      servers = {
+        hls = {
+          installGhc = true;
+        };
+        rust_analyzer = {
+          installCargo = true;
+          installRustc = true;
+        };
       };
     };
   };


### PR DESCRIPTION
Ensures `lsp.servers.hls` (haskell language server) users make an explicit choice regarding whether the required GHC dependency is installed or not.
This is the same approach as in `lsp.servers.rust_analyzer`.

Fixed #2413
