### PR TITLE
plugins/notebook-navigator: init

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ The tests are located in the [tests/test-sources](tests/test-sources) directory,
 
 Tests can either be a simple attribute set, or a function taking `{pkgs}` as an input. The keys of the set are configuration names, and the values are a nixvim configuration.
 
-You can specify the special `tests` attribute in the configuration that will not be interpreted by nixvim, but only the test runner. The following keys are available:
+You can specify the special `test` attribute in the configuration that will not be interpreted by nixvim, but only the test runner. The following keys are available:
 
-- `tests.dontRun`: avoid launching this test, simply build the configuration.
+- `test.runNvim`: Set to `false` to avoid launching nvim with this configuration and simply build the configuration.
 
 The tests are then runnable with `nix flake check --all-systems`.
 

--- a/plugins/by-name/notebook-navigator/default.nix
+++ b/plugins/by-name/notebook-navigator/default.nix
@@ -1,0 +1,122 @@
+{ lib, config, ... }:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+  inherit (lib) types;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
+  name = "notebook-navigator";
+  originalName = "NotebookNavigator-nvim";
+  package = "NotebookNavigator-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsOptions = {
+    cell_markers = defaultNullOpts.mkAttrsOf' {
+      type = types.str;
+      pluginDefault = { };
+      example = {
+        python = "# %%";
+      };
+      description = ''
+        Code cell marker.
+
+        Cells start with the marker and end either at the beginning of the next cell or at the end of
+        the file.
+
+        By default, uses language-specific double percent comments like `# %%`.
+        This can be overridden for each language with this setting.
+      '';
+    };
+
+    activate_hydra_keys = defaultNullOpts.mkStr null ''
+      If not `nil` the keymap defined in the string will activate the hydra head.
+      If you don't want to use hydra you don't need to install it either.
+    '';
+
+    show_hydra_hint = defaultNullOpts.mkBool true ''
+      If `true` a hint panel will be shown when the hydra head is active.
+      If `false` you get a minimalistic hint on the command line.
+    '';
+
+    hydra_keys =
+      defaultNullOpts.mkAttrsOf types.str
+        {
+          comment = "c";
+          run = "X";
+          run_and_move = "x";
+          move_up = "k";
+          move_down = "j";
+          add_cell_before = "a";
+          add_cell_after = "b";
+          split_cell = "s";
+        }
+        ''
+          Mappings while the hydra head is active.
+        '';
+
+    repl_provider =
+      defaultNullOpts.mkEnumFirstDefault
+        [
+          "auto"
+          "iron"
+          "molten"
+          "toggleterm"
+        ]
+        ''
+          The repl plugin with which to interface.
+
+          Current options:
+          - "iron" for iron.nvim,
+          - "toggleterm" for toggleterm.nvim,
+          - "molten" for molten-nvim
+          - "auto" which checks which of the above are installed
+        '';
+
+    syntax_highlight = defaultNullOpts.mkBool false ''
+      Syntax based highlighting.
+
+      If you don't want to install `mini.hipattners` or enjoy a more minimalistic look.
+    '';
+
+    cell_highlight_group = defaultNullOpts.mkStr "Folded" ''
+      For use with `mini.hipatterns` to highlight cell markers.
+    '';
+  };
+
+  # Optionally, provide an example for the `settings` option.
+  settingsExample = {
+    cell_markers.python = "# %%";
+    activate_hydra_keys = "<leader>h";
+    hydra_keys = {
+      comment = "c";
+      run = "X";
+      run_and_move = "x";
+      move_up = "k";
+      move_down = "j";
+      add_cell_before = "a";
+      add_cell_after = "b";
+      split_cell = "s";
+    };
+    repl_provider = "molten";
+    syntax_highlight = true;
+    cell_highlight_group = "Folded";
+  };
+
+  extraConfig = cfg: {
+    warnings =
+      (lib.optional ((cfg.settings.activate_hydra_keys != null) && (!config.plugins.hydra.enable)) ''
+        Nixvim (plugins.notebook-navigator): `plugins.notebook-navigator.settings.activate_hydra_keys` has been set to a non-`null`
+        value but `plugins.hydra.enable` is `false`.
+      '')
+      ++
+        (lib.optional ((cfg.settings.repl_provider == "toggleterm") && (!config.plugins.toggleterm.enable)))
+          ''
+            Nixvim (plugins.notebook-navigator): `plugins.notebook-navigator.settings.repl_provider` has been set to "toggleterm"
+            but `plugins.hydra.toggleterm.enable` is `false`.
+          ''
+      ++ (lib.optional ((cfg.settings.repl_provider == "molten") && (!config.plugins.molten.enable))) ''
+        Nixvim (plugins.notebook-navigator): `plugins.notebook-navigator.settings.repl_provider` has been set to "molten"
+        but `plugins.molten.enable` is `false`.
+      '';
+  };
+}

--- a/tests/test-sources/plugins/by-name/notebook-navigator/default.nix
+++ b/tests/test-sources/plugins/by-name/notebook-navigator/default.nix
@@ -1,0 +1,67 @@
+{
+  empty = {
+    plugins = {
+      notebook-navigator.enable = true;
+      molten.enable = true;
+    };
+  };
+
+  defaults = {
+    plugins = {
+      molten.enable = true;
+      notebook-navigator = {
+        enable = true;
+
+        settings = {
+          cell_markers = { };
+          activate_hydra_keys = null;
+          show_hydra_hint = true;
+          hydra_keys = {
+            comment = "c";
+            run = "X";
+            run_and_move = "x";
+            move_up = "k";
+            move_down = "j";
+            add_cell_before = "a";
+            add_cell_after = "b";
+            split_cell = "s";
+          };
+          repl_provider = "auto";
+          syntax_highlight = false;
+          cell_highlight_group = "Folded";
+        };
+      };
+    };
+  };
+
+  example = {
+    # ERROR: [Hydra.nvim] Option "hint.border" has been deprecated and will be removed on 2024-02-01 -- See hint.float_opts
+    test.runNvim = false;
+
+    plugins = {
+      hydra.enable = true;
+      molten.enable = true;
+      notebook-navigator = {
+        enable = true;
+
+        settings = {
+          cell_markers.python = "# %%";
+          activate_hydra_keys = "<leader>h";
+          hydra_keys = {
+            comment = "c";
+            run = "X";
+            run_and_move = "x";
+            move_up = "k";
+            move_down = "j";
+            add_cell_before = "a";
+            add_cell_after = "b";
+            split_cell = "s";
+          };
+          repl_provider = "molten";
+          syntax_highlight = true;
+          cell_highlight_group = "Folded";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [NotebookNavigator.nvim](https://github.com/GCBallesteros/NotebookNavigator.nvim), a neovim plugin to navigate and execute code cells.

Fixes #2449
