### PR TITLE
plugins/cornelis: init

### DIFF
--- a/plugins/by-name/cornelis/default.nix
+++ b/plugins/by-name/cornelis/default.nix
@@ -1,0 +1,54 @@
+{ lib, pkgs, ... }:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.plugins.mkVimPlugin {
+  name = "cornelis";
+  globalPrefix = "cornelis_";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  extraOptions = {
+    cornelisPackage = lib.mkPackageOption pkgs "cornelis" {
+      nullable = true;
+    };
+  };
+
+  extraConfig = cfg: {
+    extraPackages = [ cfg.cornelisPackage ];
+  };
+
+  settingsOptions = {
+    use_global_binary = defaultNullOpts.mkFlagInt 0 ''
+      Whether to use global binary instead of stack.
+    '';
+
+    agda_prefix = defaultNullOpts.mkStr' {
+      pluginDefault = "<localleader>";
+      example = "<Tab>";
+      description = ''
+        Prefix used for agda keybindings.
+      '';
+    };
+
+    no_agda_input = defaultNullOpts.mkFlagInt 0 ''
+      Disable the default keybindings.
+    '';
+
+    bind_input_hook = defaultNullOpts.mkStr' {
+      pluginDefault = null;
+      example = "MyCustomHook";
+      description = ''
+        If you'd prefer to manage agda-input entirely on your own (perhaps in a snippet system), you
+        can customize the bind input hook.
+      '';
+    };
+  };
+
+  settingsExample = {
+    use_global_binary = 1;
+    agda_prefix = "<Tab>";
+    no_agda_input = 1;
+    bind_input_hook = "MyCustomHook";
+  };
+}

--- a/tests/test-sources/plugins/by-name/cornelis/default.nix
+++ b/tests/test-sources/plugins/by-name/cornelis/default.nix
@@ -1,0 +1,31 @@
+{
+  empty = {
+    plugins.cornelis.enable = true;
+  };
+
+  defaults = {
+    plugins.cornelis = {
+      enable = true;
+
+      settings = {
+        use_global_binary = 0;
+        agda_prefix = "<localleader>";
+        no_agda_input = 0;
+        bind_input_hook = null;
+      };
+    };
+  };
+
+  example = {
+    plugins.cornelis = {
+      enable = true;
+
+      settings = {
+        use_global_binary = 1;
+        agda_prefix = "<Tab>";
+        no_agda_input = 1;
+        bind_input_hook = "MyCustomHook";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [cornelis](https://github.com/agda/cornelis), a plugin providing agda-mode for neovim.

Fixes #2280
