### PR TITLE
Revert "plugins/cmp/sources: use mkNeovimPlugin instead of mkVimPlugin for source plugins"

### DIFF
--- a/plugins/cmp/sources/_mk-cmp-plugin.nix
+++ b/plugins/cmp/sources/_mk-cmp-plugin.nix
@@ -14,12 +14,8 @@
   imports ? [ ],
   ...
 }@args:
-lib.nixvim.neovim-plugin.mkNeovimPlugin (
-  {
-    hasSettings = false;
-    callSetup = false;
-  }
-  // builtins.removeAttrs args [
+lib.nixvim.vim-plugin.mkVimPlugin (
+  builtins.removeAttrs args [
     "pluginName"
     "sourceName"
   ]


### PR DESCRIPTION
This reverts commit 6a9d840370647abb0c980ff1bb8e47edd1255789.

It is not really needed anymore.
