### PR TITLE
plugins/palette: fix minor typo;

### DIFF
--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -123,7 +123,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         (
           name: defaultPaletteNames:
           let
-            customPalettesNames = lib.attrNames cfg.settings.custom_palettes.${name};
+            customPalettesNames = lib.attrNames cfg.settings.customPalettes.${name};
             allowedPaletteNames = customPalettesNames ++ defaultPaletteNames;
 
             palette = cfg.settings.palettes.${name};

--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -123,7 +123,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
         (
           name: defaultPaletteNames:
           let
-            customPalettesNames = lib.attrNames cfg.settings.customPalettes.${name};
+            customPalettesNames = lib.attrNames cfg.settings.custom_palettes.${name};
             allowedPaletteNames = customPalettesNames ++ defaultPaletteNames;
 
             palette = cfg.settings.palettes.${name};

--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -47,7 +47,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
       '';
     };
 
-    customPalettes =
+    custom_palettes =
       lib.mapAttrs
         (
           name: colorNames:

--- a/tests/test-sources/plugins/colorschemes/palette.nix
+++ b/tests/test-sources/plugins/colorschemes/palette.nix
@@ -13,7 +13,7 @@
           accent = "pastel";
           state = "pastel";
         };
-        custom_palettes = {
+        customPalettes = {
           main = { };
           accent = { };
           state = { };
@@ -35,7 +35,7 @@
           main = "dust_dusk";
         };
 
-        custom_palettes = {
+        customPalettes = {
           main = {
             dust_dusk = {
               color0 = "#121527";

--- a/tests/test-sources/plugins/colorschemes/palette.nix
+++ b/tests/test-sources/plugins/colorschemes/palette.nix
@@ -13,7 +13,7 @@
           accent = "pastel";
           state = "pastel";
         };
-        customPalettes = {
+        custom_palettes = {
           main = { };
           accent = { };
           state = { };
@@ -35,7 +35,7 @@
           main = "dust_dusk";
         };
 
-        customPalettes = {
+        custom_palettes = {
           main = {
             dust_dusk = {
               color0 = "#121527";


### PR DESCRIPTION
the option is declared as settings.customPalettes, but is accessed as settings.custom_palettes;
corrected the tests as well;