### PR TITLE
docs/ci: fix docs being installed to `nixvim/nixvim/<subdir>`

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -54,8 +54,9 @@ jobs:
           # 2: dest-dir (relative to /nixvim/)
           build() {
             flake="github:${repo}${1:+/$1}"
-            baseHref="/${repoName}/${2:+$2/}"
-            destDir="${out}${baseHref}"
+            dir="${2:+/$2}"
+            baseHref="/${repoName}${dir}/"
+            installDir="${out}${dir}"
 
             # Build docs for the given flake ref, overriding baseHref in the derivation args
             nix build --impure --expr '(builtins.getFlake "'"$flake"'").outputs.packages.${builtins.currentSystem}.docs.override {
@@ -64,7 +65,7 @@ jobs:
 
             # Copy the result to the dest-dir
             mkdir -p "$destDir"
-            cp -r result/share/doc/* "$destDir"
+            cp -r result/share/doc/* "$installDir"
           }
 
           # Install main-branch docs at the top-level


### PR DESCRIPTION
Everything now seems to be working, other than the docs being incorrectly nested at `/nixvim/nixvim/*`!

- https://nix-community.github.io/nixvim/ (404)
- https://nix-community.github.io/nixvim/nixvim/
- https://nix-community.github.io/nixvim/nixvim/stable/

We don't need to specify `/nixvim/` as part of our install path as that is where gh-pages uploads to by default.

Rather, we only need to specify the full `/nixvim/foo/` in the base-href and the install path should just be `/foo`.


