### PR TITLE
plugins/lsp: remove buf-language-server

### DIFF
--- a/plugins/lsp/lsp-packages.nix
+++ b/plugins/lsp/lsp-packages.nix
@@ -16,6 +16,7 @@
     "bright_script"
     "bsl_ls"
     "buddy_ls"
+    "bufls"
     "bzl"
     "c3_lsp"
     "cadence"
@@ -194,7 +195,6 @@
     bitbake_language_server = "bitbake-language-server";
     blueprint_ls = "blueprint-compiler";
     buck2 = "buck2";
-    bufls = "buf-language-server";
     ccls = "ccls";
     clangd = "clang-tools";
     clojure_lsp = "clojure-lsp";


### PR DESCRIPTION
buf-language-server is officially deprecated and removed from `nixpkgs/master` [here](https://github.com/NixOS/nixpkgs/pull/356199). Removing it here to allow nixvim to continue to build.

I don't know enough about the main-project `buf` to know how to make the language server actually work, if someone else does feel free to close this PR!