### PR TITLE
modules/keymap: include buffer when registering `keymapsOnEvents`

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -97,11 +97,13 @@
       inherit event;
       group = "nixvim_binds_${event}";
       callback = helpers.mkRaw ''
-        function()
+        function(args)
           do
             local __nixvim_binds = ${lib.nixvim.toLuaObject (map helpers.keymaps.removeDeprecatedMapAttrs mappings)}
+
             for i, map in ipairs(__nixvim_binds) do
-              vim.keymap.set(map.mode, map.key, map.action, map.options)
+              local options = vim.tbl_extend("error", map.options or {}, { buffer = args.buf })
+              vim.keymap.set(map.mode, map.key, map.action, options)
             end
           end
         end


### PR DESCRIPTION
This feels more correct to me: I believe we were registering a keymap for all buffers, even if only some of them have experienced the relevant autocmd.

I don't know if it's guaranteed here that `args.buf` always exists (but maybe it's not a problem if it doesn't exist, because we'll still register a keymap for all buffers?).

This fixes https://github.com/nix-community/nixvim/issues/2711