### PR TITLE
experimental configuration-based nixvim template

### DIFF
--- a/flake/templates.nix
+++ b/flake/templates.nix
@@ -5,6 +5,10 @@
       path = ../templates/simple;
       description = "A simple nix flake template for getting started with nixvim";
     };
+    new = {
+      path = ../templates/experimental-flake-parts;
+      description = "An experimental flake template for configuring nixvim using evalNixvim and flake.parts";
+    };
   };
 
   # The following adds the template flake's checks to the main (current) flake's checks.

--- a/templates/experimental-flake-parts/README.md
+++ b/templates/experimental-flake-parts/README.md
@@ -1,0 +1,31 @@
+# New Nixvim template
+
+This template gives you a good starting point for configuring nixvim as a standalone module configuration.
+
+## Configuring
+
+To start configuring, just add or modify the module files in `./config`.
+If you add new modules, remember to import them in [`./config/default.nix`](./config/default.nix).
+
+## Using your vim configuration
+
+To use your configuration simply run the following command
+
+```
+nix run
+```
+
+## Configurations and packages
+
+Your nixvim configuration is created using `evalNixvim`.
+This is outputted as the `nixvimConfigurations.<system>.default` flake output.
+
+You can access your configuration's package outputs `<configuration>.config.build.package`.
+This is exported as the flake output `packages.<system>.default`.
+This package can be run using `nix run`.
+
+A test is also available as `<configuration>.config.build.test`.
+This is exported as the flake output `checks.<system>.default`.
+This test can be run using `nix flake check`.
+
+<!-- TODO: figure out how to _wrap_ an existing configuration as a nixos/hm module -->

--- a/templates/experimental-flake-parts/config/bufferline.nix
+++ b/templates/experimental-flake-parts/config/bufferline.nix
@@ -1,0 +1,6 @@
+{
+  plugins = {
+    bufferline.enable = true;
+    web-devicons.enable = true;
+  };
+}

--- a/templates/experimental-flake-parts/config/default.nix
+++ b/templates/experimental-flake-parts/config/default.nix
@@ -1,0 +1,4 @@
+{
+  # Import all your configuration modules here
+  imports = [ ./bufferline.nix ];
+}

--- a/templates/experimental-flake-parts/flake.nix
+++ b/templates/experimental-flake-parts/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "A nixvim configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixvim.url = "github:nix-community/nixvim";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    { self, flake-parts, ... }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      imports = [
+        # Import nixvim's flake-parts module;
+        # Adds `flake.nixvimModules` and `perSystem.nixvimConfigurations`
+        inputs.nixvim.flakeModules.default
+      ];
+
+      nixvim = {
+        # Automatically install corresponding packages for each nixvimConfiguration
+        # Lets you run `nix run .#<name>`, or simply `nix run` if you have a default
+        packages.enable = true;
+        # Automatically install checks for each nixvimConfiguration
+        # Run `nix flake check` to verify that your config is not broken
+        checks.enable = true;
+      };
+
+      # You can define your reusable Nixvim modules here
+      flake.nixvimModules = {
+        default = ./config;
+      };
+
+      perSystem =
+        { system, ... }:
+        {
+          # You can define actual Nixvim configurations here
+          nixvimConfigurations = {
+            default = inputs.nixvim.lib.evalNixvim {
+              inherit system;
+              modules = [
+                self.nixvimModules.default
+              ];
+            };
+          };
+        };
+    };
+}


### PR DESCRIPTION
Adds an experimental flake template that configures Nixvim directly using `evalNixvim` rather than the current standalone functions.

### Related issues
- #2210
- #2858
- #2867
- #2868

### Real world usage
- https://github.com/khaneliman/khanelivim/pull/12

### Todo

- [ ] Document new template/approach
- [x] Ensure **all** template's `checks` are inherited into the main flake's `checks`
- [x] Include `nixvim-print-init` in `build.package` #2874
- [x] Include man-docs in `build.package` #2874

Since this is experimental/draft, we don't need to tick off everything above before merging.
