### PR TITLE
colorschemes/catppuccin: add originalName

### DIFF
--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -8,6 +8,7 @@ let
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "catppuccin";
+  originalName = "catppuccin-nvim";
   isColorscheme = true;
   package = "catppuccin-nvim";
 


### PR DESCRIPTION
Supports lazy loading

Lz-n will look for the colorscheme in packpath by originalName. Without change it will throw an error when trying to lazy load. This plugin has a unique `originalName` because the upstream repo is just `nvim` and upstream package is being added to packpath as `catppuccin-nvim`. 