### PR TITLE
modules/clipboard: allow raw lua code in `register` option

### DIFF
--- a/modules/clipboard.nix
+++ b/modules/clipboard.nix
@@ -15,7 +15,7 @@ in
           Sets the register to use for the clipboard.
           Learn more in [`:h 'clipboard'`](https://neovim.io/doc/user/options.html#'clipboard').
         '';
-        type = with lib.types; nullOr (either str (listOf str));
+        type = with lib.types; nullOr (maybeRaw (either str (listOf (maybeRaw str))));
         default = null;
         example = "unnamedplus";
       };

--- a/tests/test-sources/modules/clipboard.nix
+++ b/tests/test-sources/modules/clipboard.nix
@@ -17,4 +17,11 @@
       providers.xsel.enable = true;
     };
   };
+
+  example-with-raw-lua = {
+    clipboard = {
+      register.__raw = ''vim.env.SSH_TTY and "" or "unnamedplus"'';
+      providers.wl-copy.enable = true;
+    };
+  };
 }


### PR DESCRIPTION
Allows raw lua in the `clipboard.register` option, so something like this can be set:
```nix
{
  # Only set clipboard when not in SSH
  clipboard.register.__raw = ''vim.env.SSH_TTY and "" or "unnamedplus"''
}
```