### PR TITLE
modules/test: hide the deprecated `check*` options

### DIFF
--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -100,17 +100,19 @@ in
 
     checkWarnings = lib.mkOption {
       type = lib.types.bool;
-      description = "Whether to check `config.warnings` in the test.";
+      description = "Whether to check `config.warnings` in the test. (deprecated)";
       apply = x: lib.warnIfNot x "`test.checkWarnings = false` is replaced with `test.warnings = [ ]`." x;
       default = true;
+      visible = false;
     };
 
     checkAssertions = lib.mkOption {
       type = lib.types.bool;
-      description = "Whether to check `config.assertions` in the test.";
+      description = "Whether to check `config.assertions` in the test. (deprecated)";
       apply =
         x: lib.warnIfNot x "`test.checkAssertions = false` is replaced with `test.assertions = [ ]`." x;
       default = true;
+      visible = false;
     };
 
     warnings = lib.mkOption {


### PR DESCRIPTION
TBH these should probably be removed entirely and/or throw rather than warn, but for now we should at least hide them from the public docs.
