### PR TITLE
docs: refactor wrapper-options docs

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -42,13 +42,6 @@ let
     ];
   };
 
-  hmOptions = builtins.removeAttrs (lib.evalModules {
-    modules = [
-      ../wrappers/modules/hm.nix
-      { _module.check = false; } # Ignore missing option declarations
-    ];
-  }).options [ "_module" ];
-
   options-json =
     (pkgs.nixosOptionsDoc {
       inherit (evaledModules) options;
@@ -83,7 +76,7 @@ in
     # Do not check if documentation builds fine on darwin as it fails:
     # > sandbox-exec: pattern serialization length 69298 exceeds maximum (65535)
     docs = pkgs.callPackage ./mdbook {
-      inherit evaledModules hmOptions transformOptions;
+      inherit evaledModules transformOptions;
       # TODO: Find how to handle stable when 24.11 lands
       search = mkSearch "/nixvim/search/";
     };

--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -11,7 +11,7 @@
 
 # Platforms
 
-- [Home Manager Usage](./modules/hm.md)
+- [Platform-specific options](./modules/wrapper-options.md)
 - [Standalone Usage](./modules/standalone.md)
 
 # Options

--- a/docs/modules/hm.md
+++ b/docs/modules/hm.md
@@ -1,6 +1,0 @@
-# Home Manager Usage
-
-All nixvim options are available at `programs.nixvim.*` when nixvim is used in home-manager.
-There are a few home-manager specific options that are documented here.
-
-@HM_OPTIONS@

--- a/docs/modules/wrapper-options.md
+++ b/docs/modules/wrapper-options.md
@@ -1,0 +1,24 @@
+# Platform-specific options
+
+All of Nixvim's options are available within `programs.nixvim.*` when Nixvim is used via wrapper modules,
+such as our NixOS, home-manager, or nix-darwin modules.
+
+When Nixvim is used standalone (without a wrapper module), its options are available at the "top-level".
+See [Standalone Usage](./standalone.md) for more info.
+
+There are a few wrapper specific options that are documented below:
+
+## NixOS
+
+@NIXOS_OPTIONS@
+
+## home-manager
+
+@HM_OPTIONS@
+
+## nix-darwin
+
+@DARWIN_OPTIONS@
+
+<!-- TODO: Add @STANDALONE_OPTIONS@ if we ever have standalone-specific options -->
+

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -70,7 +70,7 @@ options as `programs.nixvim.<path>.<to>.<option> = <value>`.
 When you use nixvim as a module, an additional module argument is passed on allowing you to peek through the configuration with `hmConfig`, `nixosConfig`, and `darwinConfig` for home-manager, NixOS, and nix-darwin respectively.
 This is useful is you use nixvim both as part of an environment and as standalone.
 
-If using the home-manager module, see [Home Manager Usage](../modules/hm.md) for more information.
+For more information on module-specific options, see [Platform-specific options](../modules/wrapper-options.md).
 
 ### Standalone usage
 


### PR DESCRIPTION
Refactor the previous `hm.md` docs to cover platform-specific options for _all_ wrappers.

#### Future work

In the future, we could factor out "common" options, but I think that is best done if we end up with lots of them. For now it is probably simpler to keep things as-is; i.e. common options are displayed multiple times.

We probably also want the hm-specific options to be available on all platforms. This may be best achieved by upstreaming `vimdiff` alias to the nixpkgs vim wrapper, as discussed in https://github.com/nix-community/nixvim/pull/1353 (tracked in https://github.com/nix-community/nixvim/issues/1621).
