### PR TITLE
docs: only set base-href in CI built docs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -26,6 +26,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+      repo: "${{ github.repository }}"
+      repoName: "${{ github.event.repository.name }}"
+      out: docs-build
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -40,14 +43,33 @@ jobs:
           name: nix-community
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - run: |
+      - name: Build docs
+        run: |
           set -ex
-          mkdir -p docs-build
-          nix build github:nix-community/nixvim#docs
-          cp -r result/share/doc/nixvim/* docs-build
-          nix build github:nix-community/nixvim/nixos-24.05#docs
-          # TODO: use the new path when 24.11 hits
-          cp -r result/share/doc docs-build/stable
+
+          # 1: branch
+          # 2: dest-dir (relative to /nixvim/)
+          build() {
+            flake="github:${repo}${1:+/$1}"
+            baseHref="/${repoName}/${2:+$2/}"
+            destDir="${out}${baseHref}"
+
+            # Build docs for the given flake ref, overriding baseHref in the derivation args
+            nix build --impure --expr '(builtins.getFlake "'"$flake"'").outputs.packages.${builtins.currentSystem}.docs.override {
+              baseHref = "'"$baseHref"'";
+            }'
+
+            # Copy the result to the dest-dir
+            mkdir -p "$destDir"
+            cp -r result/share/doc/* "$destDir"
+          }
+
+          # Install main-branch docs at the top-level
+          build 'main' ''
+
+          # Install 24.05 docs under 'stable'
+          # TODO: consider having `<release>` instead of `stable`
+          build 'nixos-24.05' 'stable'
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -6,7 +6,7 @@
   transformOptions,
   search,
   # The root directory of the site
-  baseHref ? "/nixvim/",
+  baseHref ? "/",
 }:
 let
   inherit (evaledModules.config.meta) nixvimInfo;
@@ -305,7 +305,7 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
   };
 
   buildPhase = ''
-    dest=$out/share/doc/nixvim
+    dest=$out/share/doc
     mkdir -p $dest
 
     # Copy (and flatten) src into the build directory

--- a/flake-modules/dev/server.py
+++ b/flake-modules/dev/server.py
@@ -12,5 +12,5 @@ class UncachedHTTPHandler(http.server.SimpleHTTPRequestHandler):
 
 
 with http.server.HTTPServer(("", PORT), UncachedHTTPHandler) as httpd:
-    print(f"Serving documentation at http://localhost:{PORT}/nixvim")
+    print(f"Serving documentation at http://localhost:{PORT}")
     httpd.serve_forever()


### PR DESCRIPTION
By shifting the responsibility to set the `baseHref` from the docs to the CI workflow, we remove the need for the docs to know where they will be installed.

- This reverts #1930
- This relies on #2538
