### PR TITLE
plugins/blink-cmp: fix `sources.per_filetype` option type

### DIFF
--- a/plugins/by-name/blink-cmp/settings-options.nix
+++ b/plugins/by-name/blink-cmp/settings-options.nix
@@ -490,7 +490,7 @@ in
       Default sources.
     '';
 
-    per_filetype = defaultNullOpts.mkAttrsOf (with types; attrsOf str) { } ''
+    per_filetype = defaultNullOpts.mkAttrsOf (with types; listOf str) { } ''
       Sources per filetype.
     '';
 


### PR DESCRIPTION
cc @GaetanLepage 