### PR TITLE
plugins/lsp/gopls: Only add goPackage to extraPackages if enabled

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -20,7 +20,7 @@ let
         };
       };
       extraConfig = cfg: {
-        extraPackages = [ cfg.goPackage ];
+        extraPackages = optionals cfg.enable [ cfg.goPackage ];
       };
     };
     idris2_lsp = {


### PR DESCRIPTION
Currently unconditional, and blow the closure size.

CC @khaneliman