### PR TITLE
plugins/blink-cmp: update completion.list.selection type 

### DIFF
--- a/plugins/by-name/blink-cmp/default.nix
+++ b/plugins/by-name/blink-cmp/default.nix
@@ -7,7 +7,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "blink.cmp";
   package = "blink-cmp";
 
-  maintainers = [ lib.maintainers.balssh ];
+  maintainers = with lib.maintainers; [
+    balssh
+    khaneliman
+  ];
 
   description = ''
     Performant, batteries-included completion plugin for Neovim.

--- a/plugins/by-name/blink-cmp/settings-options.nix
+++ b/plugins/by-name/blink-cmp/settings-options.nix
@@ -164,10 +164,16 @@ in
         Maximum number of items to display.
       '';
 
-      selection = defaultNullOpts.mkEnumFirstDefault [ "preselect" "manual" "auto_insert" ] ''
-        Controls if completion items will be selected automatically, and whether selection
-        automatically inserts.
-      '';
+      selection =
+        defaultNullOpts.mkNullableWithRaw (types.either types.str (types.attrsOf types.anything))
+          {
+            preselect = true;
+            auto_insert = true;
+          }
+          ''
+            Controls if completion items will be selected automatically, and whether selection
+            automatically inserts.
+          '';
 
       cycle = {
         from_bottom = defaultNullOpts.mkBool true ''

--- a/tests/test-sources/plugins/by-name/blink-cmp/default.nix
+++ b/tests/test-sources/plugins/by-name/blink-cmp/default.nix
@@ -42,7 +42,10 @@
           };
           list = {
             max_items = 200;
-            selection = "preselect";
+            selection = {
+              preselect = true;
+              auto_insert = true;
+            };
             cycle = {
               from_bottom = true;
               from_top = true;


### PR DESCRIPTION
https://github.com/Saghen/blink.cmp/releases/tag/v0.10.0

Can be merged after next flake update with new version. 

> [!TIP] 
> Workaround for users not tracking nixvim nixpkgs.
> ```nix
>            plugins.blink-cmp.settings = {
>              completion.list.selection.__raw = ''{auto_insert = true, preselect = false}'';
>            };
> ```