### PR TITLE
lib/modules: clean `specialArgs`: drop `lib`, add `modulesPath`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -36,7 +36,6 @@ in
         }
       ];
       specialArgs = {
-        inherit lib;
         # TODO: deprecate `helpers`
         helpers = self;
       } // extraSpecialArgs;

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -36,6 +36,7 @@ in
         }
       ];
       specialArgs = {
+        modulesPath = ../modules;
         # TODO: deprecate `helpers`
         helpers = self;
       } // extraSpecialArgs;


### PR DESCRIPTION

`lib.evalModules` will automatically add `lib` to the module args internally. Doing it explicitly is redundant.

`specialArgs.modulesPath` can be used to allow users to manually import modules relative to our `./modules` directory.
It is also used by the module system to provide a base path for relative `disabledModules` paths.


