### PR TITLE
[backport-24.05] docs: specify `site-url`

### DIFF
--- a/docs/mdbook/book.toml
+++ b/docs/mdbook/book.toml
@@ -5,6 +5,9 @@ multilingual = false
 src = "."
 title = "nixvim docs"
 
+[output.html]
+site-url = "@SITE_URL@"
+
 [output.html.fold]
 enable = true
 level = 0

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -6,6 +6,8 @@
   nixosOptionsDoc,
   transformOptions,
   hmOptions,
+  # The root directory of the site
+  baseHref ? "/",
 }:
 with lib;
 let
@@ -237,6 +239,10 @@ let
     # Copy the generated MD docs into the build directory
     # Using pkgs.writeShellScript helps to avoid the "bash: argument list too long" error
     bash -e ${pkgs.writeShellScript "copy_docs" docs.commands}
+
+    # Patch book.toml
+    substituteInPlace ./book.toml \
+      --replace-fail "@SITE_URL@" "${baseHref}"
 
     # Prepare SUMMARY.md for mdBook
     # Using pkgs.writeText helps to avoid the same error as above


### PR DESCRIPTION
Selectively backport changes from:
- a92339d83bdc47f6d42998a5ac96020f9dd7c2d6 #2507
- cdbda982f04bd021cfa8d549896410c5caf84fdf #2536

Unblocks #2537 by adding the overridable `baseHref` arg to the `docs` package.

