### PR TITLE
plugins/neotest: fix adapter warning

### DIFF
--- a/plugins/by-name/neotest/adapters.nix
+++ b/plugins/by-name/neotest/adapters.nix
@@ -46,7 +46,7 @@ let
 
           warnings = optional (!config.plugins.treesitter.enable) ''
             Nixvim (plugins.neotest.adapters.${name}): This adapter requires `treesitter` to be enabled.
-            You might want to set `plugins.treesitter.enable = true` and ensure that the `${props.treesitter-parser}` parser is enabled.
+            You might want to set `plugins.treesitter.enable = true` and ensure that the `${treesitter-parser}` parser is enabled.
           '';
 
           plugins.neotest.settings.adapters =


### PR DESCRIPTION
```bash
error: undefined variable 'props'
       at /nix/store/hrvknxmyxnhswx4wj7mksix7i08vli8k-source/plugins/by-name/neotest/adapters.nix:49:93:
           48|             Nixvim (plugins.neotest.adapters.${name}): This adapter requires `treesitter` to be enabled.
           49|             You might want to set `plugins.treesitter.enable = true` and ensure that the `${props.treesitter-parser}` parser is enabled.
             |                                                                                             ^
           50|           '';
```
Not sure where that value is supposed to come from ? Any ideas?

This change will output 
```bash
evaluation warning: Nixvim (plugins.neotest.adapters.zig): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `zig` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.python): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `python` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.plenary): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `plenary` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.playwright): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `playwright` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.jest): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `jest` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.java): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `java` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.go): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `go` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.dotnet): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `dotnet` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.deno): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `deno` parser is enabled.
evaluation warning: Nixvim (plugins.neotest.adapters.bash): This adapter requires `treesitter` to be enabled.
                    You might want to set `plugins.treesitter.enable = true` and ensure that the `bash` parser is enabled
```