### PR TITLE
modules: add `flake` and `build.manDocsPackage`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -30,11 +30,9 @@ in
     lib.evalModules {
       modules = modules ++ [
         ../modules/top-level
-
-        # Pass our locked nixpkgs into the configuration
         {
           _file = "<nixvim-flake>";
-          nixpkgs.source = lib.mkOptionDefault flake.inputs.nixpkgs;
+          flake = lib.mkOptionDefault flake;
         }
       ];
       specialArgs = {

--- a/modules/misc/context.nix
+++ b/modules/misc/context.nix
@@ -1,6 +1,20 @@
 { lib, ... }:
+let
+  isFlake = x: x._type or null == "flake";
+  flakeType = lib.types.addCheck lib.types.path isFlake // {
+    name = "flake";
+    description = "flake";
+  };
+in
 {
   options = {
+    flake = lib.mkOption {
+      type = flakeType;
+      description = ''
+        Nixvim's flake.
+      '';
+      internal = true;
+    };
     isTopLevel = lib.mkOption {
       type = lib.types.bool;
       default = false;

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -129,7 +129,7 @@ in
     # NOTE: This is a nixvim-specific option; there's no equivalent in nixos
     source = lib.mkOption {
       type = lib.types.path;
-      # NOTE: default is only set if `flake` is passed to our lib
+      default = config.flake.inputs.nixpkgs;
       defaultText = lib.literalMD "Nixvim's flake `input.nixpkgs`";
       description = ''
         The path to import Nixpkgs from.

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -9,6 +9,7 @@ let
   inherit (lib) types mkOption mkPackageOption;
   inherit (lib) optional optionalAttrs;
   builders = lib.nixvim.builders.withPkgs pkgs;
+  inherit (pkgs.stdenv.hostPlatform) system;
 in
 {
   options = {
@@ -142,6 +143,16 @@ in
         description = ''
           A tool to show the content of the generated `init.lua` file.
           Run using `${config.build.printInitPackage.meta.mainProgram}`.
+        '';
+        readOnly = true;
+        visible = false;
+      };
+
+      manDocsPackage = mkOption {
+        type = types.package;
+        defaultText = lib.literalMD "`packages.<system>.man-docs` from Nixvim's flake";
+        description = ''
+          Nixvim's manpage documentation.
         '';
         readOnly = true;
         visible = false;
@@ -370,6 +381,8 @@ in
             bat --language=lua "$init"
           '';
         };
+
+        manDocsPackage = config.flake.packages.${system}.man-docs;
       };
 
       # Set `wrapRc` and `impureRtp`s option defaults with even lower priority than `mkOptionDefault`

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -1,6 +1,5 @@
 self:
 {
-  pkgs,
   config,
   lib,
   ...
@@ -28,6 +27,6 @@ in
     environment.systemPackages = [
       cfg.build.package
       cfg.build.printInitPackage
-    ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
+    ] ++ lib.optional cfg.enableMan cfg.build.manDocsPackage;
   };
 }

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -1,6 +1,5 @@
 self:
 {
-  pkgs,
   config,
   lib,
   ...
@@ -36,7 +35,7 @@ in
     home.packages = [
       cfg.build.package
       cfg.build.printInitPackage
-    ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
+    ] ++ lib.optional cfg.enableMan cfg.build.manDocsPackage;
 
     home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
 

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -1,6 +1,5 @@
 self:
 {
-  pkgs,
   config,
   lib,
   ...
@@ -37,7 +36,7 @@ in
     environment.systemPackages = [
       cfg.build.package
       cfg.build.printInitPackage
-    ] ++ lib.optional cfg.enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
+    ] ++ lib.optional cfg.enableMan cfg.build.manDocsPackage;
 
     environment.variables = {
       VIM = mkIf (!cfg.wrapRc) "/etc/nvim";

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -33,7 +33,7 @@ let
       paths = [
         build.package
         build.printInitPackage
-      ] ++ pkgs.lib.optional enableMan self.packages.${pkgs.stdenv.hostPlatform.system}.man-docs;
+      ] ++ lib.optional enableMan build.manDocsPackage;
       meta.mainProgram = "nvim";
     })
     // rec {


### PR DESCRIPTION
- **modules/context: `flake` option, provides access to our flake**
- **modules/output: add `manDocsPackage`**

Rather than only providing the configuration with access to `<flake>.inputs.nixpkgs`, we should probably pass the entire `<flake>` in. This is made available by a new `flake` option declared in `modules/misc/context.nix` and the default is set within `evalNixvim` in `lib/modules.nix`.

We then use this context option to define the default for `nixpkgs.source` and to enable a new `build.manDocsPackage`, exposing the man-docs package as part of the configuration.

Having the `manDocsPackage` as part of the module configuration will enable having the standalone package also be part of the configuration and/or having the locally installed docs be based on the local modules, rather than only what's in our flake.
