### PR TITLE
tests/nixpkgs: move nixpkgs module test to dedicated drv

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -43,6 +43,7 @@ in
   no-flake = callTest ./no-flake.nix { };
   lib-tests = callTest ./lib-tests.nix { };
   maintainers = callTest ./maintainers.nix { };
+  nixpkgs-module = callTest ./nixpkgs-module.nix { };
   plugins-by-name = callTest ./plugins-by-name.nix { };
   generated = callTest ./generated.nix { };
   package-options = callTest ./package-options.nix { };

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -8,7 +8,6 @@
   pkgs,
   pkgsUnfree,
   self,
-  system,
 }:
 let
   fetchTests = callTest ./fetch-tests.nix { };
@@ -19,14 +18,12 @@ let
     file: name: module:
     mkTestDerivationFromNixvimModule {
       inherit name;
+      # Use a single common instance of nixpkgs, with allowUnfree
+      # Having a single shared instance should speed up tests a little
       module = {
         _file = file;
         imports = [ module ];
-        _module.args = {
-          # Give tests access to the flake
-          inherit self system;
-          inherit (self) inputs;
-        };
+        nixpkgs.pkgs = pkgsUnfree;
       };
       pkgs = pkgsUnfree;
     };


### PR DESCRIPTION
We don't need a full test that actually _builds_ or _runs_ nixvim. All we need is some assertions on the result of a nixvim configuration.

Currently #2738 needs to change the module tests to construct their own `pkgs` instance, so that we can test how the module behaves. However this is likely to have a performance hit since we are repeatedly instanciating `pkgs` again for each test case. It's probably better to use a single `pkgs` instance for all test case modules, but move the nixpkgs-module tests to their own dedicated test derivation.

This PR does that, moving the existing tests to a dedicated link-farm.

This also allows creating some bespoke helpers to streamline writing the tests and _may_ improve performance slightly because we don't need to also build `config.build.package` for the nixpkgs-module unit tests.

The bespoke helpers are a little cumbersome, so I'm open to feedback on them. Some of them may also be useful more generally, so may be worth moving to some kinda "test utils" file. This can be done now or later.
