### PR TITLE
plugins/persistence: convert to mkNeovimPlugin and fix settings

### DIFF
--- a/tests/test-sources/plugins/by-name/persistence/default.nix
+++ b/tests/test-sources/plugins/by-name/persistence/default.nix
@@ -7,15 +7,11 @@
     plugins.persistence = {
       enable = true;
 
-      dir.__raw = ''vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/")'';
-      options = [
-        "buffers"
-        "curdir"
-        "tabpages"
-        "winsize"
-      ];
-      preSave = null;
-      saveEmpty = false;
+      settings = {
+        branch = true;
+        dir.__raw = ''vim.fn.expand(vim.fn.stdpath("state") .. "/sessions/")'';
+        need = 1;
+      };
     };
   };
 }


### PR DESCRIPTION
- Converted the plugin to use mkNeovimPlugin
- Removed some arguments that have been removed upstream and have no effect. I wasn't sure how to handle this. Right now enabling those options throws an error, but maybe there should just be a warning?