### PR TITLE
plugins/muren: init

### DIFF
--- a/plugins/by-name/muren/default.nix
+++ b/plugins/by-name/muren/default.nix
@@ -1,0 +1,147 @@
+{
+  lib,
+  ...
+}:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+  inherit (lib) types;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
+  name = "muren";
+  originalName = "muren.nvim";
+  package = "muren-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsOptions = {
+    create_commands = defaultNullOpts.mkBool true ''
+      Automatically creates commands for the plugin.
+    '';
+
+    filetype_in_preview = defaultNullOpts.mkBool true ''
+      Applies file type highlighting in the preview window.
+    '';
+
+    two_step = defaultNullOpts.mkBool false ''
+      Enables two-step replacements for non-recursive replacements.
+    '';
+
+    all_on_line = defaultNullOpts.mkBool true ''
+      When enabled, all replacements are applied on the same line.
+    '';
+
+    preview = defaultNullOpts.mkBool true ''
+      Show a preview of the replacements.
+    '';
+
+    cwd = defaultNullOpts.mkBool false ''
+      Use the current working directory for replacements.
+    '';
+
+    files = defaultNullOpts.mkStr "**/*" ''
+      Specify the file pattern for replacements.
+    '';
+
+    keys =
+      defaultNullOpts.mkAttrsOf types.str
+        {
+          close = "q";
+          toggle_side = "<Tab>";
+          toggle_options_focus = "<C-s>";
+          toggle_option_under_cursor = "<CR>";
+          scroll_preview_up = "<Up>";
+          scroll_preview_down = "<Down>";
+          do_replace = "<CR>";
+          do_undo = "<localleader>u";
+          do_redo = "<localleader>r";
+        }
+        ''
+          Specify the keyboard shortcuts for various actions.
+        '';
+
+    patterns_width = defaultNullOpts.mkUnsignedInt 30 ''
+      Width of the patterns panel.
+    '';
+
+    patterns_height = defaultNullOpts.mkUnsignedInt 10 ''
+      Height of the patterns panel.
+    '';
+
+    options_width = defaultNullOpts.mkUnsignedInt 20 ''
+      Width of the options panel.
+    '';
+
+    preview_height = defaultNullOpts.mkUnsignedInt 12 ''
+      Height of the preview panel.
+    '';
+
+    anchor =
+      defaultNullOpts.mkEnumFirstDefault
+        [
+          "center"
+          "top"
+          "bottom"
+          "left"
+          "right"
+          "top_left"
+          "top_right"
+          "bottom_left"
+          "bottom_right"
+        ]
+        ''
+          Specify the location of the muren UI.
+        '';
+
+    vertical_offset = defaultNullOpts.mkUnsignedInt 0 ''
+      Vertical offset relative to the anchor.
+    '';
+
+    horizontal_offset = defaultNullOpts.mkUnsignedInt 0 ''
+      Horizontal offset relative to the anchor.
+    '';
+
+    order =
+      defaultNullOpts.mkListOf types.str
+        [
+
+          "buffer"
+          "dir"
+          "files"
+          "two_step"
+          "all_on_line"
+          "preview"
+        ]
+        ''
+          Specify the order of options in the UI.
+        '';
+
+    hl = {
+      options = {
+        on = defaultNullOpts.mkStr "@string" ''
+          Highlight group for enabled options.
+        '';
+
+        off = defaultNullOpts.mkStr "@variable.builtin" ''
+          Highlight group for disabled options.
+        '';
+      };
+
+      preview = {
+        cwd = {
+          path = defaultNullOpts.mkStr "Comment" ''
+            Highlight group for the directory path in the preview.
+          '';
+
+          lnum = defaultNullOpts.mkStr "Number" ''
+            Highlight group for line numbers in the preview.
+          '';
+        };
+      };
+    };
+  };
+
+  settingsExample = {
+    create_commands = true;
+    filetype_in_preview = true;
+  };
+}

--- a/tests/test-sources/plugins/by-name/muren/default.nix
+++ b/tests/test-sources/plugins/by-name/muren/default.nix
@@ -1,0 +1,71 @@
+{
+  empty = {
+    plugins.muren.enable = true;
+  };
+
+  defaults = {
+    plugins.muren = {
+      enable = true;
+
+      settings = {
+        create_commands = true;
+        filetype_in_preview = true;
+        two_step = false;
+        all_on_line = true;
+        preview = true;
+        cwd = false;
+        files = "**/*";
+        keys = {
+          close = "q";
+          toggle_side = "<Tab>";
+          toggle_options_focus = "<C-s>";
+          toggle_option_under_cursor = "<CR>";
+          scroll_preview_up = "<Up>";
+          scroll_preview_down = "<Down>";
+          do_replace = "<CR>";
+          do_undo = "<localleader>u";
+          do_redo = "<localleader>r";
+        };
+        patterns_width = 30;
+        patterns_height = 10;
+        options_width = 20;
+        preview_height = 12;
+        anchor = "center";
+        vertical_offset = 0;
+        horizontal_offset = 0;
+        order = [
+
+          "buffer"
+          "dir"
+          "files"
+          "two_step"
+          "all_on_line"
+          "preview"
+        ];
+        hl = {
+          options = {
+            on = "@string";
+            off = "@variable.builtin";
+          };
+          preview = {
+            cwd = {
+              path = "Comment";
+              lnum = "Number";
+            };
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.muren = {
+      enable = true;
+
+      settings = {
+        create_commands = true;
+        filetype_in_preview = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [muren.nvim](https://github.com/AckslD/muren.nvim), a plugin to do multi-replacements.

Fixes #2482
