### PR TITLE
docs: specify `site-url`

### DIFF
--- a/docs/mdbook/book.toml
+++ b/docs/mdbook/book.toml
@@ -5,6 +5,9 @@ multilingual = false
 src = "."
 title = "nixvim docs"
 
+[output.html]
+site-url = "@SITE_URL@"
+
 [output.html.fold]
 enable = true
 level = 0

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -321,6 +321,10 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
       cp "$file" "$path"
     done
 
+    # Patch book.toml
+    substituteInPlace ./book.toml \
+      --replace-fail "@SITE_URL@" "$siteURL"
+
     # Patch SUMMARY.md - which defiens mdBook's table of contents
     substituteInPlace ./SUMMARY.md \
       --replace-fail "@PLATFORM_OPTIONS@" "$wrapperOptionsSummary" \
@@ -331,6 +335,10 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
     mkdir -p $dest/search
     cp -r ${search}/* $dest/search
   '';
+
+  # The root directory of the site
+  # Can be overridden, e.g. by CI
+  siteURL = "/nixvim/";
 
   inherit (mdbook)
     nixvimOptionsSummary


### PR DESCRIPTION
This should fix the 404 page's relative links and styling being relative to `/`.

This works by telling mdbook to set the `<base href>` tag to `"/nixvim/"` instead of `"/"`. This is used as the "base" of relative paths.

I added it as a derivation attr, so we could do something like this to apply a different site-url to the stable branch once this is available on a stable branch:
```
 nix build --impure --expr '(builtins.getFlake "github:nix-community/nixvim/nixos-24.11").outputs.packages.${builtins.currentSystem}.docs.overrideAttrs { siteURL = "/foo/bar/"; }'
```
