### PR TITLE
plugins/cmp: add cmp-nixpkgs-maintainers source

### DIFF
--- a/plugins/cmp/sources/default.nix
+++ b/plugins/cmp/sources/default.nix
@@ -110,6 +110,10 @@ let
       sourceName = "luasnip";
     }
     {
+      pluginName = "cmp-nixpkgs-maintainers";
+      sourceName = "nixpkgs_maintainers";
+    }
+    {
       pluginName = "cmp-nvim-lsp";
       sourceName = "nvim_lsp";
     }

--- a/tests/test-sources/plugins/cmp/all-sources.nix
+++ b/tests/test-sources/plugins/cmp/all-sources.nix
@@ -21,6 +21,8 @@
                 "cmp_ai"
                 # Triggers the warning complaining about treesitter highlighting being disabled
                 "otter"
+                # Invokes the `nix` command at startup which is not available in the sandbox
+                "nixpkgs_maintainers"
               ] ++ optional (pkgs.stdenv.hostPlatform.system == "aarch64-linux") "cmp_tabnine";
             in
             pipe config.cmpSourcePlugins [


### PR DESCRIPTION
Add [cmp-nixpkgs-maintainers](https://github.com/GaetanLepage/cmp-nixpkgs-maintainers) source for `cmp`.
It auto-completes nixpkgs maintainers' GH handles when editing PR messages.
