### PR TITLE
plugins/tiny-devicons-auto-colors: init

### DIFF
--- a/plugins/by-name/mini/default.nix
+++ b/plugins/by-name/mini/default.nix
@@ -5,6 +5,8 @@
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
   name = "mini";
   packPathName = "mini.nvim";
+  # Just want it before most other plugins for the icons provider.
+  configLocation = lib.mkOrder 800 "extraConfigLua";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/tiny-devicons-auto-colors/default.nix
+++ b/plugins/by-name/tiny-devicons-auto-colors/default.nix
@@ -1,0 +1,109 @@
+{ config, lib, ... }:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.neovim-plugin.mkNeovimPlugin {
+  name = "tiny-devicons-auto-colors";
+  packPathName = "tiny-devicons-auto-colors.nvim";
+  package = "tiny-devicons-auto-colors-nvim";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsOptions = {
+    colors =
+      defaultNullOpts.mkNullableWithRaw (with lib.types; either (attrsOf anything) (listOf str)) [ ]
+        ''
+          A table of color codes that the plugin will use to assign colors to devicons.
+          If not provided, the plugin will fetch highlights from the current theme to generate a color palette.
+        '';
+
+    factors = {
+      lightness = defaultNullOpts.mkNum 1.75 ''
+        Adjust the lightness factor.
+      '';
+      chroma = defaultNullOpts.mkNum 1 ''
+        Adjust the chroma factor.
+      '';
+      hue = defaultNullOpts.mkNum 1.25 ''
+        Adjust the hue factor.
+      '';
+    };
+
+    cache = {
+      enabled = defaultNullOpts.mkBool true ''
+        Enable or disable caching to improve performance.
+      '';
+      path = defaultNullOpts.mkStr (lib.nixvim.literalLua ''vim.fn.stdpath("cache") .. "/tiny-devicons-auto-colors-cache.json"'') ''
+        Path to the cache file.
+      '';
+    };
+
+    precise_search = {
+      enabled = defaultNullOpts.mkBool true ''
+        Enable or disable precise search for better color matching.
+      '';
+      iteration = defaultNullOpts.mkNum 10 ''
+        Number of iterations for precise search.
+      '';
+      precision = defaultNullOpts.mkNum 20 ''
+        Precision level for the search.
+      '';
+      threshold = defaultNullOpts.mkNum 23 ''
+        Threshold to consider a color as a match.
+      '';
+    };
+
+    ignore = defaultNullOpts.mkListOf lib.types.str [ ] ''
+      A list of icon names to ignore.
+    '';
+
+    autoreload = defaultNullOpts.mkBool false ''
+      Automatically reload colors when the colorscheme changes.
+    '';
+  };
+
+  settingsExample = {
+    colors = {
+      red = "#ff0000";
+      green = "#00ff00";
+    };
+    factors = {
+      lightness = 1.5;
+      chroma = 1.2;
+      hue = 1.1;
+    };
+    cache = {
+      enabled = true;
+      path = "/path/to/cache.json";
+    };
+    precise_search = {
+      enabled = true;
+      iteration = 15;
+      precision = 25;
+      threshold = 20;
+    };
+    ignore = [
+      "lua"
+      "vim"
+    ];
+    autoreload = true;
+  };
+
+  extraConfig = {
+    assertions = [
+      {
+        assertion =
+          config.plugins.web-devicons.enable
+          || (
+            config.plugins.mini.enable
+            && config.plugins.mini.modules ? icons
+            && config.plugins.mini.mockDevIcons
+          );
+        message = ''
+          Nixvim: Either `plugins.web-devicons` or `plugins.mini`* must be enabled to use `tiny-devicons-auto-colors`.
+            *If using `plugins.mini`, you must enable the `icons` module and the `mockDevIcons` option.
+        '';
+      }
+    ];
+  };
+}

--- a/plugins/by-name/web-devicons/default.nix
+++ b/plugins/by-name/web-devicons/default.nix
@@ -7,6 +7,8 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   packPathName = "nvim-web-devicons";
   moduleName = "nvim-web-devicons";
   package = "nvim-web-devicons";
+  # Just want it before most other plugins for the icons provider.
+  configLocation = lib.mkOrder 800 "extraConfigLua";
 
   maintainers = [ lib.maintainers.refaelsh ];
 

--- a/tests/test-sources/plugins/by-name/tiny-devicons-auto-colors/default.nix
+++ b/tests/test-sources/plugins/by-name/tiny-devicons-auto-colors/default.nix
@@ -1,0 +1,63 @@
+{
+  empty = {
+    plugins = {
+      web-devicons.enable = true;
+      tiny-devicons-auto-colors.enable = true;
+    };
+  };
+
+  defaults = {
+    plugins = {
+      web-devicons.enable = true;
+      tiny-devicons-auto-colors = {
+        enable = true;
+
+        settings = {
+          colors = null;
+          factors = {
+            lightness = 1.75;
+            chroma = 1;
+            hue = 1.25;
+          };
+          cache = {
+            enabled = true;
+            path.__raw = ''vim.fn.stdpath("cache") .. "/tiny-devicons-auto-colors-cache.json"'';
+          };
+          precise_search = {
+            enabled = true;
+            iteration = 10;
+            precision = 20;
+            threshold = 23;
+          };
+          ignore = [ ];
+          autoreload = false;
+        };
+      };
+    };
+  };
+
+  catppuccin = {
+    colorschemes.catppuccin.enable = true;
+    plugins = {
+      web-devicons.enable = true;
+      tiny-devicons-auto-colors = {
+        enable = true;
+
+        settings = {
+          colors.__raw = ''require("catppuccin.palettes").get_palette("macchiato")'';
+        };
+      };
+    };
+  };
+
+  mini = {
+    plugins = {
+      mini = {
+        enable = true;
+        mockDevIcons = true;
+        modules.icons = { };
+      };
+      tiny-devicons-auto-colors.enable = true;
+    };
+  };
+}


### PR DESCRIPTION
Resolves https://github.com/nix-community/nixvim/issues/2381

~Attempted to see if it would work with mini mockDevicons and it still seemed to throw an error.~

Looked like a load order issue from dependencies, manually inserting setupCode in corresponding plugin's `luaConfig.post` until we can handle `mkOrder` or `dag` https://github.com/nix-community/nixvim/issues/2292 is available