### PR TITLE
lib/mkSettingsRenamedOptionModules: allow attrs value with 'old' and 'new' keys

### DIFF
--- a/plugins/by-name/auto-save/default.nix
+++ b/plugins/by-name/auto-save/default.nix
@@ -28,26 +28,21 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     "triggerEvents"
     "writeAllBuffers"
     "debounceDelay"
+    {
+      old = "enableAutoSave";
+      new = "enabled";
+    }
   ];
 
-  imports =
-    let
-      basePluginPath = [
-        "plugins"
-        "auto-save"
-      ];
-      settingsPath = basePluginPath ++ [ "settings" ];
-    in
-    [
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "enableAutoSave" ]) (settingsPath ++ [ "enabled" ]))
-      (lib.mkRemovedOptionModule (basePluginPath ++ [ "keymaps" ]) ''
-        Use the top-level `keymaps` option to create a keymap that runs :ASToggle
+  imports = [
+    (lib.mkRemovedOptionModule [ "plugins" "auto-save" "keymaps" ] ''
+      Use the top-level `keymaps` option to create a keymap that runs :ASToggle
 
-        keymaps = [
-          { key = "<leader>s"; action = "<cmd>ASToggle<CR>"; }
-        ];
-      '')
-    ];
+      keymaps = [
+        { key = "<leader>s"; action = "<cmd>ASToggle<CR>"; }
+      ];
+    '')
+  ];
 
   settingsOptions = {
     enabled = defaultNullOpts.mkBool true ''

--- a/plugins/by-name/auto-session/default.nix
+++ b/plugins/by-name/auto-session/default.nix
@@ -14,82 +14,12 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
   # TODO: added 204-10-05 remove after 24.11
   deprecateExtraOptions = true;
-  optionsRenamedToSettings = [
-    "logLevel"
-    [
-      "sessionLens"
-      "loadOnSetup"
-    ]
-    [
-      "sessionLens"
-      "themeConf"
-    ]
-    [
-      "sessionLens"
-      "previewer"
-    ]
-    [
-      "sessionControl"
-      "controlDir"
-    ]
-    [
-      "sessionControl"
-      "controlFilename"
-    ]
+  optionsRenamedToSettings = import ./renamed-options.nix;
+  imports = [
+    (lib.mkRemovedOptionModule [ "plugins" "auto-session" "cwdChangeHandling" ] ''
+      Please switch to `cwd_change_handling` with just a boolean value.
+    '')
   ];
-  # NOTE: rename the old settings to use the correct variables
-  imports =
-    let
-      basePluginPath = [
-        "plugins"
-        "auto-session"
-      ];
-      settingsPath = basePluginPath ++ [ "settings" ];
-      nestedAutoSessionPluginPath = basePluginPath ++ [ "autoSession" ];
-    in
-    [
-      (lib.mkRenamedOptionModule (
-        basePluginPath
-        ++ [
-          "autoSave"
-          "enabled"
-        ]
-      ) (settingsPath ++ [ "auto_save" ]))
-      (lib.mkRenamedOptionModule (
-        basePluginPath
-        ++ [
-          "autoRestore"
-          "enabled"
-        ]
-      ) (settingsPath ++ [ "auto_restore" ]))
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "bypassSessionSaveFileTypes" ]) (
-        settingsPath ++ [ "bypass_save_filetypes" ]
-      ))
-      (lib.mkRenamedOptionModule (nestedAutoSessionPluginPath ++ [ "enableLastSession" ]) (
-        settingsPath ++ [ "auto_restore_last_session" ]
-      ))
-      (lib.mkRenamedOptionModule (nestedAutoSessionPluginPath ++ [ "rootDir" ]) (
-        settingsPath ++ [ "root_dir" ]
-      ))
-      (lib.mkRenamedOptionModule (nestedAutoSessionPluginPath ++ [ "enabled" ]) (
-        settingsPath ++ [ "enabled" ]
-      ))
-      (lib.mkRenamedOptionModule (nestedAutoSessionPluginPath ++ [ "createEnabled" ]) (
-        settingsPath ++ [ "auto_create" ]
-      ))
-      (lib.mkRenamedOptionModule (nestedAutoSessionPluginPath ++ [ "suppressDirs" ]) (
-        settingsPath ++ [ "suppressed_dirs" ]
-      ))
-      (lib.mkRenamedOptionModule (nestedAutoSessionPluginPath ++ [ "allowedDirs" ]) (
-        settingsPath ++ [ "allowed_dirs" ]
-      ))
-      (lib.mkRenamedOptionModule (nestedAutoSessionPluginPath ++ [ "useGitBranch" ]) (
-        settingsPath ++ [ "use_git_branch" ]
-      ))
-      (lib.mkRemovedOptionModule (basePluginPath ++ [ "cwdChangeHandling" ]) ''
-        Please switch to `cwd_change_handling` with just a boolean value.
-      '')
-    ];
 
   settingsOptions = {
     enabled = defaultNullOpts.mkBool true ''

--- a/plugins/by-name/auto-session/renamed-options.nix
+++ b/plugins/by-name/auto-session/renamed-options.nix
@@ -1,0 +1,90 @@
+[
+  "logLevel"
+  [
+    "sessionLens"
+    "loadOnSetup"
+  ]
+  [
+    "sessionLens"
+    "themeConf"
+  ]
+  [
+    "sessionLens"
+    "previewer"
+  ]
+  [
+    "sessionControl"
+    "controlDir"
+  ]
+  [
+    "sessionControl"
+    "controlFilename"
+  ]
+  {
+    old = [
+      "autoSave"
+      "enabled"
+    ];
+    new = "auto_save";
+  }
+  {
+    old = [
+      "autoRestore"
+      "enabled"
+    ];
+    new = "auto_auto_restore";
+  }
+  {
+    old = "bypassSessionSaveFileTypes";
+    new = "bypass_save_filetypes";
+  }
+  {
+    old = [
+      "autoSession"
+      "enableLastSession"
+    ];
+    new = "auto_restore_last_session";
+  }
+  {
+    old = [
+      "autoSession"
+      "rootDir"
+    ];
+    new = "root_dir";
+  }
+  {
+    old = [
+      "autoSession"
+      "enabled"
+    ];
+    new = "enabled";
+  }
+  {
+    old = [
+      "autoSession"
+      "createEnabled"
+    ];
+    new = "auto_create";
+  }
+  {
+    old = [
+      "autoSession"
+      "suppressDirs"
+    ];
+    new = "suppressed_dirs";
+  }
+  {
+    old = [
+      "autoSession"
+      "allowedDirs"
+    ];
+    new = "allowed_dirs";
+  }
+  {
+    old = [
+      "autoSession"
+      "useGitBranch"
+    ];
+    new = "use_git_branch";
+  }
+]

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -125,6 +125,26 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     "sidebarFiletypes"
     "noNameTitle"
     "tabpages"
+    {
+      old = "excludeFileTypes";
+      new = "exclude_ft";
+    }
+    {
+      old = "excludeFileNames";
+      new = "exclude_name";
+    }
+    {
+      old = [
+        "icons"
+        "filetype"
+        "enable"
+      ];
+      new = [
+        "icons"
+        "filetype"
+        "enabled"
+      ];
+    }
   ];
   imports =
     let
@@ -132,7 +152,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         "plugins"
         "barbar"
       ];
-      settingsPath = basePluginPath ++ [ "settings" ];
     in
     [
       (mkRemovedOptionModule (
@@ -142,12 +161,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           "silent"
         ]
       ) "Keymaps will be silent anyways. This option has always been useless.")
-      (mkRenamedOptionModule (basePluginPath ++ [ "excludeFileTypes" ]) (
-        settingsPath ++ [ "exclude_ft" ]
-      ))
-      (mkRenamedOptionModule (basePluginPath ++ [ "excludeFileNames" ]) (
-        settingsPath ++ [ "exclude_name" ]
-      ))
       (mkRemovedOptionModule (
         basePluginPath
         ++ [
@@ -155,45 +168,27 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           "diagnostics"
         ]
       ) "Use `settings.icons.diagnostics` instead, but pay attention as the keys have changed.")
-      (mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "icons"
-            "filetype"
-            "enable"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "icons"
-            "filetype"
-            "enabled"
-          ]
-        )
-      )
     ]
