### PR TITLE
lib/{neovim,vim}-plugin: use loc throughout & cleanup parens

### DIFF
--- a/lib/neovim-plugin.nix
+++ b/lib/neovim-plugin.nix
@@ -147,7 +147,7 @@
                     ];
                   }
 
-                  (lib.optionalAttrs (isColorscheme && (colorscheme != null)) {
+                  (lib.optionalAttrs (isColorscheme && colorscheme != null) {
                     colorscheme = lib.mkDefault colorscheme;
                   })
 
@@ -159,7 +159,7 @@
                   ))
                 ]
                 # Lua configuration code generation
-                ++ (lib.optionals hasLuaConfig [
+                ++ lib.optionals hasLuaConfig [
 
                   # Add the plugin setup code `require('foo').setup(...)` to the lua configuration
                   (lib.optionalAttrs callSetup (lib.setAttrByPath loc { luaConfig.content = setupCode; }))
@@ -197,7 +197,7 @@
                       ];
                     };
                   })
-                ])
+                ]
               )
             );
         };
@@ -209,9 +209,9 @@
         in
         imports
         ++ [ module ]
-        ++ (lib.optional deprecateExtraOptions (
+        ++ lib.optional deprecateExtraOptions (
           lib.mkRenamedOptionModule (loc ++ [ "extraOptions" ]) settingsPath
-        ))
-        ++ (lib.nixvim.mkSettingsRenamedOptionModules loc settingsPath optionsRenamedToSettings);
+        )
+        ++ lib.nixvim.mkSettingsRenamedOptionModules loc settingsPath optionsRenamedToSettings;
     };
 }

--- a/lib/vim-plugin.nix
+++ b/lib/vim-plugin.nix
@@ -61,7 +61,7 @@ rec {
         name
       ];
 
-      createSettingsOption = (lib.isString globalPrefix) && (globalPrefix != "");
+      createSettingsOption = lib.isString globalPrefix && globalPrefix != "";
 
       settingsOption = lib.optionalAttrs createSettingsOption {
         settings = mkSettingsOption {
@@ -133,7 +133,7 @@ rec {
                 ];
                 globals = lib.nixvim.applyPrefixToAttrs globalPrefix (cfg.settings or { });
               }
-              (lib.optionalAttrs (isColorscheme && (colorscheme != null)) {
+              (lib.optionalAttrs (isColorscheme && colorscheme != null) {
                 colorscheme = lib.mkDefault colorscheme;
               })
               (lib.optionalAttrs (args ? extraConfig) (
@@ -152,9 +152,9 @@ rec {
         in
         imports
         ++ [ module ]
-        ++ (lib.optional (deprecateExtraConfig && createSettingsOption) (
+        ++ lib.optional (deprecateExtraConfig && createSettingsOption) (
           lib.mkRenamedOptionModule (loc ++ [ "extraConfig" ]) settingsPath
-        ))
-        ++ (lib.nixvim.mkSettingsRenamedOptionModules loc settingsPath optionsRenamedToSettings);
+        )
+        ++ lib.nixvim.mkSettingsRenamedOptionModules loc settingsPath optionsRenamedToSettings;
     };
 }


### PR DESCRIPTION
- **lib/{neovim,vim}-plugin: use `loc` throughout**
- **lib/{neovim,vim}-plugin: remove redundant parens**

Purely cosmetic, assuming tests pass 😅
