### PR TITLE
lib/tests: remove deprecated dontRun

### DIFF
--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -13,22 +13,14 @@ let
     {
       name,
       nvim,
-      # TODO: Deprecated 2024-08-20, remove after 24.11
-      dontRun ? false,
       ...
-    }@args:
+    }:
     let
       # FIXME: this doesn't support helpers.enableExceptInTests, a context option would be better
       result = nvim.extend {
-        config.test =
-          {
-            inherit name;
-          }
-          // lib.optionalAttrs (args ? dontRun) (
-            lib.warn
-              "mkTestDerivationFromNvim: the `dontRun` argument is deprecated. You should use the `test.runNvim` module option instead."
-              { runNvim = !dontRun; }
-          );
+        config.test = {
+          inherit name;
+        };
       };
     in
     result.config.build.test;
@@ -41,9 +33,7 @@ let
       pkgs ? defaultPkgs,
       module,
       extraSpecialArgs ? { },
-      # TODO: Deprecated 2024-08-20, remove after 24.11
-      dontRun ? false,
-    }@args:
+    }:
     let
       # NOTE: we are importing this just for evalNixvim
       helpers = self.lib.nixvim.override {
@@ -56,11 +46,6 @@ let
         modules = [
           module
           (lib.optionalAttrs (name != null) { test.name = name; })
-          (lib.optionalAttrs (args ? dontRun) (
-            lib.warn
-              "mkTestDerivationFromNixvimModule: the `dontRun` argument is deprecated. You should use the `test.runNvim` module option instead."
-              { config.test.runNvim = !dontRun; }
-          ))
           { wrapRc = true; }
           # TODO: Only do this when `args?pkgs`
           # Consider deprecating the `pkgs` arg too...


### PR DESCRIPTION
As this was an internal option, I don't see a reason to keep it around forever.