### PR TITLE
modules/test: allow arbitrary warning/assertion expecations

### DIFF
--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -94,12 +94,15 @@ in
     checkWarnings = lib.mkOption {
       type = lib.types.bool;
       description = "Whether to check `config.warnings` in the test.";
+      apply = x: lib.warnIfNot x "`test.checkWarnings = false` is replaced with `test.warnings = [ ]`." x;
       default = true;
     };
 
     checkAssertions = lib.mkOption {
       type = lib.types.bool;
       description = "Whether to check `config.assertions` in the test.";
+      apply =
+        x: lib.warnIfNot x "`test.checkAssertions = false` is replaced with `test.assertions = [ ]`." x;
       default = true;
     };
 

--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -39,7 +39,14 @@ let
           default = null;
         };
         value = lib.mkOption {
-          type = lib.types.anything;
+          type =
+            if config.expect == null then
+              lib.types.unspecified
+              // {
+                description = "defined by `expect`";
+              }
+            else
+              namedPredicate.valueType;
           description = ''
             If defined, will be used together with `expect` to define `predicate`.
           '';
@@ -137,6 +144,12 @@ in
                 Expectation message supplier, matching `(value) -> String` or `(value) -> [(message)] -> String`.
               '';
             };
+            valueType = lib.mkOption {
+              type = lib.types.optionType;
+              description = ''
+                The type to use for `value` when this expectation is used.
+              '';
+            };
           };
         });
       description = ''
@@ -196,14 +209,17 @@ in
           count = {
             predicate = v: l: builtins.length l == v;
             message = v: l: "Expected length to be ${toString v} but found ${toString (builtins.length l)}.";
+            valueType = lib.types.ints.unsigned;
           };
           any = {
             predicate = v: builtins.any (lib.hasInfix v);
             message = v: "Expected ${lib.toJSON v} infix to be present.";
+            valueType = lib.types.str;
           };
           anyExact = {
             predicate = builtins.elem;
             message = v: "Expected ${lib.toJSON v} to be present.";
+            valueType = lib.types.str;
           };
         };
       };

--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -19,10 +19,17 @@ in
       description = "The test derivation's name.";
     };
 
