### PR TITLE
plugins/prettierd: add disableTsServerFormatter like for prettier

### DIFF
--- a/plugins/by-name/none-ls/prettier.nix
+++ b/plugins/by-name/none-ls/prettier.nix
@@ -1,38 +1,41 @@
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  options,
+  ...
+}:
 let
   cfg = config.plugins.none-ls.sources.formatting.prettier;
   ts-ls-cfg = config.plugins.lsp.servers.ts_ls;
+  opt = options.plugins.none-ls.sources.formatting.prettier;
+  defaultPrio = (lib.mkOptionDefault null).priority;
 in
 {
   options.plugins.none-ls.sources.formatting.prettier = {
     disableTsServerFormatter = lib.mkOption {
-      type = with lib.types; nullOr bool;
+      type = lib.types.bool;
       description = ''
         Disables the formatting capability of the `ts_ls` language server if it is enabled.
       '';
-      default = null;
+      default = false;
       example = true;
     };
   };
 
   config = lib.mkIf cfg.enable {
-    warnings = lib.optional ((cfg.disableTsServerFormatter == null) && ts-ls-cfg.enable) ''
-      You have enabled the `prettier` formatter in none-ls.
-      You have also enabled the `ts_ls` language server which also brings a formatting feature.
+    warnings =
+      lib.optional (opt.disableTsServerFormatter.highestPrio == defaultPrio && ts-ls-cfg.enable)
+        ''
+          You have enabled the `prettier` formatter in none-ls.
+          You have also enabled the `ts_ls` language server which also brings a formatting feature.
 
-      - To disable the formatter built-in the `ts_ls` language server, set
-        `plugins.none-ls.sources.formatting.prettier.disableTsServerFormatter` to `true`.
-      - Else, to silence this warning, explicitly set the option to `false`.
-    '';
+          - To disable the formatter built-in the `ts_ls` language server, set
+            `plugins.none-ls.sources.formatting.prettier.disableTsServerFormatter` to `true`.
+          - Else, to silence this warning, explicitly set the option to `false`.
+        '';
 
     plugins.lsp.servers.ts_ls =
-      lib.mkIf
-        (
-          cfg.enable
-          && ts-ls-cfg.enable
-          && (lib.isBool cfg.disableTsServerFormatter)
-          && cfg.disableTsServerFormatter
-        )
+      lib.mkIf (cfg.enable && ts-ls-cfg.enable && cfg.disableTsServerFormatter)
         {
           onAttach.function = ''
             client.server_capabilities.documentFormattingProvider = false

--- a/plugins/by-name/none-ls/prettierd.nix
+++ b/plugins/by-name/none-ls/prettierd.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+let
+  cfg = config.plugins.none-ls.sources.formatting.prettierd;
+  ts-ls-cfg = config.plugins.lsp.servers.ts_ls;
+  opt = options.plugins.none-ls.sources.formatting.prettierd;
+  defaultPrio = (lib.mkOptionDefault null).priority;
+in
+{
+  options.plugins.none-ls.sources.formatting.prettierd = {
+    disableTsServerFormatter = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Disables the formatting capability of the `ts_ls` language server if it is enabled.
+      '';
+      default = false;
+      example = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    warnings =
+      lib.optional (opt.disableTsServerFormatter.highestPrio == defaultPrio && ts-ls-cfg.enable)
+        ''
+          You have enabled the `prettierd` formatter in none-ls.
+          You have also enabled the `ts_ls` language server which also brings a formatting feature.
+
+          - To disable the formatter built-in the `ts_ls` language server, set
+            `plugins.none-ls.sources.formatting.prettierd.disableTsServerFormatter` to `true`.
+          - Else, to silence this warning, explicitly set the option to `false`.
+        '';
+
+    plugins.lsp.servers.ts_ls =
+      lib.mkIf (cfg.enable && ts-ls-cfg.enable && cfg.disableTsServerFormatter)
+        {
+          onAttach.function = ''
+            client.server_capabilities.documentFormattingProvider = false
+          '';
+        };
+  };
+}

--- a/plugins/by-name/none-ls/sources.nix
+++ b/plugins/by-name/none-ls/sources.nix
@@ -5,7 +5,10 @@ let
 in
 {
   imports =
-    [ ./prettier.nix ]
+    [
+      ./prettier.nix
+      ./prettierd.nix
+    ]
     ++ (lib.flatten (
       lib.mapAttrsToList (category: (lib.map (mkSourcePlugin category))) noneLsBuiltins
     ));


### PR DESCRIPTION
Add a new option (and warning) to disable the typescript-language-server (ts_ls) formatting just like with prettier.

```nix
none-ls = {
  enable = true;

  sources = {
    formatting.prettierd = {
      enable = true;
      disableTsServerFormatter = true;
    };
  };
};
```

I simply copied the implementation from prettier, to keep the source code more readable. If you'd like me to make this more generic instead I could create a function that reduces repetition.
