### PR TITLE
modules/opts: fix code generation condition to prevent false positives

### DIFF
--- a/modules/opts.nix
+++ b/modules/opts.nix
@@ -67,12 +67,12 @@ in
             }:
             let
               varName = "nixvim_${luaVariableName}";
-              optionDefinitions = config.${optionName};
+              optionDefinitions = helpers.toLuaObject config.${optionName};
             in
-            lib.optionalString (optionDefinitions != { }) ''
+            lib.optionalString (optionDefinitions != "{ }") ''
               -- Set up ${prettyName} {{{
               do
-                local ${varName} = ${helpers.toLuaObject optionDefinitions}
+                local ${varName} = ${optionDefinitions}
 
                 for k,v in pairs(${varName}) do
                   vim.${luaApi}[k] = v


### PR DESCRIPTION
Currently, we generate the lua code as soon as the value of the option is not an empty attrs.
However, a case where the attrs only contains `null` values (`nord_colorscheme = null; nord_foo = null;}` would pass the `if` condition, but the generated lua table would still be empty because `toLua` filters out those values.

Hence, we should directly check if the attrs would be translated to an empty lua table or not to decide whether we should generate the lua snippet or not.
