### PR TITLE
modules/lazyload: init w/ assertion

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -16,6 +16,7 @@
     ./filetype.nix
     ./highlights.nix
     ./keymaps.nix
+    ./lazyload.nix
     ./lua-loader.nix
     ./opts.nix
     ./output.nix

--- a/modules/lazyload.nix
+++ b/modules/lazyload.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  implementations = [
+    "lz-n"
+    "lazy"
+  ];
+in
+{
+  config = {
+    assertions =
+      let
+        enabled = builtins.filter (x: config.plugins.${x}.enable) implementations;
+        count = builtins.length enabled;
+      in
+      [
+        {
+          assertion = count < 2;
+          message = ''
+            You have multiple lazy-loaders enabled:
+            ${lib.concatImapStringsSep "\n" (i: x: "${toString i}. plugins.${x}") enabled}
+            Please ensure only one is enabled at a time.
+          '';
+        }
+      ];
+  };
+}


### PR DESCRIPTION
Adds a global lazyloading assertion. No module options yet, and none are likely to be added until after we have per-plugin options.