+    buildNixvim = lib.mkOption {
+      type = lib.types.bool;
+      description = "Whether to build the nixvim config in the test.";
+      default = true;
+    };
+
     runNvim = lib.mkOption {
       type = lib.types.bool;
       description = "Whether to run `nvim` in the test.";
-      default = true;
+      defaultText = lib.literalExpression "config.test.buildNixvim";
+      default = cfg.buildNixvim;
     };
 
     checkWarnings = lib.mkOption {
@@ -68,9 +75,12 @@ in
     in
     {
       build.test =
+        assert lib.assertMsg (cfg.runNvim -> cfg.buildNixvim) "`test.runNvim` requires `test.buildNixvim`.";
         pkgs.runCommandNoCCLocal cfg.name
           {
-            nativeBuildInputs = [ config.build.packageUnchecked ];
+            nativeBuildInputs = lib.optionals cfg.buildNixvim [
+              config.build.packageUnchecked
+            ];
 
             # Allow inspecting the test's module a little from the repl
             # e.g.

--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -8,8 +8,60 @@
 let
   cfg = config.test;
 
-  inherit (config) warnings;
-  assertions = builtins.concatMap (x: lib.optional (!x.assertion) x.message) config.assertions;
+  # Expectation submodule used for checking warnings and/or assertions
+  expectationType = lib.types.submodule (
+    { config, ... }:
+    let
+      # NOTE: ensure `config.expect != null` before evaluating this!
+      namedPredicate = cfg.namedExpectationPredicates.${config.expect};
+    in
+    {
+      options = {
+        predicate = lib.mkOption {
+          type = with lib.types; functionTo bool;
+          description = ''
+            A predicate of that determines whether this expectation is met.
+
+            Type
+            ```
+            [String] -> Boolean
+            ```
+
+            Parameters
+            1. values - all warnings or matched assertions
+          '';
+        };
+        expect = lib.mkOption {
+          type = with lib.types; nullOr (enum (builtins.attrNames cfg.namedExpectationPredicates));
+          description = ''
+            If non-null, will be used together with `value` to define `predicate`.
+          '';
+          default = null;
+        };
+        value = lib.mkOption {
+          type = lib.types.anything;
+          description = ''
+            If defined, will be used together with `expect` to define `predicate`.
+          '';
+        };
+        message = lib.mkOption {
+          type = with lib.types; either str (functionTo str);
+          description = ''
+            The assertion message.
+
+            If the value is a function, it is called with the same list of warning/assertion messages that is applied to `predicate`.
+          '';
+          defaultText = lib.literalMD ''
+            If `assertion` is non-null, a default is computed. Otherwise, there is no default.
+          '';
+        };
+      };
+      config = lib.mkIf (config.expect != null) {
+        predicate = lib.mkOptionDefault (namedPredicate.predicate config.value);
+        message = lib.mkOptionDefault (namedPredicate.message config.value);
+      };
+    }
+  );
 in
 {
   options.test = {
@@ -43,6 +95,55 @@ in
       description = "Whether to check `config.assertions` in the test.";
       default = true;
     };
+
+    warnings = lib.mkOption {
+      type = lib.types.listOf expectationType;
+      description = "A list of expectations for `warnings`.";
+      defaultText = lib.literalMD "Expect `count == 0`";
+      default = [
+        {
+          expect = "count";
+          value = 0;
+        }
+      ];
+    };
+
+    assertions = lib.mkOption {
+      type = lib.types.listOf expectationType;
+      description = "A list of expectations for `assertions`.";
+      defaultText = lib.literalMD "Expect `count == 0`";
+      default = [
+        {
+          expect = "count";
+          value = 0;
+        }
+      ];
+    };
+
+    namedExpectationPredicates = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (submodule {
+          options = {
+            predicate = lib.mkOption {
+              type = functionTo (functionTo bool);
+              description = ''
+                Predicate matching `(value) -> [(message)] -> Boolean`.
+              '';
+            };
+            message = lib.mkOption {
+              type = functionTo (either str (functionTo str));
+              description = ''
+                Expectation message supplier, matching `(value) -> String` or `(value) -> [(message)] -> String`.
+              '';
+            };
+          };
+        });
+      description = ''
+        A list of named expectation predicates, for use with `test.warnings.*.expect` and `test.assertions.*.expect`.
+      '';
+      internal = true;
+    };
   };
 
   options.build = {
@@ -57,23 +158,56 @@ in
 
   config =
     let
-      showErr =
-        name: lines:
-        lib.optionalString (lines != [ ]) ''
-          Unexpected ${name}:
-          ${lib.concatStringsSep "\n" (lib.map (v: "- ${v}") lines)}
-        '';
+      input = {
+        inherit (config) warnings;
+        assertions = builtins.concatMap (x: lib.optional (!x.assertion) x.message) config.assertions;
+      };
 
-      toCheck =
-        lib.optionalAttrs cfg.checkWarnings { inherit warnings; }
-        // lib.optionalAttrs cfg.checkAssertions { inherit assertions; };
+      expectationMessages =
+        name:
+        lib.pipe cfg.${name} [
+          (builtins.filter (x: !x.predicate input.${name}))
+          (builtins.map (x: x.message))
+          (builtins.map (msg: if lib.isFunction msg then msg input.${name} else msg))
+          (
+            x:
+            if x == [ ] then
+              null
+            else
+              ''
+                Failed ${toString (builtins.length x)} expectation${lib.optionalString (builtins.length x > 1) "s"}:
+                ${lib.concatMapStringsSep "\n" (line: "- ${line}") x}
+                For ${name}:
+                ${lib.concatMapStringsSep "\n" (line: "- ${line}") input.${name}}
+              ''
+          )
+        ];
 
-      errors = lib.foldlAttrs (
-        err: name: lines:
-        err + showErr name lines
-      ) "" toCheck;
+      failedExpectations = lib.genAttrs [ "warnings" "assertions" ] expectationMessages;
     in
     {
+      test = {
+        # If checkWarnings or checkAssertions are disabled, ensure the default expectations are overridden
+        assertions = lib.mkIf (!cfg.checkAssertions) [ ];
+        warnings = lib.mkIf (!cfg.checkWarnings) [ ];
+
+        # Expectation predicates available via the `expect` enum-option
+        namedExpectationPredicates = {
+          count = {
+            predicate = v: l: builtins.length l == v;
+            message = v: l: "Expected length to be ${toString v} but found ${toString (builtins.length l)}.";
+          };
+          any = {
+            predicate = v: builtins.any (lib.hasInfix v);
+            message = v: "Expected ${lib.toJSON v} infix to be present.";
+          };
+          anyExact = {
+            predicate = builtins.elem;
+            message = v: "Expected ${lib.toJSON v} to be present.";
+          };
+        };
+      };
+
       build.test =
         assert lib.assertMsg (cfg.runNvim -> cfg.buildNixvim) "`test.runNvim` requires `test.buildNixvim`.";
         pkgs.runCommandNoCCLocal cfg.name
@@ -81,6 +215,8 @@ in
             nativeBuildInputs = lib.optionals cfg.buildNixvim [
               config.build.packageUnchecked
             ];
+
+            inherit (failedExpectations) warnings assertions;
 
             # Allow inspecting the test's module a little from the repl
             # e.g.
@@ -94,9 +230,15 @@ in
           }
           (
             # First check warnings/assertions, then run nvim
-            lib.optionalString (errors != "") ''
-              echo -n ${lib.escapeShellArg errors}
-              exit 1
+            ''
+              if [ -n "$warnings" ]; then
+                echo -n "$warnings"
+                exit 1
+              fi
+              if [ -n "$assertions" ]; then
+                echo -n "$assertions"
+                exit 1
+              fi
             ''
             # We need to set HOME because neovim will try to create some files
             #

--- a/tests/failing-tests.nix
+++ b/tests/failing-tests.nix
@@ -38,7 +38,9 @@ linkFarmFromDrvs "failing-tests" [
     }
     ''
       [[ 1 = $(cat "$failed/testBuildFailure.exit") ]]
-      grep -F 'Unexpected warnings:' "$failed/testBuildFailure.log"
+      grep -F 'Failed 1 expectation' "$failed/testBuildFailure.log"
+      grep -F 'Expected length to be 0 but found 1.' "$failed/testBuildFailure.log"
+      grep -F 'For warnings' "$failed/testBuildFailure.log"
       grep -F 'Hello, world!' "$failed/testBuildFailure.log"
       touch $out
     ''
@@ -59,7 +61,9 @@ linkFarmFromDrvs "failing-tests" [
     }
     ''
       [[ 1 = $(cat "$failed/testBuildFailure.exit") ]]
-      grep -F 'Unexpected assertions:' "$failed/testBuildFailure.log"
+      grep -F 'Failed 1 expectation' "$failed/testBuildFailure.log"
+      grep -F 'Expected length to be 0 but found 1.' "$failed/testBuildFailure.log"
+      grep -F 'For assertions' "$failed/testBuildFailure.log"
       grep -F 'Hello, world!' "$failed/testBuildFailure.log"
       touch $out
     ''

--- a/tests/test-sources/plugins/by-name/nvim-osc52/default.nix
+++ b/tests/test-sources/plugins/by-name/nvim-osc52/default.nix
@@ -1,9 +1,17 @@
+let
+  expect = expect: value: { inherit expect value; };
+
+  # This plugin is deprecated
+  warnings = [
+    (expect "count" 1)
+    (expect "any" "this plugin is obsolete and will be removed after 24.11.")
+  ];
+in
 {
   empty = {
     plugins.nvim-osc52.enable = true;
 
-    # Hide warnings, since this plugin is deprecated
-    test.checkWarnings = false;
+    test = { inherit warnings; };
   };
 
   defaults = {
@@ -20,7 +28,6 @@
       };
     };
 
-    # Hide warnings, since this plugin is deprecated
-    test.checkWarnings = false;
+    test = { inherit warnings; };
   };
 }

--- a/tests/test-sources/plugins/by-name/rust-tools/default.nix
+++ b/tests/test-sources/plugins/by-name/rust-tools/default.nix
@@ -1,13 +1,20 @@
+let
+  expect = expect: value: { inherit expect value; };
+
+  # This plugin is deprecated
+  warnings = [
+    (expect "count" 1)
+    (expect "any" "The `rust-tools` project has been abandoned.")
+  ];
+in
 {
   empty = {
-    # Plugin deprecated
-    test.checkWarnings = false;
+    test = { inherit warnings; };
     plugins.rust-tools.enable = true;
   };
 
   defaults = {
-    # Plugin deprecated
-    test.checkWarnings = false;
+    test = { inherit warnings; };
     plugins.rust-tools = {
       enable = true;
       executor = "termopen";
@@ -77,8 +84,7 @@
   };
 
   rust-analyzer-options = {
-    # Plugin deprecated
-    test.checkWarnings = false;
+    test = { inherit warnings; };
     plugins.rust-tools = {
       enable = true;
       server = {


### PR DESCRIPTION
- **modules/test: allow not building nixvim config**
- **modules/test: allow arbitrary warning/assertion expecations**
- **tests: use warning-expectations options**

Long overdue options for "expecting" warnings or assertions to match arbitrary predicates.

Common use-cases can de defined declaratively using an enum of pre-defined predicates, while more advanced use-cases can provide an arbitrary predicate function.

Also made it possible to write a test that does not build nixvim's "wrapped" nvim w/config, although I wonder if such tests are better off written manually using runCommand & evalNixvim?
