### PR TITLE
tests: omit `default` suffix in test names

### DIFF
--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -36,7 +36,9 @@ let
         in
         if type == "regular" then
           lib.optional (lib.hasSuffix ".nix" name) (
-            handleTestFile file (namespace ++ [ (lib.removeSuffix ".nix" name) ])
+            handleTestFile file (
+              namespace ++ lib.optional (name != "default.nix") (lib.removeSuffix ".nix" name)
+            )
           )
         else
           fetchTests file (namespace ++ [ name ]);


### PR DESCRIPTION
If the test file is `default.nix`, we don't need to append the filename
to the test namespace.
