### PR TITLE
ci: bump nix-install-action (**fixes** docs build)

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Install nix
-        uses: cachix/install-nix-action@v26
+        uses: cachix/install-nix-action@30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -51,7 +51,7 @@ jobs:
           gh workflow run update.yml --ref nixos-24.05
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v26
+        uses: cachix/install-nix-action@30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The new docs CI (#2554) relies on `--arg-from-file`, which was [added in 2.24](https://nix.dev/manual/nix/2.25/release-notes/rl-2.24#release-2240-2024-07-31).

nix-install-action [v26](https://github.com/cachix/install-nix-action/releases/tag/v26) installs nix 2.20.5, updating to [v30](https://github.com/cachix/install-nix-action/releases/tag/v30) will install nix 2.24.9.
