### PR TITLE
plugins/blink-cmp: force version for blink.cmp >= 0.8.2

### DIFF
--- a/plugins/by-name/blink-cmp/default.nix
+++ b/plugins/by-name/blink-cmp/default.nix
@@ -162,5 +162,11 @@ lib.nixvim.plugins.mkNeovimPlugin {
     warnings = lib.optional (cfg.settings ? documentation) ''
       Nixvim(plugins.blink): `settings.documentation` does not correspond to a known setting, use `settings.windows.documentation` instead.
     '';
+
+    # After version 0.8.2, if we don't force the version, the plugin return an error after being loaded.
+    # This happens because when we use nix to install the plugin, blink.cmp can't find the git hash or git tag that was used to build the plugin.
+    plugins.blink-cmp.settings.fuzzy.prebuilt_binaries.force_version = lib.mkIf (
+      builtins.compareVersions cfg.package.version "0.8.2" >= 0
+    ) (lib.mkDefault "v${cfg.package.version}");
   };
 }


### PR DESCRIPTION
When using nix to install blink-cmp plugin version 0.8.2 or higher, the plugin fails to load because it cannot find the git hash or tag used during build. So we force define the current version based on the current package version.