### PR TITLE
lib/utils: add mkWarnings

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -86,6 +86,7 @@ lib.makeExtensible (
       mkIfNonNull'
       mkRaw
       mkRawKey
+      mkWarnings
       nestedLiteral
       nestedLiteralLua
       override

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -158,6 +158,7 @@ rec {
     ```
 
     # Type
+
     ```
     literalLua :: String -> AttrSet
     ```
@@ -171,6 +172,34 @@ rec {
       exp = "lib.nixvim.mkRaw " + builtins.toJSON raw.__raw;
     in
     lib.literalExpression exp;
+
+  /**
+    Convert one or several conditional warnings to a final warning list.
+    The second argument can either be a list of _conditional warnings_ or a single one.
+
+    # Example
+
+    ```nix
+    warnings = mkWarnings "plugins.foo" {
+      when = plugins.foo.settings.barIntegration && (!plugins.bar.enable);
+      message = "`barIntegration` is enabled but the `bar` plugin is not."
+    }
+    ```
+
+    # Type
+
+    ```
+    mkWarnings :: String -> List -> List
+    ```
+  */
+  mkWarnings =
+    scope: warnings:
+    let
+      processWarning =
+        warning:
+        lib.optional (warning.when or true) "Nixvim (${scope}): ${lib.trim (warning.message or warning)}";
+    in
+    builtins.concatMap processWarning (lib.toList warnings);
 
   /**
     Convert the given string into a `__pretty` printed mkRaw expression.
@@ -190,6 +219,7 @@ rec {
     ```
 
     # Type
+
     ```
     nestedLiteralLua :: String -> AttrSet
     ```
@@ -221,6 +251,7 @@ rec {
     ```
 
     # Type
+
     ```
     nestedLiteral :: (String | literalExpression) -> AttrSet
     ```

--- a/plugins/by-name/haskell-scope-highlighting/default.nix
+++ b/plugins/by-name/haskell-scope-highlighting/default.nix
@@ -1,10 +1,8 @@
 {
   lib,
-  helpers,
   config,
   ...
 }:
-with lib;
 lib.nixvim.plugins.mkVimPlugin {
   name = "haskell-scope-highlighting";
   packPathName = "haskell-scope-highlighting.nvim";
@@ -13,9 +11,12 @@ lib.nixvim.plugins.mkVimPlugin {
   maintainers = [ lib.maintainers.GaetanLepage ];
 
   extraConfig = {
-    warnings = optional (!config.plugins.treesitter.enable) ''
-      Nixvim (plugins.haskell-scope-highlighting): haskell-scope-highlighting needs treesitter to function as intended.
-      Please, enable it by setting `plugins.treesitter.enable` to `true`.
-    '';
+    warnings = lib.nixvim.mkWarnings "plugins.haskell-scope-highlighting" {
+      when = !config.plugins.treesitter.enable;
+      message = ''
+        haskell-scope-highlighting needs treesitter to function as intended.
+        Please, enable it by setting `plugins.treesitter.enable` to `true`.
+      '';
+    };
   };
 }

--- a/plugins/by-name/nvim-autopairs/default.nix
+++ b/plugins/by-name/nvim-autopairs/default.nix
@@ -189,12 +189,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    warnings =
-      optional
-        ((isBool cfg.settings.check_ts) && cfg.settings.check_ts && !config.plugins.treesitter.enable)
-        ''
-          Nixvim (plugins.nvim-autopairs): You have set `settings.check_ts` to `true` but have not enabled the treesitter plugin.
-          We suggest you to set `plugins.treesitter.enable` to `true`.
-        '';
+    warnings = lib.nixvim.mkWarnings "plugins.nvim-autopairs" {
+      when = (isBool cfg.settings.check_ts) && cfg.settings.check_ts && !config.plugins.treesitter.enable;
+      message = ''
+        You have set `settings.check_ts` to `true` but have not enabled the treesitter plugin.
+        We suggest you to set `plugins.treesitter.enable` to `true`.
+      '';
+    };
   };
 }

--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -249,13 +249,16 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    warnings =
-      let
-        nvimCmpEnabled = isBool cfg.settings.completion.nvim_cmp && cfg.settings.completion.nvim_cmp;
-      in
-      optional (nvimCmpEnabled && !config.plugins.cmp.enable) ''
-        Nixvim (plugins.obsidian): You have enabled `completion.nvim_cmp` but `plugins.cmp.enable` is `false`.
+    warnings = lib.nixvim.mkWarnings "plugins.obsidian" {
+      when =
+        let
+          nvimCmpEnabled = isBool cfg.settings.completion.nvim_cmp && cfg.settings.completion.nvim_cmp;
+        in
+        nvimCmpEnabled && (!config.plugins.cmp.enable);
+      message = ''
+        You have enabled `completion.nvim_cmp` but `plugins.cmp.enable` is `false`.
         You should probably enable `nvim-cmp`.
       '';
+    };
   };
 }

--- a/plugins/by-name/rustaceanvim/default.nix
+++ b/plugins/by-name/rustaceanvim/default.nix
@@ -68,19 +68,19 @@ lib.nixvim.plugins.mkNeovimPlugin {
         ];
 
         # TODO: remove after 24.11
-        warnings =
-          optional
-            (hasAttrByPath [
-              "settings"
-              "server"
-              "settings"
-            ] cfg)
-            ''
-              The `plugins.rustaceanvim.settings.server.settings' option has been renamed to `plugins.rustaceanvim.settings.server.default_settings'.
+        warnings = lib.nixvim.mkWarnings "plugins.rustaceanvim" {
+          when = hasAttrByPath [
+            "settings"
+            "server"
+            "settings"
+          ] cfg;
+          message = ''
+            The `settings.server.settings' option has been renamed to `settings.server.default_settings'.
 
-              Note that if you supplied an attrset and not a function you need to set this attr set in:
-                `plugins.rustaceanvim.settings.server.default_settings.rust-analyzer'.
-            '';
+            Note that if you supplied an attrset and not a function you need to set this attr set in:
+              `settings.server.default_settings.rust-analyzer'.
+          '';
+        };
       }
       # If nvim-lspconfig is enabled:
       (mkIf config.plugins.lsp.enable {

--- a/plugins/by-name/twilight/default.nix
+++ b/plugins/by-name/twilight/default.nix
@@ -70,11 +70,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    warnings =
-      optional
-        ((isBool cfg.settings.treesitter) && cfg.settings.treesitter && (!config.plugins.treesitter.enable))
-        ''
-          Nixvim (plugins.twilight): You have set `plugins.twilight.treesitter` to `true` but `plugins.treesitter.enable` is false.
-        '';
+    warnings = lib.nixvim.mkWarnings "plugins.twilight" {
+      when =
+        (isBool cfg.settings.treesitter) && cfg.settings.treesitter && (!config.plugins.treesitter.enable);
+      message = ''
+        You have set `plugins.twilight.treesitter` to `true` but `plugins.treesitter.enable` is false.
+      '';
+    };
   };
 }

--- a/plugins/cmp/auto-enable.nix
+++ b/plugins/cmp/auto-enable.nix
@@ -58,22 +58,29 @@ in
   config = lib.mkIf (cfg.enable && cfg.autoEnableSources) (
     lib.mkMerge [
       {
-        warnings =
+        warnings = lib.nixvim.mkWarnings "plugins.cmp" [
           # TODO: expand this warning to ft & cmd sources lists and `showDefs` the offending definitions
-          lib.optional (lib.types.isRawType cfg.settings.sources) ''
-            Nixvim (plugins.cmp): You have enabled `autoEnableSources` that tells Nixvim to automatically
-            enable the source plugins with respect to the list of sources provided in `settings.sources`.
-            However, the latter is proveded as a raw lua string which is not parseable by Nixvim.
+          {
+            when = lib.types.isRawType cfg.settings.sources;
+            message = ''
+              You have enabled `autoEnableSources` that tells Nixvim to automatically
+              enable the source plugins with respect to the list of sources provided in `settings.sources`.
+              However, the latter is proveded as a raw lua string which is not parseable by Nixvim.
 
-            If you want to keep using raw lua for defining your sources:
-            - Ensure you enable the relevant plugins manually in your configuration;
-            - Dismiss this warning by explicitly setting `autoEnableSources` to `false`;
-          ''
+              If you want to keep using raw lua for defining your sources:
+              - Ensure you enable the relevant plugins manually in your configuration;
+              - Dismiss this warning by explicitly setting `autoEnableSources` to `false`;
+            '';
+          }
           # TODO: Added 2024-09-22; remove after 24.11
-          ++ lib.optional (lib.elem "otter" enabledSources) ''
-            Nixvim (plugins.cmp): "otter" is listed in `settings.sources`, however it is no longer a cmp source.
-            Instead, you should enable `plugins.otter` and use the "cmp-nvim-lsp" completion source.
-          '';
+          {
+            when = lib.elem "otter" enabledSources;
+            message = ''
+              "otter" is listed in `settings.sources`, however it is no longer a cmp source.
+              Instead, you should enable `plugins.otter` and use the "cmp-nvim-lsp" completion source.
+            '';
+          }
+        ];
 
         # If the user has enabled the `foo` and `bar` sources, then `plugins` will look like:
         # {

--- a/plugins/colorschemes/monokai-pro.nix
+++ b/plugins/colorschemes/monokai-pro.nix
@@ -116,14 +116,15 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    warnings =
-      lib.optional
-        (
-          (lib.isBool cfg.settings.devicons) && cfg.settings.devicons && (!config.plugins.web-devicons.enable)
-        )
-        ''
-          Nixvim (colorschemes.monokai-pro): You have enabled `settings.devicons` but `plugins.web-devicons.enable` is `false`.
-          Consider enabling the plugin for proper devicons support.
-        '';
+    warnings = lib.nixvim.mkWarnings "colorschemes.monokai-pro" {
+      when =
+        (lib.isBool cfg.settings.devicons)
+        && cfg.settings.devicons
+        && (!config.plugins.web-devicons.enable);
+      message = ''
+        You have enabled `settings.devicons` but `plugins.web-devicons.enable` is `false`.
+        Consider enabling the plugin for proper devicons support.
+      '';
+    };
   };
 }

--- a/tests/lib-tests.nix
+++ b/tests/lib-tests.nix
@@ -490,6 +490,30 @@ let
         "mkAfter list".foo.bar = lib.mkAfter "Hello!";
       };
     };
+
+    testMkWarnings = {
+      expr =
+        (lib.nixvim.mkWarnings "foo-bar" [
+          {
+            when = true;
+            message = "This is the message";
+          }
+          {
+            when = false;
+            message = "This should not be included";
+          }
+          "This is an unconditional warning"
+        ])
+        ++ (lib.nixvim.mkWarnings "single-element") {
+          when = true;
+          message = "Hello";
+        };
+      expected = [
+        "Nixvim (foo-bar): This is the message"
+        "Nixvim (foo-bar): This is an unconditional warning"
+        "Nixvim (single-element): Hello"
+      ];
+    };
   };
 in
 if results == [ ] then


### PR DESCRIPTION
This aims to provide more consistency for our warnings.

- **lib/utils: add mkWarnings**
- **treewide: use mkWarnings wherever possible**

Before:
```nix
warnings = lib.optional COND ''
  Nixvim (plugins.foo): MESSAGE
'';
```
After:
```nix
warnings = lib.nixvim.mkWarnings "plugins.foo" {
  condition = COND; # Or `cond = `, to be discussed
  message = "MESSAGE";
};
```

### Notes:
- The second argument of `mkWarnings` can either be a single _conditional warning_ or a list of several ones.
- A _conditional warning_ is either a string (i.e. non-conditional) or a `{ condition = ...; message = ...; }` attrs.