### PR TITLE
{lightline,nvim-autopairs,treesitter}: extraConfigLua -> luaConfig

### DIFF
--- a/plugins/by-name/lightline/default.nix
+++ b/plugins/by-name/lightline/default.nix
@@ -22,20 +22,20 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
        settings.component_function = {
          readonly = "LightlineReadonly";
        };
-     };
 
-     extraConfigLua = '''
-       function LightlineReadonly()
-         local is_readonly = vim.bo.readonly == 1
-         local filetype = vim.bo.filetype
+       luaConfig.pre= '''
+         function LightlineReadonly()
+           local is_readonly = vim.bo.readonly == 1
+           local filetype = vim.bo.filetype
 
-         if is_readonly and filetype ~= "help" then
-           return "RO"
-         else
-           return ""
+           if is_readonly and filetype ~= "help" then
+             return "RO"
+           else
+             return ""
+           end
          end
-       end
-     ''';
+       ''';
+     };
   '';
 
   # TODO: Added 2024-08-23, remove after 24.11

--- a/plugins/by-name/nvim-autopairs/default.nix
+++ b/plugins/by-name/nvim-autopairs/default.nix
@@ -46,7 +46,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
       ))
       (mkRemovedOptionModule (basePluginPaths ++ [ "pairs" ]) ''
         This option was having no effect.
-        If you want to customize pairs, please use `extraConfigLua` to define them as described in the plugin documentation.
+        If you want to customize pairs, please use `luaConfig` to define them as described in the plugin documentation.
       '')
     ];
 

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -102,7 +102,6 @@ helpers.neovim-plugin.mkNeovimPlugin {
       # treesitter-nu-grammar = pkgs.tree-sitter-grammars.tree-sitter-nu;
     in
     {
-
       programs.nixvim.plugins = {
         treesitter = {
           enable = true;
@@ -110,9 +109,7 @@ helpers.neovim-plugin.mkNeovimPlugin {
           grammarPackages = pkgs.vimPlugins.nvim-treesitter.passthru.allGrammars ++ [
             treesitter-nu-grammar
           ];
-        };
-
-        extraConfigLua =
+          luaConfig.post=
           '''
             do
               local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
@@ -130,15 +127,14 @@ helpers.neovim-plugin.mkNeovimPlugin {
               }
             end
           ''';
+        };
 
         # Add as extra plugins so that their `queries/{language}/*.scm` get
         # installed and can be picked up by `tree-sitter`
         extraPlugins = [
           treesitter-nu-grammar
         ];
-
       };
-
     }
     ```
 


### PR DESCRIPTION
Just replacing the occurrences of extraConfigLua in plugins that have been migrated to use the recommended approach instead of the deprecated approach. 