### PR TITLE
plugins/lsp-format: migrate to mkNeovimPlugin

### DIFF
--- a/tests/test-sources/plugins/by-name/lsp-format/default.nix
+++ b/tests/test-sources/plugins/by-name/lsp-format/default.nix
@@ -20,7 +20,7 @@
       lsp-format = {
         enable = true;
 
-        setup = {
+        settings = {
           go = {
             exclude = [ "gopls" ];
             order = [


### PR DESCRIPTION
Not sure if anyone is familiar with a good way to represent the submodule options for the top level language options. I decided to just do a rename from setup -> settings and mention the configuration through a description and examples. 