### PR TITLE
lib/options: mkAttrsOf, mkListOf, mkAttributeSet should accept raw values

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -182,17 +182,17 @@ rec {
       mkStr' = args: mkNullableWithRaw' (args // { type = types.str; });
       mkStr = pluginDefault: description: mkStr' { inherit pluginDefault description; };
 
-      mkAttributeSet' = args: mkNullable' (args // { type = types.attrs; });
+      mkAttributeSet' = args: mkNullableWithRaw' (args // { type = types.attrs; });
       mkAttributeSet = pluginDefault: description: mkAttributeSet' { inherit pluginDefault description; };
 
       mkListOf' =
-        { type, ... }@args: mkNullable' (args // { type = with types; listOf (maybeRaw type); });
+        { type, ... }@args: mkNullableWithRaw' (args // { type = with types; listOf (maybeRaw type); });
       mkListOf =
         type: pluginDefault: description:
         mkListOf' { inherit type pluginDefault description; };
 
       mkAttrsOf' =
-        { type, ... }@args: mkNullable' (args // { type = with types; attrsOf (maybeRaw type); });
+        { type, ... }@args: mkNullableWithRaw' (args // { type = with types; attrsOf (maybeRaw type); });
       mkAttrsOf =
         type: pluginDefault: description:
         mkAttrsOf' { inherit type pluginDefault description; };


### PR DESCRIPTION
Currently, an option created with `mkListOf type` allows only
- `null`
- A list of elements of type "type" or `rawLua`

According to me, it should also accept `rawLua` values directly, like all other options.