### PR TITLE
plugins/wezterm: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -124,4 +124,10 @@
     githubId = 38228372;
     name = "Katie Janzen";
   };
+  samos667 = {
+    email = "sammyetur11@gmail.com";
+    github = "samos667";
+    githubId = 50653464;
+    name = "samos667";
+  };
 }

--- a/plugins/by-name/molten/default.nix
+++ b/plugins/by-name/molten/default.nix
@@ -80,9 +80,12 @@ mkVimPlugin {
         [
           "none"
           "image.nvim"
+          "wezterm"
         ]
         ''
           How images are displayed.
+
+          If set to `"wezterm"`, `plugins.wezterm.enable` must be true.
         '';
 
     open_cmd = helpers.mkNullOrOption types.str ''

--- a/plugins/by-name/wezterm/default.nix
+++ b/plugins/by-name/wezterm/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
+  name = "wezterm";
+  originalName = "wezterm.nvim";
+  package = "wezterm-nvim";
+
+  maintainers = [ lib.maintainers.samos667 ];
+
+  extraOptions = {
+    weztermPackage = lib.mkPackageOption pkgs "wezterm" {
+      nullable = true;
+      default = null;
+      example = [ "wezterm" ];
+    };
+  };
+
+  settingsOptions = {
+    create_commands = defaultNullOpts.mkBool true ''
+      Whether to create plugin commands.
+    '';
+  };
+
+  settingsExample = {
+    create_commands = false;
+  };
+
+  extraConfig = cfg: {
+    extraPackages = [
+      cfg.weztermPackage
+    ];
+  };
+}

--- a/tests/test-sources/plugins/by-name/wezterm/default.nix
+++ b/tests/test-sources/plugins/by-name/wezterm/default.nix
@@ -1,0 +1,23 @@
+{
+  empty =
+    { pkgs, ... }:
+    {
+      plugins.wezterm = {
+        enable = true;
+        weztermPackage = pkgs.wezterm;
+      };
+    };
+
+  defaults =
+    { pkgs, ... }:
+    {
+      plugins.wezterm = {
+        enable = true;
+        weztermPackage = pkgs.wezterm;
+
+        settings = {
+          create_commands = true;
+        };
+      };
+    };
+}


### PR DESCRIPTION
This pull request introduces a new Neovim plugin for `wezterm` and integrates it into the existing plugin system. The changes include adding the `wezterm` plugin to the `molten` plugin list, defining the `wezterm` plugin in its own file, and adding test cases for the new plugin.

### New Plugin Addition:

* [`plugins/by-name/molten/default.nix`](diffhunk://#diff-230d660b843085745a52be69db8e4aa925f8c0297745d7b7bccbefc9c9ad2e29R83-R87): Added the `wezterm` plugin to the list of plugins and enabled it by default.
* [`plugins/by-name/wezterm/default.nix`](diffhunk://#diff-f8bd7524f04fe0ddf164336d51c3b20e34fcdc9c647a9948b32f068a4ffc3dd8R1-R21): Defined the `wezterm` plugin with its settings and maintainers.

### Testing:

* [`tests/test-sources/plugins/by-name/wezterm/default.nix`](diffhunk://#diff-62ec656d1f81a46b27b8ceb653a8e1db164bbc350bf6f34f9af9383d60b3c190R1-R12): Added test cases for the `wezterm` plugin to ensure it is enabled and its settings are correctly applied.

fixes https://github.com/nix-community/nixvim/issues/2596