### PR TITLE
plugins/avante: add missing mappings description

### DIFF
--- a/plugins/by-name/avante/default.nix
+++ b/plugins/by-name/avante/default.nix
@@ -22,6 +22,9 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     '';
 
     mappings = mkNullOrOption' {
+      description = ''
+        Key mappings for various functionalities within avante.
+      '';
       type = with lib.types; attrsOf (either str (attrsOf str));
       example = {
         diff = {


### PR DESCRIPTION
Just keep seeing a warning about the missing description when doing some profiling. Not sure of a better description.