### PR TITLE
options: add defaultNullOpts.mkRaw

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -147,6 +147,19 @@ rec {
       mkLuaFn' = args: mkNullOrLuaFn' (processDefaultNullArgs args);
       mkLuaFn = pluginDefault: description: mkLuaFn' { inherit pluginDefault description; };
 
+      mkRaw' =
+        args:
+        mkNullable' (
+          args
+          // {
+            type = types.rawLua;
+          }
+          // lib.optionalAttrs (args ? pluginDefault) {
+            pluginDefault = lib.nixvim.mkRaw args.pluginDefault;
+          }
+        );
+      mkRaw = pluginDefault: description: mkRaw' { inherit pluginDefault description; };
+
       mkNum' = args: mkNullableWithRaw' (args // { type = types.number; });
       mkNum = pluginDefault: description: mkNum' { inherit pluginDefault description; };
       mkInt' = args: mkNullableWithRaw' (args // { type = types.int; });

--- a/plugins/by-name/fastaction/default.nix
+++ b/plugins/by-name/fastaction/default.nix
@@ -140,7 +140,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           Keys to use to dismiss the popup.
         '';
 
-    override_function = defaultNullOpts.mkNullable types.rawLua { __raw = "function(_) end"; } ''
+    override_function = defaultNullOpts.mkRaw "function(_) end" ''
       Override function to map keys to actions.
 
       ```lua


### PR DESCRIPTION
As we plan to move away from `mkLua` and `mkLuaFn` options, declaring options that only accept a `rawLua` value will be more and more common.
This PR adds the `defaultNullOpts.mkRaw` and `defaultNullOpts.mkRaw'` helpers to create such options easily.

Example:
```nix
# Before
custom_func = defaultNullOpts.mkNullable types.rawLua { __raw = "function(x) return x + 1 end"; } ''
  Description.
'';

# After
custom_func = defaultNullOpts.mkRaw "function(x) return x + 1 end" ''
  Description.
'';
```
