### PR TITLE
modules/test: document possible types for expectation `value`

### DIFF
--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -43,7 +43,14 @@ let
             if config.expect == null then
               lib.types.unspecified
               // {
-                description = "defined by `expect`";
+                description = ''
+                  Depends on `expect`:
+                  ${lib.concatStringsSep "\n" (
+                    lib.mapAttrsToList (
+                      name: spec: "- ${builtins.toJSON name}: ${spec.valueType.description}"
+                    ) cfg.namedExpectationPredicates
+                  )}
+                '';
               }
             else
               namedPredicate.valueType;


### PR DESCRIPTION
Small followup to #2752, kept separate to avoid further bloating that PR

![image](https://github.com/user-attachments/assets/bfb66fdc-8918-4110-b498-74424724200c)