-    ++ (map
-      (
-        name:
-        mkRemovedOptionModule (
-          basePluginPath
-          ++ [
-            "icons"
-            name
-          ]
-        ) "Use `settings.icons.${name}` instead, but you should now use the real `snake_case` key names."
-      )
-      [
-        "alternate"
-        "current"
-        "inactive"
-        "modified"
-        "pinned"
-        "visible"
-      ]
-    );
+    ++
+      map
+        (
+          name:
+          mkRemovedOptionModule (
+            basePluginPath
+            ++ [
+              "icons"
+              name
+            ]
+          ) "Use `settings.icons.${name}` instead, but you should now use the real `snake_case` key names."
+        )
+        [
+          "alternate"
+          "current"
+          "inactive"
+          "modified"
+          "pinned"
+          "visible"
+        ];
 
   extraOptions = {
     keymaps = mapAttrs (

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -82,6 +82,13 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           "logging"
         ]
         "customFilter"
+        {
+          old = "diagnosticsUpdateInInsert";
+          new = [
+            "diagnostics"
+            "update_in_insert"
+          ];
+        }
       ];
 
       oldHighlightOptions = [
@@ -142,6 +149,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         "pickVisible"
         "pickSelected"
         "offsetSeparator"
+        {
+          old = "trunkMarker";
+          new = "trunc_marker";
+        }
       ];
 
       basePluginPath = [
@@ -155,13 +166,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     in
     [
       (lib.mkRenamedOptionModule (basePluginPath ++ [ "extraOptions" ]) optionsPath)
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "diagnosticsUpdateInInsert" ]) [
-        "diagnostics"
-        "update_in_insert"
-      ])
-      (lib.mkRenamedOptionModule (oldHighlightsPath ++ [ "trunkMarker" ]) (
-        newHighlightsPath ++ [ "trunc_marker" ]
-      ))
     ]
     ++ mkSettingsRenamedOptionModules basePluginPath optionsPath oldOptions
     ++ mkSettingsRenamedOptionModules oldHighlightsPath newHighlightsPath oldHighlightOptions;

--- a/plugins/by-name/colorizer/default.nix
+++ b/plugins/by-name/colorizer/default.nix
@@ -25,60 +25,61 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         "colorizer"
       ];
 
-      optionsToRename = [
-        "RGB"
-        "RRGGBB"
-        "names"
-        "RRGGBBAA"
-        "AARRGGBB"
-        "rgb_fn"
-        "hsl_fn"
-        "tailwind"
-        "sass"
-        "virtualtext"
-        "virtualtext_inline"
-        "virtualtext_mode"
-        "always_update"
-      ];
-
-      renameOption =
-        optionName:
-        lib.mkRenamedOptionModule
-          (
-            oldPluginPath
-            ++ [
+      # {
+      #   old = ["userDefaultOptions" "RGB"]; }
+      #   new = ["settings" "user_default_options" "RGB"];
+      # }
+      userOptsRenames =
+        map
+          (name: {
+            old = [
               "userDefaultOptions"
-              optionName
-            ]
-          )
-          (
-            newPluginPath
-            ++ [
+              name
+            ];
+            new = [
               "settings"
               "user_default_options"
-              optionName
-            ]
-          );
+              name
+            ];
+          })
+          [
+            "RGB"
+            "RRGGBB"
+            "names"
+            "RRGGBBAA"
+            "AARRGGBB"
+            "rgb_fn"
+            "hsl_fn"
+            "tailwind"
+            "sass"
+            "virtualtext"
+            "virtualtext_inline"
+            "virtualtext_mode"
+            "always_update"
+          ];
+
     in
-    map renameOption optionsToRename
-    ++
-      lib.mapAttrsToList
-        (
-          oldOptionName: newPath:
-          lib.mkRenamedOptionModule (oldPluginPath ++ [ oldOptionName ]) (newPluginPath ++ newPath)
-        )
+    lib.nixvim.mkSettingsRenamedOptionModules oldPluginPath newPluginPath (
+      [
+        "enable"
+        "package"
         {
-          enable = [ "enable" ];
-          package = [ "package" ];
-          fileTypes = [
+          old = "fileTypes";
+          new = [
             "settings"
             "filetypes"
           ];
-          bufTypes = [
+        }
+        {
+          old = "bufTypes";
+          new = [
             "settings"
-            "bufTypes"
+            "buftypes"
           ];
-        };
+        }
+      ]
+      ++ userOptsRenames
+    );
 
   settingsOptions =
     let

--- a/plugins/by-name/comment/default.nix
+++ b/plugins/by-name/comment/default.nix
@@ -24,109 +24,12 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         "comment"
       ];
       settingsPath = newPluginPath ++ [ "settings" ];
