### PR TITLE
plugins/telescope/live-greps-args: fix `to_fuzzy_refine` example

### DIFF
--- a/plugins/by-name/telescope/extensions/live-greps-args.nix
+++ b/plugins/by-name/telescope/extensions/live-greps-args.nix
@@ -50,7 +50,7 @@ telescopeHelpers.mkExtension {
       i = {
         "<C-k>".__raw = ''require("telescope-live-grep-args.actions").quote_prompt()'';
         "<C-i>".__raw = ''require("telescope-live-grep-args.actions").quote_prompt({ postfix = " --iglob " })'';
-        "<C-space>".__raw = ''require("telescope-live-grep-args.actions").actions.to_fuzzy_refine'';
+        "<C-space>".__raw = ''require("telescope.actions").to_fuzzy_refine'';
       };
     };
     theme = "dropdown";


### PR DESCRIPTION
Function `to_fuzzy_refine` in examples is part of Telescope, not the `live-greps-args` extension.