### PR TITLE
plugins/otter: fix treesitter warning

### DIFF
--- a/plugins/by-name/otter/default.nix
+++ b/plugins/by-name/otter/default.nix
@@ -101,10 +101,12 @@ helpers.neovim-plugin.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings =
-      lib.optional (cfg.enable && config.plugins.treesitter.settings.highlight.enable == null)
+      lib.optional
+        (config.plugins.treesitter.enable -> config.plugins.treesitter.settings.highlight.enable == null)
+
         ''
-          NixVim(plugins.otter): you have enabled otter, but `plugins.treesitter.settings.highlight.enable` is not enabled.
-          Otter functionality might not work as expected without it and `plugins.treesitter.enable` enabled.
+          NixVim(plugins.otter): you have enabled otter, but treesitter syntax highlighting is not enabled.
+          Otter functionality might not work as expected without it. Make sure `plugins.treesitter.settings.highlight.enable` and `plugins.treesitter.enable` are enabled.
         '';
 
     plugins.lsp.onAttach = lib.mkIf cfg.autoActivate ''

--- a/tests/test-sources/plugins/by-name/otter/default.nix
+++ b/tests/test-sources/plugins/by-name/otter/default.nix
@@ -3,14 +3,20 @@
     plugins = {
       otter.enable = true;
       # Avoid the warning
-      treesitter.settings.highlight.enable = true;
+      treesitter = {
+        enable = true;
+        settings.highlight.enable = true;
+      };
     };
   };
 
   defaults = {
     plugins = {
       # Avoid the warning
-      treesitter.settings.highlight.enable = true;
+      treesitter = {
+        enable = true;
+        settings.highlight.enable = true;
+      };
 
       otter = {
         enable = true;


### PR DESCRIPTION
Doesn't actually check if treesitter is enabled. 