### PR TITLE
lib/plugins: make plugin optional when lazy-loading

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -46,6 +46,7 @@ lib.makeExtensible (
 
     inherit (self.options)
       defaultNullOpts
+      mkAutoLoadOption
       mkCompositeOption
       mkCompositeOption'
       mkLazyLoadOption

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -381,5 +381,18 @@ rec {
         }
       );
     };
+
+  mkAutoLoadOption =
+    cfg: name:
+    lib.mkOption {
+      description = ''
+        Whether to automatically load ${name} when neovim starts.
+      '';
+      type = types.bool;
+      default = !(cfg.lazyLoad.enable or false);
+      defaultText =
+        if cfg ? lazyLoad then lib.literalMD "`false` when lazy-loading is enabled." else true;
+      example = false;
+    };
 }
 // removed

--- a/lib/plugins/mk-neovim-plugin.nix
+++ b/lib/plugins/mk-neovim-plugin.nix
@@ -74,6 +74,7 @@ let
       options = lib.setAttrByPath loc (
         {
           enable = lib.mkEnableOption packPathName;
+          autoLoad = lib.nixvim.mkAutoLoadOption cfg packPathName;
           lazyLoad = lib.nixvim.mkLazyLoadOption packPathName;
         }
         // lib.optionalAttrs hasSettings {

--- a/lib/plugins/mk-vim-plugin.nix
+++ b/lib/plugins/mk-vim-plugin.nix
@@ -67,6 +67,7 @@ let
       options = lib.setAttrByPath loc (
         {
           enable = lib.mkEnableOption packPathName;
+          autoLoad = lib.nixvim.mkAutoLoadOption cfg packPathName;
         }
         // settingsOption
         // extraOptions

--- a/lib/plugins/utils.nix
+++ b/lib/plugins/utils.nix
@@ -74,7 +74,12 @@
       };
 
       config = lib.mkIf cfg.enable {
-        extraPlugins = [ (cfg.packageDecorator cfg.package) ];
+        extraPlugins = [
+          {
+            plugin = cfg.packageDecorator cfg.package;
+            optional = !cfg.autoLoad;
+          }
+        ];
       };
     };
 }


### PR DESCRIPTION
I thought nixvim was already doing this when lazy-loading were implemented, since it was in `lz.n` documentation. But few days ago, I noticed it was not being done. So this PR makes plugins optional when lazy-loading is enable, instead of just lazy-loading plugins when they require setup for loading, which some don't.