### PR TITLE
plugins/treesitter: injections support luaConfig strings

### DIFF
--- a/plugins/by-name/treesitter/injections.scm
+++ b/plugins/by-name/treesitter/injections.scm
@@ -38,3 +38,39 @@
         (#set! injection.language "vim")))
   ]
   (#match? @_path "(^extraConfigVim(Pre|Post)?)$"))
+
+(binding
+  attrpath: (attrpath
+    (identifier) @namespace
+    (identifier) @name)
+  expression: [
+    (string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "lua")))
+    (indented_string_expression
+      ((string_fragment) @injection.content
+        (#set! injection.language "lua")))
+  ]
+  (#match? @namespace "^luaConfig$")
+  (#match? @name "^(pre|post|content)$"))
+
+(binding
+  attrpath: (attrpath
+    (identifier) @_path)
+  expression: [
+    (attrset_expression
+      (binding_set
+        (binding
+          attrpath: (attrpath
+            (identifier) @_nested_path)
+          expression: [
+            (string_expression
+              ((string_fragment) @injection.content
+                (#set! injection.language "lua")))
+            (indented_string_expression
+              ((string_fragment) @injection.content
+                (#set! injection.language "lua")))
+          ]
+          (#match? @_nested_path "^(pre|post|content)$"))))
+  ]
+  (#match? @_path "^luaConfig$"))


### PR DESCRIPTION
Played around with `:InspectTree` and writing injections to support our `luaConfig` attributes for writing lua. This supports `luaConfig.pre|post|content` and `luaConfig = { pre|post|content }`

<img width="661" alt="image" src="https://github.com/user-attachments/assets/f0ec8582-82ba-4c74-a8bf-cf4a56d05ae8" />
