### PR TITLE
modules/nixpkgs: allow creating a nixpkgs internally

### DIFF
--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -137,6 +137,52 @@ in
         Ignored when `nixpkgs.pkgs` is set.
       '';
     };
+
+    hostPlatform = lib.mkOption {
+      type = with lib.types; either str attrs;
+      example = {
+        system = "aarch64-linux";
+      };
+      apply = lib.systems.elaborate;
+      defaultText = lib.literalMD ''
+        Inherited from the "host" configuration's `pkgs`.
+        Must be specified manually when building a standalone nixvim.
+      '';
+      description = ''
+        Specifies the platform where the Nixvim configuration will run.
+
+        To cross-compile, also set `nixpkgs.buildPlatform`.
+
+        Ignored when `nixpkgs.pkgs` is set.
+      '';
+    };
+
+    buildPlatform = lib.mkOption {
+      type = with lib.types; either str attrs;
+      default = cfg.hostPlatform;
+      example = {
+        system = "x86_64-linux";
+      };
+      apply =
+        value:
+        let
+          elaborated = lib.systems.elaborate value;
+        in
+        # If equivalent to `hostPlatform`, make it actually identical so that `==` can be used
+        # See https://github.com/NixOS/nixpkgs/issues/278001
+        if lib.systems.equals elaborated cfg.hostPlatform then cfg.hostPlatform else elaborated;
+      defaultText = lib.literalMD ''
+        Inherited from the "host" configuration's `pkgs`.
+        Or `config.nixpkgs.hostPlatform` when building a standalone nixvim.
+      '';
+      description = ''
+        Specifies the platform on which Nixvim should be built.
+        By default, Nixvim is built on the system where it runs, but you can change where it's built.
+        Setting this option will cause Nixvim to be cross-compiled.
+
+        Ignored when `nixpkgs.pkgs` is set.
+      '';
+    };
   };
 
   config =

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -136,9 +136,6 @@ in
 
         Ignored when `nixpkgs.pkgs` is set.
       '';
-
-      # FIXME: This is a stub option for now
-      internal = true;
     };
   };
 
@@ -165,10 +162,5 @@ in
       # evaluate the wrapper to find out that the priority is lower, and then we
       # don't need to evaluate `finalPkgs`.
       _module.args.pkgs = lib.mkOverride lib.modules.defaultOverridePriority finalPkgs.__splicedPackages;
-
-      # FIXME: This is a stub option for now
-      warnings = lib.optional (
-        opt.source.isDefined && opt.source.highestPrio < (lib.mkOptionDefault null).priority
-      ) "Defining the option `nixpkgs.source` currently has no effect";
     };
 }

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -32,10 +32,11 @@ let
     evalArgs
     // {
       modules = evalArgs.modules or [ ] ++ [
-        # Use global packages by default in nixvim's submodule
-        # TODO: `useGlobalPackages` option and/or deprecate using host packages?
         {
           _file = ./_shared.nix;
+
+          # Use global packages by default in nixvim's submodule
+          # TODO: `useGlobalPackages` option and/or deprecate using host packages?
           nixpkgs.pkgs = lib.mkDefault pkgs;
         }
       ];

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -35,9 +35,17 @@ let
         {
           _file = ./_shared.nix;
 
-          # Use global packages by default in nixvim's submodule
-          # TODO: `useGlobalPackages` option and/or deprecate using host packages?
-          nixpkgs.pkgs = lib.mkDefault pkgs;
+          nixpkgs = {
+            # Use global packages by default in nixvim's submodule
+            # TODO: `useGlobalPackages` option and/or deprecate using host packages?
+            pkgs = lib.mkDefault pkgs;
+
+            # Inherit platform spec
+            # FIXME: buildPlatform can't use option-default because it already has a default
+            #        (it defaults to hostPlatform)...
+            hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform;
+            buildPlatform = lib.mkDefault pkgs.stdenv.buildPlatform;
+          };
         }
       ];
     }


### PR DESCRIPTION
WIP draft. I've started adding some of the options required and their defaults. Still need to work on the implementation, assertions and add some tests.

Source option based on [nix-darwin's `source` option](https://github.com/LnL7/nix-darwin/blob/a60ac02f9466f85f092e576fd8364dfc4406b5a6/modules/nix/nixpkgs.nix#L235-L248).
