### PR TITLE
ci/docs: remove on 24.05 branch

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -5,7 +5,6 @@ on:
     # Runs on pushes targeting the release branches
     branches:
       - main
-      - nixos-24.05
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This doesn't work because we can only deploy docs from the main branch.
