### PR TITLE
modules/nixpkgs: complete the MVP

### DIFF
--- a/flake-modules/legacy-packages.nix
+++ b/flake-modules/legacy-packages.nix
@@ -2,9 +2,8 @@
 {
   perSystem =
     {
-      pkgs,
-      lib,
       makeNixvimWithModule,
+      system,
       ...
     }:
     {
@@ -13,12 +12,7 @@
         makeNixvim = module: makeNixvimWithModule { inherit module; };
 
         nixvimConfiguration = helpers.modules.evalNixvim {
-          modules = [
-            {
-              _file = ./legacy-packages.nix;
-              nixpkgs.pkgs = lib.mkDefault pkgs;
-            }
-          ];
+          inherit system;
         };
       };
     };

--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -27,7 +27,9 @@
         { pkgs, system, ... }:
         {
           # NOTE: this is the publicly documented flake output we've had for a while
-          check = pkgs.callPackage ../lib/tests.nix { inherit self; };
+          check = pkgs.callPackage ../lib/tests.nix {
+            inherit lib self system;
+          };
 
           # NOTE: no longer needs to be per-system
           helpers = lib.warn "nixvim: `<nixvim>.lib.${system}.helpers` has been moved to `<nixvim>.lib.nixvim` and no longer depends on a specific system" self.lib.nixvim;

--- a/flake-modules/wrappers.nix
+++ b/flake-modules/wrappers.nix
@@ -1,10 +1,18 @@
-{ inputs, self, ... }:
+{
+  inputs,
+  self,
+  lib,
+  ...
+}:
 {
   perSystem =
     { system, pkgs, ... }:
     {
       _module.args = {
-        makeNixvimWithModule = import ../wrappers/standalone.nix pkgs self;
+        makeNixvimWithModule = import ../wrappers/standalone.nix {
+          inherit lib self;
+          defaultSystem = system;
+        };
       };
 
       checks =

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -1,11 +1,10 @@
 {
   self,
-  pkgs,
-  lib ? pkgs.lib,
-  ...
+  system,
+  lib,
 }:
 let
-  defaultPkgs = pkgs;
+  defaultSystem = system;
 
   # Create a nix derivation from a nixvim executable.
   # The build phase simply consists in running the provided nvim binary.
@@ -31,7 +30,7 @@ let
     {
       name ? null,
       pkgs ? null,
-      system ? defaultPkgs.stdenv.hostPlatform.system,
+      system ? defaultSystem,
       module,
       extraSpecialArgs ? { },
     }:

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -34,20 +34,6 @@ in
 {
   options.nixpkgs = {
     pkgs = lib.mkOption {
-      # TODO:
-      # defaultText = lib.literalExpression ''
-      #   import "''${nixos}/.." {
-      #     inherit (cfg) config overlays localSystem crossSystem;
-      #   }
-      # '';
-      defaultText = lib.literalMD ''
-        If `useGlobalPackages` is true, `pkgs` is inherited from your host config
-        (i.e. NixOS, home-manager, or nix-darwin).
-        Or the `pkgs` supplied to `makeNixvimWithModule` when building a standalone nixvim.
-
-        > [!CAUTION]
-        > This default will be removed in a future version of nixvim
-      '';
       type = lib.types.pkgs // {
         description = "An evaluation of Nixpkgs; the top level attribute set of packages";
       };

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -164,7 +164,8 @@ in
       apply = lib.systems.elaborate;
       defaultText = lib.literalMD ''
         - Inherited from the "host" configuration's `pkgs`
-        - Must be specified manually when building a standalone nixvim
+        - Or `evalNixvim`'s `system` argument
+        - Otherwise, must be specified manually
       '';
       description = ''
         Specifies the platform where the Nixvim configuration will run.

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -172,6 +172,52 @@ in
       '';
     };
 
+    hostPlatform = lib.mkOption {
+      type = with lib.types; either str attrs;
+      example = {
+        system = "aarch64-linux";
+      };
+      apply = lib.systems.elaborate;
+      defaultText = lib.literalMD ''
+        - Inherited from the "host" configuration's `pkgs`
+        - Must be specified manually when building a standalone nixvim
+      '';
+      description = ''
+        Specifies the platform where the Nixvim configuration will run.
+
+        To cross-compile, also set `nixpkgs.buildPlatform`.
+
+        Ignored when `nixpkgs.pkgs` is set.
+      '';
+    };
+
+    buildPlatform = lib.mkOption {
+      type = with lib.types; either str attrs;
+      default = cfg.hostPlatform;
+      example = {
+        system = "x86_64-linux";
+      };
+      apply =
+        value:
+        let
+          elaborated = lib.systems.elaborate value;
+        in
+        # If equivalent to `hostPlatform`, make it actually identical so that `==` can be used
+        # See https://github.com/NixOS/nixpkgs/issues/278001
+        if lib.systems.equals elaborated cfg.hostPlatform then cfg.hostPlatform else elaborated;
+      defaultText = lib.literalMD ''
+        Inherited from the "host" configuration's `pkgs`.
+        Or `config.nixpkgs.hostPlatform` when building a standalone nixvim.
+      '';
+      description = ''
+        Specifies the platform on which Nixvim should be built.
+        By default, Nixvim is built on the system where it runs, but you can change where it's built.
+        Setting this option will cause Nixvim to be cross-compiled.
+
+        Ignored when `nixpkgs.pkgs` is set.
+      '';
+    };
+
     # NOTE: This is a nixvim-specific option; there's no equivalent in nixos
     source = lib.mkOption {
       type = lib.types.path;

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -41,8 +41,9 @@ in
       #   }
       # '';
       defaultText = lib.literalMD ''
-        The `pkgs` inherited from your host config (i.e. NixOS, home-manager, or nix-darwin),
-        or the `pkgs` supplied to `makeNixvimWithModule` when building a standalone nixvim.
+        If `useGlobalPackages` is true, `pkgs` is inherited from your host config
+        (i.e. NixOS, home-manager, or nix-darwin).
+        Or the `pkgs` supplied to `makeNixvimWithModule` when building a standalone nixvim.
 
         > [!CAUTION]
         > This default will be removed in a future version of nixvim

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -18,12 +18,12 @@
       ];
 
       perSystem =
-        { pkgs, system, ... }:
+        { system, ... }:
         let
           nixvimLib = nixvim.lib.${system};
           nixvim' = nixvim.legacyPackages.${system};
           nixvimModule = {
-            inherit pkgs;
+            inherit system; # or alternatively, set `pkgs`
             module = import ./config; # import the module directly
             # You can use `extraSpecialArgs` to pass additional arguments to your module files
             extraSpecialArgs = {

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -8,10 +8,13 @@
   pkgs,
   pkgsUnfree,
   self,
+  system,
 }:
 let
   fetchTests = callTest ./fetch-tests.nix { };
-  test-derivation = callPackage ../lib/tests.nix { inherit self; };
+  test-derivation = callPackage ../lib/tests.nix {
+    inherit lib self system;
+  };
   inherit (test-derivation) mkTestDerivationFromNixvimModule;
 
   moduleToTest =

--- a/tests/nixpkgs-mock.nix
+++ b/tests/nixpkgs-mock.nix
@@ -1,0 +1,15 @@
+# This mock nixpkgs can be used as `nixpkgs.source` in nixpkgs-module-test
+# if we want/need to avoid importing & instantiating a real nixpkgs
+{
+  config ? { },
+  ...
+}:
+let
+  pkgs = {
+    _type = "pkgs";
+    __splicedPackages = pkgs;
+    inherit config pkgs;
+    mock = true;
+  };
+in
+pkgs

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -32,11 +32,20 @@ let
     evalArgs
     // {
       modules = evalArgs.modules or [ ] ++ [
-        # Use global packages by default in nixvim's submodule
-        # TODO: `useGlobalPackages` option and/or deprecate using host packages?
         {
           _file = ./_shared.nix;
-          nixpkgs.pkgs = lib.mkDefault pkgs;
+
+          nixpkgs = {
+            # Use global packages by default in nixvim's submodule
+            # TODO: `useGlobalPackages` option and/or deprecate using host packages?
+            pkgs = lib.mkDefault pkgs;
+
+            # Inherit platform spec
+            # FIXME: buildPlatform can't use option-default because it already has a default
+            #        (it defaults to hostPlatform)...
+            hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform;
+            buildPlatform = lib.mkDefault pkgs.stdenv.buildPlatform;
+          };
         }
       ];
     }

--- a/wrappers/modules/nixpkgs.nix
+++ b/wrappers/modules/nixpkgs.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+let
+  cfg = config.nixpkgs;
+  opts = options.nixpkgs;
+  argOpts = lib.modules.mergeAttrDefinitionsWithPrio options._module.args;
+
+  normalPrio = lib.modules.defaultOverridePriority;
+  defaultPrio = (lib.mkDefault null).priority;
+  optionDefaultPrio = (lib.mkOptionDefault null).priority;
+  # FIXME: buildPlatform can't use mkOptionDefault because it already defaults to hostPlatform
+  buildPlatformPrio = optionDefaultPrio - 1;
+
+  mkGlobalPackagesAssertion =
+    {
+      assertion,
+      option ? null,
+      loc ? option.loc,
+      issue ? "is overridden",
+    }:
+    {
+      assertion = cfg.useGlobalPackages -> assertion;
+      message =
+        "`${lib.showOption opts.useGlobalPackages.loc}' is enabled, "
+        + "but `${lib.showOption loc}' ${issue}. "
+        + lib.optionalString (
+          option != null
+        ) "Definition values:${lib.options.showDefs option.definitionsWithLocations}";
+    };
+in
+{
+  options = {
+    nixpkgs.useGlobalPackages = lib.mkOption {
+      type = lib.types.bool;
+      default = true; # TODO: Added 2025-01-15; switch to false one release after adding a deprecation warning
+      defaultText = lib.literalMD ''`true`, but will change to `false` in a future version.'';
+      description = ''
+        Whether Nixvim should use the ${config.meta.wrapper.name} configuration's `pkgs`,
+        instead of constructing its own instance.
+      '';
+    };
+  };
+
+  config = {
+    assertions = map mkGlobalPackagesAssertion [
+      {
+        assertion = opts.pkgs.highestPrio == defaultPrio;
+        option = opts.pkgs;
+        issue = "is overridden";
+      }
+      {
+        assertion = argOpts.pkgs.highestPrio == normalPrio;
+        # FIXME: can't showDefs for an attrOf an option
+        loc = options._module.args.loc ++ [ "pkgs" ];
+        issue = "is overridden";
+      }
+      {
+        assertion = opts.hostPlatform.highestPrio == optionDefaultPrio;
+        option = opts.hostPlatform;
+        issue = "is overridden";
+      }
+      {
+        assertion = opts.buildPlatform.highestPrio == buildPlatformPrio;
+        option = opts.buildPlatform;
+        issue = "is overridden";
+      }
+      {
+        assertion = cfg.config == { };
+        option = opts.config;
+        issue = "is not empty";
+      }
+      {
+        assertion = cfg.overlays == [ ];
+        option = opts.overlays;
+        issue = "is not empty";
+      }
+    ];
+  };
+}

--- a/wrappers/modules/shared.nix
+++ b/wrappers/modules/shared.nix
@@ -11,4 +11,8 @@
       };
     };
   };
+
+  imports = [
+    ./nixpkgs.nix
+  ];
 }


