### PR TITLE
plugins/nui: add nui and its test

### DIFF
--- a/plugins/by-name/nui/default.nix
+++ b/plugins/by-name/nui/default.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
+  name = "nui";
+  originalName = "nui.nvim";
+  package = "nui-nvim";
+  description = "UI Component Library for Neovim";
+  maintainers = [ lib.maintainers.DataHearth ];
+
+  callSetup = false;
+  hasSettings = false;
+}

--- a/tests/test-sources/plugins/by-name/nui/default.nix
+++ b/tests/test-sources/plugins/by-name/nui/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.nui.enable = true;
+  };
+}


### PR DESCRIPTION
I added the <https://github.com/MunifTanjim/nui.nvim/> plugin. It was already packed at nixpkgs and up-to-date on unstable