### PR TITLE
plugins/persisted: init

### DIFF
--- a/plugins/by-name/persisted/default.nix
+++ b/plugins/by-name/persisted/default.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+  inherit (lib) types;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
+  name = "persisted";
+  originalName = "persisted.nvim";
+  package = "persisted-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  extraOptions = {
+    enableTelescope = lib.mkEnableOption "persisted-nvim telescope integration";
+  };
+
+  extraConfig = cfg: {
+    warnings = lib.optional (cfg.enableTelescope && (!config.plugins.telescope.enable)) ''
+      Telescope support for `plugins.persisted` is enabled but the telescope plugin is not.
+    '';
+
+    plugins.telescope.enabledExtensions = lib.mkIf cfg.enableTelescope [ "persisted" ];
+  };
+
+  settingsOptions = {
+    autostart = defaultNullOpts.mkBool true ''
+      Whether to automatically start the plugin on load.
+    '';
+
+    should_save =
+      defaultNullOpts.mkRaw
+        ''
+          function()
+            return true
+          end
+        ''
+        ''
+          Function to determine if a session should be saved.
+
+          ```lua
+          @type fun(): boolean
+          ```
+        '';
+
+    save_dir = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.expand(vim.fn.stdpath('data') .. '/sessions/')") ''
+      Directory where session files are saved.
+    '';
+
+    follow_cwd = defaultNullOpts.mkBool true ''
+      Whether to change the session file to match any change in the cwd.
+    '';
+
+    use_git_branch = defaultNullOpts.mkBool false ''
+      Whether to include the git branch in the session file name.
+    '';
+
+    autoload = defaultNullOpts.mkBool false ''
+      Whether to automatically load the session for the cwd on Neovim startup.
+    '';
+
+    on_autoload_no_session = defaultNullOpts.mkRaw "function() end" ''
+
+      Function to run when `autoload = true` but there is no session to load.
+
+      ```lua
+      @type fun(): any
+      ```
+    '';
+
+    allowed_dirs = defaultNullOpts.mkListOf types.str [ ] ''
+      List of dirs that the plugin will start and autoload from.
+    '';
+
+    ignored_dirs = defaultNullOpts.mkListOf types.str [ ] ''
+      List of dirs that are ignored for starting and autoloading.
+    '';
+
+    telescope = {
+      mappings =
+        defaultNullOpts.mkAttrsOf types.str
+          {
+            copy_session = "<C-c>";
+            change_branch = "<C-b>";
+            delete_session = "<C-d>";
+          }
+          ''
+            Mappings for managing sessions in Telescope.
+          '';
+
+      icons =
+        defaultNullOpts.mkAttrsOf types.str
+          {
+            selected = " ";
+            dir = "  ";
+            branch = " ";
+          }
+          ''
+            Icons displayed in the Telescope picker.
+          '';
+    };
+  };
+
+  settingsExample = {
+    use_git_branch = true;
+    autoload = true;
+    on_autoload_no_session.__raw = ''
+      function()
+        vim.notify("No existing session to load.")
+      end
+    '';
+  };
+}

--- a/tests/test-sources/plugins/by-name/persisted/default.nix
+++ b/tests/test-sources/plugins/by-name/persisted/default.nix
@@ -1,0 +1,80 @@
+{
+  empty = {
+    plugins.persisted.enable = true;
+  };
+
+  defaults = {
+    plugins.persisted = {
+      enable = true;
+
+      settings = {
+        autostart = true;
+        should_save.__raw = ''
+          function()
+            return true
+          end
+        '';
+        save_dir.__raw = "vim.fn.expand(vim.fn.stdpath('data') .. '/sessions/')";
+        follow_cwd = true;
+        use_git_branch = false;
+        autoload = false;
+        on_autoload_no_session.__raw = "function() end";
+        allowed_dirs = [ ];
+        ignored_dirs = [ ];
+        telescope = {
+          mappings = {
+            copy_session = "<C-c>";
+            change_branch = "<C-b>";
+            delete_session = "<C-d>";
+          };
+          icons = {
+            selected = " ";
+            dir = "  ";
+            branch = " ";
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.gitlab = {
+      enable = true;
+
+      settings = {
+        use_git_branch = true;
+        autoload = true;
+        on_autoload_no_session.__raw = ''
+          function()
+            vim.notify("No existing session to load.")
+          end
+        '';
+        should_save.__raw = ''
+          function()
+            -- Do not save session when the current cwd is git root
+            local uv = vim.loop
+            local cwd = uv.cwd()
+            local git_dir = uv.fs_stat(cwd .. "/.git")
+            if git_dir == nil then
+              return false
+            end
+
+            -- Check if the current buffer is a GIT COMMIT message buffer
+            local current_buf = vim.api.nvim_get_current_buf()
+            local buf_name = vim.api.nvim_buf_get_name(current_buf)
+            local is_git_commit = buf_name:match("COMMIT_EDITMSG$") ~= nil
+            if is_git_commit then
+              return false
+            end
+
+            if vim.fn.argc() > 0 then
+              return false
+            end
+
+            return true
+          end
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [persisted.nvim](https://github.com/olimorris/persisted.nvim), a plugin for simple session management.

Fixes #2603
