### PR TITLE
docs: treat internal options as invisible

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -41,9 +41,9 @@ let
   isVisible =
     opts:
     if lib.isOption opts then
-      opts.visible or true
+      opts.visible or true && !(opts.internal or false)
     else if opts.isOption then
-      opts.index.options.visible or true
+      opts.index.options.visible or true && !(opts.index.options.internal or false)
     else
       let
         filterFunc = lib.filterAttrs (_: v: if lib.isAttrs v then isVisible v else true);


### PR DESCRIPTION
`internal` options are intended to be implicitly not `visible`. This is already handled correctly by the nixos tooling, but our custom tooling did not correctly handle the edge case.

This lead to strange cases where an internal option is not included in the docs, but its sub-options were still visible.

For example, the new internal option `test.namedExpectationPredicates` is not in the docs, but its sub-options are:


<details><summary>Without this PR</summary>
<p>

![image](https://github.com/user-attachments/assets/8c2ff32d-f9f7-4d5e-a3c6-45df20a03201)

</p>
</details> 


<details><summary>With this PR</summary>
<p>


![image](https://github.com/user-attachments/assets/76d1710d-daf1-45a1-a805-ef3d7e1422ce)


</p>
</details> 