### PR TITLE
lib: remove dependency on `pkgs`

### DIFF
--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -14,8 +14,8 @@
       {
         # NOTE: this is the publicly documented flake output we've had for a while
         check = import ../lib/tests.nix { inherit lib pkgs; };
-        # NOTE: user-facing so we must include the legacy `pkgs` argument
-        helpers = import ../lib { inherit lib pkgs; };
+        # TODO: no longer needs to be per-system
+        helpers = import ../lib { inherit lib; };
       }
     )
   );

--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -158,3 +158,18 @@ lib.fix (builders: {
       }
     );
 })
+# Removed because it depended on `pkgs`
+# Deprecated 2024-09-13; Removed 2024-12-15
+//
+  lib.genAttrs
+    [
+      "byteCompileLuaDrv"
+      "byteCompileLuaFile"
+      "byteCompileLuaHook"
+      "writeByteCompiledLua"
+      "writeLua"
+    ]
+    (
+      name:
+      throw "`${name}` is no longer available directly. You can access it via `withPkgs` or use `${name}With`."
+    )

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -44,9 +44,9 @@ let
       dontRun ? false,
     }@args:
     let
+      # NOTE: we are importing this just for evalNixvim
       helpers = import ../lib {
-        # NOTE: must match the user-facing functions, so we still include the `pkgs` argument
-        inherit pkgs lib;
+        inherit lib;
         # TODO: deprecate helpers.enableExceptInTests,
         # add a context option e.g. `config.isTest`?
         _nixvimTests = true;

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -57,8 +57,7 @@ in
   config = mkMerge [
     {
       # Make our lib available to the host modules
-      # NOTE: user-facing so we must include the legacy `pkgs` argument
-      lib.nixvim = lib.mkDefault (import ../lib { inherit pkgs lib; });
+      lib.nixvim = lib.mkDefault (import ../lib { inherit lib; });
 
       # Make nixvim's "extended" lib available to the host's module args
       _module.args.nixvimLib = lib.mkDefault config.lib.nixvim.extendedLib;

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -8,9 +8,8 @@ default_pkgs: self:
   module,
 }:
 let
-  # NOTE: user-facing so we must include the legacy `pkgs` argument
-  helpers = import ../lib { inherit pkgs lib _nixvimTests; };
-
+  # NOTE: we are importing this just for evalNixvim
+  helpers = import ../lib { inherit lib _nixvimTests; };
   inherit (helpers.modules) evalNixvim;
 
   mkNvim =


### PR DESCRIPTION
We had a few things in `lib.nixvim.builders` that depend on `pkgs` and are therefore also per-system.

These were deprecated in #2231, with a view to fully remove after 24.11 was released.

With these fully removed, the lib now has zero dependency on a `pkgs` instance or a `system`.

Fixes #2186