### PR TITLE
lib/modules: pass `inputs.nixpkgs` into `evalNixvim`

### DIFF
--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -1,11 +1,15 @@
 {
+  self,
   config,
   lib,
   withSystem,
   ...
 }:
 {
-  _module.args.helpers = import ../lib { inherit lib; };
+  _module.args.helpers = import ../lib {
+    inherit lib;
+    flake = self;
+  };
 
   # TODO: output lib without pkgs at the top-level
   flake.lib = lib.genAttrs config.systems (
@@ -13,9 +17,12 @@
       { pkgs, ... }:
       {
         # NOTE: this is the publicly documented flake output we've had for a while
-        check = import ../lib/tests.nix { inherit lib pkgs; };
+        check = import ../lib/tests.nix { inherit self lib pkgs; };
         # TODO: no longer needs to be per-system
-        helpers = import ../lib { inherit lib; };
+        helpers = import ../lib {
+          inherit lib;
+          flake = self;
+        };
       }
     )
   );

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  flake ? null, # Optionally, provide the lib with access to the flake
   _nixvimTests ? false,
 }:
 lib.fix (
@@ -18,7 +19,7 @@ lib.fix (
     extendedLib = call ./extend-lib.nix { inherit lib; };
     keymaps = call ./keymap-helpers.nix { };
     lua = call ./to-lua.nix { };
-    modules = call ./modules.nix { };
+    modules = call ./modules.nix { inherit flake; };
     neovim-plugin = call ./neovim-plugin.nix { };
     options = call ./options.nix { };
     utils = call ./utils.nix { inherit _nixvimTests; };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1,6 +1,7 @@
 {
   lib,
   self,
+  flake ? null,
 }:
 let
   removed = {
@@ -29,7 +30,15 @@ in
       Nixvim requires a lib that includes some custom extensions, however the `lib` from `specialArgs` does not have a `nixvim` attr.
       Remove `lib` from nixvim's `specialArgs` or ensure you apply nixvim's extensions to your `lib`.'';
     lib.evalModules {
-      modules = [ ../modules/top-level ] ++ modules;
+      modules = modules ++ [
+        ../modules/top-level
+
+        # Pass our locked nixpkgs into the configuration
+        (lib.optionalAttrs (flake != null) {
+          _file = "<nixvim-flake>";
+          nixpkgs.source = lib.mkOptionDefault flake.inputs.nixpkgs;
+        })
+      ];
       specialArgs = {
         inherit lib;
         # TODO: deprecate `helpers`

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -1,4 +1,5 @@
 {
+  self,
   pkgs,
   lib ? pkgs.lib,
   ...
@@ -47,6 +48,7 @@ let
       # NOTE: we are importing this just for evalNixvim
       helpers = import ../lib {
         inherit lib;
+        flake = self;
         # TODO: deprecate helpers.enableExceptInTests,
         # add a context option e.g. `config.isTest`?
         _nixvimTests = true;

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -125,6 +125,21 @@ in
         -->
       '';
     };
+
+    # NOTE: This is a nixvim-specific option; there's no equivalent in nixos
+    source = lib.mkOption {
+      type = lib.types.path;
+      # NOTE: default is only set if `flake` is passed to our lib
+      defaultText = lib.literalMD "Nixvim's flake `input.nixpkgs`";
+      description = ''
+        The path to import Nixpkgs from.
+
+        Ignored when `nixpkgs.pkgs` is set.
+      '';
+
+      # FIXME: This is a stub option for now
+      internal = true;
+    };
   };
 
   config =
@@ -150,5 +165,10 @@ in
       # evaluate the wrapper to find out that the priority is lower, and then we
       # don't need to evaluate `finalPkgs`.
       _module.args.pkgs = lib.mkOverride lib.modules.defaultOverridePriority finalPkgs.__splicedPackages;
+
+      # FIXME: This is a stub option for now
+      warnings = lib.optional (
+        opt.source.isDefined && opt.source.highestPrio < (lib.mkOptionDefault null).priority
+      ) "Defining the option `nixpkgs.source` currently has no effect";
     };
 }

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -12,7 +12,7 @@
 }:
 let
   fetchTests = callTest ./fetch-tests.nix { };
-  test-derivation = callPackage ../lib/tests.nix { };
+  test-derivation = callPackage ../lib/tests.nix { inherit self; };
   inherit (test-derivation) mkTestDerivationFromNixvimModule;
 
   moduleToTest =

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,4 +1,6 @@
 {
+  # The nixvim flake
+  self,
   # Extra args for the `evalNixvim` call that produces the type for `programs.nixvim`
   evalArgs ? { },
   # Option path where extraFiles should go
@@ -57,7 +59,13 @@ in
   config = mkMerge [
     {
       # Make our lib available to the host modules
-      lib.nixvim = lib.mkDefault (import ../lib { inherit lib; });
+      # NOTE: user-facing so we must include the legacy `pkgs` argument
+      lib.nixvim = lib.mkDefault (
+        import ../lib {
+          inherit lib;
+          flake = self;
+        }
+      );
 
       # Make nixvim's "extended" lib available to the host's module args
       _module.args.nixvimLib = lib.mkDefault config.lib.nixvim.extendedLib;

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -22,7 +22,7 @@ in
 {
   _file = ./darwin.nix;
 
-  imports = [ (import ./_shared.nix { inherit evalArgs; }) ];
+  imports = [ (import ./_shared.nix { inherit self evalArgs; }) ];
 
   config = mkIf cfg.enable {
     environment.systemPackages = [

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -24,7 +24,7 @@ in
 
   imports = [
     (import ./_shared.nix {
-      inherit evalArgs;
+      inherit self evalArgs;
       filesOpt = [
         "xdg"
         "configFile"

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -24,7 +24,7 @@ in
 
   imports = [
     (import ./_shared.nix {
-      inherit evalArgs;
+      inherit self evalArgs;
       filesOpt = [
         "environment"
         "etc"

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -9,7 +9,11 @@ default_pkgs: self:
 }:
 let
   # NOTE: we are importing this just for evalNixvim
-  helpers = import ../lib { inherit lib _nixvimTests; };
+  helpers = import ../lib {
+    inherit lib _nixvimTests;
+    flake = self;
+  };
+
   inherit (helpers.modules) evalNixvim;
 
   mkNvim =


### PR DESCRIPTION
Expose our locked nixpkgs as the `nixpkgs.source` module options.

This only happens when `evalNixvim` is part of a lib that was provided `flake` as an argument.

Stubbed the `nixpkgs.source` option for now. Eventually, this will be used to construct `pkgs` internally. For now, it's purely informational.

This is another small step towards #1784. See also #2022
