### PR TITLE
lib: mk overridable & extendable; also move flake output

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,4 +1,5 @@
 {
+  helpers,
   system,
   nixpkgs,
   nuschtosSearch,
@@ -7,7 +8,6 @@ let
   # We overlay a few tweaks into pkgs, for use in the docs
   pkgs = import ./pkgs.nix { inherit system nixpkgs; };
   inherit (pkgs) lib;
-  helpers = import ../lib { inherit lib; };
 
   nixvimPath = toString ./..;
 

--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -21,13 +21,13 @@
     }
     // lib.genAttrs config.systems (
       lib.flip withSystem (
-        { pkgs, ... }:
+        { pkgs, system, ... }:
         {
           # NOTE: this is the publicly documented flake output we've had for a while
           check = pkgs.callPackage ../lib/tests.nix { inherit self; };
 
           # NOTE: no longer needs to be per-system
-          helpers = self.lib.nixvim;
+          helpers = lib.warn "nixvim: `<nixvim>.lib.${system}.helpers` has been moved to `<nixvim>.lib.nixvim` and no longer depends on a specific system" self.lib.nixvim;
         }
       )
     );

--- a/flake-modules/packages.nix
+++ b/flake-modules/packages.nix
@@ -1,4 +1,8 @@
-{ inputs, ... }:
+{
+  inputs,
+  helpers,
+  ...
+}:
 {
   perSystem =
     {
@@ -9,6 +13,7 @@
     }:
     {
       packages = import ../docs {
+        inherit helpers;
         inherit system;
         inherit (inputs) nixpkgs;
         inherit (inputs') nuschtosSearch;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,7 +3,7 @@
   flake ? null, # Optionally, provide the lib with access to the flake
   _nixvimTests ? false,
 }:
-lib.fix (
+lib.makeExtensible (
   self:
   let
     # Used when importing parts of our lib

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -46,9 +46,7 @@ let
     }@args:
     let
       # NOTE: we are importing this just for evalNixvim
-      helpers = import ../lib {
-        inherit lib;
-        flake = self;
+      helpers = self.lib.nixvim.override {
         # TODO: deprecate helpers.enableExceptInTests,
         # add a context option e.g. `config.isTest`?
         _nixvimTests = true;

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -59,13 +59,7 @@ in
   config = mkMerge [
     {
       # Make our lib available to the host modules
-      # NOTE: user-facing so we must include the legacy `pkgs` argument
-      lib.nixvim = lib.mkDefault (
-        import ../lib {
-          inherit lib;
-          flake = self;
-        }
-      );
+      lib.nixvim = lib.mkDefault self.lib.nixvim;
 
       # Make nixvim's "extended" lib available to the host's module args
       _module.args.nixvimLib = lib.mkDefault config.lib.nixvim.extendedLib;

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -9,11 +9,7 @@ default_pkgs: self:
 }:
 let
   # NOTE: we are importing this just for evalNixvim
-  helpers = import ../lib {
-    inherit lib _nixvimTests;
-    flake = self;
-  };
-
+  helpers = self.lib.nixvim.override { inherit _nixvimTests; };
   inherit (helpers.modules) evalNixvim;
 
   mkNvim =


### PR DESCRIPTION

- make overrideable (`override` function is added by `makeOverridable`)
- make nixvim-lib extendable (`extend` function is added by `makeExtensible`)
- treewide: access nixvim-lib via flake instead of directly importing it

Add a non-system specific `<flake>.lib.nixvim` output, which is equivalent to the existing `<flake>.lib.<system>.helpers` output.
A warning is traced when the per-system output is used.

This is now also wrapped with `lib.makeOverridable` to allow overriding the function args used to construct the nixvim-lib. Additionally, `lib.fix` was replaced with `lib.makeExtensible`, allowing nixvim's sub-lib to be directly extended via overlays.

Throughout the codebase, nixvim-lib now comes from the flake outpets, rather than being imported manually. Where `_nixvimTests` needs to be passed, we use `.override`.

---

Note, any overlays will be reset if you subsequently use `override`. E.g.
```nix
{ lib }:
rec {
  extended = lib.nixvim.extend (final: prev: {
    # Overlay
    hello-world = "hi there";
  });

  overridden = extended.override {/* args */};

  extendedHasHello = extended ? hello-world; # true

  overriddenHasHello = overridden ? hello-world; # false
}
```

---

In follow up work I'd also like to offer a `<flake>.lib.overlay` which should replace the current `lib.nixvim.extendedLib` hack. This will allow wrapper modules and end-users to apply nixvim's lib extensions to any compatible nixpkgs lib, rather than always using the `lib` that provided by flake-parts.

Perhaps this could also be done automatically by `evalNixvim` when users supply their own `specialArgs.lib`?
