### PR TITLE
plugins/obsidian: add missing word in description

### DIFF
--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -210,7 +210,7 @@ lib.nixvim.neovim-plugin.mkNeovimPlugin {
 
                   path = mkOption {
                     type = with lib.types; maybeRaw str;
-                    description = "The of the workspace.";
+                    description = "The path of the workspace.";
                   };
 
                   overrides = opts;


### PR DESCRIPTION
add missing word in description of option
`plugins.obsidian.settings.workspaces.*.path`

DIdn't run fmt or checks since it's just a small addition.