### PR TITLE
plugins/image.nvim: ueberzugPackage default to ueberzugpp

### DIFF
--- a/plugins/by-name/image/default.nix
+++ b/plugins/by-name/image/default.nix
@@ -26,7 +26,7 @@ in
       nullable = true;
     };
 
-    ueberzugPackage = lib.mkPackageOption pkgs "ueberzug" {
+    ueberzugPackage = lib.mkPackageOption pkgs "ueberzugpp" {
       nullable = true;
     };
 


### PR DESCRIPTION
ueberzug is not maintained anymore and is not working.

[ueberzugpp](https://github.com/jstkdng/ueberzugpp) is a active fork, that I think , should be used as default