+
+      optionsRenamedToSettings = import ./renamed-options.nix;
     in
     [
       (mkRenamedOptionModule (oldPluginPath ++ [ "enable" ]) (newPluginPath ++ [ "enable" ]))
       (mkRenamedOptionModule (oldPluginPath ++ [ "package" ]) (newPluginPath ++ [ "package" ]))
-      (mkRenamedOptionModule (oldPluginPath ++ [ "padding" ]) (settingsPath ++ [ "padding" ]))
-      (mkRenamedOptionModule (oldPluginPath ++ [ "sticky" ]) (settingsPath ++ [ "sticky" ]))
-      (mkRenamedOptionModule (oldPluginPath ++ [ "ignore" ]) (settingsPath ++ [ "ignore" ]))
-      (mkRenamedOptionModule
-        (
-          oldPluginPath
-          ++ [
-            "toggler"
-            "line"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "toggler"
-            "line"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          oldPluginPath
-          ++ [
-            "toggler"
-            "block"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "toggler"
-            "block"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          oldPluginPath
-          ++ [
-            "opleader"
-            "line"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "opleader"
-            "line"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          oldPluginPath
-          ++ [
-            "opleader"
-            "block"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "opleader"
-            "block"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          oldPluginPath
-          ++ [
-            "mappings"
-            "basic"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "mappings"
-            "basic"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          oldPluginPath
-          ++ [
-            "mappings"
-            "extra"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "mappings"
-            "extra"
-          ]
-        )
-      )
       (mkRemovedOptionModule (
         oldPluginPath
         ++ [
@@ -134,9 +37,8 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           "extended"
         ]
       ) "This option has been removed upstream.")
-      (mkRenamedOptionModule (oldPluginPath ++ [ "preHook" ]) (settingsPath ++ [ "pre_hook" ]))
-      (mkRenamedOptionModule (oldPluginPath ++ [ "postHook" ]) (settingsPath ++ [ "post_hook" ]))
-    ];
+    ]
+    ++ (lib.nixvim.mkSettingsRenamedOptionModules oldPluginPath settingsPath optionsRenamedToSettings);
 
   settingsOptions = {
     padding = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/by-name/comment/renamed-options.nix
+++ b/plugins/by-name/comment/renamed-options.nix
@@ -1,0 +1,31 @@
+[
+  "padding"
+  "sticky"
+  "ignore"
+  [
+    "toggler"
+    "line"
+  ]
+  [
+    "toggler"
+    "block"
+  ]
+  [
+    "opleader"
+    "line"
+  ]
+  [
+    "opleader"
+    "block"
+  ]
+  [
+    "mappings"
+    "basic"
+  ]
+  [
+    "mappings"
+    "extra"
+  ]
+  "preHook"
+  "postHook"
+]

--- a/plugins/by-name/coq-nvim/default.nix
+++ b/plugins/by-name/coq-nvim/default.nix
@@ -33,32 +33,21 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   optionsRenamedToSettings = [
     "xdg"
     "autoStart"
-  ];
-  imports =
-    let
-      basePath = [
-        "plugins"
-        "coq-nvim"
+    {
+      old = "recommendedKeymaps";
+      new = [
+        "keymap"
+        "recommended"
       ];
-      settingsPath = basePath ++ [ "settings" ];
-    in
-    [
-      (lib.mkRenamedOptionModule (basePath ++ [ "recommendedKeymaps" ]) (
-        settingsPath
-        ++ [
-          "keymap"
-          "recommended"
-        ]
-      ))
-
-      (lib.mkRenamedOptionModule (basePath ++ [ "alwaysComplete" ]) (
-        settingsPath
-        ++ [
-          "completion"
-          "always"
-        ]
-      ))
-    ];
+    }
+    {
+      old = "alwaysComplete";
+      new = [
+        "completion"
+        "always"
+      ];
+    }
+  ];
 
   callSetup = false;
   settingsOptions = {

--- a/plugins/by-name/dashboard/default.nix
+++ b/plugins/by-name/dashboard/default.nix
@@ -12,73 +12,84 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   maintainers = [ maintainers.MattSturgeon ];
 
   # TODO introduced 2024-05-30: remove 2024-09-01
-  imports =
-    let
-      basePluginPath = [
-        "plugins"
-        "dashboard"
+  optionsRenamedToSettings = [
+    {
+      old = "header";
+      new = [
+        "config"
+        "header"
       ];
-    in
+    }
+    {
+      old = "footer";
+      new = [
+        "config"
+        "footer"
+      ];
+    }
+    {
+      old = "center";
+      new = [
+        "config"
+        "shortcut"
+      ];
+    }
+    {
+      old = "hideStatusline";
+      new = [
+        "hide"
+        "statusline"
+      ];
+    }
+    {
+      old = "hideTabline";
+      new = [
+        "hide"
+        "tabline"
+      ];
+    }
     [
-      (mkRemovedOptionModule (
-        basePluginPath ++ [ "sessionDirectory" ]
-      ) "This plugin no longer has session support.")
+      "preview"
+      "command"
     ]
-    ++ (mapAttrsToList
-      (
-        old: new:
-        mkRenamedOptionModule (basePluginPath ++ [ old ]) (basePluginPath ++ [ "settings" ] ++ new)
-      )
-      {
-        header = [
-          "config"
-          "header"
-        ];
-        footer = [
-          "config"
-          "footer"
-        ];
-        center = [
-          "config"
-          "shortcut"
-        ];
-        hideStatusline = [
-          "hide"
-          "statusline"
-        ];
-        hideTabline = [
-          "hide"
-          "tabline"
-        ];
-      }
-    )
-    ++ (mapAttrsToList
-      (
-        old: new:
-        mkRenamedOptionModule
-          (
-            basePluginPath
-            ++ [
-              "preview"
-              old
-            ]
-          )
-          (
-            basePluginPath
-            ++ [
-              "settings"
-              "preview"
-              new
-            ]
-          )
-      )
-      {
-        command = "command";
-        file = "file_path";
-        height = "file_height";
-        width = "file_width";
-      }
-    );
+    {
+      old = [
+        "preview"
+        "file"
+      ];
+      new = [
+        "preview"
+        "file_path"
+      ];
+    }
+    {
+      old = [
+        "preview"
+        "height"
+      ];
+      new = [
+        "preview"
+        "file_height"
+      ];
+    }
+    {
+      old = [
+        "preview"
+        "width"
+      ];
+      new = [
+        "preview"
+        "file_width"
+      ];
+    }
+  ];
+  imports = [
+    (mkRemovedOptionModule [
+      "plugins"
+      "dashboard"
+      "sessionDirectory"
+    ] "This plugin no longer has session support.")
+  ];
 
   settingsExample = {
     theme = "hyper";

--- a/plugins/by-name/emmet/default.nix
+++ b/plugins/by-name/emmet/default.nix
@@ -15,21 +15,12 @@ mkVimPlugin {
 
   # TODO introduced 2024-03-01: remove 2024-05-01
   deprecateExtraConfig = true;
-  optionsRenamedToSettings = [ "mode" ];
-  imports = [
-    (mkRenamedOptionModule
-      [
-        "plugins"
-        "emmet"
-        "leader"
-      ]
-      [
-        "plugins"
-        "emmet"
-        "settings"
-        "leader_key"
-      ]
-    )
+  optionsRenamedToSettings = [
+    "mode"
+    {
+      old = "leader";
+      new = "leader_key";
+    }
   ];
 
   settingsOptions = {

--- a/plugins/by-name/gitsigns/default.nix
+++ b/plugins/by-name/gitsigns/default.nix
@@ -15,114 +15,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
   # TODO: introduced 2024-03-12, remove on 2024-05-12
   deprecateExtraOptions = true;
-  optionsRenamedToSettings = [
-    [
-      "signs"
-      "add"
-      "text"
-    ]
-    [
-      "signs"
-      "add"
-      "showCount"
-    ]
-    [
-      "signs"
-      "change"
-      "text"
-    ]
-    [
-      "signs"
-      "change"
-      "showCount"
-    ]
-    [
-      "signs"
-      "topdelete"
-      "text"
-    ]
-    [
-      "signs"
-      "topdelete"
-      "showCount"
-    ]
-    [
-      "signs"
-      "changedelete"
-      "text"
-    ]
-    [
-      "signs"
-      "changedelete"
-      "showCount"
-    ]
-    [
-      "signs"
-      "untracked"
-      "text"
-    ]
-    [
-      "signs"
-      "untracked"
-      "showCount"
-    ]
-    "worktrees"
-    "signPriority"
-    "signcolumn"
-    "numhl"
-    "linehl"
-    "showDeleted"
-    [
-      "diffOpts"
-      "algorithm"
-    ]
-    [
-      "diffOpts"
-      "internal"
-    ]
-    [
-      "diffOpts"
-      "indentHeuristic"
-    ]
-    [
-      "diffOpts"
-      "vertical"
-    ]
-    [
-      "diffOpts"
-      "linematch"
-    ]
-    "base"
-    "countChars"
-    "maxFileLength"
-    "previewConfig"
-    "attachToUntracked"
-    "updateDebounce"
-    "currentLineBlame"
-    [
-      "currentLineBlameOpts"
-      "virtText"
-    ]
-    [
-      "currentLineBlameOpts"
-      "virtTextPos"
-    ]
-    [
-      "currentLineBlameOpts"
-      "delay"
-    ]
-    [
-      "currentLineBlameOpts"
-      "ignoreWhitespace"
-    ]
-    [
-      "currentLineBlameOpts"
-      "virtTextPriority"
-    ]
-    "trouble"
-    "wordDiff"
-    "debugMode"
-  ];
+  optionsRenamedToSettings = import ./renamed-options.nix;
   imports =
     let
       basePluginPaths = [
@@ -165,29 +58,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       helpers.mkDeprecatedSubOptionModule optionPath "Please define the `${hlg}` highlight group instead."
     ) highlightRemovals)
     ++ [
-      (mkRenamedOptionModule (
-        basePluginPaths
-        ++ [
-          "onAttach"
-          "function"
-        ]
-      ) (settingsPath ++ [ "on_attach" ]))
-      (mkRenamedOptionModule
-        (
-          basePluginPaths
-          ++ [
-            "watchGitDir"
-            "enable"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "watch_gitdir"
-            "enable"
-          ]
-        )
-      )
       (mkRemovedOptionModule (
         basePluginPaths
         ++ [
@@ -195,43 +65,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           "interval"
         ]
       ) "The option has been removed from upstream.")
-      (mkRenamedOptionModule
-        (
-          basePluginPaths
-          ++ [
-            "watchGitDir"
-            "followFiles"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "watch_gitdir"
-            "follow_files"
-          ]
-        )
-      )
-      (mkRenamedOptionModule (
-        basePluginPaths
-        ++ [
-          "statusFormatter"
-          "function"
-        ]
-      ) (settingsPath ++ [ "status_formatter" ]))
-      (mkRenamedOptionModule (
-        basePluginPaths
-        ++ [
-          "currentLineBlameFormatter"
-          "normal"
-        ]
-      ) (settingsPath ++ [ "current_line_blame_formatter" ]))
-      (mkRenamedOptionModule (
-        basePluginPaths
-        ++ [
-          "currentLineBlameFormatter"
-          "nonCommitted"
-        ]
-      ) (settingsPath ++ [ "current_line_blame_formatter_nc" ]))
       (helpers.mkDeprecatedSubOptionModule (
         settingsPath
         ++ [

--- a/plugins/by-name/gitsigns/renamed-options.nix
+++ b/plugins/by-name/gitsigns/renamed-options.nix
@@ -1,0 +1,156 @@
+[
+  [
+    "signs"
+    "add"
+    "text"
+  ]
+  [
+    "signs"
+    "add"
+    "showCount"
+  ]
+  [
+    "signs"
+    "change"
+    "text"
+  ]
+  [
+    "signs"
+    "change"
+    "showCount"
+  ]
+  [
+    "signs"
+    "topdelete"
+    "text"
+  ]
+  [
+    "signs"
+    "topdelete"
+    "showCount"
+  ]
+  [
+    "signs"
+    "changedelete"
+    "text"
+  ]
+  [
+    "signs"
+    "changedelete"
+    "showCount"
+  ]
+  [
+    "signs"
+    "untracked"
+    "text"
+  ]
+  [
+    "signs"
+    "untracked"
+    "showCount"
+  ]
+  "worktrees"
+  "signPriority"
+  "signcolumn"
+  "numhl"
+  "linehl"
+  "showDeleted"
+  [
+    "diffOpts"
+    "algorithm"
+  ]
+  [
+    "diffOpts"
+    "internal"
+  ]
+  [
+    "diffOpts"
+    "indentHeuristic"
+  ]
+  [
+    "diffOpts"
+    "vertical"
+  ]
+  [
+    "diffOpts"
+    "linematch"
+  ]
+  "base"
+  "countChars"
+  "maxFileLength"
+  "previewConfig"
+  "attachToUntracked"
+  "updateDebounce"
+  "currentLineBlame"
+  [
+    "currentLineBlameOpts"
+    "virtText"
+  ]
+  [
+    "currentLineBlameOpts"
+    "virtTextPos"
+  ]
+  [
+    "currentLineBlameOpts"
+    "delay"
+  ]
+  [
+    "currentLineBlameOpts"
+    "ignoreWhitespace"
+  ]
+  [
+    "currentLineBlameOpts"
+    "virtTextPriority"
+  ]
+  "trouble"
+  "wordDiff"
+  "debugMode"
+  {
+    old = [
+      "onAttach"
+      "function"
+    ];
+    new = "on_attach";
+  }
+  {
+    old = [
+      "watchGitDir"
+      "enable"
+    ];
+    new = [
+      "watch_gitdir"
+      "enable"
+    ];
+  }
+  {
+    old = [
+      "watchGitDir"
+      "followFiles"
+    ];
+    new = [
+      "watch_gitdir"
+      "follow_files"
+    ];
+  }
+  {
+    old = [
+      "statusFormatter"
+      "function"
+    ];
+    new = "status_formatter";
+  }
+  {
+    old = [
+      "currentLineBlameFormatter"
+      "normal"
+    ];
+    new = "current_line_blame_formatter";
+  }
+  {
+    old = [
+      "currentLineBlameFormatter"
+      "nonCommitted"
+    ];
+    new = "current_line_blame_formatter_nc";
+  }
+]

--- a/plugins/by-name/goyo/default.nix
+++ b/plugins/by-name/goyo/default.nix
@@ -18,21 +18,10 @@ mkVimPlugin {
   optionsRenamedToSettings = [
     "width"
     "height"
-  ];
-  imports = [
-    (mkRenamedOptionModule
-      [
-        "plugins"
-        "goyo"
-        "showLineNumbers"
-      ]
-      [
-        "plugins"
-        "goyo"
-        "settings"
-        "linenr"
-      ]
-    )
+    {
+      old = "showLineNumbers";
+      new = "linenr";
+    }
   ];
 
   settingsOptions = {

--- a/plugins/by-name/ledger/default.nix
+++ b/plugins/by-name/ledger/default.nix
@@ -19,30 +19,15 @@ mkVimPlugin {
   optionsRenamedToSettings = [
     "detailedFirst"
     "foldBlanks"
+    {
+      old = "maxWidth";
+      new = "maxwidth";
+    }
+    {
+      old = "fillString";
+      new = "fillstring";
+    }
   ];
-  imports =
-    let
-      basePluginPath = [
-        "plugins"
-        "ledger"
-      ];
-    in
-    [
-      (mkRenamedOptionModule (basePluginPath ++ [ "maxWidth" ]) (
-        basePluginPath
-        ++ [
-          "settings"
-          "maxwidth"
-        ]
-      ))
-      (mkRenamedOptionModule (basePluginPath ++ [ "fillString" ]) (
-        basePluginPath
-        ++ [
-          "settings"
-          "fillstring"
-        ]
-      ))
-    ];
 
   extraOptions = {
     ledgerPackage = lib.mkPackageOption pkgs "ledger" {

--- a/plugins/by-name/markdown-preview/default.nix
+++ b/plugins/by-name/markdown-preview/default.nix
@@ -30,16 +30,14 @@ mkVimPlugin {
     "port"
     "pageTitle"
     "theme"
-  ];
-  imports = [
-    (mkRenamedOptionModule
-      [ "plugins" "markdown-preview" "fileTypes" ]
-      [ "plugins" "markdown-preview" "settings" "filetypes" ]
-    )
-    (mkRenamedOptionModule
-      [ "plugins" "markdown-preview" "browserFunc" ]
-      [ "plugins" "markdown-preview" "settings" "browserfunc" ]
-    )
+    {
+      old = "fileTypes";
+      new = "filetypes";
+    }
+    {
+      old = "browserFunc";
+      new = "browserfunc";
+    }
   ];
 
   settingsOptions = {

--- a/plugins/by-name/neorg/default.nix
+++ b/plugins/by-name/neorg/default.nix
@@ -46,6 +46,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       "logger"
       "floatPrecision"
     ]
+    {
+      old = "modules";
+      new = "load";
+    }
   ];
   imports = [
     ./deprecations.nix

--- a/plugins/by-name/neorg/deprecations.nix
+++ b/plugins/by-name/neorg/deprecations.nix
@@ -7,13 +7,6 @@ let
 in
 {
   imports = [
-    (lib.mkRenamedOptionModule (basePluginPath ++ [ "modules" ]) (
-      basePluginPath
-      ++ [
-        "settings"
-        "load"
-      ]
-    ))
     (lib.mkRemovedOptionModule (
       basePluginPath
       ++ [

--- a/plugins/by-name/none-ls/default.nix
+++ b/plugins/by-name/none-ls/default.nix
@@ -32,6 +32,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     "shouldAttach"
     "tempDir"
     "updateInInsert"
+    {
+      old = "sourcesItems";
+      new = "sources";
+    }
   ];
 
   imports =
@@ -45,12 +49,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         namespace
         "none-ls"
       ];
-      settingsPath = basePluginPath ++ [ "settings" ];
     in
     [
       ./sources.nix
       (lib.mkRenamedOptionModule oldPluginPath basePluginPath)
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "sourcesItems" ]) (settingsPath ++ [ "sources" ]))
     ];
 
   settingsExample = {

--- a/plugins/by-name/nvim-autopairs/default.nix
+++ b/plugins/by-name/nvim-autopairs/default.nix
@@ -28,27 +28,21 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     "mapBs"
     "mapCH"
     "mapCW"
+    {
+      old = "disabledFiletypes";
+      new = "disable_filetype";
+    }
+    {
+      old = "enableAfterQuote";
+      new = "enable_afterquote";
+    }
   ];
-  imports =
-    let
-      basePluginPaths = [
-        "plugins"
-        "nvim-autopairs"
-      ];
-      settingsPath = basePluginPaths ++ [ "settings" ];
-    in
-    [
-      (mkRenamedOptionModule (basePluginPaths ++ [ "disabledFiletypes" ]) (
-        settingsPath ++ [ "disable_filetype" ]
-      ))
-      (mkRenamedOptionModule (basePluginPaths ++ [ "enableAfterQuote" ]) (
-        settingsPath ++ [ "enable_afterquote" ]
-      ))
-      (mkRemovedOptionModule (basePluginPaths ++ [ "pairs" ]) ''
-        This option was having no effect.
-        If you want to customize pairs, please use `luaConfig` to define them as described in the plugin documentation.
-      '')
-    ];
+  imports = [
+    (mkRemovedOptionModule [ "plugins" "nvim-autopairs" "pairs" ] ''
+      This option was having no effect.
+      If you want to customize pairs, please use `luaConfig` to define them as described in the plugin documentation.
+    '')
+  ];
 
   settingsOptions = {
     disable_filetype = helpers.defaultNullOpts.mkListOf types.str [

--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -116,6 +116,22 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       "imgTextFunc"
     ]
     "yamlParser"
+    {
+      old = "finder";
+      new = [
+        "settings"
+        "picker"
+        "name"
+      ];
+    }
+    # https://github.com/epwalsh/obsidian.nvim/blob/656d9c2c64528839db8b2d9a091843b3c90155a2/CHANGELOG.md?plain=1#L184
+    {
+      old = [
+        "completion"
+        "newNotesLocation"
+      ];
+      new = "new_notes_location";
+    }
   ];
   imports =
     let
@@ -130,32 +146,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         mkRemovedOptionModule (
           basePluginPath ++ [ "workspaces" ]
         ) "Please use `plugins.obsidian.settings.workspaces` instead."
-      )
-      (mkRenamedOptionModule (basePluginPath ++ [ "finder" ]) (
-        basePluginPath
-        ++ [
-          "settings"
-          "picker"
-          "name"
-        ]
-      ))
-      (
-        # https://github.com/epwalsh/obsidian.nvim/blob/656d9c2c64528839db8b2d9a091843b3c90155a2/CHANGELOG.md?plain=1#L184
-        mkRenamedOptionModule
-          (
-            basePluginPath
-            ++ [
-              "completion"
-              "newNotesLocation"
-            ]
-          )
-          (
-            basePluginPath
-            ++ [
-              "settings"
-              "new_notes_location"
-            ]
-          )
       )
       (
         # We have to remove the option here because the user could set old-style camelCase options in each checkbox element.

--- a/plugins/by-name/oil/default.nix
+++ b/plugins/by-name/oil/default.nix
@@ -164,6 +164,13 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       "progress"
       "minimizedBorder"
     ]
+    {
+      old = "lspRenameAutosave";
+      new = [
+        "lsp_file_method"
+        "autosave_changes"
+      ];
+    }
   ];
   imports =
     let
@@ -171,19 +178,11 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         "plugins"
         "oil"
       ];
-      settingsPath = basePluginPath ++ [ "settings" ];
     in
     [
       (mkRemovedOptionModule (
         basePluginPath ++ [ "columns" ]
       ) "Use `plugins.oil.settings.columns` instead but beware, the format has changed.")
-      (mkRenamedOptionModule (basePluginPath ++ [ "lspRenameAutosave" ]) (
-        settingsPath
-        ++ [
-          "lsp_file_method"
-          "autosave_changes"
-        ]
-      ))
       (mkRemovedOptionModule (
         basePluginPath ++ [ "trashCommand" ]
       ) "This option has been deprecated by upstream.")

--- a/plugins/by-name/rest/default.nix
+++ b/plugins/by-name/rest/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkRemovedOptionModule mkRenamedOptionModule types;
+  inherit (lib) mkRemovedOptionModule types;
   inherit (lib.nixvim) defaultNullOpts;
 in
 lib.nixvim.neovim-plugin.mkNeovimPlugin {
@@ -18,121 +18,15 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
   # TODO introduced 2024-04-07: remove 2024-06-07
   deprecateExtraOptions = true;
-  optionsRenamedToSettings = [
-    "envFile"
-    "encodeUrl"
-    "skipSslVerification"
-    "customDynamicVariables"
-    [
-      "highlight"
-      "timeout"
-    ]
-  ];
+  optionsRenamedToSettings = import ./renamed-options.nix;
   imports =
     let
       basePluginPath = [
         "plugins"
         "rest"
       ];
-      settingsPath = basePluginPath ++ [ "settings" ];
     in
     [
-      (mkRenamedOptionModule (basePluginPath ++ [ "resultSplitHorizontal" ]) (
-        settingsPath
-        ++ [
-          "result"
-          "split"
-          "horizontal"
-        ]
-      ))
-      (mkRenamedOptionModule (basePluginPath ++ [ "resultSplitInPlace" ]) (
-        settingsPath
-        ++ [
-          "result"
-          "split"
-          "in_place"
-        ]
-      ))
-      (mkRenamedOptionModule (basePluginPath ++ [ "stayInCurrentWindowAfterSplit" ]) (
-        settingsPath
-        ++ [
-          "result"
-          "split"
-          "stay_in_current_window_after_split"
-        ]
-      ))
-      (mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "result"
-            "showUrl"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "result"
-            "behavior"
-            "show_info"
-            "url"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "result"
-            "showHeaders"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "result"
-            "behavior"
-            "show_info"
-            "headers"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "result"
-            "showHttpInfo"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "result"
-            "behavior"
-            "show_info"
-            "http_info"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "result"
-            "showCurlCommand"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "result"
-            "behavior"
-            "show_info"
-            "curl_command"
-          ]
-        )
-      )
       (mkRemovedOptionModule
         (
           basePluginPath
@@ -146,49 +40,20 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
           Refer to the documentation for more information.
         ''
       )
-      (mkRenamedOptionModule
+    ]
+    ++
+      map
         (
-          basePluginPath
-          ++ [
-            "result"
-            "formatters"
-          ]
+          option:
+          mkRemovedOptionModule (basePluginPath ++ [ option ]) ''
+            This option has been deprecated upstream.
+          ''
         )
-        (
-          settingsPath
-          ++ [
-            "result"
-            "behavior"
-            "formatters"
-          ]
-        )
-      )
-      (mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "highlight"
-            "enabled"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "highlight"
-            "enable"
-          ]
-        )
-      )
-      (mkRemovedOptionModule (basePluginPath ++ [ "jumpToRequest" ]) ''
-        This option has been deprecated upstream.
-      '')
-      (mkRemovedOptionModule (basePluginPath ++ [ "yankDryRun" ]) ''
-        This option has been deprecated upstream.
-      '')
-      (mkRemovedOptionModule (basePluginPath ++ [ "searchBack" ]) ''
-        This option has been deprecated upstream.
-      '')
-    ];
+        [
+          "jumpToRequest"
+          "yankDryRun"
+          "searchBack"
+        ];
 
   settingsOptions = {
     custom_dynamic_variables = lib.mkOption {

--- a/plugins/by-name/rest/renamed-options.nix
+++ b/plugins/by-name/rest/renamed-options.nix
@@ -1,0 +1,105 @@
+[
+  "envFile"
+  "encodeUrl"
+  "skipSslVerification"
+  "customDynamicVariables"
+  [
+    "highlight"
+    "timeout"
+  ]
+  {
+    old = "resultSplitHorizontal";
+    new = [
+      "result"
+      "split"
+      "horizontal"
+    ];
+  }
+  {
+    old = "resultSplitInPlace";
+    new = [
+      "result"
+      "split"
+      "in_place"
+    ];
+  }
+  {
+    old = "stayInCurrentWindowAfterSplit";
+    new = [
+      "result"
+      "split"
+      "stay_in_current_window_after_split"
+    ];
+  }
+  {
+    old = [
+      "result"
+      "showUrl"
+    ];
+    new = [
+
+      "result"
+      "behavior"
+      "show_info"
+      "url"
+    ];
+  }
+  {
+    old = [
+      "result"
+      "showHeaders"
+    ];
+    new = [
+
+      "result"
+      "behavior"
+      "show_info"
+      "headers"
+    ];
+  }
+  {
+    old = [
+      "result"
+      "showHttpInfo"
+    ];
+    new = [
+      "result"
+      "behavior"
+      "show_info"
+      "http_info"
+    ];
+  }
+  {
+    old = [
+      "result"
+      "showCurlCommand"
+    ];
+    new = [
+      "result"
+      "behavior"
+      "show_info"
+      "curl_command"
+    ];
+  }
+  {
+    old = [
+      "result"
+      "formatters"
+    ];
+    new = [
+      "result"
+      "behavior"
+      "formatters"
+    ];
+  }
+  {
+    old = [
+      "highlight"
+      "enabled"
+    ];
+    new = [
+      "highlight"
+      "enable"
+    ];
+  }
+]

--- a/plugins/by-name/specs/default.nix
+++ b/plugins/by-name/specs/default.nix
@@ -15,45 +15,44 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   optionsRenamedToSettings = [
     "show_jumps"
     "min_jump"
+    {
+      old = "delay";
+      new = [
+        "popup"
+        "delay_ms"
+      ];
+    }
+    {
+      old = "increment";
+      new = [
+        "popup"
+        "inc_ms"
+      ];
+    }
+    {
+      old = "blend";
+      new = [
+        "popup"
+        "blend"
+      ];
+    }
+    {
+      old = "width";
+      new = [
+        "popup"
+        "width"
+      ];
+    }
   ];
   imports =
-    let
-      basePluginPath = [
-        "plugins"
-        "specs"
-      ];
-      settingsPath = basePluginPath ++ [ "settings" ];
-      renameToPopup =
-        old: new:
-        mkRenamedOptionModule (basePluginPath ++ [ old ]) (
-          settingsPath
-          ++ [
-            "popup"
-            new
-          ]
-        );
-    in
-    [
-      (renameToPopup "delay" "delay_ms")
-      (renameToPopup "increment" "inc_ms")
-      (renameToPopup "blend" "blend")
-      (renameToPopup "width" "width")
-      (mkRemovedOptionModule (
-        basePluginPath ++ [ "color" ]
-      ) "Please, use `settings.popup.winhl` directly.")
-      (mkRemovedOptionModule (
-        basePluginPath ++ [ "fader" ]
-      ) "Please, use `settings.popup.fader` directly.")
-      (mkRemovedOptionModule (
-        basePluginPath ++ [ "resizer" ]
-      ) "Please, use `settings.popup.resizer` directly.")
-      (mkRemovedOptionModule (
-        basePluginPath ++ [ "ignored_filetypes" ]
-      ) "Please, use `settings.ignore_filetypes` instead.")
-      (mkRemovedOptionModule (
-        basePluginPath ++ [ "ignored_buffertypes" ]
-      ) "Please, use `settings.ignore_buftypes` instead.")
-    ];
+    lib.mapAttrsToList (old: message: mkRemovedOptionModule [ "plugins" "specs" old ] message)
+      {
+        color = "Please, use `settings.popup.winhl` directly.";
+        fader = "Please, use `settings.popup.fader` directly.";
+        resizer = "Please, use `settings.popup.resizer` directly.";
+        ignored_filetypes = "Please, use `settings.ignore_filetypes` instead.";
+        ignored_buffertypes = "Please, use `settings.ignore_buftypes` instead.";
+      };
 
   settingsOptions = {
     show_jumps = helpers.defaultNullOpts.mkBool true ''

--- a/plugins/by-name/startify/default.nix
+++ b/plugins/by-name/startify/default.nix
@@ -39,58 +39,39 @@ mkVimPlugin {
     "customFooter"
     "relativePath"
     "useEnv"
+    {
+      old = "updateOldFiles";
+      new = "update_oldfiles";
+    }
+    {
+      old = "skipList";
+      new = "skiplist";
+    }
+    {
+      old = "useUnicode";
+      new = "fortune_use_unicode";
+    }
+    {
+      old = "skipListServer";
+      new = "skiplist_server";
+    }
+    {
+      old = "sessionSaveVars";
+      new = "session_savevars";
+    }
+    {
+      old = "sessionCmds";
+      new = "session_savecmds";
+    }
+    {
+      old = "customQuotes";
+      new = "custom_header_quotes";
+    }
+    {
+      old = "disableAtVimEnter";
+      new = "disable_at_vimenter";
+    }
   ];
-  imports =
-    map
-      (
-        option:
-        mkRenamedOptionModule
-          [
-            "plugins"
-            "startify"
-            option.old
-          ]
-          [
-            "plugins"
-            "startify"
-            "settings"
-            option.new
-          ]
-      )
-      [
-        {
-          old = "updateOldFiles";
-          new = "update_oldfiles";
-        }
-        {
-          old = "skipList";
-          new = "skiplist";
-        }
-        {
-          old = "useUnicode";
-          new = "fortune_use_unicode";
-        }
-        {
-          old = "skipListServer";
-          new = "skiplist_server";
-        }
-        {
-          old = "sessionSaveVars";
-          new = "session_savevars";
-        }
-        {
-          old = "sessionCmds";
-          new = "session_savecmds";
-        }
-        {
-          old = "customQuotes";
-          new = "custom_header_quotes";
-        }
-        {
-          old = "disableAtVimEnter";
-          new = "disable_at_vimenter";
-        }
-      ];
 
   settingsOptions = import ./options.nix { inherit lib helpers; };
 

--- a/plugins/by-name/telescope/extensions/_mk-extension.nix
+++ b/plugins/by-name/telescope/extensions/_mk-extension.nix
@@ -26,14 +26,7 @@ let
           ];
           settingsPath = basePluginPath ++ [ "settings" ];
         in
-        builtins.map (
-          option:
-          let
-            optionPath = lib.toList option;
-            optionPathSnakeCase = map lib.nixvim.toSnakeCase optionPath;
-          in
-          lib.mkRenamedOptionModule (basePluginPath ++ optionPath) (settingsPath ++ optionPathSnakeCase)
-        ) optionsRenamedToSettings;
+        lib.nixvim.mkSettingsRenamedOptionModules basePluginPath settingsPath optionsRenamedToSettings;
     };
 
   module =

--- a/plugins/by-name/telescope/extensions/media-files.nix
+++ b/plugins/by-name/telescope/extensions/media-files.nix
@@ -21,30 +21,27 @@ mkExtension {
         "telescope"
         "extensions"
       ];
+      oldPath = telescopeExtensionsPath ++ [ "media_files" ];
+      newPath = telescopeExtensionsPath ++ [ "media-files" ];
     in
-    mapAttrsToList
-      (
-        oldOptionName: newOptionPath:
-        mkRenamedOptionModule (
-          telescopeExtensionsPath
-          ++ [
-            "media_files"
-            oldOptionName
-          ]
-        ) (telescopeExtensionsPath ++ [ "media-files" ] ++ newOptionPath)
-      )
+    lib.nixvim.mkSettingsRenamedOptionModules oldPath newPath [
+      "enable"
+      "package"
       {
-        enable = [ "enable" ];
-        package = [ "package" ];
-        filetypes = [
+        old = "filetypes";
+        new = [
           "settings"
           "filetypes"
         ];
-        find_cmd = [
+      }
+      {
+        old = "find_cmd";
+        new = [
           "settings"
           "find_cmd"
         ];
-      };
+      }
+    ];
 
   extraOptions = {
     dependencies =

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -193,6 +193,27 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       "initSelection"
       "scopeIncremental"
     ]
+    {
+      old = "customCaptures";
+      new = [
+        "highlight"
+        "custom_captures"
+      ];
+    }
+    {
+      old = "disabledLanguages";
+      new = [
+        "highlight"
+        "disable"
+      ];
+    }
+    {
+      old = "indent";
+      new = [
+        "indent"
+        "enable"
+      ];
+    }
   ];
 
   imports =
@@ -201,30 +222,10 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         "plugins"
         "treesitter"
       ];
-      settingsPath = basePluginPath ++ [ "settings" ];
     in
     [
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "moduleConfig" ]) settingsPath)
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "customCaptures" ]) (
-        settingsPath
-        ++ [
-          "highlight"
-          "custom_captures"
-        ]
-      ))
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "disabledLanguages" ]) (
-        settingsPath
-        ++ [
-          "highlight"
-          "disable"
-        ]
-      ))
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "indent" ]) (
-        settingsPath
-        ++ [
-          "indent"
-          "enable"
-        ]
+      (lib.mkRenamedOptionModule (basePluginPath ++ [ "moduleConfig" ]) (
+        basePluginPath ++ [ "settings" ]
       ))
     ];
 

--- a/plugins/by-name/undotree/default.nix
+++ b/plugins/by-name/undotree/default.nix
@@ -13,42 +13,72 @@ mkVimPlugin {
 
   # TODO introduced 2024-02-22: remove 2024-04-22
   deprecateExtraConfig = true;
-  imports =
-    let
-      basePluginPath = [
-        "plugins"
-        "undotree"
-      ];
-    in
-    mapAttrsToList
-      (
-        old: new:
-        mkRenamedOptionModule (basePluginPath ++ [ old ]) (
-          basePluginPath
-          ++ [
-            "settings"
-            new
-          ]
-        )
-      )
-      {
-        windowLayout = "WindowLayout";
-        shortIndicators = "ShortIndicators";
-        windowWidth = "WindowWidth";
-        diffHeight = "DiffHeight";
-        autoOpenDiff = "AutoOpenDiff";
-        focusOnToggle = "FocusOnToggle";
-        treeNodeShape = "TreeNodeShape";
-        diffCommand = "DiffCommand";
-        relativeTimestamp = "RelativeTimestamp";
-        highlightChangedText = "HighlightChangedText";
-        highlightChangesWithSign = "HighlightChangesWithSign";
-        highlightSyntaxAdd = "HighlightSyntaxAdd";
-        highlightSyntaxChange = "HighlightSyntaxChange";
-        highlightSyntaxDel = "HighlightSyntaxDel";
-        showHelpLine = "ShowHelpLine";
-        showCursorLine = "ShowCursorLine";
-      };
+  optionsRenamedToSettings = [
+    {
+      old = "windowLayout";
+      new = "WindowLayout";
+    }
+    {
+      old = "shortIndicators";
+      new = "ShortIndicators";
+    }
+    {
+      old = "windowWidth";
+      new = "WindowWidth";
+    }
+    {
+      old = "diffHeight";
+      new = "DiffHeight";
+    }
+    {
+      old = "autoOpenDiff";
+      new = "AutoOpenDiff";
+    }
+    {
+      old = "focusOnToggle";
+      new = "FocusOnToggle";
+    }
+    {
+      old = "treeNodeShape";
+      new = "TreeNodeShape";
+    }
+    {
+      old = "diffCommand";
+      new = "DiffCommand";
+    }
+    {
+      old = "relativeTimestamp";
+      new = "RelativeTimestamp";
+    }
+    {
+      old = "highlightChangedText";
+      new = "HighlightChangedText";
+    }
+    {
+      old = "highlightChangesWithSign";
+      new = "HighlightChangesWithSign";
+    }
+    {
+      old = "highlightSyntaxAdd";
+      new = "HighlightSyntaxAdd";
+    }
+    {
+      old = "highlightSyntaxChange";
+      new = "HighlightSyntaxChange";
+    }
+    {
+      old = "highlightSyntaxDel";
+      new = "HighlightSyntaxDel";
+    }
+    {
+      old = "showHelpLine";
+      new = "ShowHelpLine";
+    }
+    {
+      old = "showCursorLine";
+      new = "ShowCursorLine";
+    }
+  ];
 
   settingsExample = {
     WindowLayout = 4;

--- a/plugins/by-name/which-key/default.nix
+++ b/plugins/by-name/which-key/default.nix
@@ -77,142 +77,15 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   # TODO: introduced 2024-08-05: remove after 24.11
-  optionsRenamedToSettings = [
-    "hidden"
-    "icons"
-    "ignoreMissing"
-    "keyLabels"
-    "layout"
-    "motions"
-    "operators"
-    [
-      "plugins"
-      "mark"
-    ]
-    [
-      "plugins"
-      "registers"
-    ]
-    [
-      "plugins"
-      "spelling"
-    ]
-    [
-      "plugins"
-      "presets"
-      "textObjects"
-    ]
-    [
-      "plugins"
-      "presets"
-      "operators"
-    ]
-    [
-      "plugins"
-      "presets"
-      "motions"
-    ]
-    [
-      "plugins"
-      "presets"
-      "windows"
-    ]
-    [
-      "plugins"
-      "presets"
-      "nav"
-    ]
-    [
-      "plugins"
-      "presets"
-      "z"
-    ]
-    [
-      "plugins"
-      "presets"
-      "g"
-    ]
-    "popupMappings"
-    "showHelp"
-    "showKeys"
-    "triggersBlackList"
-    "triggersNoWait"
-  ];
-
+  optionsRenamedToSettings = import ./renamed-options.nix;
   imports =
     let
       basePluginPath = [
         "plugins"
         "which-key"
       ];
-      settingsPath = basePluginPath ++ [ "settings" ];
     in
     [
-      (lib.mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "disable"
-            "buftypes"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "disable"
-            "bt"
-          ]
-        )
-      )
-      (lib.mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "disable"
-            "filetypes"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "disable"
-            "ft"
-          ]
-        )
-      )
-      (lib.mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "window"
-            "winblend"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "win"
-            "wo"
-            "winblend"
-          ]
-        )
-      )
-      (lib.mkRenamedOptionModule
-        (
-          basePluginPath
-          ++ [
-            "window"
-            "border"
-          ]
-        )
-        (
-          settingsPath
-          ++ [
-            "win"
-            "border"
-          ]
-        )
-      )
       (lib.mkRemovedOptionModule (basePluginPath ++ [ "triggers" ]) ''
         Please use `plugins.which-key.settings.triggers` instead.
 

--- a/plugins/by-name/which-key/renamed-options.nix
+++ b/plugins/by-name/which-key/renamed-options.nix
@@ -1,0 +1,102 @@
+[
+  "hidden"
+  "icons"
+  "ignoreMissing"
+  "keyLabels"
+  "layout"
+  "motions"
+  "operators"
+  [
+    "plugins"
+    "mark"
+  ]
+  [
+    "plugins"
+    "registers"
+  ]
+  [
+    "plugins"
+    "spelling"
+  ]
+  [
+    "plugins"
+    "presets"
+    "textObjects"
+  ]
+  [
+    "plugins"
+    "presets"
+    "operators"
+  ]
+  [
+    "plugins"
+    "presets"
+    "motions"
+  ]
+  [
+    "plugins"
+    "presets"
+    "windows"
+  ]
+  [
+    "plugins"
+    "presets"
+    "nav"
+  ]
+  [
+    "plugins"
+    "presets"
+    "z"
+  ]
+  [
+    "plugins"
+    "presets"
+    "g"
+  ]
+  "popupMappings"
+  "showHelp"
+  "showKeys"
+  "triggersBlackList"
+  "triggersNoWait"
+  {
+    old = [
+      "disable"
+      "buftypes"
+    ];
+    new = [
+      "disable"
+      "bt"
+    ];
+  }
+  {
+    old = [
+      "disable"
+      "filetypes"
+    ];
+    new = [
+      "disable"
+      "ft"
+    ];
+  }
+  {
+    old = [
+      "window"
+      "winblend"
+    ];
+    new = [
+      "win"
+      "wo"
+      "winblend"
+    ];
+  }
+  {
+    old = [
+      "window"
+      "border"
+    ];
+    new = [
+      "win"
+      "border"
+    ];
+  }
+]

--- a/plugins/by-name/zig/default.nix
+++ b/plugins/by-name/zig/default.nix
@@ -15,20 +15,11 @@ mkVimPlugin {
 
   # TODO introduced 2024-03-02: remove 2024-05-02
   deprecateExtraConfig = true;
-  imports = [
-    (mkRenamedOptionModule
-      [
-        "plugins"
-        "zig"
-        "formatOnSave"
-      ]
-      [
-        "plugins"
-        "zig"
-        "settings"
-        "fmt_autosave"
-      ]
-    )
+  optionsRenamedToSettings = [
+    {
+      old = "formatOnSave";
+      new = "fmt_autosave";
+    }
   ];
 
   settingsOptions = {

--- a/plugins/cmp/deprecations.nix
+++ b/plugins/cmp/deprecations.nix
@@ -13,302 +13,158 @@ let
   settingsPath = newPluginBasePath ++ [ "settings" ];
 
   renamedOptions = [
-    {
-      old = [
-        "performance"
-        "debounce"
-      ];
-    }
-    {
-      old = [
-        "performance"
-        "throttle"
-      ];
-    }
-    {
-      old = [
-        "performance"
-        "fetchingTimeout"
-      ];
-      new = [
-        "performance"
-        "fetching_timeout"
-      ];
-    }
-    {
-      old = [
-        "performance"
-        "asyncBudget"
-      ];
-      new = [
-        "performance"
-        "async_budget"
-      ];
-    }
-    {
-      old = [
-        "performance"
-        "maxViewEntries"
-      ];
-      new = [
-        "performance"
-        "max_view_entries"
-      ];
-    }
-    { old = [ "mapping" ]; }
-    {
-      old = [
-        "completion"
-        "keywordLength"
-      ];
-      new = [
-        "completion"
-        "keyword_length"
-      ];
-    }
-    {
-      old = [
-        "completion"
-        "keywordPattern"
-      ];
-      new = [
-        "completion"
-        "keyword_pattern"
-      ];
-    }
-    {
-      old = [
-        "completion"
-        "autocomplete"
-      ];
-    }
-    {
-      old = [
-        "completion"
-        "completeopt"
-      ];
-    }
-    {
-      old = [
-        "confirmation"
-        "getCommitCharacters"
-      ];
-      new = [
-        "confirmation"
-        "get_commit_characters"
-      ];
-    }
-    {
-      old = [
-        "formatting"
-        "expandableIndicator"
-      ];
-      new = [
-        "formatting"
-        "expandable_indicator"
-      ];
-    }
-    {
-      old = [
-        "formatting"
-        "fields"
-      ];
-    }
-    {
-      old = [
-        "formatting"
-        "format"
-      ];
-    }
-    {
-      old = [
-        "matching"
-        "disallowFuzzyMatching"
-      ];
-      new = [
-        "matching"
-        "disallow_fuzzy_matching"
-      ];
-    }
-    {
-      old = [
-        "matching"
-        "disallowFullfuzzyMatching"
-      ];
-      new = [
-        "matching"
-        "disallow_fullfuzzy_matching"
-      ];
-    }
-    {
-      old = [
-        "matching"
-        "disallowPartialFuzzyMatching"
-      ];
-      new = [
-        "matching"
-        "disallow_partial_fuzzy_matching"
-      ];
-    }
-    {
-      old = [
-        "matching"
-        "disallowPartialMatching"
-      ];
-      new = [
-        "matching"
-        "disallow_partial_matching"
-      ];
-    }
-    {
-      old = [
-        "matching"
-        "disallowPrefixUnmatching"
-      ];
-      new = [
-        "matching"
-        "disallow_prefix_unmatching"
-      ];
-    }
-    {
-      old = [
-        "sorting"
-        "priorityWeight"
-      ];
-      new = [
-        "sorting"
-        "priority_weight"
-      ];
-    }
-    {
-      old = [
-        "view"
-        "entries"
-      ];
-    }
-    {
-      old = [
-        "view"
-        "docs"
-        "autoOpen"
-      ];
-      new = [
-        "view"
-        "docs"
-        "auto_open"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "completion"
-        "border"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "completion"
-        "winhighlight"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "completion"
-        "zindex"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "completion"
-        "scrolloff"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "completion"
-        "colOffset"
-      ];
-      new = [
-        "window"
-        "completion"
-        "col_offset"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "completion"
-        "sidePadding"
-      ];
-      new = [
-        "window"
-        "completion"
-        "side_padding"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "completion"
-        "scrollbar"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "documentation"
-        "border"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "documentation"
-        "winhighlight"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "documentation"
-        "zindex"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "documentation"
-        "maxWidth"
-      ];
-      new = [
-        "window"
-        "documentation"
-        "max_width"
-      ];
-    }
-    {
-      old = [
-        "window"
-        "documentation"
-        "maxHeight"
-      ];
-      new = [
-        "window"
-        "documentation"
-        "max_height"
-      ];
-    }
-    { old = [ "experimental" ]; }
+    [
+      "performance"
+      "debounce"
+    ]
+    [
+      "performance"
+      "throttle"
+    ]
+    [
+      "performance"
+      "fetchingTimeout"
+    ]
+    [
+      "performance"
+      "asyncBudget"
+    ]
+    [
+      "performance"
+      "maxViewEntries"
+    ]
+    "mapping"
+    [
+      "completion"
+      "keywordLength"
+    ]
+    [
+      "completion"
+      "keywordPattern"
+    ]
+    [
+      "completion"
+      "autocomplete"
+    ]
+    [
+      "completion"
+      "completeopt"
+    ]
+    [
+      "confirmation"
+      "getCommitCharacters"
+    ]
+    [
+      "formatting"
+      "expandableIndicator"
+    ]
+    [
+      "formatting"
+      "fields"
+    ]
+    [
+      "formatting"
+      "format"
+    ]
+    [
+      "matching"
+      "disallowFuzzyMatching"
+    ]
+    [
+      "matching"
+      "disallowFullfuzzyMatching"
+    ]
+    [
+      "matching"
+      "disallowPartialFuzzyMatching"
+    ]
+    [
+      "matching"
+      "disallowPartialMatching"
+    ]
+    [
+      "matching"
+      "disallowPrefixUnmatching"
+    ]
+    [
+      "sorting"
+      "priorityWeight"
+    ]
+    [
+      "view"
+      "entries"
+    ]
+    [
+      "view"
+      "docs"
+      "autoOpen"
+    ]
+    [
+      "window"
+      "completion"
+      "border"
+    ]
+    [
+      "window"
+      "completion"
+      "winhighlight"
+    ]
+    [
+      "window"
+      "completion"
+      "zindex"
+    ]
+    [
+      "window"
+      "completion"
+      "scrolloff"
+    ]
+    [
+      "window"
+      "completion"
+      "colOffset"
+    ]
+    [
+      "window"
+      "completion"
+      "sidePadding"
+    ]
+    [
+      "window"
+      "completion"
+      "scrollbar"
+    ]
+    [
+      "window"
+      "documentation"
+      "border"
+    ]
+    [
+      "window"
+      "documentation"
+      "winhighlight"
+    ]
+    [
+      "window"
+      "documentation"
+      "zindex"
+    ]
+    [
+      "window"
+      "documentation"
+      "maxWidth"
+    ]
+    [
+      "window"
+      "documentation"
+      "maxHeight"
+    ]
+    "experimental"
   ];
 
-  renameWarnings = map (
-    rename:
-    mkRenamedOptionModule (oldPluginBasePath ++ rename.old) (settingsPath ++ (rename.new or rename.old))
-  ) renamedOptions;
+  renameWarnings =
+    lib.nixvim.mkSettingsRenamedOptionModules oldPluginBasePath settingsPath
+      renamedOptions;
 in
 {
   imports = renameWarnings ++ [

--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -89,22 +89,27 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
     "colorOverrides"
     "customHighlights"
     "integrations"
+    {
+      old = "showBufferEnd";
+      new = "show_end_of_buffer";
+    }
+    {
+      old = "terminalColors";
+      new = "term_colors";
+    }
+    {
+      old = "disableItalic";
+      new = "no_italic";
+    }
+    {
+      old = "disableBold";
+      new = "no_bold";
+    }
+    {
+      old = "disableUnderline";
+      new = "no_underline";
+    }
   ];
-  imports =
-    lib.mapAttrsToList
-      (
-        old: new:
-        lib.mkRenamedOptionModule
-          [ "colorschemes" "catppuccin" old ]
-          [ "colorschemes" "catppuccin" "settings" new ]
-      )
-      {
-        showBufferEnd = "show_end_of_buffer";
-        terminalColors = "term_colors";
-        disableItalic = "no_italic";
-        disableBold = "no_bold";
-        disableUnderline = "no_underline";
-      };
 
   settingsOptions =
     let

--- a/plugins/colorschemes/kanagawa.nix
+++ b/plugins/colorschemes/kanagawa.nix
@@ -22,60 +22,53 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
   # TODO introduced 2024-03-15: remove 2024-05-15
   deprecateExtraOptions = true;
-  imports =
-    let
-      basePluginPath = [
+  optionsRenamedToSettings = [
+    "compile"
+    "undercurl"
+    "commentStyle"
+    "functionStyle"
+    "keywordStyle"
+    "statementStyle"
+    "typeStyle"
+    "transparent"
+    "dimInactive"
+    "terminalColors"
+    [
+      "colors"
+      "palette"
+    ]
+    [
+      "colors"
+      "theme"
+    ]
+    "theme"
+    [
+      "background"
+      "dark"
+    ]
+    [
+      "background"
+      "light"
+    ]
+
+  ];
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
         "colorschemes"
         "kanagawa"
-      ];
-    in
-    (map
-      (
-        optionPath:
-        lib.mkRenamedOptionModule (basePluginPath ++ optionPath) (
-          basePluginPath ++ [ "settings" ] ++ optionPath
-        )
-      )
-      [
-        [ "compile" ]
-        [ "undercurl" ]
-        [ "commentStyle" ]
-        [ "functionStyle" ]
-        [ "keywordStyle" ]
-        [ "statementStyle" ]
-        [ "typeStyle" ]
-        [ "transparent" ]
-        [ "dimInactive" ]
-        [ "terminalColors" ]
-        [
-          "colors"
-          "palette"
-        ]
-        [
-          "colors"
-          "theme"
-        ]
-        [ "theme" ]
-        [
-          "background"
-          "dark"
-        ]
-        [
-          "background"
-          "light"
-        ]
+        "overrides"
       ]
-    )
-    ++ [
-      (lib.mkRemovedOptionModule (basePluginPath ++ [ "overrides" ]) ''
+      ''
         Use `colorschemes.kanagawa.settings.overrides` but you now have to add the full function definition:
         ```
           function(colors)
             ...
           end
         ```
-      '')
-    ];
+      ''
+    )
+  ];
 
   settingsOptions = {
     compile = defaultNullOpts.mkBool false ''

--- a/plugins/colorschemes/rose-pine.nix
+++ b/plugins/colorschemes/rose-pine.nix
@@ -15,6 +15,21 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
   optionsRenamedToSettings = [
     "groups"
     "highlightGroups"
+    {
+      old = "style";
+      new = "dark_variant";
+    }
+    {
+      old = "dimInactive";
+      new = "dim_inactive_windows";
+    }
+    {
+      old = "transparentBackground";
+      new = [
+        "enable"
+        "transparency"
+      ];
+    }
   ];
   imports =
     let
@@ -24,20 +39,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       ];
     in
     [
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "style" ]) (
-        basePluginPath
-        ++ [
-          "settings"
-          "dark_variant"
-        ]
-      ))
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "dimInactive" ]) (
-        basePluginPath
-        ++ [
-          "settings"
-          "dim_inactive_windows"
-        ]
-      ))
       (lib.mkRemovedOptionModule (
         basePluginPath ++ [ "disableItalics" ]
       ) "Use `colorschemes.rose-pine.settings.enable.italics` instead.")
