### PR TITLE
plugins/lsp: enable auto-installing rustfmt

### DIFF
--- a/plugins/lsp/language-servers/rust-analyzer.nix
+++ b/plugins/lsp/language-servers/rust-analyzer.nix
@@ -30,6 +30,16 @@ in
 
     # TODO: make nullable
     rustcPackage = mkPackageOption pkgs "rustc" { };
+
+    installRustfmt = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      example = true;
+      description = "Whether to install `rustfmt`.";
+    };
+
+    # TODO: make nullable
+    rustfmtPackage = mkPackageOption pkgs "rustfmt" { };
   };
   config = mkIf cfg.enable {
     warnings =
@@ -56,7 +66,8 @@ in
 
     extraPackages =
       with pkgs;
-      (optional ((isBool cfg.installCargo) && cfg.installCargo) cfg.cargoPackage)
-      ++ (optional ((isBool cfg.installRustc) && cfg.installRustc) cfg.rustcPackage);
+      optional (isBool cfg.installCargo && cfg.installCargo) cfg.cargoPackage
+      ++ optional (isBool cfg.installRustc && cfg.installRustc) cfg.rustcPackage
+      ++ optional (isBool cfg.installRustfmt && cfg.installRustfmt) cfg.rustfmtPackage;
   };
 }


### PR DESCRIPTION
Adds an option to automatically install rustfmt when using rust-analyzer. This is a draft as I was not sure exactly how to define the option so any suggestions on how to better implement it are welcome. Thanks!