### PR TITLE
plugins/schemastore: remove table wrapping

### DIFF
--- a/plugins/by-name/schemastore/default.nix
+++ b/plugins/by-name/schemastore/default.nix
@@ -136,7 +136,7 @@ helpers.vim-plugin.mkVimPlugin {
     plugins.lsp.servers = {
       jsonls.settings = mkIf cfg.json.enable {
         schemas.__raw = ''
-          require('schemastore').json.schemas({${helpers.toLuaObject cfg.json.settings}})
+          require('schemastore').json.schemas(${helpers.toLuaObject cfg.json.settings})
         '';
 
         # The plugin recommends to enable this option in its README.
@@ -155,7 +155,7 @@ helpers.vim-plugin.mkVimPlugin {
         };
 
         schemas.__raw = ''
-          require('schemastore').yaml.schemas({${helpers.toLuaObject cfg.yaml.settings}})
+          require('schemastore').yaml.schemas(${helpers.toLuaObject cfg.yaml.settings})
         '';
       };
     };


### PR DESCRIPTION
I was unable to add extra schemas into the schemastore plugin. After some digging I found out that an extra table is created when injected into the LSP server config. Here's an example of what it looks like before this fix:

```lua
    local __lspServers = {
        {
            extraOptions = {
                settings = {
                    yaml = {
                        schemaStore = { enable = false, url = "" },
                        schemas = require("schemastore").yaml.schemas({
                            {
                                extra = {
                                    {
                                        description = "Kyverno Chainsaw Test Manifest",
                                        fileMatch = { "chainsaw-test.yaml", "chainsaw-test.yml" },
                                        name = "chainsaw-test.yaml",
                                        url = "https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json",
                                    },
                                },
                            },
                        }),
                    },
                },
            },
            name = "yamlls",
        },
````

After this fix:

```lua
    local __lspServers = {
        {
            extraOptions = {
                settings = {
                    yaml = {
                        schemaStore = { enable = false, url = "" },
                        schemas = require("schemastore").yaml.schemas({
                            extra = {
                                {
                                    description = "Kyverno Chainsaw Test Manifest",
                                    fileMatch = { "chainsaw-test.yaml", "chainsaw-test.yml" },
                                    name = "chainsaw-test.yaml",
                                    url = "https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json",
                                },
                            },
                        }),
                    },
                },
            },
            name = "yamlls",
        },
```
