### PR TITLE
plugins/lsp: fix `enabledServers.extraOptions` type merging

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -29,7 +29,7 @@ in
         };
 
         diagnostic = mkOption {
-          type = with types; attrsOf (either str attrs);
+          type = with types; attrsOf (either str (attrsOf anything));
           description = "Mappings for `vim.diagnostic.<action>` functions to be added when an LSP is attached.";
           example = {
             "<leader>k" = "goto_prev";
@@ -39,7 +39,7 @@ in
         };
 
         lspBuf = mkOption {
-          type = with types; attrsOf (either str attrs);
+          type = with types; attrsOf (either str (attrsOf anything));
           description = "Mappings for `vim.lsp.buf.<action>` functions to be added when an LSP it attached.";
           example = {
             "gd" = "definition";
@@ -106,7 +106,7 @@ in
                 };
 
                 extraOptions = mkOption {
-                  type = attrs;
+                  type = attrsOf anything;
                   description = "Extra options for the server";
                 };
               };

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -156,4 +156,114 @@
         }
       ];
     };
+
+  settings-merge =
+    { config, lib, ... }:
+    {
+      test.runNvim = false;
+
+      plugins = {
+        lsp = {
+          enable = true;
+          servers.nil_ls = {
+            enable = true;
+            settings.formatting.command = lib.mkForce [
+              "real"
+              "example"
+            ];
+          };
+          enabledServers = lib.mkAfter [
+            {
+              name = "second";
+              extraOptions.settings = lib.mkIf false {
+                should.be = "missing";
+              };
+            }
+            {
+              name = "third";
+              extraOptions.settings = lib.mkIf true {
+                should.be = "present";
+              };
+            }
+          ];
+        };
+      };
+
+      assertions =
+        let
+          toLua = lib.nixvim.lua.toLua' {
+            removeNullAttrValues = true;
+            removeEmptyAttrValues = true;
+            removeEmptyListEntries = false;
+            removeNullListEntries = false;
+            multiline = true;
+          };
+
+          print = lib.generators.toPretty {
+            multiline = true;
+          };
+
+          serverCount = builtins.length config.plugins.lsp.enabledServers;
+          expectedCount = 3;
+
+          nilServer = builtins.head config.plugins.lsp.enabledServers;
+          nilSettings = toLua nilServer.extraOptions.settings;
+          expectedNilSettings = toLua {
+            nil.formatting.command = [
+              "real"
+              "example"
+            ];
+          };
+
+          secondServer = builtins.elemAt config.plugins.lsp.enabledServers 1;
+          expectedSecondServer = {
+            name = "second";
+            capabilities = null;
+            extraOptions = { };
+          };
+
+          thirdServer = builtins.elemAt config.plugins.lsp.enabledServers 2;
+          expectedThirdServer = {
+            name = "third";
+            capabilities = null;
+            extraOptions.settings.should.be = "present";
+          };
+        in
+        [
+          {
+            assertion = serverCount == expectedCount;
+            message = "Expected ${toString expectedCount} enabled LSP server!";
+          }
+          {
+            assertion = nilSettings == expectedNilSettings;
+            message = ''
+              nil's `extraOptions.settings` does not match expected value.
+
+              Expected: ${expectedNilSettings}
+
+              Actual: ${nilSettings}
+            '';
+          }
+          {
+            assertion = secondServer == expectedSecondServer;
+            message = ''
+              `secondServer` does not match expected value.
+
+              Expected: ${print expectedSecondServer}
+
+              Actual: ${print secondServer}
+            '';
+          }
+          {
+            assertion = secondServer == expectedSecondServer;
+            message = ''
+              `thirdServer` does not match expected value.
+
+              Expected: ${print expectedThirdServer}
+
+              Actual: ${print thirdServer}
+            '';
+          }
+        ];
+    };
 }


### PR DESCRIPTION
Use `attrsOf` instead of `attrs` to ensure recursive merging, otherwise things like `extraOptions.settings = lib.mkIf` will not be unwrapped by the module system.

Added a small regression test to ensure "wrapped" values are properly unwrapped.

Fixes #2562
