### PR TITLE
plugings/obsidian: add follow_img_func function setting

### DIFF
--- a/plugins/by-name/obsidian/options.nix
+++ b/plugins/by-name/obsidian/options.nix
@@ -157,6 +157,19 @@ with lib;
     ```
   '';
 
+  follow_img_func = helpers.mkNullOrLuaFn ''
+    By default when you use `:ObsidianFollowLink` on a link to an image file it will be
+    ignored but you can customize this behavior here.
+
+    Example:
+    ```lua
+       function(img)
+         vim.fn.jobstart { "qlmanage", "-p", img }  -- Mac OS quick look preview
+         -- vim.fn.jobstart({"xdg-open", url})  -- linux
+         -- vim.cmd(':silent exec "!start ' .. url .. '"') -- Windows
+    ```
+  '';
+
   image_name_func = helpers.mkNullOrLuaFn ''
     Customize the default name or prefix when pasting images via `:ObsidianPasteImg`.
 


### PR DESCRIPTION
This setting is almost identical to `follow_url_func`.
Currently if one tries to add this setting like this:
```nix  
plugins.obsidian = {
  # ...
  settings = {
    follow_img_func = ''
    function(img)
      vim.fn.jobstart { "xdg-open", img }
    end
  ''; 
    follow_url_func = ''
      function(url)
        vim.fn.jobstart({"xdg-open", url})  -- linux
      end
  '';
}; 
}    
```
The generated configuration uses the literal string, and fails when used:
```lua
      follow_img_func = 'function(img)\n  vim.fn.jobstart({"xdg-open", img})  -- linux\nend\n',
      follow_url_func = function(url)
          vim.fn.jobstart({ "xdg-open", url }) -- linux
      end,
```