### PR TITLE
plugins/inc-rename: convert to mkNeovimPlugin and add option

### DIFF
--- a/plugins/by-name/inc-rename/default.nix
+++ b/plugins/by-name/inc-rename/default.nix
@@ -1,61 +1,69 @@
-{
-  lib,
-  helpers,
-  config,
-  pkgs,
-  ...
-}:
-with lib;
-{
-  options.plugins.inc-rename = {
-    enable = mkEnableOption "inc-rename, a plugin previewing LSP renaming";
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "inc-rename";
+  moduleName = "inc_rename";
+  packPathName = "inc-rename.nvim";
+  package = "inc-rename-nvim";
+  description = ''
+    A small Neovim plugin that provides a command for LSP renaming with
+    immediate visual feedback thanks to Neovim's command preview feature.
+  '';
 
-    package = lib.mkPackageOption pkgs "inc-rename" {
-      default = [
-        "vimPlugins"
-        "inc-rename-nvim"
-      ];
-    };
+  maintainers = [ lib.maintainers.jolars ];
 
-    cmdName = helpers.defaultNullOpts.mkStr "IncRename" "the name of the command";
+  # TODO: introduced 2025-01-08: remove after 25.05
+  optionsRenamedToSettings = [
+    "cmdName"
+    "hlGroup"
+    "previewEmptyName"
+    "showMessage"
+    "inputBufferType"
+    "postHook"
+  ];
 
-    hlGroup = helpers.defaultNullOpts.mkStr "Substitute" "the highlight group used for highlighting the identifier's new name";
+  settingsOptions = {
+    cmd_name = defaultNullOpts.mkStr "IncRename" "The name of the command.";
 
-    previewEmptyName = helpers.defaultNullOpts.mkBool false ''
-      whether an empty new name should be previewed; if false the command preview will be cancelled
-      instead
+    hl_group = defaultNullOpts.mkStr "Substitute" ''
+      The highlight group used for highlighting the identifier's new name.
     '';
 
-    showMessage = helpers.defaultNullOpts.mkBool true ''
-      whether to display a `Renamed m instances in n files` message after a rename operation
+    preview_empty_name = defaultNullOpts.mkBool false ''
+      Whether an empty new name should be previewed; if false the command
+      preview will be cancelled instead.
     '';
 
-    inputBufferType = helpers.defaultNullOpts.mkNullable (types.enum [ "dressing" ]) null ''
-      the type of the external input buffer to use
+    show_message = defaultNullOpts.mkBool true ''
+      Whether to display a `Renamed m instances in n files` message after a rename operation.
     '';
 
-    postHook = helpers.defaultNullOpts.mkLuaFn null ''
-      callback to run after renaming, receives the result table (from LSP handler) as an argument
+    save_in_cmdline_history = defaultNullOpts.mkBool true ''
+      Whether to save the `IncRename` command in the commandline history. Set to
+      false to prevent issues with navigating to older entries that may arise due to
+      the behavior of command preview).
+    '';
+
+    input_buffer_type = defaultNullOpts.mkNullable (types.enum [ "dressing" ]) null ''
+      The type of the external input buffer to use.
+    '';
+
+    post_hook = defaultNullOpts.mkRaw null ''
+      Callback to run after renaming, receives the result table (from LSP
+      handler) as an argument.
     '';
   };
 
-  config =
-    let
-      cfg = config.plugins.inc-rename;
-      setupOptions = {
-        cmd_name = cfg.cmdName;
-        hl_group = cfg.hlGroup;
-        preview_empty_name = cfg.previewEmptyName;
-        show_message = cfg.showMessage;
-        input_buffer_type = cfg.inputBufferType;
-        post_hook = cfg.postHook;
-      };
-    in
-    mkIf cfg.enable {
-      extraPlugins = [ cfg.package ];
-
-      extraConfigLua = ''
-        require("inc_rename").setup(${lib.nixvim.toLuaObject setupOptions})
-      '';
-    };
+  settingsExample = {
+    input_buffer_type = "dressing";
+    preview_empty_name = false;
+    show_message.__raw = ''
+      function(msg)
+        vim.notify(msg, vim.log.levels.INFO, { title = "Rename" })
+      end
+    '';
+  };
 }

--- a/tests/test-sources/plugins/by-name/inc-rename/default.nix
+++ b/tests/test-sources/plugins/by-name/inc-rename/default.nix
@@ -6,12 +6,32 @@
   defaults = {
     plugins.inc-rename = {
       enable = true;
-      cmdName = "IncRename";
-      hlGroup = "Substitute";
-      previewEmptyName = false;
-      showMessage = true;
-      inputBufferType = null;
-      postHook = null;
+
+      settings = {
+        cmd_name = "IncRename";
+        hl_group = "Substitute";
+        preview_empty_name = false;
+        show_message = true;
+        save_in_cmdline_history = true;
+        input_buffer_type = null;
+        post_hook = null;
+      };
+    };
+  };
+
+  example = {
+    plugins.inc-rename = {
+      enable = true;
+
+      settings = {
+        input_buffer_type = "dressing";
+        preview_empty_name = false;
+        show_message.__raw = ''
+          function(msg)
+            vim.notify(msg, vim.log.levels.INFO, { title = "Rename" })
+          end
+        '';
+      };
     };
   };
 }


### PR DESCRIPTION
- Converted the inc-rename plugin to use `mkNeovimPlugin`
- Added a missing option `save_in_cmdline_history`
- Changed description slightly.