### PR TITLE
lib/types: allow inline-lua in `rawLua` type

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -14,7 +14,7 @@ let
       name = "strLua";
       inherit description;
       descriptionClass = "noun";
-      check = v: lib.isString v || isRawType v;
+      check = v: lib.isString v || types.rawLua.check v;
       merge =
         loc: defs:
         lib.pipe defs [
@@ -24,7 +24,8 @@ let
           (lib.options.mergeEqualOption loc)
         ];
     };
-  isRawType = v: v ? __raw && lib.isString v.__raw;
+
+  isRawType = v: lib.isString (v.__raw or null);
 in
 rec {
   # TODO: deprecate in favor of types.rawLua.check
@@ -36,7 +37,7 @@ rec {
     description = "raw lua code";
     descriptionClass = "noun";
     merge = lib.options.mergeEqualOption;
-    check = v: (isRawType v) || (v ? __empty);
+    check = v: isRawType v || lib.nixvim.lua.isInline v || v ? __empty;
   };
 
   maybeRaw =


### PR DESCRIPTION
Another step towards #1935, allowing `types.rawLua` and `strLua` to accept `_type = "lua-inline"` values as an alternative to our custom `__raw` values.


It may be nice to also implement some "merge" functionality allowing otherwise "equal" definitions to not conflict based on which wrapper type they're using. I.e. currently having an option defined as `mkRaw "foo"` in multiple places merges fine using `mergeEqualOption`, but having a `mkInlineLua "foo"` would not merge.

Maybe we'll deal with that when we get around to coercing `__raw` -> `lua-inline`? As currently we'd need to only coerce if there's multiple definitions of different types.
