### PR TITLE
plugins/blink-cmp: remove forced version override

### DIFF
--- a/plugins/by-name/blink-cmp/default.nix
+++ b/plugins/by-name/blink-cmp/default.nix
@@ -44,11 +44,5 @@ lib.nixvim.plugins.mkNeovimPlugin {
     warnings = lib.optional (cfg.settings ? documentation) ''
       Nixvim(plugins.blink): `settings.documentation` does not correspond to a known setting, use `settings.windows.documentation` instead.
     '';
-
-    # After version 0.8.2, if we don't force the version, the plugin return an error after being loaded.
-    # This happens because when we use nix to install the plugin, blink.cmp can't find the git hash or git tag that was used to build the plugin.
-    plugins.blink-cmp.settings.fuzzy.prebuilt_binaries.force_version = lib.mkIf (
-      builtins.compareVersions cfg.package.version "0.8.2" >= 0
-    ) (lib.mkDefault "v${cfg.package.version}");
   };
 }


### PR DESCRIPTION
Forgot to remove this after I submitted the patch in nixpkgs