### PR TITLE
plugins/lsp: no call fn in keymaps.extra example

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -73,7 +73,7 @@ in
             }
             {
               key = "gd";
-              action.__raw = "require('telescope.builtin').lsp_definitions()";
+              action.__raw = "require('telescope.builtin').lsp_definitions";
             }
             {
               key = "K";


### PR DESCRIPTION
Because by calling we do not get the function reference but its return
value, instead.