@@ -47,14 +48,6 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       (lib.mkRemovedOptionModule (
         basePluginPath ++ [ "transparentFloat" ]
       ) "Use `colorschemes.rose-pine.settings.highlight_groups.NormalFloat` instead.")
-      (lib.mkRenamedOptionModule (basePluginPath ++ [ "transparentBackground" ]) (
-        basePluginPath
-        ++ [
-          "settings"
-          "enable"
-          "transparency"
-        ]
-      ))
     ];
 
   settingsOptions = {


### PR DESCRIPTION
The `optionRenamedToSettings` attribute allows to automatically create `mkRenamedOptionModule`s for simple renames (options that move from plugin top-level to `settings`).
This helper is implemented using the `lib.nixvim.mkSettingsRenamedOptionModules` function.

This PR improves this function by making it accept `attrs` elements in the form
```nix
{
  old = ["one" "fooBar"];
  new = "one_foo_bar";
}
```
This makes it much more flexible and allows us to get rid of several calls to the native `lib.mkRenamedOptionModule` in the plugin modules.

- **lib/mkSettingsRenamedOptionModules: allow attrs value with 'old' and 'new' keys**
  -> Makes the change to `mkSettingsRenamedOptionModules`
- **plugins/*: use new mkSettingsRenamedOptionModules**
  -> Takes advantage of this implementation tree-wide
