### PR TITLE
treewide: migrate & deprecate `neovim-plugin` & `vim-plugin` aliases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ To add a new plugin you need to do the following.
 2. The vast majority of plugins fall into one of those two categories:
 
 - _vim plugins_: They are configured through **global variables** (`g:plugin_foo_option` in vimscript and `vim.g.plugin_foo_option` in lua).\
-  For those, you should use the `lib.nixvim.vim-plugin.mkVimPlugin`.\
+  For those, you should use the `lib.nixvim.plugins.mkVimPlugin`.\
   -> See [this plugin](plugins/utils/direnv.nix) for an example.
 - _neovim plugins_: They are configured through a `setup` function (`require('plugin').setup({opts})`).\
   For those, you should use the `lib.nixvim.plugins.mkNeovimPlugin`.\

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ To add a new plugin you need to do the following.
   For those, you should use the `lib.nixvim.vim-plugin.mkVimPlugin`.\
   -> See [this plugin](plugins/utils/direnv.nix) for an example.
 - _neovim plugins_: They are configured through a `setup` function (`require('plugin').setup({opts})`).\
-  For those, you should use the `lib.nixvim.neovim-plugin.mkNeovimPlugin`.\
+  For those, you should use the `lib.nixvim.plugins.mkNeovimPlugin`.\
   -> See the [template](plugins/TEMPLATE.nix).
 
 3. Add the necessary arguments when calling either [`mkNeovimPlugin`](#mkneovimplugin) or [`mkVimPlugin`](#mkvimplugin)

--- a/flake-modules/dev/new-plugin.py
+++ b/flake-modules/dev/new-plugin.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 # Template for default.nix
 # TODO: conditionally include parts of the template based on args
 default_nix_template = """{{ lib, ... }}:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {{
+lib.nixvim.plugins.mkNeovimPlugin {{
   name = "{name}";
   packPathName = "{originalName}";
   package = "{package}";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -24,21 +24,6 @@ lib.makeExtensible (
     plugins = call ./plugins { };
     utils = call ./utils.nix { inherit _nixvimTests; };
 
-    # plugin aliases
-    neovim-plugin = {
-      inherit (self.plugins.neovim)
-        extraOptionsOptions
-        mkNeovimPlugin
-        ;
-    };
-    vim-plugin = {
-      inherit (self.plugins.vim)
-        mkSettingsOption
-        mkSettingsOptionDescription
-        mkVimPlugin
-        ;
-    };
-
     # Top-level helper aliases:
     # TODO: deprecate some aliases
 
@@ -119,5 +104,27 @@ lib.makeExtensible (
       {
         maintainers = "lib.maintainers";
         nixvimTypes = "lib.types";
+      }
+  //
+    # TODO: neovim-plugin & vim-plugin aliases deprecated 2024-12-22; internal functions
+    lib.mapAttrs'
+      (scope: names: {
+        name = "${scope}-plugin";
+        value = lib.genAttrs names (
+          name:
+          lib.warn "`${scope}-plugin.${name}` has been moved to `plugins.${scope}.${name}`."
+            self.plugins.${scope}.${name}
+        );
+      })
+      {
+        neovim = [
+          "extraOptionsOptions"
+          "mkNeovimPlugin"
+        ];
+        vim = [
+          "mkSettingsOption"
+          "mkSettingsOptionDescription"
+          "mkVimPlugin"
+        ];
       }
 )

--- a/plugins/TEMPLATE.nix
+++ b/plugins/TEMPLATE.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "my-plugin";
   moduleName = "my-plugin"; # TODO replace (or remove entirely if it is the same as `name`)
   packPathName = "my-plugin.nvim"; # TODO replace (or remove entirely if it is the same as `name`)

--- a/plugins/by-name/aerial/default.nix
+++ b/plugins/by-name/aerial/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "aerial";
   packPathName = "aerial.nvim";
   package = "aerial-nvim";

--- a/plugins/by-name/airline/default.nix
+++ b/plugins/by-name/airline/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "airline";
   packPathName = "vim-airline";
   package = "vim-airline";

--- a/plugins/by-name/arrow/default.nix
+++ b/plugins/by-name/arrow/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "arrow";
   packPathName = "arrow.nvim";
   package = "arrow-nvim";

--- a/plugins/by-name/auto-save/default.nix
+++ b/plugins/by-name/auto-save/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "auto-save";
   packPathName = "auto-save.nvim";
   package = "auto-save-nvim";

--- a/plugins/by-name/auto-session/default.nix
+++ b/plugins/by-name/auto-session/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "auto-session";
   package = "auto-session";
 

--- a/plugins/by-name/autosource/default.nix
+++ b/plugins/by-name/autosource/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "autosource";
   packPathName = "vim-autosource";
   package = "vim-autosource";

--- a/plugins/by-name/avante/default.nix
+++ b/plugins/by-name/avante/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption';
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "avante";
   packPathName = "avante.nvim";
   package = "avante-nvim";

--- a/plugins/by-name/bacon/default.nix
+++ b/plugins/by-name/bacon/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "bacon";
   package = "nvim-bacon";
   maintainers = [ lib.maintainers.alisonjenkins ];

--- a/plugins/by-name/baleia/default.nix
+++ b/plugins/by-name/baleia/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "baleia";
   packPathName = "baleia.nvim";
   package = "baleia-nvim";

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -51,7 +51,7 @@ let
     orderByWindowNumber = "OrderByWindowNumber";
   };
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "barbar";
   packPathName = "barbar.nvim";
   package = "barbar-nvim";

--- a/plugins/by-name/barbecue/default.nix
+++ b/plugins/by-name/barbecue/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "barbecue";
   packPathName = "barbecue.nvim";
   package = "barbecue-nvim";

--- a/plugins/by-name/better-escape/default.nix
+++ b/plugins/by-name/better-escape/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "better-escape";
   packPathName = "better-escape.nvim";
   moduleName = "better_escape";

--- a/plugins/by-name/blink-cmp/default.nix
+++ b/plugins/by-name/blink-cmp/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "blink-cmp";
   packPathName = "blink.cmp";
   package = "blink-cmp";

--- a/plugins/by-name/bufdelete/default.nix
+++ b/plugins/by-name/bufdelete/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "bufdelete";
   packPathName = "bufdelete.nvim";
   package = "bufdelete-nvim";

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -8,7 +8,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts mkSettingsRenamedOptionModules;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "bufferline";
   packPathName = "bufferline.nvim";
   package = "bufferline-nvim";

--- a/plugins/by-name/ccc/default.nix
+++ b/plugins/by-name/ccc/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "ccc";
   packPathName = "ccc.nvim";
   package = "ccc-nvim";

--- a/plugins/by-name/chadtree/default.nix
+++ b/plugins/by-name/chadtree/default.nix
@@ -12,7 +12,7 @@ let
   mkListStr = helpers.defaultNullOpts.mkNullable (types.listOf types.str);
 in
 {
-  options.plugins.chadtree = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.chadtree = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "chadtree";
 
     package = lib.mkPackageOption pkgs "chadtree" {

--- a/plugins/by-name/chatgpt/default.nix
+++ b/plugins/by-name/chatgpt/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "chatgpt";
   packPathName = "ChatGPT.nvim";
   package = "ChatGPT-nvim";

--- a/plugins/by-name/clangd-extensions/default.nix
+++ b/plugins/by-name/clangd-extensions/default.nix
@@ -95,7 +95,7 @@ in
       ]
     );
 
-  options.plugins.clangd-extensions = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.clangd-extensions = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "clangd_extensions, plugins implementing clangd LSP extensions";
 
     package = lib.mkPackageOption pkgs "clangd_extensions.nvim" {

--- a/plugins/by-name/clipboard-image/default.nix
+++ b/plugins/by-name/clipboard-image/default.nix
@@ -85,7 +85,7 @@ in
 {
   meta.maintainers = [ maintainers.GaetanLepage ];
 
-  options.plugins.clipboard-image = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.clipboard-image = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "clipboard-image.nvim";
 
     package = lib.mkPackageOption pkgs "clipboard-image.nvim" {

--- a/plugins/by-name/cloak/default.nix
+++ b/plugins/by-name/cloak/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cloak";
   packPathName = "cloak.nvim";
   package = "cloak-nvim";

--- a/plugins/by-name/cmake-tools/default.nix
+++ b/plugins/by-name/cmake-tools/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmake-tools";
   packPathName = "cmake-tools.nvim";
   package = "cmake-tools-nvim";

--- a/plugins/by-name/cmp-ai/default.nix
+++ b/plugins/by-name/cmp-ai/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-ai";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/by-name/cmp-git/default.nix
+++ b/plugins/by-name/cmp-git/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-git";
   moduleName = "cmp_git";
 

--- a/plugins/by-name/cmp-tabby/default.nix
+++ b/plugins/by-name/cmp-tabby/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-tabby";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/by-name/cmp-tabnine/default.nix
+++ b/plugins/by-name/cmp-tabnine/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-tabnine";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/by-name/codecompanion/default.nix
+++ b/plugins/by-name/codecompanion/default.nix
@@ -7,7 +7,7 @@ let
     ;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "codecompanion";
   packPathName = "codecompanion.nvim";
   package = "codecompanion-nvim";

--- a/plugins/by-name/codeium-nvim/default.nix
+++ b/plugins/by-name/codeium-nvim/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "codeium-nvim";
   packPathName = "codeium.nvim";
   moduleName = "codeium";

--- a/plugins/by-name/codeium-vim/default.nix
+++ b/plugins/by-name/codeium-vim/default.nix
@@ -34,7 +34,7 @@ let
     };
   };
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "codeium-vim";
   packPathName = "codeium.vim";
   globalPrefix = "codeium_";

--- a/plugins/by-name/codesnap/default.nix
+++ b/plugins/by-name/codesnap/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "codesnap";
   packPathName = "codesnap.nvim";
   package = "codesnap-nvim";

--- a/plugins/by-name/colorizer/default.nix
+++ b/plugins/by-name/colorizer/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "colorizer";
   packPathName = "nvim-colorizer.lua";
   package = "nvim-colorizer-lua";

--- a/plugins/by-name/comment-box/default.nix
+++ b/plugins/by-name/comment-box/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "comment-box";
   packPathName = "comment-box.nvim";
   package = "comment-box-nvim";

--- a/plugins/by-name/comment/default.nix
+++ b/plugins/by-name/comment/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "comment";
   packPathName = "Comment.nvim";
   moduleName = "Comment";

--- a/plugins/by-name/commentary/default.nix
+++ b/plugins/by-name/commentary/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "commentary";
   packPathName = "vim-commentary";
   package = "vim-commentary";

--- a/plugins/by-name/committia/default.nix
+++ b/plugins/by-name/committia/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "committia";
   packPathName = "committia.vim";
   package = "committia-vim";

--- a/plugins/by-name/competitest/default.nix
+++ b/plugins/by-name/competitest/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "competitest";
   packPathName = "competitest.nvim";
   package = "competitest-nvim";

--- a/plugins/by-name/compiler/default.nix
+++ b/plugins/by-name/compiler/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "compiler";
   packPathName = "compiler.nvim";
   package = "compiler-nvim";

--- a/plugins/by-name/conform-nvim/default.nix
+++ b/plugins/by-name/conform-nvim/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "conform-nvim";
   moduleName = "conform";
   packPathName = "conform.nvim";

--- a/plugins/by-name/conjure/default.nix
+++ b/plugins/by-name/conjure/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "conjure";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/by-name/copilot-chat/default.nix
+++ b/plugins/by-name/copilot-chat/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "copilot-chat";
   packPathName = "CopilotChat.nvim";
   moduleName = "CopilotChat";

--- a/plugins/by-name/copilot-cmp/default.nix
+++ b/plugins/by-name/copilot-cmp/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "copilot-cmp";
   moduleName = "copilot_cmp";
 

--- a/plugins/by-name/copilot-lua/default.nix
+++ b/plugins/by-name/copilot-lua/default.nix
@@ -15,7 +15,7 @@ in
       let
         keymapOption = helpers.defaultNullOpts.mkNullable (with types; either (enum [ false ]) str);
       in
-      lib.nixvim.neovim-plugin.extraOptionsOptions
+      lib.nixvim.plugins.neovim.extraOptionsOptions
       // {
         enable = mkEnableOption "copilot.lua";
 

--- a/plugins/by-name/copilot-vim/default.nix
+++ b/plugins/by-name/copilot-vim/default.nix
@@ -5,8 +5,8 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
-lib.nixvim.vim-plugin.mkVimPlugin {
+with lib.nixvim.plugins;
+lib.nixvim.plugins.mkVimPlugin {
   name = "copilot-vim";
   packPathName = "copilot.vim";
   globalPrefix = "copilot_";

--- a/plugins/by-name/coq-nvim/default.nix
+++ b/plugins/by-name/coq-nvim/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "coq-nvim";
   packPathName = "coq_nvim";
   package = "coq_nvim";

--- a/plugins/by-name/coverage/default.nix
+++ b/plugins/by-name/coverage/default.nix
@@ -60,7 +60,7 @@ let
   };
 in
 {
-  options.plugins.coverage = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.coverage = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-coverage";
 
     package = lib.mkPackageOption pkgs "nvim-coverage" {

--- a/plugins/by-name/crates/default.nix
+++ b/plugins/by-name/crates/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "crates";
   packPathName = "crates.nvim";
   package = "crates-nvim";

--- a/plugins/by-name/cursorline/default.nix
+++ b/plugins/by-name/cursorline/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.cursorline;
 in
 {
-  options.plugins.cursorline = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.cursorline = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-cursorline";
 
     package = lib.mkPackageOption pkgs "nvim-cursorline" {

--- a/plugins/by-name/dap-lldb/default.nix
+++ b/plugins/by-name/dap-lldb/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "dap-lldb";
   packPathName = "nvim-dap-lldb";
   package = "nvim-dap-lldb";

--- a/plugins/by-name/dap/dap-ui.nix
+++ b/plugins/by-name/dap/dap-ui.nix
@@ -56,7 +56,7 @@ let
   };
 in
 {
-  options.plugins.dap.extensions.dap-ui = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.dap.extensions.dap-ui = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "dap-ui";
 
     package = lib.mkPackageOption pkgs "dap-ui" {

--- a/plugins/by-name/dap/default.nix
+++ b/plugins/by-name/dap/default.nix
@@ -19,7 +19,7 @@ with dapHelpers;
     ./dap-virtual-text.nix
   ];
 
-  options.plugins.dap = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.dap = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "dap";
 
     package = lib.mkPackageOption pkgs "dap" {

--- a/plugins/by-name/dashboard/default.nix
+++ b/plugins/by-name/dashboard/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "dashboard";
   packPathName = "dashboard-nvim";
   package = "dashboard-nvim";

--- a/plugins/by-name/debugprint/default.nix
+++ b/plugins/by-name/debugprint/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "debugprint";
   packPathName = "debugprint.nvim";
   package = "debugprint-nvim";

--- a/plugins/by-name/diffview/default.nix
+++ b/plugins/by-name/diffview/default.nix
@@ -83,7 +83,7 @@ in
 {
   options.plugins.diffview =
     with helpers.defaultNullOpts;
-    lib.nixvim.neovim-plugin.extraOptionsOptions
+    lib.nixvim.plugins.neovim.extraOptionsOptions
     // {
       enable = mkEnableOption "diffview";
 

--- a/plugins/by-name/direnv/default.nix
+++ b/plugins/by-name/direnv/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "direnv";
   packPathName = "direnv.vim";
   package = "direnv-vim";

--- a/plugins/by-name/dotnet/default.nix
+++ b/plugins/by-name/dotnet/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "dotnet";
   packPathName = "dotnet.nvim";
   package = "dotnet-nvim";

--- a/plugins/by-name/dressing/default.nix
+++ b/plugins/by-name/dressing/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "dressing";
   packPathName = "dressing.nvim";
   package = "dressing-nvim";

--- a/plugins/by-name/earthly/default.nix
+++ b/plugins/by-name/earthly/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "earthly";
   packPathName = "earthly.vim";
   package = "earthly-vim";

--- a/plugins/by-name/easyescape/default.nix
+++ b/plugins/by-name/easyescape/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "easyescape";
   packPathName = "vim-easyescape";
   package = "vim-easyescape";

--- a/plugins/by-name/edgy/default.nix
+++ b/plugins/by-name/edgy/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "edgy";
   packPathName = "edgy.nvim";
   package = "edgy-nvim";

--- a/plugins/by-name/emmet/default.nix
+++ b/plugins/by-name/emmet/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "emmet";
   packPathName = "emmet-vim";

--- a/plugins/by-name/endwise/default.nix
+++ b/plugins/by-name/endwise/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "endwise";
   packPathName = "vim-endwise";
   package = "vim-endwise";

--- a/plugins/by-name/fastaction/default.nix
+++ b/plugins/by-name/fastaction/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrStr';
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "fastaction";
   packPathName = "fastaction.nvim";
   package = "fastaction-nvim";

--- a/plugins/by-name/fidget/default.nix
+++ b/plugins/by-name/fidget/default.nix
@@ -142,7 +142,7 @@ in
       ];
 
   options = {
-    plugins.fidget = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+    plugins.fidget = lib.nixvim.plugins.neovim.extraOptionsOptions // {
       enable = mkEnableOption "fidget-nvim";
 
       package = lib.mkPackageOption pkgs "fidget-nvim" {

--- a/plugins/by-name/firenvim/default.nix
+++ b/plugins/by-name/firenvim/default.nix
@@ -8,7 +8,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "firenvim";
 
   maintainers = with lib.maintainers; [ GaetanLepage ];

--- a/plugins/by-name/flash/default.nix
+++ b/plugins/by-name/flash/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "flash";
   packPathName = "flash.nvim";
   package = "flash-nvim";

--- a/plugins/by-name/floaterm/default.nix
+++ b/plugins/by-name/floaterm/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrStr;
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "floaterm";
   packPathName = "vim-floaterm";
   package = "vim-floaterm";

--- a/plugins/by-name/friendly-snippets/default.nix
+++ b/plugins/by-name/friendly-snippets/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "friendly-snippets";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/by-name/fugitive/default.nix
+++ b/plugins/by-name/fugitive/default.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "fugitive";
   packPathName = "vim-fugitive";
   package = "vim-fugitive";

--- a/plugins/by-name/fzf-lua/default.nix
+++ b/plugins/by-name/fzf-lua/default.nix
@@ -31,7 +31,7 @@ let
     };
   };
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "fzf-lua";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/by-name/git-conflict/default.nix
+++ b/plugins/by-name/git-conflict/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "git-conflict";
   packPathName = "git-conflict.nvim";
   package = "git-conflict-nvim";

--- a/plugins/by-name/gitblame/default.nix
+++ b/plugins/by-name/gitblame/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "gitblame";
   packPathName = "git-blame.nvim";
   package = "git-blame-nvim";

--- a/plugins/by-name/gitgutter/default.nix
+++ b/plugins/by-name/gitgutter/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "gitgutter";
   packPathName = "vim-gitgutter";
   package = "vim-gitgutter";

--- a/plugins/by-name/gitignore/default.nix
+++ b/plugins/by-name/gitignore/default.nix
@@ -6,7 +6,7 @@
 with lib;
 # We use `mkVimPlugin` to avoid having a `settings` option.
 # Indeed, this plugin is not configurable in the common sense (no `setup` function).
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "gitignore";
   packPathName = "gitignore.nvim";
   package = "gitignore-nvim";

--- a/plugins/by-name/gitlab/default.nix
+++ b/plugins/by-name/gitlab/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "gitlab";
   packPathName = "gitlab.vim";
   package = "gitlab-vim";

--- a/plugins/by-name/gitlinker/default.nix
+++ b/plugins/by-name/gitlinker/default.nix
@@ -7,7 +7,7 @@
 }:
 with lib;
 {
-  options.plugins.gitlinker = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.gitlinker = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "gitlinker.nvim";
 
     package = lib.mkPackageOption pkgs "gitlinker.nvim" {

--- a/plugins/by-name/gitmessenger/default.nix
+++ b/plugins/by-name/gitmessenger/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "gitmessenger";
   packPathName = "git-messenger.vim";
   package = "git-messenger-vim";

--- a/plugins/by-name/gitsigns/default.nix
+++ b/plugins/by-name/gitsigns/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "gitsigns";
   packPathName = "gitsigns.nvim";
   package = "gitsigns-nvim";

--- a/plugins/by-name/glow/default.nix
+++ b/plugins/by-name/glow/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "glow";
   packPathName = "glow.nvim";
   package = "glow-nvim";

--- a/plugins/by-name/godot/default.nix
+++ b/plugins/by-name/godot/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "godot";
   packPathName = "vim-godot";
   package = "vim-godot";

--- a/plugins/by-name/goyo/default.nix
+++ b/plugins/by-name/goyo/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 with lib;
 mkVimPlugin {
   name = "goyo";

--- a/plugins/by-name/grug-far/default.nix
+++ b/plugins/by-name/grug-far/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "grug-far";
   packPathName = "grug-far.nvim";
   package = "grug-far-nvim";

--- a/plugins/by-name/guess-indent/default.nix
+++ b/plugins/by-name/guess-indent/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "guess-indent";
   packPathName = "guess-indent.nvim";
   package = "guess-indent-nvim";

--- a/plugins/by-name/hardtime/default.nix
+++ b/plugins/by-name/hardtime/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "hardtime";
   packPathName = "hardtime.nvim";
   package = "hardtime-nvim";

--- a/plugins/by-name/harpoon/default.nix
+++ b/plugins/by-name/harpoon/default.nix
@@ -22,7 +22,7 @@ let
   };
 in
 {
-  options.plugins.harpoon = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.harpoon = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "harpoon";
 
     package = lib.mkPackageOption pkgs "harpoon" {

--- a/plugins/by-name/haskell-scope-highlighting/default.nix
+++ b/plugins/by-name/haskell-scope-highlighting/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "haskell-scope-highlighting";
   packPathName = "haskell-scope-highlighting.nvim";
   package = "haskell-scope-highlighting-nvim";

--- a/plugins/by-name/headlines/default.nix
+++ b/plugins/by-name/headlines/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "headlines";
   packPathName = "headlines.nvim";
   package = "headlines-nvim";

--- a/plugins/by-name/helm/default.nix
+++ b/plugins/by-name/helm/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "helm";
   packPathName = "vim-helm";
   package = "vim-helm";

--- a/plugins/by-name/helpview/default.nix
+++ b/plugins/by-name/helpview/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "helpview";
   packPathName = "helpview.nvim";
   package = "helpview-nvim";

--- a/plugins/by-name/hex/default.nix
+++ b/plugins/by-name/hex/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrLuaFn;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "hex";
   packPathName = "hex.nvim";
   package = "hex-nvim";

--- a/plugins/by-name/hmts/default.nix
+++ b/plugins/by-name/hmts/default.nix
@@ -3,7 +3,7 @@
   config,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "hmts";
   packPathName = "hmts.nvim";
   package = "hmts-nvim";

--- a/plugins/by-name/hop/default.nix
+++ b/plugins/by-name/hop/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "hop";
   packPathName = "hop.nvim";
   package = "hop-nvim";

--- a/plugins/by-name/hydra/default.nix
+++ b/plugins/by-name/hydra/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "hydra";
   packPathName = "hydra.nvim";
   package = "hydra-nvim";

--- a/plugins/by-name/idris2/default.nix
+++ b/plugins/by-name/idris2/default.nix
@@ -3,7 +3,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "idris2";
   packPathName = "idris2";
   package = "idris2-nvim";

--- a/plugins/by-name/illuminate/default.nix
+++ b/plugins/by-name/illuminate/default.nix
@@ -83,7 +83,7 @@ in
   options.plugins.illuminate =
     with helpers;
     with defaultNullOpts;
-    lib.nixvim.neovim-plugin.extraOptionsOptions
+    lib.nixvim.plugins.neovim.extraOptionsOptions
     // {
       enable = mkEnableOption "vim-illuminate";
 

--- a/plugins/by-name/image/default.nix
+++ b/plugins/by-name/image/default.nix
@@ -12,7 +12,7 @@ in
 {
   meta.maintainers = [ maintainers.GaetanLepage ];
 
-  options.plugins.image = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.image = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "image.nvim";
 
     package = lib.mkPackageOption pkgs "image.nvim" {

--- a/plugins/by-name/improved-search/default.nix
+++ b/plugins/by-name/improved-search/default.nix
@@ -6,7 +6,7 @@
 with lib;
 # This plugin is only configured through keymaps, so we use `mkVimPlugin` without the
 # `globalPrefix` argument to avoid the creation of the `settings` option.
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "improved-search";
   packPathName = "improved-search.nvim";
   package = "improved-search-nvim";

--- a/plugins/by-name/indent-blankline/default.nix
+++ b/plugins/by-name/indent-blankline/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "indent-blankline";
   packPathName = "indent-blankline.nvim";
   moduleName = "ibl";

--- a/plugins/by-name/indent-o-matic/default.nix
+++ b/plugins/by-name/indent-o-matic/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "indent-o-matic";
   maintainers = [ lib.maintainers.alisonjenkins ];
   settingsOptions = {

--- a/plugins/by-name/instant/default.nix
+++ b/plugins/by-name/instant/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "instant";
   packPathName = "instant.nvim";

--- a/plugins/by-name/intellitab/default.nix
+++ b/plugins/by-name/intellitab/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "intellitab";
   packPathName = "intellitab.nvim";
   package = "intellitab-nvim";

--- a/plugins/by-name/julia-cell/default.nix
+++ b/plugins/by-name/julia-cell/default.nix
@@ -35,7 +35,7 @@ let
   };
 in
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "julia-cell";
   packPathName = "vim-julia-cell";
   package = "vim-julia-cell";

--- a/plugins/by-name/jupytext/default.nix
+++ b/plugins/by-name/jupytext/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "jupytext";
   packPathName = "jupytext.nvim";
   package = "jupytext-nvim";

--- a/plugins/by-name/kulala/default.nix
+++ b/plugins/by-name/kulala/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "kulala";
   packPathName = "kulala.nvim";
   package = "kulala-nvim";

--- a/plugins/by-name/lastplace/default.nix
+++ b/plugins/by-name/lastplace/default.nix
@@ -10,7 +10,7 @@ let
 in
 with lib;
 {
-  options.plugins.lastplace = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.lastplace = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "lastplace";
 
     package = lib.mkPackageOption pkgs "lastplace" {

--- a/plugins/by-name/lazygit/default.nix
+++ b/plugins/by-name/lazygit/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "lazygit";
   packPathName = "lazygit.nvim";
   package = "lazygit-nvim";

--- a/plugins/by-name/lean/default.nix
+++ b/plugins/by-name/lean/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.lean;
 in
 {
-  options.plugins.lean = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.lean = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "lean-nvim";
 
     package = lib.mkPackageOption pkgs "lean-nvim" {

--- a/plugins/by-name/leap/default.nix
+++ b/plugins/by-name/leap/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.leap;
 in
 {
-  options.plugins.leap = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.leap = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "leap.nvim";
 
     package = lib.mkPackageOption pkgs "leap.nvim" {

--- a/plugins/by-name/ledger/default.nix
+++ b/plugins/by-name/ledger/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "ledger";
   packPathName = "vim-ledger";

--- a/plugins/by-name/lightline/default.nix
+++ b/plugins/by-name/lightline/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "lightline";
   packPathName = "lightline.vim";
   package = "lightline-vim";

--- a/plugins/by-name/lint/default.nix
+++ b/plugins/by-name/lint/default.nix
@@ -133,7 +133,7 @@ let
     };
 in
 {
-  options.plugins.lint = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.lint = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-lint";
 
     package = lib.mkPackageOption pkgs "nvim-lint" {

--- a/plugins/by-name/lsp-format/default.nix
+++ b/plugins/by-name/lsp-format/default.nix
@@ -3,7 +3,7 @@
   config,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "lsp-format";
   packPathName = "lsp-format.nvim";
   package = "lsp-format-nvim";

--- a/plugins/by-name/lsp-lines/default.nix
+++ b/plugins/by-name/lsp-lines/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "lsp-lines";
   moduleName = "lsp_lines";
   packPathName = "lsp_lines.nvim";

--- a/plugins/by-name/lsp-signature/default.nix
+++ b/plugins/by-name/lsp-signature/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "lsp-signature";
   packPathName = "lsp_signature.nvim";
   package = "lsp_signature-nvim";

--- a/plugins/by-name/lsp-status/default.nix
+++ b/plugins/by-name/lsp-status/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "lsp-status";
   packPathName = "lsp-status.nvim";
   package = "lsp-status-nvim";

--- a/plugins/by-name/lspkind/default.nix
+++ b/plugins/by-name/lspkind/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.lspkind;
 in
 {
-  options.plugins.lspkind = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.lspkind = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "lspkind.nvim";
 
     package = lib.mkPackageOption pkgs "lspkind" {

--- a/plugins/by-name/lspsaga/default.nix
+++ b/plugins/by-name/lspsaga/default.nix
@@ -47,7 +47,7 @@ in
       ];
 
   options = {
-    plugins.lspsaga = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+    plugins.lspsaga = lib.nixvim.plugins.neovim.extraOptionsOptions // {
       enable = mkEnableOption "lspsaga.nvim";
 
       package = lib.mkPackageOption pkgs "lspsaga" {

--- a/plugins/by-name/ltex-extra/default.nix
+++ b/plugins/by-name/ltex-extra/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "ltex-extra";
   packPathName = "ltex_extra.nvim";
   package = "ltex_extra-nvim";

--- a/plugins/by-name/lualine/default.nix
+++ b/plugins/by-name/lualine/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkSettingsRenamedOptionModules;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "lualine";
   packPathName = "lualine.nvim";
   package = "lualine-nvim";

--- a/plugins/by-name/luasnip/default.nix
+++ b/plugins/by-name/luasnip/default.nix
@@ -43,7 +43,7 @@ let
     };
   };
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "luasnip";
   package = "luasnip";
   setup = ".config.setup";

--- a/plugins/by-name/magma-nvim/default.nix
+++ b/plugins/by-name/magma-nvim/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "magma-nvim";
   packPathName = "magma-nvim";

--- a/plugins/by-name/mark-radar/default.nix
+++ b/plugins/by-name/mark-radar/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.mark-radar;
 in
 {
-  options.plugins.mark-radar = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.mark-radar = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "mark-radar";
 
     package = lib.mkPackageOption pkgs "mark-radar" {

--- a/plugins/by-name/markdown-preview/default.nix
+++ b/plugins/by-name/markdown-preview/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "markdown-preview";
   packPathName = "markdown-preview.nvim";

--- a/plugins/by-name/marks/default.nix
+++ b/plugins/by-name/marks/default.nix
@@ -12,7 +12,7 @@ in
 {
   meta.maintainers = [ maintainers.GaetanLepage ];
 
-  options.plugins.marks = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.marks = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "marks.nvim";
 
     package = lib.mkPackageOption pkgs "marks.nvim" {

--- a/plugins/by-name/markview/default.nix
+++ b/plugins/by-name/markview/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "markview";
   packPathName = "markview.nvim";
   package = "markview-nvim";

--- a/plugins/by-name/mini/default.nix
+++ b/plugins/by-name/mini/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "mini";
   packPathName = "mini.nvim";
   # Just want it before most other plugins for the icons provider.

--- a/plugins/by-name/mkdnflow/default.nix
+++ b/plugins/by-name/mkdnflow/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.mkdnflow;
 in
 {
-  options.plugins.mkdnflow = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.mkdnflow = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "mkdnflow.nvim";
 
     package = lib.mkPackageOption pkgs "mkdnflow.nvim" {

--- a/plugins/by-name/molten/default.nix
+++ b/plugins/by-name/molten/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "molten";
   packPathName = "molten-nvim";

--- a/plugins/by-name/multicursors/default.nix
+++ b/plugins/by-name/multicursors/default.nix
@@ -45,7 +45,7 @@ let
 in
 {
   options = {
-    plugins.multicursors = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+    plugins.multicursors = lib.nixvim.plugins.neovim.extraOptionsOptions // {
       enable = mkEnableOption "multicursors.nvim";
 
       package = lib.mkPackageOption pkgs "multicursors.nvim" {

--- a/plugins/by-name/muren/default.nix
+++ b/plugins/by-name/muren/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "muren";
   packPathName = "muren.nvim";
   package = "muren-nvim";

--- a/plugins/by-name/nabla/default.nix
+++ b/plugins/by-name/nabla/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "nabla";
   packPathName = "nabla.nvim";
   package = "nabla-nvim";

--- a/plugins/by-name/navbuddy/default.nix
+++ b/plugins/by-name/navbuddy/default.nix
@@ -13,7 +13,7 @@ let
   mkPercentageOpt = default: helpers.defaultNullOpts.mkNullable percentageType (toString default);
 in
 {
-  options.plugins.navbuddy = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.navbuddy = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-navbuddy";
 
     package = lib.mkPackageOption pkgs "nvim-navbuddy" {

--- a/plugins/by-name/navic/default.nix
+++ b/plugins/by-name/navic/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "navic";
   packPathName = "nvim-navic";
   moduleName = "nvim-navic";

--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -52,7 +52,7 @@ in
         '';
       };
     in
-    lib.nixvim.neovim-plugin.extraOptionsOptions
+    lib.nixvim.plugins.neovim.extraOptionsOptions
     // {
       enable = mkEnableOption "neo-tree";
 

--- a/plugins/by-name/neoclip/default.nix
+++ b/plugins/by-name/neoclip/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "neoclip";
   packPathName = "nvim-neoclip.lua";
   package = "nvim-neoclip-lua";

--- a/plugins/by-name/neoconf/default.nix
+++ b/plugins/by-name/neoconf/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "neoconf";
   packPathName = "neoconf.nvim";
   package = "neoconf-nvim";

--- a/plugins/by-name/neocord/default.nix
+++ b/plugins/by-name/neocord/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "neocord";
 
   maintainers = [ ];

--- a/plugins/by-name/neogen/default.nix
+++ b/plugins/by-name/neogen/default.nix
@@ -44,7 +44,7 @@ let
   };
 in
 {
-  options.plugins.neogen = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.neogen = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "neogen";
 
     package = lib.mkPackageOption pkgs "neogen" {

--- a/plugins/by-name/neogit/default.nix
+++ b/plugins/by-name/neogit/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "neogit";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/by-name/neorg/default.nix
+++ b/plugins/by-name/neorg/default.nix
@@ -13,7 +13,7 @@ let
     ;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "neorg";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/by-name/neoscroll/default.nix
+++ b/plugins/by-name/neoscroll/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "neoscroll";
   packPathName = "neoscroll.nvim";
   package = "neoscroll-nvim";

--- a/plugins/by-name/neotest/default.nix
+++ b/plugins/by-name/neotest/default.nix
@@ -3,7 +3,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "neotest";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/by-name/netman/default.nix
+++ b/plugins/by-name/netman/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "netman";
   packPathName = "netman.nvim";
   package = "netman-nvim";

--- a/plugins/by-name/nix-develop/default.nix
+++ b/plugins/by-name/nix-develop/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts toLuaObject;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nix-develop";
   packPathName = "nix-develop.nvim";
   package = "nix-develop-nvim";

--- a/plugins/by-name/nix/default.nix
+++ b/plugins/by-name/nix/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "nix";
   packPathName = "vim-nix";
   package = "vim-nix";

--- a/plugins/by-name/noice/default.nix
+++ b/plugins/by-name/noice/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "noice";
   packPathName = "noice.nvim";
   package = "noice-nvim";

--- a/plugins/by-name/none-ls/default.nix
+++ b/plugins/by-name/none-ls/default.nix
@@ -4,7 +4,7 @@
   options,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "none-ls";
   packPathName = "none-ls.nvim";
   moduleName = "null-ls";

--- a/plugins/by-name/notebook-navigator/default.nix
+++ b/plugins/by-name/notebook-navigator/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "notebook-navigator";
   packPathName = "NotebookNavigator-nvim";
   package = "NotebookNavigator-nvim";

--- a/plugins/by-name/notify/default.nix
+++ b/plugins/by-name/notify/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.notify;
 in
 {
-  options.plugins.notify = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.notify = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-notify";
 
     package = lib.mkPackageOption pkgs "nvim-notify" {

--- a/plugins/by-name/nui/default.nix
+++ b/plugins/by-name/nui/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nui";
   packPathName = "nui.nvim";
   package = "nui-nvim";

--- a/plugins/by-name/numbertoggle/default.nix
+++ b/plugins/by-name/numbertoggle/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "numbertoggle";
   packPathName = "vim-numbertoggle";
   package = "vim-numbertoggle";

--- a/plugins/by-name/nvim-autopairs/default.nix
+++ b/plugins/by-name/nvim-autopairs/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-autopairs";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/by-name/nvim-bqf/default.nix
+++ b/plugins/by-name/nvim-bqf/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.nvim-bqf;
 in
 {
-  options.plugins.nvim-bqf = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.nvim-bqf = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-bqf";
 
     package = lib.mkPackageOption pkgs "nvim-bqf" {

--- a/plugins/by-name/nvim-jdtls/default.nix
+++ b/plugins/by-name/nvim-jdtls/default.nix
@@ -10,7 +10,7 @@ let
   cfg = config.plugins.nvim-jdtls;
 in
 {
-  options.plugins.nvim-jdtls = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.nvim-jdtls = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-jdtls";
 
     package = lib.mkPackageOption pkgs "nvim-jdtls" {

--- a/plugins/by-name/nvim-lightbulb/default.nix
+++ b/plugins/by-name/nvim-lightbulb/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-lightbulb";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/by-name/nvim-snippets/default.nix
+++ b/plugins/by-name/nvim-snippets/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-snippets";
   moduleName = "snippets";
 

--- a/plugins/by-name/nvim-surround/default.nix
+++ b/plugins/by-name/nvim-surround/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-surround";
   packPathName = "nvim-surround";
   package = "nvim-surround";

--- a/plugins/by-name/nvim-tree/default.nix
+++ b/plugins/by-name/nvim-tree/default.nix
@@ -36,7 +36,7 @@ in
       "hideRootFolder"
     ] "Set `plugins.nvim-tree.renderer.rootFolderLabel` to `false` to hide the root folder.")
   ];
-  options.plugins.nvim-tree = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.nvim-tree = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-tree";
 
     package = lib.mkPackageOption pkgs "nvim-tree" {

--- a/plugins/by-name/nvim-ufo/default.nix
+++ b/plugins/by-name/nvim-ufo/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-ufo";
   moduleName = "ufo";
   package = "nvim-ufo";

--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "obsidian";
   packPathName = "obsidian.nvim";
   package = "obsidian-nvim";

--- a/plugins/by-name/octo/default.nix
+++ b/plugins/by-name/octo/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "octo";
   packPathName = "octo.nvim";
   package = "octo-nvim";

--- a/plugins/by-name/oil/default.nix
+++ b/plugins/by-name/oil/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "oil";
   packPathName = "oil.nvim";
   package = "oil-nvim";

--- a/plugins/by-name/ollama/default.nix
+++ b/plugins/by-name/ollama/default.nix
@@ -60,7 +60,7 @@ in
 {
   meta.maintainers = [ maintainers.GaetanLepage ];
 
-  options.plugins.ollama = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.ollama = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "ollama.nvim";
 
     package = lib.mkPackageOption pkgs "ollama.nvim" {

--- a/plugins/by-name/openscad/default.nix
+++ b/plugins/by-name/openscad/default.nix
@@ -12,7 +12,7 @@ let
   name = "openscad";
   globalPrefix = "openscad_";
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   inherit name;
   packPathName = "openscad.nvim";
   package = "openscad-nvim";

--- a/plugins/by-name/openscad/default.nix
+++ b/plugins/by-name/openscad/default.nix
@@ -7,7 +7,7 @@
 let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts applyPrefixToAttrs;
-  inherit (lib.nixvim.vim-plugin) mkSettingsOptionDescription;
+  inherit (lib.nixvim.plugins.vim) mkSettingsOptionDescription;
 
   name = "openscad";
   globalPrefix = "openscad_";

--- a/plugins/by-name/orgmode/default.nix
+++ b/plugins/by-name/orgmode/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "orgmode";
   packPathName = "nvim-orgmode";
 

--- a/plugins/by-name/otter/default.nix
+++ b/plugins/by-name/otter/default.nix
@@ -4,7 +4,7 @@
   config,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "otter";
   packPathName = "otter.nvim";
   package = "otter-nvim";

--- a/plugins/by-name/overseer/default.nix
+++ b/plugins/by-name/overseer/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "overseer";
   packPathName = "overseer.nvim";
   package = "overseer-nvim";

--- a/plugins/by-name/package-info/default.nix
+++ b/plugins/by-name/package-info/default.nix
@@ -7,7 +7,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "package-info";
   packPathName = "package-info.nvim";
   package = "package-info-nvim";

--- a/plugins/by-name/parinfer-rust/default.nix
+++ b/plugins/by-name/parinfer-rust/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "parinfer-rust";
   globalPrefix = "parinfer_";
 

--- a/plugins/by-name/persisted/default.nix
+++ b/plugins/by-name/persisted/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "persisted";
   packPathName = "persisted.nvim";
   package = "persisted-nvim";

--- a/plugins/by-name/persistence/default.nix
+++ b/plugins/by-name/persistence/default.nix
@@ -7,7 +7,7 @@
 }:
 with lib;
 {
-  options.plugins.persistence = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.persistence = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "persistence.nvim";
 
     package = lib.mkPackageOption pkgs "persistence.nvim" {

--- a/plugins/by-name/plantuml-syntax/default.nix
+++ b/plugins/by-name/plantuml-syntax/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "plantuml-syntax";
   globalPrefix = "plantuml_";
 

--- a/plugins/by-name/precognition/default.nix
+++ b/plugins/by-name/precognition/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "precognition";
   packPathName = "precognition.nvim";
   package = "precognition-nvim";

--- a/plugins/by-name/presence-nvim/default.nix
+++ b/plugins/by-name/presence-nvim/default.nix
@@ -11,7 +11,7 @@ let
 in
 {
   options = {
-    plugins.presence-nvim = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+    plugins.presence-nvim = lib.nixvim.plugins.neovim.extraOptionsOptions // {
       enable = mkEnableOption "presence-nvim";
       package = lib.mkPackageOption pkgs "presence-nvim" {
         default = [

--- a/plugins/by-name/preview/default.nix
+++ b/plugins/by-name/preview/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "preview";
   packPathName = "Preview.nvim";
   package = "Preview-nvim";

--- a/plugins/by-name/project-nvim/default.nix
+++ b/plugins/by-name/project-nvim/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "project-nvim";
   packPathName = "project.nvim";
   moduleName = "project_nvim";

--- a/plugins/by-name/qmk/default.nix
+++ b/plugins/by-name/qmk/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "qmk";
   packPathName = "qmk.nvim";
   package = "qmk-nvim";

--- a/plugins/by-name/quarto/default.nix
+++ b/plugins/by-name/quarto/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "quarto";
   packPathName = "quarto-nvim";
   package = "quarto-nvim";

--- a/plugins/by-name/quickmath/default.nix
+++ b/plugins/by-name/quickmath/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "quickmath";
   packPathName = "quickmath.nvim";
   package = "quickmath-nvim";

--- a/plugins/by-name/rainbow-delimiters/default.nix
+++ b/plugins/by-name/rainbow-delimiters/default.nix
@@ -7,7 +7,7 @@
 }:
 with lib;
 {
-  options.plugins.rainbow-delimiters = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.rainbow-delimiters = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "rainbow-delimiters.nvim";
 
     package = lib.mkPackageOption pkgs "rainbow-delimiters.nvim" {

--- a/plugins/by-name/refactoring/default.nix
+++ b/plugins/by-name/refactoring/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "refactoring";
   packPathName = "refactoring.nvim";
   package = "refactoring-nvim";

--- a/plugins/by-name/remote-nvim/default.nix
+++ b/plugins/by-name/remote-nvim/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "remote-nvim";
   packPathName = "remote-nvim.nvim";
   package = "remote-nvim-nvim";

--- a/plugins/by-name/render-markdown/default.nix
+++ b/plugins/by-name/render-markdown/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "render-markdown";
   packPathName = "render-markdown.nvim";
   package = "render-markdown-nvim";

--- a/plugins/by-name/repeat/default.nix
+++ b/plugins/by-name/repeat/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "repeat";
   packPathName = "vim-repeat";
   package = "vim-repeat";

--- a/plugins/by-name/rest/default.nix
+++ b/plugins/by-name/rest/default.nix
@@ -8,7 +8,7 @@ let
   inherit (lib) mkRemovedOptionModule types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "rest";
   packPathName = "rest.nvim";
   moduleName = "rest-nvim";

--- a/plugins/by-name/rust-tools/default.nix
+++ b/plugins/by-name/rust-tools/default.nix
@@ -8,7 +8,7 @@ let
   cfg = config.plugins.rust-tools;
 in
 {
-  options.plugins.rust-tools = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.rust-tools = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = lib.mkEnableOption "rust tools plugins";
     package = lib.mkPackageOption pkgs "rust-tools" {
       default = [

--- a/plugins/by-name/rustaceanvim/default.nix
+++ b/plugins/by-name/rustaceanvim/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "rustaceanvim";
 
   maintainers = [ maintainers.GaetanLepage ];

--- a/plugins/by-name/sandwich/default.nix
+++ b/plugins/by-name/sandwich/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "sandwich";
   packPathName = "vim-sandwich";
   package = "vim-sandwich";

--- a/plugins/by-name/schemastore/default.nix
+++ b/plugins/by-name/schemastore/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "schemastore";
   packPathName = "SchemaStore.nvim";
   package = "SchemaStore-nvim";

--- a/plugins/by-name/scope/default.nix
+++ b/plugins/by-name/scope/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "scope";
   packPathName = "scope.nvim";
   package = "scope-nvim";

--- a/plugins/by-name/scrollview/default.nix
+++ b/plugins/by-name/scrollview/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrStr mkNullOrOption;
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "scrollview";
   packPathName = "nvim-scrollview";
   package = "nvim-scrollview";

--- a/plugins/by-name/sleuth/default.nix
+++ b/plugins/by-name/sleuth/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "sleuth";
   packPathName = "vim-sleuth";
   package = "vim-sleuth";

--- a/plugins/by-name/smart-splits/default.nix
+++ b/plugins/by-name/smart-splits/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "smart-splits";
   packPathName = "smart-splits.nvim";
   package = "smart-splits-nvim";

--- a/plugins/by-name/smartcolumn/default.nix
+++ b/plugins/by-name/smartcolumn/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "smartcolumn";
   packPathName = "smartcolumn.nvim";
   package = "smartcolumn-nvim";

--- a/plugins/by-name/snacks/default.nix
+++ b/plugins/by-name/snacks/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "snacks";
   packPathName = "snacks.nvim";
   package = "snacks-nvim";

--- a/plugins/by-name/sniprun/default.nix
+++ b/plugins/by-name/sniprun/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "sniprun";
   url = "https://github.com/michaelb/sniprun";
 

--- a/plugins/by-name/specs/default.nix
+++ b/plugins/by-name/specs/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "specs";
   packPathName = "specs.nvim";
   package = "specs-nvim";

--- a/plugins/by-name/spectre/default.nix
+++ b/plugins/by-name/spectre/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "spectre";
   packPathName = "nvim-spectre";
   package = "nvim-spectre";

--- a/plugins/by-name/spider/default.nix
+++ b/plugins/by-name/spider/default.nix
@@ -11,7 +11,7 @@ let
   cfg = config.plugins.${pluginName};
 in
 {
-  options.plugins.${pluginName} = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.${pluginName} = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption pluginName;
 
     package = lib.mkPackageOption pkgs pluginName {

--- a/plugins/by-name/sqlite-lua/default.nix
+++ b/plugins/by-name/sqlite-lua/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "sqlite-lua";
   packPathName = "sqlite.lua";
   moduleName = "sqlite.lua";

--- a/plugins/by-name/startify/default.nix
+++ b/plugins/by-name/startify/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "startify";
   packPathName = "vim-startify";

--- a/plugins/by-name/startup/default.nix
+++ b/plugins/by-name/startup/default.nix
@@ -12,7 +12,7 @@ in
 {
   meta.maintainers = [ maintainers.GaetanLepage ];
 
-  options.plugins.startup = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.startup = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "startup.nvim";
 
     package = lib.mkPackageOption pkgs "startup.nvim" {

--- a/plugins/by-name/statuscol/default.nix
+++ b/plugins/by-name/statuscol/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "statuscol";
   packPathName = "statuscol.nvim";
   package = "statuscol-nvim";

--- a/plugins/by-name/tagbar/default.nix
+++ b/plugins/by-name/tagbar/default.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "tagbar";
   globalPrefix = "tagbar_";
 

--- a/plugins/by-name/telekasten/default.nix
+++ b/plugins/by-name/telekasten/default.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "telekasten";
   packPathName = "telekasten.nvim";
   package = "telekasten-nvim";

--- a/plugins/by-name/telescope/default.nix
+++ b/plugins/by-name/telescope/default.nix
@@ -14,7 +14,7 @@ let
     ;
 in
 # TODO:add support for additional filetypes. This requires autocommands!
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "telescope";
   packPathName = "telescope.nvim";
   package = "telescope-nvim";

--- a/plugins/by-name/texpresso/default.nix
+++ b/plugins/by-name/texpresso/default.nix
@@ -7,7 +7,7 @@
 with lib;
 # This plugin has no configuration, so we use `mkVimPlugin` without the `globalPrefix` argument to
 # avoid the creation of the `settings` option.
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "texpresso";
   packPathName = "texpresso.vim";
   package = "texpresso-vim";

--- a/plugins/by-name/tiny-devicons-auto-colors/default.nix
+++ b/plugins/by-name/tiny-devicons-auto-colors/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "tiny-devicons-auto-colors";
   packPathName = "tiny-devicons-auto-colors.nvim";
   package = "tiny-devicons-auto-colors-nvim";

--- a/plugins/by-name/tmux-navigator/default.nix
+++ b/plugins/by-name/tmux-navigator/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "tmux-navigator";
   packPathName = "vim-tmux-navigator";
   package = "vim-tmux-navigator";

--- a/plugins/by-name/todo-comments/default.nix
+++ b/plugins/by-name/todo-comments/default.nix
@@ -15,7 +15,7 @@ let
     ;
 
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "todo-comments";
   packPathName = "todo-comments.nvim";
   package = "todo-comments-nvim";

--- a/plugins/by-name/toggleterm/default.nix
+++ b/plugins/by-name/toggleterm/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "toggleterm";
   packPathName = "toggleterm.nvim";
   package = "toggleterm-nvim";

--- a/plugins/by-name/transparent/default.nix
+++ b/plugins/by-name/transparent/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "transparent";
   packPathName = "transparent.nvim";
   package = "transparent-nvim";

--- a/plugins/by-name/treesitter-context/default.nix
+++ b/plugins/by-name/treesitter-context/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "treesitter-context";
   packPathName = "nvim-treesitter-context";
   package = "nvim-treesitter-context";

--- a/plugins/by-name/treesitter-textobjects/default.nix
+++ b/plugins/by-name/treesitter-textobjects/default.nix
@@ -37,7 +37,7 @@ with lib;
           })
         ) { } desc;
     in
-    lib.nixvim.neovim-plugin.extraOptionsOptions
+    lib.nixvim.plugins.neovim.extraOptionsOptions
     // {
       enable = mkEnableOption "treesitter-textobjects (requires plugins.treesitter.enable to be true)";
 

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "treesitter";
   packPathName = "nvim-treesitter";
   moduleName = "nvim-treesitter.configs";

--- a/plugins/by-name/trim/default.nix
+++ b/plugins/by-name/trim/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "trim";
   packPathName = "trim.nvim";
   package = "trim-nvim";

--- a/plugins/by-name/trouble/default.nix
+++ b/plugins/by-name/trouble/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "trouble";
   packPathName = "trouble.nvim";
   package = "trouble-nvim";

--- a/plugins/by-name/ts-autotag/default.nix
+++ b/plugins/by-name/ts-autotag/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "ts-autotag";
   packPathName = "nvim-ts-autotag";
   moduleName = "nvim-ts-autotag";

--- a/plugins/by-name/ts-comments/default.nix
+++ b/plugins/by-name/ts-comments/default.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "ts-comments";
   packPathName = "ts-comments.nvim";
   package = "ts-comments-nvim";

--- a/plugins/by-name/ts-context-commentstring/default.nix
+++ b/plugins/by-name/ts-context-commentstring/default.nix
@@ -7,7 +7,7 @@
 }:
 with lib;
 {
-  options.plugins.ts-context-commentstring = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.ts-context-commentstring = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-ts-context-commentstring";
 
     package = lib.mkPackageOption pkgs "ts-context-commentstring" {

--- a/plugins/by-name/twilight/default.nix
+++ b/plugins/by-name/twilight/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "twilight";
   packPathName = "twilight.nvim";
   package = "twilight-nvim";

--- a/plugins/by-name/typescript-tools/default.nix
+++ b/plugins/by-name/typescript-tools/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "typescript-tools";
   packPathName = "typescript-tools.nvim";
   package = "typescript-tools-nvim";

--- a/plugins/by-name/typst-vim/default.nix
+++ b/plugins/by-name/typst-vim/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "typst-vim";
   packPathName = "typst.vim";
   globalPrefix = "typst_";

--- a/plugins/by-name/undotree/default.nix
+++ b/plugins/by-name/undotree/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "undotree";
   globalPrefix = "undotree_";

--- a/plugins/by-name/vim-bbye/default.nix
+++ b/plugins/by-name/vim-bbye/default.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) mkNullOrOption;
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-bbye";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/by-name/vim-be-good/default.nix
+++ b/plugins/by-name/vim-be-good/default.nix
@@ -1,5 +1,5 @@
 { lib, pkgs, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "vim-be-good";
   package = "vim-be-good";
 

--- a/plugins/by-name/vim-colemak/default.nix
+++ b/plugins/by-name/vim-colemak/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-colemak";
   maintainers = [ lib.maintainers.kalbasit ];
 }

--- a/plugins/by-name/vim-css-color/default.nix
+++ b/plugins/by-name/vim-css-color/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-css-color";
   maintainers = [ lib.maintainers.DanielLaing ];
 }

--- a/plugins/by-name/vim-dadbod-completion/default.nix
+++ b/plugins/by-name/vim-dadbod-completion/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-dadbod-completion";
   maintainers = [ lib.maintainers.BoneyPatel ];
   imports = [

--- a/plugins/by-name/vim-dadbod-ui/default.nix
+++ b/plugins/by-name/vim-dadbod-ui/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-dadbod-ui";
   maintainers = [ lib.maintainers.BoneyPatel ];
 }

--- a/plugins/by-name/vim-dadbod/default.nix
+++ b/plugins/by-name/vim-dadbod/default.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-dadbod";
   maintainers = [ lib.maintainers.BoneyPatel ];
 }

--- a/plugins/by-name/vim-matchup/default.nix
+++ b/plugins/by-name/vim-matchup/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrStr';
   inherit (lib) types;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-matchup";
   globalPrefix = "matchup_";
 

--- a/plugins/by-name/vim-slime/default.nix
+++ b/plugins/by-name/vim-slime/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "vim-slime";
   globalPrefix = "slime_";

--- a/plugins/by-name/vim-suda/default.nix
+++ b/plugins/by-name/vim-suda/default.nix
@@ -1,6 +1,6 @@
 { lib, helpers, ... }:
 
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-suda";
   globalPrefix = "suda#";
   maintainers = [ lib.maintainers.marcel ];

--- a/plugins/by-name/vim-surround/default.nix
+++ b/plugins/by-name/vim-surround/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vim-surround";
   packPathName = "surround.vim";
   package = "vim-surround";

--- a/plugins/by-name/vimtex/default.nix
+++ b/plugins/by-name/vimtex/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "vimtex";
   globalPrefix = "vimtex_";
 

--- a/plugins/by-name/virt-column/default.nix
+++ b/plugins/by-name/virt-column/default.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "virt-column";
   packPathName = "virt-column.nvim";
   package = "virt-column-nvim";

--- a/plugins/by-name/wakatime/default.nix
+++ b/plugins/by-name/wakatime/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "wakatime";
   packPathName = "vim-wakatime";
   package = "vim-wakatime";

--- a/plugins/by-name/web-devicons/default.nix
+++ b/plugins/by-name/web-devicons/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption toLuaObject;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "web-devicons";
   packPathName = "nvim-web-devicons";
   moduleName = "nvim-web-devicons";

--- a/plugins/by-name/which-key/default.nix
+++ b/plugins/by-name/which-key/default.nix
@@ -69,7 +69,7 @@ let
   ];
 
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "which-key";
   packPathName = "which-key.nvim";
   package = "which-key-nvim";

--- a/plugins/by-name/wilder/default.nix
+++ b/plugins/by-name/wilder/default.nix
@@ -63,7 +63,7 @@ in
     )
   ];
 
-  options.plugins.wilder = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+  options.plugins.wilder = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "wilder-nvim";
 
     package = lib.mkPackageOption pkgs "wilder-nvim" {

--- a/plugins/by-name/wrapping/default.nix
+++ b/plugins/by-name/wrapping/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "wrapping";
   packPathName = "wrapping.nvim";
   package = "wrapping-nvim";

--- a/plugins/by-name/wtf/default.nix
+++ b/plugins/by-name/wtf/default.nix
@@ -40,7 +40,7 @@ let
 in
 {
   options = {
-    plugins.wtf = lib.nixvim.neovim-plugin.extraOptionsOptions // {
+    plugins.wtf = lib.nixvim.plugins.neovim.extraOptionsOptions // {
       enable = mkEnableOption "wtf.nvim";
 
       package = lib.mkPackageOption pkgs "wtf.nvim" {

--- a/plugins/by-name/yanky/default.nix
+++ b/plugins/by-name/yanky/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "yanky";
   packPathName = "yanky.nvim";
   package = "yanky-nvim";

--- a/plugins/by-name/yazi/default.nix
+++ b/plugins/by-name/yazi/default.nix
@@ -7,7 +7,7 @@ let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "yazi";
   packPathName = "yazi.nvim";
   package = "yazi-nvim";

--- a/plugins/by-name/zellij/default.nix
+++ b/plugins/by-name/zellij/default.nix
@@ -3,7 +3,7 @@
   helpers,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "zellij";
   packPathName = "zellij.nvim";
   package = "zellij-nvim";

--- a/plugins/by-name/zen-mode/default.nix
+++ b/plugins/by-name/zen-mode/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "zen-mode";
   packPathName = "zen-mode.nvim";
   package = "zen-mode-nvim";

--- a/plugins/by-name/zig/default.nix
+++ b/plugins/by-name/zig/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 with lib;
-with lib.nixvim.vim-plugin;
+with lib.nixvim.plugins;
 mkVimPlugin {
   name = "zig";
   packPathName = "zig.vim";

--- a/plugins/by-name/zk/default.nix
+++ b/plugins/by-name/zk/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib;
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "zk";
   packPathName = "zk.nvim";
   package = "zk-nvim";

--- a/plugins/cmp/default.nix
+++ b/plugins/cmp/default.nix
@@ -7,7 +7,7 @@ let
 
   cmpOptions = import ./options { inherit lib; };
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp";
   packPathName = "nvim-cmp";
   package = "nvim-cmp";

--- a/plugins/cmp/sources/_mk-cmp-plugin.nix
+++ b/plugins/cmp/sources/_mk-cmp-plugin.nix
@@ -14,7 +14,7 @@
   imports ? [ ],
   ...
 }@args:
-lib.nixvim.vim-plugin.mkVimPlugin (
+lib.nixvim.plugins.mkVimPlugin (
   builtins.removeAttrs args [
     "pluginName"
     "sourceName"

--- a/plugins/colorschemes/ayu.nix
+++ b/plugins/colorschemes/ayu.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts toLuaObject;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "ayu";
   isColorscheme = true;
   packPathName = "neovim-ayu";

--- a/plugins/colorschemes/base16/default.nix
+++ b/plugins/colorschemes/base16/default.nix
@@ -9,7 +9,7 @@ let
   moduleName = "base16-colorscheme";
   packPathName = "base16.nvim";
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   inherit name moduleName packPathName;
   setup = ".with_config";
   package = "base16-nvim";

--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption mkNullOrStrLuaFnOr;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "catppuccin";
   packPathName = "catppuccin-nvim";
   isColorscheme = true;

--- a/plugins/colorschemes/cyberdream.nix
+++ b/plugins/colorschemes/cyberdream.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "cyberdream";
   isColorscheme = true;
   packPathName = "cyberdream.nvim";

--- a/plugins/colorschemes/dracula-nvim.nix
+++ b/plugins/colorschemes/dracula-nvim.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "dracula-nvim";
   packPathName = "dracula.nvim ";
   moduleName = "dracula";

--- a/plugins/colorschemes/dracula.nix
+++ b/plugins/colorschemes/dracula.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "dracula";
   package = "dracula-vim";
   isColorscheme = true;

--- a/plugins/colorschemes/everforest.nix
+++ b/plugins/colorschemes/everforest.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "everforest";
   isColorscheme = true;
   globalPrefix = "everforest_";

--- a/plugins/colorschemes/gruvbox.nix
+++ b/plugins/colorschemes/gruvbox.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "gruvbox";
   isColorscheme = true;
   packPathName = "gruvbox.nvim";

--- a/plugins/colorschemes/kanagawa.nix
+++ b/plugins/colorschemes/kanagawa.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "kanagawa";
   isColorscheme = true;
   packPathName = "kanagawa.nvim";

--- a/plugins/colorschemes/melange.nix
+++ b/plugins/colorschemes/melange.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "melange";
   isColorscheme = true;
   packPathName = "melange-nvim";

--- a/plugins/colorschemes/modus.nix
+++ b/plugins/colorschemes/modus.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "modus";
   moduleName = "modus-themes";
   packPathName = "modus-themes.nvim";

--- a/plugins/colorschemes/nightfox.nix
+++ b/plugins/colorschemes/nightfox.nix
@@ -6,7 +6,7 @@ let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
   inherit (lib) types;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "nightfox";
   isColorscheme = true;
   packPathName = "nightfox.nvim";

--- a/plugins/colorschemes/nord.nix
+++ b/plugins/colorschemes/nord.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "nord";
   isColorscheme = true;
   packPathName = "nord.nvim";

--- a/plugins/colorschemes/one.nix
+++ b/plugins/colorschemes/one.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "one";
   isColorscheme = true;
   packPathName = "vim-one";

--- a/plugins/colorschemes/onedark.nix
+++ b/plugins/colorschemes/onedark.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "onedark";
   isColorscheme = true;
   packPathName = "onedark.nvim";

--- a/plugins/colorschemes/oxocarbon.nix
+++ b/plugins/colorschemes/oxocarbon.nix
@@ -2,7 +2,7 @@
   lib,
   ...
 }:
-lib.nixvim.vim-plugin.mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "oxocarbon";
   isColorscheme = true;
   packPathName = "oxocarbon.nvim";

--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -6,7 +6,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "palette";
   isColorscheme = true;
   packPathName = "palette.nvim";

--- a/plugins/colorschemes/poimandres.nix
+++ b/plugins/colorschemes/poimandres.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "poimandres";
   isColorscheme = true;
   packPathName = "poimandres.nvim";

--- a/plugins/colorschemes/rose-pine.nix
+++ b/plugins/colorschemes/rose-pine.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "rose-pine";
   isColorscheme = true;
 

--- a/plugins/colorschemes/tokyonight.nix
+++ b/plugins/colorschemes/tokyonight.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "tokyonight";
   isColorscheme = true;
   packPathName = "tokyonight.nvim";

--- a/plugins/colorschemes/vscode.nix
+++ b/plugins/colorschemes/vscode.nix
@@ -5,7 +5,7 @@
 let
   inherit (lib.nixvim) defaultNullOpts toLuaObject;
 in
-lib.nixvim.neovim-plugin.mkNeovimPlugin {
+lib.nixvim.plugins.mkNeovimPlugin {
   name = "vscode";
   isColorscheme = true;
   packPathName = "vscode-nvim";

--- a/plugins/pluginmanagers/lz-n.nix
+++ b/plugins/pluginmanagers/lz-n.nix
@@ -7,7 +7,7 @@ with lib;
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
-nixvim.neovim-plugin.mkNeovimPlugin {
+nixvim.plugins.mkNeovimPlugin {
   name = "lz-n";
   packPathName = "lz.n";
   maintainers = [ maintainers.psfloyd ];


### PR DESCRIPTION
- **treewide: `neovim-plugin` -> `plugins`**
- **treewide: `vim-plugin` -> `plugins`**
- **lib/plugins: deprecate `neovim-plugin` & `vim-plugin` aliases**

Follow up to #2715, this PR deprecates the old attr names by showing a warning when they are used.

This PR includes the treewide migration, which was a fairly simple substitution pattern.
