### PR TITLE
tests: refactor to use `callTest(s)` pattern + move calls to `tests/default.nix`

### DIFF
--- a/flake-modules/tests.nix
+++ b/flake-modules/tests.nix
@@ -1,57 +1,27 @@
-{ self, helpers, ... }:
+{
+  self,
+  lib,
+  helpers,
+  ...
+}:
 {
   perSystem =
     {
       pkgs,
       pkgsUnfree,
       system,
-      makeNixvimWithModule,
-      self',
       ...
     }:
-    let
-      inherit (self'.legacyPackages) nixvimConfiguration;
-    in
     {
-      checks = {
-        extra-args-tests = import ../tests/extra-args.nix {
-          inherit pkgs;
-          inherit makeNixvimWithModule;
-        };
-
-        extend = import ../tests/extend.nix { inherit pkgs makeNixvimWithModule; };
-
-        extra-files = import ../tests/extra-files.nix { inherit pkgs makeNixvimWithModule; };
-
-        enable-except-in-tests = import ../tests/enable-except-in-tests.nix {
-          inherit pkgs makeNixvimWithModule;
-          inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
-        };
-
-        failing-tests = pkgs.callPackage ../tests/failing-tests.nix {
-          inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
-        };
-
-        no-flake = import ../tests/no-flake.nix {
-          inherit system;
-          inherit (self.lib.${system}.check) mkTestDerivationFromNvim;
-          nixvim = "${self}";
-        };
-
-        lib-tests = import ../tests/lib-tests.nix {
-          inherit pkgs helpers;
-          inherit (pkgs) lib;
-        };
-
-        maintainers = import ../tests/maintainers.nix { inherit pkgs; };
-
-        plugins-by-name = pkgs.callPackage ../tests/plugins-by-name.nix { inherit nixvimConfiguration; };
-
-        generated = pkgs.callPackage ../tests/generated.nix { };
-
-        package-options = pkgs.callPackage ../tests/package-options.nix { inherit nixvimConfiguration; };
-
-        lsp-all-servers = pkgs.callPackage ../tests/lsp-servers.nix { inherit nixvimConfiguration; };
-      } // import ../tests { inherit pkgs pkgsUnfree helpers; };
+      checks = import ../tests {
+        inherit
+          helpers
+          lib
+          pkgs
+          pkgsUnfree
+          self
+          system
+          ;
+      };
     };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,47 +7,43 @@
   self, # The flake instance
 }:
 let
-  inherit (self.legacyPackages.${system})
-    makeNixvimWithModule
-    nixvimConfiguration
-    ;
+  autoArgs = pkgs // {
+    inherit
+      helpers
+      lib
+      pkgsUnfree
+      self
+      system
+      ;
+    inherit (self.legacyPackages.${system})
+      makeNixvimWithModule
+      nixvimConfiguration
+      ;
+    inherit (self.lib.${system}.check)
+      mkTestDerivationFromNvim
+      mkTestDerivationFromNixvimModule
+      ;
+    # Recursive:
+    inherit callTest callTests;
+  };
+
+  callTest = lib.callPackageWith autoArgs;
+  callTests = lib.callPackagesWith autoArgs;
 in
 {
-  extra-args-tests = import ./extra-args.nix {
-    inherit pkgs;
-    inherit makeNixvimWithModule;
-  };
-  extend = import ./extend.nix { inherit pkgs makeNixvimWithModule; };
-  extra-files = import ./extra-files.nix { inherit pkgs makeNixvimWithModule; };
-  enable-except-in-tests = import ./enable-except-in-tests.nix {
-    inherit pkgs makeNixvimWithModule;
-    inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
-  };
-  failing-tests = pkgs.callPackage ./failing-tests.nix {
-    inherit (self.lib.${system}.check) mkTestDerivationFromNixvimModule;
-  };
-  no-flake = import ./no-flake.nix {
-    inherit system;
-    inherit (self.lib.${system}.check) mkTestDerivationFromNvim;
-    nixvim = "${self}";
-  };
-  lib-tests = import ./lib-tests.nix {
-    inherit pkgs helpers;
-    inherit (pkgs) lib;
-  };
-  maintainers = import ./maintainers.nix { inherit pkgs; };
-  plugins-by-name = pkgs.callPackage ./plugins-by-name.nix { inherit nixvimConfiguration; };
-  generated = pkgs.callPackage ./generated.nix { };
-  package-options = pkgs.callPackage ./package-options.nix { inherit nixvimConfiguration; };
-  lsp-all-servers = pkgs.callPackage ./lsp-servers.nix { inherit nixvimConfiguration; };
+  extra-args-tests = callTest ./extra-args.nix { };
+  extend = callTest ./extend.nix { };
+  extra-files = callTest ./extra-files.nix { };
+  enable-except-in-tests = callTest ./enable-except-in-tests.nix { };
+  failing-tests = callTest ./failing-tests.nix { };
+  no-flake = callTest ./no-flake.nix { };
+  lib-tests = callTest ./lib-tests.nix { };
+  maintainers = callTest ./maintainers.nix { };
+  plugins-by-name = callTest ./plugins-by-name.nix { };
+  generated = callTest ./generated.nix { };
+  package-options = callTest ./package-options.nix { };
+  lsp-all-servers = callTest ./lsp-servers.nix { };
 }
 # Tests generated from ./test-sources
 # Grouped as a number of link-farms in the form { test-1, test-2, ... test-N }
