### PR TITLE
plugins/lsp: Fix enable conditions

### DIFF
--- a/plugins/lsp/language-servers/_mk-lsp.nix
+++ b/plugins/lsp/language-servers/_mk-lsp.nix
@@ -168,7 +168,7 @@ in
       (mkRemovedOptionModule (
         basePluginPath ++ [ "extraSettings" ]
       ) "You can use `${basePluginPathString}.extraOptions.settings` instead.")
-      (extraConfig cfg)
+      (lib.mkIf cfg.enable (extraConfig cfg))
     ]
     # Add an alias (with warning) for the lspconfig server name, if different to `name`.
     # Note: users may use lspconfig's docs to guess the `plugins.lsp.servers.*` name

--- a/plugins/lsp/language-servers/_mk-lsp.nix
+++ b/plugins/lsp/language-servers/_mk-lsp.nix
@@ -30,6 +30,8 @@ with lib;
 let
   cfg = config.plugins.lsp.servers.${name};
   opt = options.plugins.lsp.servers.${name};
+
+  enabled = config.plugins.lsp.enable && cfg.enable;
 in
 {
   meta.nixvimInfo = {
@@ -131,7 +133,7 @@ in
     } // extraOptions;
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf enabled {
     extraPackages = [ cfg.package ];
 
     plugins.lsp.enabledServers = [
@@ -168,7 +170,7 @@ in
       (mkRemovedOptionModule (
         basePluginPath ++ [ "extraSettings" ]
       ) "You can use `${basePluginPathString}.extraOptions.settings` instead.")
-      (lib.mkIf cfg.enable (extraConfig cfg))
+      (lib.mkIf enabled (extraConfig cfg))
     ]
     # Add an alias (with warning) for the lspconfig server name, if different to `name`.
     # Note: users may use lspconfig's docs to guess the `plugins.lsp.servers.*` name


### PR DESCRIPTION
There were two bugs in the lsp server modules:
- They unconditionally evaluated extraConfig
- They did not take into account if the global lsp plugin was enabled or not

Fixes #2543 