### PR TITLE
modules/keymap: quickfix, use "keep" rather than "error"

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -102,7 +102,7 @@
             local __nixvim_binds = ${lib.nixvim.toLuaObject (map helpers.keymaps.removeDeprecatedMapAttrs mappings)}
 
             for i, map in ipairs(__nixvim_binds) do
-              local options = vim.tbl_extend("error", map.options or {}, { buffer = args.buf })
+              local options = vim.tbl_extend("keep", map.options or {}, { buffer = args.buf })
               vim.keymap.set(map.mode, map.key, map.action, options)
             end
           end


### PR DESCRIPTION
There are some codepaths out there in the wild that seem to be explicitly setting a buffer at build time. I'm not convinced that's a sane thing to do, but I don't have time to dig any further right now.

See the discussion starting here:
https://github.com/nix-community/nixvim/pull/2712#issuecomment-2556330101 for more context.