### PR TITLE
lib/utils: add `literalLua` & `nestedLiteralLua` option docs

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -92,6 +92,7 @@ lib.fix (
       hasContent
       ifNonNull'
       listToUnkeyedAttrs
+      literalLua
       mkIfNonNull
       mkIfNonNull'
       mkRaw

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -97,6 +97,8 @@ lib.fix (
       mkIfNonNull'
       mkRaw
       mkRawKey
+      nestedLiteral
+      nestedLiteralLua
       override
       overrideDerivation
       toRawKeys

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -155,7 +155,7 @@ rec {
             type = types.rawLua;
           }
           // lib.optionalAttrs (args ? pluginDefault) {
-            pluginDefault = lib.nixvim.mkRaw args.pluginDefault;
+            pluginDefault = lib.nixvim.literalLua args.pluginDefault;
           }
         );
       mkRaw = pluginDefault: description: mkRaw' { inherit pluginDefault description; };

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -124,6 +124,37 @@ rec {
     else
       throw "mkRaw: invalid input: ${lib.generators.toPretty { multiline = false; } r}";
 
+  /**
+    Convert the given string into a literalExpression mkRaw.
+
+    For use in option documentation, such as examples and defaults.
+
+    # Example
+
+    ```nix
+    literalLua "print('hi')"
+    => literalExpression ''lib.nixvim.mkRaw "print('hi')"''
+    => {
+      _type = "literalExpression";
+      text = ''lib.nixvim.mkRaw "print('hi')"'';
+    }
+    ```
+
+    # Type
+    ```
+    literalLua :: String -> AttrSet
+    ```
+  */
+  literalLua =
+    r:
+    let
+      # Pass the value through mkRaw for validation
+      raw = mkRaw r;
+      # TODO: consider switching to lib.generators.mkLuaInline ?
+      exp = "lib.nixvim.mkRaw " + builtins.toJSON raw.__raw;
+    in
+    lib.literalExpression exp;
+
   wrapDo = string: ''
     do
       ${string}

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -155,6 +155,64 @@ rec {
     in
     lib.literalExpression exp;
 
+  /**
+    Convert the given string into a `__pretty` printed mkRaw expression.
+
+    For use in nested values that will be printed by `lib.generators.toPretty`,
+    or `lib.options.renderOptionValue`.
+
+    # Example
+
+    ```nix
+    nestedLiteralLua "print('hi')"
+    => nestedLiteral (literalLua "print('hi')")
+    => {
+      __pretty = lib.getAttr "text";
+      val = literalLua "print('hi')";
+    }
+    ```
+
+    # Type
+    ```
+    nestedLiteralLua :: String -> AttrSet
+    ```
+  */
+  nestedLiteralLua = r: nestedLiteral (literalLua r);
+
+  /**
+    Convert the given string or literalExpression into a `__pretty` printed expression.
+
+    For use in nested values that will be printed by `lib.generators.toPretty`,
+    or `lib.options.renderOptionValue`.
+
+    # Examples
+
+    ```nix
+    nestedLiteral "example"
+    => {
+      __pretty = lib.getAttr "text";
+      val = literalExpression "example";
+    }
+    ```
+
+    ```nix
+    nestedLiteral (literalExpression ''"hello, world"'')
+    => {
+      __pretty = lib.getAttr "text";
+      val = literalExpression ''"hello, world"'';
+    }
+    ```
+
+    # Type
+    ```
+    nestedLiteral :: (String | literalExpression) -> AttrSet
+    ```
+  */
+  nestedLiteral = val: {
+    __pretty = lib.getAttr "text";
+    val = if val._type or null == "literalExpression" then val else lib.literalExpression val;
+  };
+
   wrapDo = string: ''
     do
       ${string}

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -318,6 +318,19 @@ let
       };
     };
 
+    testLiteralLua = {
+      expr = builtins.mapAttrs (_: helpers.literalLua) {
+        print = "print('hi')";
+        nil = "nil";
+        table = "{}";
+      };
+      expected = builtins.mapAttrs (_: lib.literalExpression) {
+        print = ''lib.nixvim.mkRaw "print('hi')"'';
+        nil = ''lib.nixvim.mkRaw "nil"'';
+        table = ''lib.nixvim.mkRaw "{}"'';
+      };
+    };
+
     testUpperFirstChar = {
       expr = map helpers.upperFirstChar [
         "foo"

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -331,6 +331,34 @@ let
       };
     };
 
+    # Integration test for nestedLiteral and renderOptionValue
+    testNestedLiteral_withRenderOptionValue = {
+      expr =
+        builtins.mapAttrs
+          (
+            _: v:
+            (lib.options.renderOptionValue {
+              literal = helpers.nestedLiteral v;
+            }).text
+          )
+          {
+            empty = "";
+            sum = "1 + 1";
+            print = ''lib.mkRaw "print('hi')"'';
+          };
+      expected =
+        builtins.mapAttrs
+          (_: literal: ''
+            {
+              literal = ${literal};
+            }'')
+          {
+            empty = "";
+            sum = "1 + 1";
+            print = ''lib.mkRaw "print('hi')"'';
+          };
+    };
+
     testUpperFirstChar = {
       expr = map helpers.upperFirstChar [
         "foo"


### PR DESCRIPTION
Creates a `literalExpression` equivalent to using `lib.nixvim.mkRaw`.

This can be used in place of `{ __raw = "foo"; }` in option docs and provides us with a central place where we would be able to switch to documenting [`lib.generators.mkLuaInline`](https://noogle.dev/f/lib/generators/mkLuaInline) instead.

Design considerations:
- The name: I went with `literalLua` instead of `literalMkRaw` because it seems likely we'll want to transition away from `mkRaw` in the future.
  I am a little concerned that end-users will stumble upon `literalLua` and not realize it is intended for documentation though...
- I've used the full `lib.nixvim.mkRaw` path for clarity. But this has its own issues since non-standalone users will have a different path.
  Perhaps just `mkRaw` would be better? Either way, we're relying on users understanding other parts of our docs to interpret the context.
    - If we switch to [`lib.generators.mkLuaInline`](https://noogle.dev/f/lib/generators/mkLuaInline) then the above problem goes away, but there's more prep work to do before we can do that.
      See #1935
- The function returns a literalExpression. This can be used directly with `pluginDefault`, `defaultText`, and `example`, but _cannot_ be nested within a non-larger value.
    - If we need that, we'll need another function that produces a `__pretty` printer, as supported by [`lib.generators.toPretty`](https://noogle.dev/f/lib/generators/toPretty).
      Such a function could wrap this one, and could be called something like `nestedLiteralLua`.
    - EDIT: **Done** in a follow up commit, included in this PR