### PR DESCRIPTION
This PR finally gets the `nixpkgs` module to a fully functional state. If `nixpkgs.pkgs` is not defined, then an instance of nixpkgs is constructed from `nixpkgs.source`.

Constructing nixpkgs also requires knowing which system to target, so the `hostPlatform` and `buildPlatform` options are included.

I also included the `nixpkgs.config` option. This could just be `attrsOf anything`, but I've used the upstream option-type because it handles some special cases while merging definitions.

I've also added the non-standalone option `nixpkgs.useGlobalPackages`, which automatically sets `nixpkgs.pkgs` to the "host" or "global" packages; i.e. the `pkgs` arg in use by the outer module eval.

Most implementation is directly based on https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/misc/nixpkgs.nix

Follow up to:
- #2835
- #2740
- #2670
- #2430
- #2301

Closes #2022
Closes #2437
Fixes #1784

### Future work

#### `system` agnostic Nixvim factory

- #2210

Constructing `pkgs` within the module system allows us to have a system-agnostic replacement for `makeNixvimWithModule` and somewhat simplify the [standalone template](https://github.com/nix-community/nixvim/blob/main/templates/simple/flake.nix)

Note: `lib.nixvim.modules.evalNixvim` is already system-agnostic. We simply need to provide documentation and/or new wrapper-functions for use by end-users.

#### Migrating `useGlobalPackages` default

- #2839

I'm not 100% sure I know a good way to warn about that planned transition though. Maybe we'll just have to have an obnoxious but temporary warning shown to all users? Could still be missed by users who don't update very often.