### PR TITLE
modules/nixpkgs: add `overlays` option

### DIFF
--- a/tests/main.nix
+++ b/tests/main.nix
@@ -7,6 +7,8 @@
   linkFarm,
   pkgs,
   pkgsUnfree,
+  self,
+  system,
 }:
 let
   fetchTests = callTest ./fetch-tests.nix { };
@@ -20,6 +22,11 @@ let
       module = {
         _file = file;
         imports = [ module ];
+        _module.args = {
+          # Give tests access to the flake
+          inherit self system;
+          inherit (self) inputs;
+        };
       };
       pkgs = pkgsUnfree;
     };

--- a/tests/test-sources/modules/nixpkgs.nix
+++ b/tests/test-sources/modules/nixpkgs.nix
@@ -1,0 +1,74 @@
+{
+  # TODO: expect not setting `nixpkgs.pkgs` to throw
+
+  overlays =
+    { pkgs, ... }:
+    {
+      test.runNvim = false;
+
+      nixpkgs.overlays = [
+        (final: prev: {
+          foobar = "foobar";
+        })
+      ];
+
+      assertions = [
+        {
+          assertion = pkgs.foobar or null == "foobar";
+          message = ''
+            Expected `pkgs.foobar` to be "foobar"
+          '';
+        }
+      ];
+    };
+
+  # Test that overlays from both `nixpkgs.pkgs` _and_ `nixpkgs.overlays` are applied
+  stacked_overlays =
+    {
+      inputs,
+      system,
+      pkgs,
+      ...
+    }:
+    {
+      test.runNvim = false;
+
+      nixpkgs.pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          (final: prev: {
+            foobar = "foobar";
+            conflict = "a";
+          })
+        ];
+      };
+
+      nixpkgs.overlays = [
+        (final: prev: {
+          hello = "world";
+          conflict = "b";
+        })
+      ];
+
+      assertions = [
+        {
+          assertion = pkgs.foobar or null == "foobar";
+          message = ''
+            Expected `pkgs.foobar` to be "foobar"
+          '';
+        }
+        {
+          assertion = pkgs.hello or null == "world";
+          message = ''
+            Expected `pkgs.hello` to be "world"
+          '';
+        }
+        {
+          assertion = pkgs.conflict or null == "b";
+          message = ''
+            Expected `pkgs.conflict` to be "b"
+          '';
+        }
+      ];
+    };
+}


### PR DESCRIPTION
- **modules/nixpkgs: restructure `nixpkgs.pkgs.isDefined` assertion**
- **modules/nixpkgs: add `overlays` option**

Follow up to #2301 and working towards #1784; this PR adds the `nixpkgs.overlays` option.

This change is supported by some related refactoring to the existing assertion to a) reduce future indentation changes to the module and b) ensure the assertion message is actually shown to users. Without this change, `_module.args.pkgs` being absent will cause other errors that get thrown before we are able to check the module assertions.

Additionally, I've added a test to ensure the new option works correctly.

I would like a better option example for `nixpkgs.overlays`. Currently I'm using the same example as NixOS. Perhaps we could do something using the `vimPlugins = prev.vimPlugins.extend` pattern? IDK, struggling to find "useful" real-world examples that are small and obvious enough to be a good example.