-// import ./main.nix {
-  inherit
-    lib
-    pkgs
-    pkgsUnfree
-    helpers
-    ;
-}
+// callTests ./main.nix { }

--- a/tests/enable-except-in-tests.nix
+++ b/tests/enable-except-in-tests.nix
@@ -1,5 +1,7 @@
 {
   pkgs,
+  linkFarm,
+  runCommandNoCCLocal,
   mkTestDerivationFromNixvimModule,
   makeNixvimWithModule,
 }:
@@ -19,7 +21,7 @@ let
     let
       nvim = makeNixvimWithModule { inherit pkgs module; };
     in
-    pkgs.runCommand "enable-except-in-tests-not-in-test"
+    runCommandNoCCLocal "enable-except-in-tests-not-in-test"
       { printConfig = "${nvim}/bin/nixvim-print-init"; }
       ''
         if ! "$printConfig" | grep 'require("image").setup'; then
@@ -31,7 +33,7 @@ let
         touch $out
       '';
 in
-pkgs.linkFarm "enable-except-in-tests" [
+linkFarm "enable-except-in-tests" [
   {
     name = "in-test";
     path = inTest;

--- a/tests/extend.nix
+++ b/tests/extend.nix
@@ -1,4 +1,7 @@
-{ makeNixvimWithModule, pkgs }:
+{
+  makeNixvimWithModule,
+  runCommandNoCCLocal,
+}:
 let
   firstStage = makeNixvimWithModule {
     module = {
@@ -10,7 +13,7 @@ let
 
   generated = secondStage.extend { extraConfigLua = "-- third stage"; };
 in
-pkgs.runCommand "extend-test" { printConfig = "${generated}/bin/nixvim-print-init"; } ''
+runCommandNoCCLocal "extend-test" { printConfig = "${generated}/bin/nixvim-print-init"; } ''
   config=$($printConfig)
   for stage in "first" "second" "third"; do
     if ! "$printConfig" | grep -q -- "-- $stage stage"; then

--- a/tests/extra-args.nix
+++ b/tests/extra-args.nix
@@ -1,4 +1,7 @@
-{ makeNixvimWithModule, pkgs }:
+{
+  makeNixvimWithModule,
+  runCommandNoCCLocal,
+}:
 let
   defaultModule =
     { regularArg, ... }:
@@ -28,7 +31,7 @@ let
     };
   };
 in
-pkgs.runCommand "special-arg-test" { printConfig = "${generated}/bin/nixvim-print-init"; } ''
+runCommandNoCCLocal "special-arg-test" { printConfig = "${generated}/bin/nixvim-print-init"; } ''
   config=$($printConfig)
   if ! "$printConfig" | grep -- '-- regularArg=regularValue'; then
     echo "Missing regularArg in config"

--- a/tests/extra-files.nix
+++ b/tests/extra-files.nix
@@ -1,4 +1,7 @@
-{ makeNixvimWithModule, pkgs }:
+{
+  makeNixvimWithModule,
+  runCommandNoCCLocal,
+}:
 let
   extraFiles = {
     "one".text = "one";
@@ -12,7 +15,7 @@ let
     };
   };
 in
-pkgs.runCommand "extra-files-test"
+runCommandNoCCLocal "extra-files-test"
   {
     root = build.config.build.extraFiles;
     files = builtins.attrNames extraFiles;

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -1,9 +1,10 @@
 # For shorter test iterations run the following in the root of the repo:
 #   `echo ':b checks.${builtins.currentSystem}.lib-tests' | nix repl .`
 {
-  lib,
-  pkgs,
   helpers,
+  lib,
+  runCommandNoCCLocal,
+  writeText,
 }:
 let
   luaNames = {
@@ -45,9 +46,9 @@ let
     ];
   };
 
-  drv = pkgs.writeText "example-derivation" "hello, world!";
+  drv = writeText "example-derivation" "hello, world!";
 
-  results = pkgs.lib.runTests {
+  results = lib.runTests {
     testToLuaObject = {
       expr = helpers.toLuaObject {
         foo = "bar";
@@ -412,11 +413,11 @@ let
   };
 in
 if results == [ ] then
-  pkgs.runCommand "lib-tests-success" { } "touch $out"
+  runCommandNoCCLocal "lib-tests-success" { } "touch $out"
 else
-  pkgs.runCommand "lib-tests-failure"
+  runCommandNoCCLocal "lib-tests-failure"
     {
-      results = pkgs.lib.concatStringsSep "\n" (
+      results = lib.concatStringsSep "\n" (
         builtins.map (result: ''
           ${result.name}:
             expected: ${lib.generators.toPretty { } result.expected}

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -1,0 +1,66 @@
+# Collects the various test modules in tests/test-sources/ and groups them into a number of test derivations
+{
+  lib ? pkgs.lib,
+  helpers,
+  pkgs,
+  pkgsUnfree,
+}:
+let
+  fetchTests = import ./fetch-tests.nix { inherit lib pkgs helpers; };
+  test-derivation = import ../lib/tests.nix { inherit pkgs lib; };
+  inherit (test-derivation) mkTestDerivationFromNixvimModule;
+
+  moduleToTest =
+    file: name: module:
+    mkTestDerivationFromNixvimModule {
+      inherit name;
+      module = {
+        _file = file;
+        imports = [ module ];
+      };
+      pkgs = pkgsUnfree;
+    };
+
+  # List of files containing configurations
+  testFiles = fetchTests ./test-sources;
+
+  exampleFiles = {
+    name = "examples";
+    file = ../example.nix;
+    cases =
+      let
+        config = import ../example.nix { inherit pkgs; };
+      in
+      {
+        main = builtins.removeAttrs config.programs.nixvim [
+          # This is not available to standalone modules, only HM & NixOS Modules
+          "enable"
+          # This is purely an example, it does not reflect a real usage
+          "extraConfigLua"
+          "extraConfigVim"
+        ];
+      };
+  };
+in
+# We attempt to build & execute all configurations
+lib.pipe (testFiles ++ [ exampleFiles ]) [
+  (builtins.map (
+    {
+      name,
+      file,
+      cases,
+    }:
+    {
+      inherit name;
+      path = pkgs.linkFarm name (builtins.mapAttrs (moduleToTest file) cases);
+    }
+  ))
+  (helpers.groupListBySize 10)
+  (lib.imap1 (
+    i: group: rec {
+      name = "test-${toString i}";
+      value = pkgs.linkFarm name group;
+    }
+  ))
+  builtins.listToAttrs
+]

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -1,13 +1,15 @@
 # Collects the various test modules in tests/test-sources/ and groups them into a number of test derivations
 {
-  lib ? pkgs.lib,
+  callPackage,
+  callTest,
   helpers,
+  lib ? pkgs.lib,
   pkgs,
   pkgsUnfree,
 }:
 let
-  fetchTests = import ./fetch-tests.nix { inherit lib pkgs helpers; };
-  test-derivation = import ../lib/tests.nix { inherit pkgs lib; };
+  fetchTests = callTest ./fetch-tests.nix { };
+  test-derivation = callPackage ../lib/tests.nix { };
   inherit (test-derivation) mkTestDerivationFromNixvimModule;
 
   moduleToTest =

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -4,6 +4,7 @@
   callTest,
   helpers,
   lib ? pkgs.lib,
+  linkFarm,
   pkgs,
   pkgsUnfree,
 }:
@@ -54,14 +55,14 @@ lib.pipe (testFiles ++ [ exampleFiles ]) [
     }:
     {
       inherit name;
-      path = pkgs.linkFarm name (builtins.mapAttrs (moduleToTest file) cases);
+      path = linkFarm name (builtins.mapAttrs (moduleToTest file) cases);
     }
   ))
   (helpers.groupListBySize 10)
   (lib.imap1 (
     i: group: rec {
       name = "test-${toString i}";
-      value = pkgs.linkFarm name group;
+      value = linkFarm name group;
     }
   ))
   builtins.listToAttrs

--- a/tests/maintainers.nix
+++ b/tests/maintainers.nix
@@ -1,6 +1,6 @@
 {
-  pkgs ? import <nixpkgs> { },
-  lib ? pkgs.lib,
+  lib,
+  runCommandNoCCLocal,
 }:
 let
   inherit (lib) attrNames filter length;
@@ -9,7 +9,7 @@ let
   duplicates = filter (name: nixpkgsList ? ${name}) (attrNames nixvimList);
   count = length duplicates;
 in
-pkgs.runCommand "maintainers-test" { inherit count duplicates; } ''
+runCommandNoCCLocal "maintainers-test" { inherit count duplicates; } ''
   if [ $count -gt 0 ]; then
     echo "$count nixvim maintainers are also nixpkgs maintainers:"
     for name in $duplicates; do

--- a/tests/no-flake.nix
+++ b/tests/no-flake.nix
@@ -1,6 +1,7 @@
 {
+  nixvim ? "${self}",
+  self ? throw "either supply `self` or `nixvim`",
   system,
-  nixvim,
   mkTestDerivationFromNvim,
 }:
 let


### PR DESCRIPTION
- **tests: move test derivations to `tests/default.nix`**
- **tests: use `callTest` pattern**
- **tests: cleanup tests to better use `callTest` pattern**

This takes ideas from #2104 (reducing the scope of that PR) and is required for #2430, as otherwise the auto-formatting leads to an unnecessarily large diff.

This PR contains two key ideas in its refactoring:
- use the `callPackage` pattern with a nixvim-specific `callTest` variant
- rename `tests/default.nix` -> `tests/main.nix` since there are other tests in `tests/` not "owned" by `default.nix`
- move the builk of the implementation in `flake-modules/test.nix` to a new `tests/default.nix`, so that we minimize the implementation details contained within `flake-modules` and allow `tests/` to take responsibility for all its test derivations.