### PR TITLE
{docs,wrappers}: refactor to prepare for separated wrapper-option doc pages

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -208,7 +208,7 @@ let
     nixvimOptions = mapModulesToString (
       name: opts:
       let
-        isBranch = if name == "index" then true else opts.hasComponents && opts.index.options != { };
+        isBranch = name == "index" || (opts.hasComponents && opts.index.options != { });
 
         path =
           if isBranch then
@@ -218,9 +218,9 @@ let
           else
             "";
 
-        indentLevel = with builtins; length (filter isString (split "/" opts.index.path)) - 1;
+        indentLevel = lib.count (c: c == "/") (lib.stringToCharacters opts.index.path);
 
-        padding = lib.concatStrings (builtins.genList (_: "\t") indentLevel);
+        padding = lib.strings.replicate indentLevel "\t";
       in
       "${padding}- [${name}](${path})"
     ) docs.modules;

--- a/docs/modules/wrapper-options.md
+++ b/docs/modules/wrapper-options.md
@@ -8,17 +8,5 @@ See [Standalone Usage](./standalone.md) for more info.
 
 There are a few wrapper specific options that are documented below:
 
-## NixOS
-
-@NIXOS_OPTIONS@
-
-## home-manager
-
-@HM_OPTIONS@
-
-## nix-darwin
-
-@DARWIN_OPTIONS@
-
-<!-- TODO: Add @STANDALONE_OPTIONS@ if we ever have standalone-specific options -->
+@WRAPPER_OPTIONS@
 

--- a/wrappers/modules/darwin.nix
+++ b/wrappers/modules/darwin.nix
@@ -1,3 +1,3 @@
 {
-  imports = [ ./enable.nix ];
+  imports = [ ./shared.nix ];
 }

--- a/wrappers/modules/darwin.nix
+++ b/wrappers/modules/darwin.nix
@@ -1,3 +1,7 @@
 {
   imports = [ ./shared.nix ];
+
+  config = {
+    meta.wrapper.name = "nix-darwin";
+  };
 }

--- a/wrappers/modules/enable.nix
+++ b/wrappers/modules/enable.nix
@@ -1,4 +1,0 @@
-{ lib, ... }:
-{
-  options.enable = lib.mkEnableOption "nixvim";
-}

--- a/wrappers/modules/hm.nix
+++ b/wrappers/modules/hm.nix
@@ -17,5 +17,6 @@
   config = {
     wrapRc = lib.mkOptionDefault false;
     impureRtp = lib.mkOptionDefault true;
+    meta.wrapper.name = "home-manager";
   };
 }

--- a/wrappers/modules/hm.nix
+++ b/wrappers/modules/hm.nix
@@ -12,7 +12,7 @@
     };
   };
 
-  imports = [ ./enable.nix ];
+  imports = [ ./shared.nix ];
 
   config = {
     wrapRc = lib.mkOptionDefault false;

--- a/wrappers/modules/nixos.nix
+++ b/wrappers/modules/nixos.nix
@@ -4,5 +4,5 @@
     defaultEditor = lib.mkEnableOption "nixvim as the default editor";
   };
 
-  imports = [ ./enable.nix ];
+  imports = [ ./shared.nix ];
 }

--- a/wrappers/modules/nixos.nix
+++ b/wrappers/modules/nixos.nix
@@ -5,4 +5,8 @@
   };
 
   imports = [ ./shared.nix ];
+
+  config = {
+    meta.wrapper.name = "NixOS";
+  };
 }

--- a/wrappers/modules/shared.nix
+++ b/wrappers/modules/shared.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+{
+  options = {
+    enable = lib.mkEnableOption "nixvim";
+  };
+}

--- a/wrappers/modules/shared.nix
+++ b/wrappers/modules/shared.nix
@@ -2,5 +2,13 @@
 {
   options = {
     enable = lib.mkEnableOption "nixvim";
+
+    meta.wrapper = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        description = "The human-readable name of this nixvim wrapper. Used in documentation.";
+        internal = true;
+      };
+    };
   };
 }


### PR DESCRIPTION
- ~~**docs: move `user-guide` and `modules` into `mdbood` dir**~~
- **docs: simplify `mdbook.nixvimOptions` impl**
- **wrappers/modules: move `enable` to `shared.nix`**
- **wrappers: add `meta.wrappers` options to wrappers**

I've moved `modules/` to `wrappers/` in docs URLs. `modules/` felt confusing, but I'm not convinced `wrappers/` is right either. Maybe `platforms/` would be better? If we're gonna change the URLs let's try and get it right first time, or postpone the change for later.

I've introduced a `meta.wrappers.name` option, that is only present on wrapper modules (i.e. not currently in standalone). If standalone ever wanted to be part of the "wrapper" docs maybe it should also get the option, but that's easily refactored.
This option is used to set the "human readable" name of the wrapper module, as it should appear in documentation (headings, links, etc).

I'm unsure currently if it will be best to a) show "common" options shared by all non-standalone wrappers together and then unique options separately, or b) continue showing all options per wrapper, but split the docs into several pages.

Perhaps structured as a nested tree:
- Platforms (index page with summary): `wrappers/index.md`
  - NixOS: `wrappers/nixos.md`
  - home-manager: `wrappers/hm.md`
  - nix-darwin: `wrappers/darwin.md`

While feedback on next steps is welcome, and _may_ influence this PR, currently I think it best to actually implement it in a follow up PR. (We'll see)...

Additionally, for context: the new `shared.nix` wrapper module will likely house the option declaration for the proposed `nixpkgs.useGlobalPackages` option. This option is where we'll handle gradually deprecating the current behaviour of inheriting the host module's `pkgs` into our module eval.
