### PR TITLE
plugins/nvim-notify: add more render styles

### DIFF
--- a/plugins/by-name/notify/default.nix
+++ b/plugins/by-name/notify/default.nix
@@ -78,6 +78,9 @@ in
     render = helpers.defaultNullOpts.mkEnumFirstDefault [
       "default"
       "minimal"
+      "simple"
+      "compact"
+      "wrapped-compact"
     ] "Function to render a notification buffer or a built-in renderer name.";
 
     minimumWidth = helpers.defaultNullOpts.mkUnsignedInt 50 ''


### PR DESCRIPTION
For nvim-notify
`:help notify-render`

```
Built-in renderers:
- `"default"`
- `"minimal"`
- `"simple"`
- `"compact"`
- `"wrapped-compact"`
```