### PR TITLE
lib,lsp,none-ls: Add a standard way to handle automatic installation of packages that may not exist in nixpkgs

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -54,6 +54,7 @@ lib.makeExtensible (
       mkCompositeOption
       mkCompositeOption'
       mkLazyLoadOption
+      mkMaybeUnpackagedOption
       mkNullOrLua
       mkNullOrLua'
       mkNullOrLuaFn
@@ -69,6 +70,7 @@ lib.makeExtensible (
       mkPackageOption
       mkPluginPackageOption
       mkSettingsOption
+      mkUnpackagedOption
       pluginDefaultText
       ;
 

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -403,5 +403,43 @@ rec {
         if cfg ? lazyLoad then lib.literalMD "`false` when lazy-loading is enabled." else true;
       example = false;
     };
+
+  /**
+    Create an option for a package not currently available in nixpkgs.
+
+    The option will throw an error if a value is not explicitly set by the end user.
+  */
+  mkUnpackagedOption =
+    optionName: packageName:
+    lib.mkOption {
+      type = types.nullOr types.package;
+      description = ''
+        Package to use for ${packageName}.
+        Nixpkgs does not include this package, and as such an external derivation or null must be provided.
+      '';
+      default = throw ''
+        Nixvim (${optionName}): No package is known for ${packageName}, to resolve this either:
+          - install externally and set this option to `null`
+          - or provide a derviation to install this package
+      '';
+      defaultText = lib.literalMD "No package, throws when undefined";
+    };
+
+  /**
+    Create an option for a package that may not be currently available in nixpkgs.
+
+    See `mkUnpackagedOption`
+  */
+  mkMaybeUnpackagedOption =
+    optionName: pkgs: packageName: package:
+    if lib.isOption package then
+      package
+    else if package != null then
+      lib.mkPackageOption pkgs packageName {
+        nullable = true;
+        default = package;
+      }
+    else
+      mkUnpackagedOption optionName packageName;
 }
 // removed

--- a/plugins/by-name/none-ls/_mk-source-plugin.nix
+++ b/plugins/by-name/none-ls/_mk-source-plugin.nix
@@ -9,7 +9,6 @@ sourceType: sourceName:
 let
   inherit (import ./packages.nix lib) packaged;
   pkg = packaged.${sourceName};
-  loc = lib.toList pkg;
 
   cfg = config.plugins.none-ls;
   cfg' = config.plugins.none-ls.sources.${sourceType}.${sourceName};
@@ -41,27 +40,11 @@ in
     }
     # Only declare a package option if a package is required
     // lib.optionalAttrs (packaged ? ${sourceName}) {
-      package = lib.mkOption (
-        {
-          type = lib.types.nullOr lib.types.package;
-          description =
-            "Package to use for ${sourceName}."
-            + (lib.optionalString (pkg == null) (
-              "\n\n"
-              + ''
-                Currently not packaged in nixpkgs.
-                Either set this to `null` and install ${sourceName} outside of nix,
-                or set this to a custom nix package.
-              ''
-            ));
-        }
-        // lib.optionalAttrs (pkg != null) {
-          default =
-            lib.attrByPath loc (lib.warn "${lib.concatStringsSep "." loc} cannot be found in pkgs!" null)
-              pkgs;
-          defaultText = lib.literalExpression "pkgs.${lib.concatStringsSep "." loc}";
-        }
-      );
+      package =
+        lib.nixvim.mkMaybeUnpackagedOption "plugins.none-ls.sources.${sourceType}.${sourceName}.package"
+          pkgs
+          sourceName
+          pkg;
     };
 
   # TODO: Added 2024-07-16; remove after 24.11

--- a/tests/lsp-servers.nix
+++ b/tests/lsp-servers.nix
@@ -82,7 +82,10 @@ let
           {
             enable = !(lib.elem server disabled);
           }
-          // lib.optionalAttrs (opts ? package && !(opts.package ? default)) { package = null; }
+          # Some servers are defined using mkUnpackagedOption whose default will throw
+          // lib.optionalAttrs (opts ? package && !(builtins.tryEval opts.package.default).success) {
+            package = null;
+          }
         ))
         (lib.filterAttrs (server: _: !(lib.elem server renamed)))
       ];

--- a/tests/test-sources/plugins/by-name/none-ls/default.nix
+++ b/tests/test-sources/plugins/by-name/none-ls/default.nix
@@ -100,7 +100,6 @@
 
   with-sources =
     {
-      config,
       options,
       lib,
       pkgs,
@@ -158,8 +157,10 @@
                 # Enable unless disabled above
                 enable = !(lib.elem sourceName disabled);
               }
-              # Some sources have a package option with no default
-              // lib.optionalAttrs (opts ? package && !(opts.package ? default)) { package = null; }
+              # Some sources are defined using mkUnpackagedOption whose default will throw
+              // lib.optionalAttrs (opts ? package && !(builtins.tryEval opts.package.default).success) {
+                package = null;
+              }
             )
           ) options.plugins.none-ls.sources;
       };


### PR DESCRIPTION
If such a package is used by an end user an error will be raised with a message of the form:

```
       error: Nixvim (plugins.none-ls.sources.formatting.textlint.package): No package is known for textlint, install externally and set this option to null
```

I'm open to changing that to a warning and returning null instead, though this would complicate the implementation as we would now need to check the priorities