### PR TITLE
flake: remove unneeded follows after git-hooks dropped their nixpkgs-stable input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,6 @@
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-stable.follows = "nixpkgs";
       inputs.flake-compat.follows = "flake-compat";
     };
   };


### PR DESCRIPTION
Remove `inputs.git-hooks.inputs.nixpkgs-stable.follows`, see https://github.com/cachix/git-hooks.nix/pull/543
