### PR TITLE
modules/test: provide access to `expect` function

### DIFF
--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -76,6 +76,19 @@ let
       };
     }
   );
+
+  expectationListType =
+    let
+      fnType = lib.mkOptionType {
+        name = "function";
+        description = "function";
+        descriptionClass = "noun";
+        check = builtins.isFunction;
+      };
+      # Supply the function with an `expect` function
+      coerceFn = fn: fn (expect: value: { inherit expect value; });
+    in
+    lib.types.coercedTo fnType coerceFn (lib.types.listOf expectationType);
 in
 {
   options.test = {
@@ -116,9 +129,22 @@ in
     };
 
     warnings = lib.mkOption {
-      type = lib.types.listOf expectationType;
-      description = "A list of expectations for `warnings`.";
-      defaultText = lib.literalMD "Expect `count == 0`";
+      type = expectationListType;
+      description = ''
+        A list of expectations for `warnings`.
+
+        Function definitions will be supplied a `mkExpectation` function that
+        enables defining simple expectations less verbosely.
+      '';
+      example = lib.literalExpression ''
+        expect: [
+          (expect "count" 1)
+          (expect "any" "Hello, world!")
+        ]
+      '';
+      defaultText = lib.literalExpression ''
+        expect: [ (expect "count" 0) ]
+      '';
       default = [
         {
           expect = "count";
@@ -128,9 +154,22 @@ in
     };
 
     assertions = lib.mkOption {
-      type = lib.types.listOf expectationType;
-      description = "A list of expectations for `assertions`.";
-      defaultText = lib.literalMD "Expect `count == 0`";
+      type = expectationListType;
+      description = ''
+        A list of expectations for `warnings`.
+
+        Function definitions will be supplied a `mkExpectation` function that
+        enables defining simple expectations less verbosely.
+      '';
+      example = lib.literalExpression ''
+        expect: [
+          (expect "count" 1)
+          (expect "any" "Hello, world!")
+        ]
+      '';
+      defaultText = lib.literalExpression ''
+        expect: [ (expect "count" 0) ]
+      '';
       default = [
         {
           expect = "count";

--- a/tests/test-sources/plugins/by-name/nvim-osc52/default.nix
+++ b/tests/test-sources/plugins/by-name/nvim-osc52/default.nix
@@ -1,8 +1,6 @@
 let
-  expect = expect: value: { inherit expect value; };
-
   # This plugin is deprecated
-  warnings = [
+  warnings = expect: [
     (expect "count" 1)
     (expect "any" "this plugin is obsolete and will be removed after 24.11.")
   ];

--- a/tests/test-sources/plugins/by-name/rust-tools/default.nix
+++ b/tests/test-sources/plugins/by-name/rust-tools/default.nix
@@ -1,8 +1,6 @@
 let
-  expect = expect: value: { inherit expect value; };
-
   # This plugin is deprecated
-  warnings = [
+  warnings = expect: [
     (expect "count" 1)
     (expect "any" "The `rust-tools` project has been abandoned.")
   ];


### PR DESCRIPTION
Allow `test.warnings` and `test.assertions` to be defined as either a list, or a function coerced to a list.

When defined as a function, it is supplied an `expect` function which provides some syntactic-sugar for defining simple expectations.

This is an alternative to the current approach of defining that `expect` function on an ad-hoc basis.

I prefer this to adding `expect` to nixvim's lib because:
1. That would require having access to `lib`
2. IDK where in `lib` such a specialized function should live

Note: this can also be used in #2738

![image](https://github.com/user-attachments/assets/6a2965c7-9dca-4fe4-9739-2fd1b73b7d12)

