### PR TITLE
plugins/lz-n: earlier lua loading

### DIFF
--- a/plugins/pluginmanagers/lz-n.nix
+++ b/plugins/pluginmanagers/lz-n.nix
@@ -11,6 +11,8 @@ nixvim.neovim-plugin.mkNeovimPlugin {
   name = "lz-n";
   originalName = "lz.n";
   maintainers = [ maintainers.psfloyd ];
+  # NOTE: We want to load lz.n as early as possible so that triggers are respected
+  configLocation = "extraConfigLuaPre";
 
   settingsDescription = ''
     Options provided to `vim.g.lz_n`.


### PR DESCRIPTION
Discovered during testing lazy loading colorscheme that we aren't loading the config early enough to catch all triggers.