### PR TITLE
flake: initial flake-parts modules

### DIFF
--- a/flake/default.nix
+++ b/flake/default.nix
@@ -4,6 +4,7 @@
     ./flake-modules
     ./lib.nix
     ./legacy-packages.nix
+    ./nixvim-configurations.nix
     ./overlays.nix
     ./packages.nix
     ./templates.nix

--- a/flake/default.nix
+++ b/flake/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./dev
+    ./flake-modules
     ./lib.nix
     ./legacy-packages.nix
     ./overlays.nix

--- a/flake/flake-modules/default.nix
+++ b/flake/flake-modules/default.nix
@@ -1,0 +1,18 @@
+{ inputs, ... }:
+let
+  # Modules for the flakeModules output and the default module
+  defaultModules = { };
+
+  # Modules for the flakeModules output, but not the default module
+  extraModules = {
+    default.imports = builtins.attrValues defaultModules;
+  };
+in
+{
+  imports = [
+    inputs.flake-parts.flakeModules.flakeModules
+    extraModules.default
+  ];
+
+  flake.flakeModules = defaultModules // extraModules;
+}

--- a/flake/flake-modules/default.nix
+++ b/flake/flake-modules/default.nix
@@ -2,6 +2,7 @@
 let
   # Modules for the flakeModules output and the default module
   defaultModules = {
+    nixvimModules = ./nixvimModules.nix;
     nixvimConfigurations = ./nixvimConfigurations.nix;
   };
 

--- a/flake/flake-modules/default.nix
+++ b/flake/flake-modules/default.nix
@@ -1,7 +1,9 @@
 { inputs, ... }:
 let
   # Modules for the flakeModules output and the default module
-  defaultModules = { };
+  defaultModules = {
+    nixvimConfigurations = ./nixvimConfigurations.nix;
+  };
 
   # Modules for the flakeModules output, but not the default module
   extraModules = {

--- a/flake/flake-modules/nixvimConfigurations.nix
+++ b/flake/flake-modules/nixvimConfigurations.nix
@@ -1,0 +1,21 @@
+{ lib, flake-parts-lib, ... }:
+let
+  configurationType = lib.mkOptionType {
+    name = "configuration";
+    description = "configuration";
+    descriptionClass = "noun";
+    merge = lib.options.mergeOneOption;
+    check = x: x._type or null == "configuration";
+  };
+in
+flake-parts-lib.mkTransposedPerSystemModule {
+  name = "nixvimConfigurations";
+  option = lib.mkOption {
+    type = lib.types.lazyAttrsOf configurationType;
+    default = { };
+    description = ''
+      An attribute set of Nixvim configurations.
+    '';
+  };
+  file = ./nixvimConfigurations.nix;
+}

--- a/flake/flake-modules/nixvimModules.nix
+++ b/flake/flake-modules/nixvimModules.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  flake-parts-lib,
+  moduleLocation,
+  ...
+}:
+{
+  options = {
+    flake = flake-parts-lib.mkSubmoduleOptions {
+      nixvimModules = lib.mkOption {
+        type = with lib.types; lazyAttrsOf deferredModule;
+        default = { };
+        apply = lib.mapAttrs (
+          name: module: {
+            _file = "${toString moduleLocation}#nixvimModules.${name}";
+            imports = [ module ];
+          }
+        );
+        description = ''
+          Nixvim modules.
+
+          You may use this for reusable pieces of configuration, utility modules, etc.
+        '';
+      };
+    };
+  };
+}

--- a/flake/legacy-packages.nix
+++ b/flake/legacy-packages.nix
@@ -1,19 +1,15 @@
-{ helpers, ... }:
 {
   perSystem =
     {
+      config,
       makeNixvimWithModule,
-      system,
       ...
     }:
     {
       legacyPackages = rec {
         inherit makeNixvimWithModule;
         makeNixvim = module: makeNixvimWithModule { inherit module; };
-
-        nixvimConfiguration = helpers.modules.evalNixvim {
-          inherit system;
-        };
+        nixvimConfiguration = config.nixvimConfigurations.default;
       };
     };
 }

--- a/flake/nixvim-configurations.nix
+++ b/flake/nixvim-configurations.nix
@@ -1,0 +1,10 @@
+{ helpers, ... }:
+{
+  perSystem =
+    { system, ... }:
+    {
+      nixvimConfigurations.default = helpers.modules.evalNixvim {
+        inherit system;
+      };
+    };
+}


### PR DESCRIPTION
- **flake: add initial flake-parts module**
- **flake: add `nixvimConfigurations` flake-parts module**
- **flake: add `nixvimModules` flake-parts module**

This adds flake-parts modules for declaring `flake.nixvimModules` and `perSystem.nixvimConfigurations`. A `default` module imports both of these.

This is currently undocumented. It should be possible to document these modules in a similar way to how we document platform-wrappers. We may also want to document our flake-parts modules on the flake.parts website?

@traxys also [proposed](https://github.com/nix-community/nixvim/pull/2854#issuecomment-2600121408) having some auto-configuration, which I agree is a good idea. However I'd like to keep the scope of this PR small, so let's postpone that for now.
