### PR TITLE
treewide: replace mentions of 24.05 with 24.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you have any question, please use the [discussions page](https://github.com/n
 > NixVim needs to be installed with a compatible nixpkgs version.
 > This means that the `main` branch of NixVim requires to be installed with `nixos-unstable`.
 >
-> If you want to use NixVim with nixpkgs 24.05 you should use the `nixos-24.05` branch.
+> If you want to use NixVim with nixpkgs 24.11 you should use the `nixos-24.11` branch.
 
 For more detail, see the [Installation](https://nix-community.github.io/nixvim) section of our documentation.
 
@@ -104,7 +104,7 @@ let
   nixvim = import (builtins.fetchGit {
     url = "https://github.com/nix-community/nixvim";
     # If you are not running an unstable channel of nixpkgs, select the corresponding branch of nixvim.
-    # ref = "nixos-24.05";
+    # ref = "nixos-24.11";
   });
 in
 {
@@ -147,7 +147,7 @@ flakes, just add the nixvim input:
   inputs.nixvim = {
     url = "github:nix-community/nixvim";
     # If you are not running an unstable channel of nixpkgs, select the corresponding branch of nixvim.
-    # url = "github:nix-community/nixvim/nixos-24.05";
+    # url = "github:nix-community/nixvim/nixos-24.11";
 
     inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -281,7 +281,7 @@ in pkgs.mkShell {
 Documentation is available on this project's GitHub Pages page:
 [https://nix-community.github.io/nixvim](https://nix-community.github.io/nixvim)
 
-The stable documentation is also available at [https://nix-community.github.io/nixvim/24.05](https://nix-community.github.io/nixvim/24.05).
+The stable documentation is also available at [https://nix-community.github.io/nixvim/24.11](https://nix-community.github.io/nixvim/24.11).
 
 If the option `enableMan` is set to `true` (by default it is), man pages will also
 be installed containing the same information, they can be viewed with `man nixvim`.

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -54,7 +54,7 @@ When using Nixvim, it is possible to encounter errors about something not being 
 ```
 
 This usually means one of two things:
-- The nixpkgs version is not in line with NixVim (for example nixpkgs nixos-24.05 is used with NixVim master)
+- The nixpkgs version is not in line with NixVim (for example nixpkgs nixos-24.11 is used with NixVim master)
 - The nixpkgs unstable version used with NixVim is not recent enough.
 
 When building nixvim using flakes and our ["standalone mode"][standalone], we usually recommend _not_ declaring a "follows" for `inputs.nixvim`.

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -5,7 +5,7 @@ You must use a `nixpkgs` version compatible with the nixvim version you choose.
 The `main` branch requires to use a _very recent_ version of nixpkgs unstable.
 In order to guarantee the compatibility between nixvim & nixpkgs it is recommended to always update both at the same time.
 
-When using a `stable` version you must use the corresponding nixvim branch, for example `nixos-24.05` when using NixOS 24.05.
+When using a `stable` version you must use the corresponding nixvim branch, for example `nixos-24.11` when using NixOS 24.11.
 
 Failure to use the correct branch, or an old revision of nixpkgs will likely result in errors of the form `vimPlugins.<name> attribute not found`.
 

--- a/tests/modules/hm-extra-files-byte-compiling.nix
+++ b/tests/modules/hm-extra-files-byte-compiling.nix
@@ -8,7 +8,7 @@ let
     home = {
       username = "nixvim";
       homeDirectory = "/invalid/dir";
-      stateVersion = "24.05";
+      stateVersion = "24.11";
     };
 
     programs.nixvim = {

--- a/tests/modules/hm.nix
+++ b/tests/modules/hm.nix
@@ -11,7 +11,7 @@ home-manager.lib.homeManagerConfiguration {
       home.username = "nixvim";
       home.homeDirectory = "/invalid/dir";
 
-      home.stateVersion = "24.05";
+      home.stateVersion = "24.11";
 
       programs.nixvim = {
         enable = true;

--- a/tests/modules/nixos.nix
+++ b/tests/modules/nixos.nix
@@ -8,7 +8,7 @@ nixpkgs.lib.nixosSystem {
 
   modules = [
     {
-      system.stateVersion = "24.05";
+      system.stateVersion = "24.11";
       boot.loader.systemd-boot.enable = true;
       fileSystems."/" = {
         device = "/non/existent/device";


### PR DESCRIPTION
This PR will contain changes needed to be made before the branch-off.

## Before branching off:

- [x] Update documentation (refer to 24.11)


## After branching off

- [ ] Update flake inputs to use stable branches
- [ ] Have both 24.05 and 24.11 in build-docs CI
- [ ] Add 24.11 branch to build-docs [triggers](https://github.com/nix-community/nixvim/blob/2f71c4250bef7a52fe21bd00d1e58c119f62008c/.github/workflows/build_documentation.yml#L5-L8)
- [ ] Build 24.11 (in addition to 24.05) in build-docs [task](https://github.com/nix-community/nixvim/blob/2f71c4250bef7a52fe21bd00d1e58c119f62008c/.github/workflows/build_documentation.yml#L86-L91)
  - Add 24.11 to "docs versions" array
  - If we don't have a stable -> versioned URL redirect, I think a breaking change is ok here?
- [ ] Add 24.11 [input](https://github.com/nix-community/nixvim/blob/2f71c4250bef7a52fe21bd00d1e58c119f62008c/.github/workflows/update.yml#L17-L19) to update CI
- [ ] Add 24.11 [task](https://github.com/nix-community/nixvim/blob/2f71c4250bef7a52fe21bd00d1e58c119f62008c/.github/workflows/update.yml#L45-L51) to update CI

