### PR TITLE
ci: drop 24.05 support

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -61,11 +61,6 @@ jobs:
                 "branch": "nixos-24.11",
                 "nixpkgsBranch": "nixos-24.11",
                 "subPath": "24.11"
-              },
-              {
-                "branch": "nixos-24.05",
-                "nixpkgsBranch": "nixos-24.05",
-                "subPath": "24.05"
               }
             ]
           ' | jq \

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -46,6 +46,7 @@ jobs:
           ssh-key: ${{ secrets.CI_UPDATE_SSH_KEY }}
 
       # NOTE: If additional "inputs" are added, copy this step
+      # Drop the `github.event_name` condition when a branch reaches end-of-life
       - name: Update nixos-24.11
         if: inputs['nixos-24.11'] || github.event_name == 'schedule'
         env:
@@ -54,7 +55,7 @@ jobs:
           gh workflow run update.yml --ref nixos-24.11
 
       - name: Update nixos-24.05
-        if: inputs['nixos-24.05'] || github.event_name == 'schedule'
+        if: inputs['nixos-24.05']
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
24.05 has reached end-of-life. Let's not auto-update its lockfile or generated docs for it anymore.

I've kept the ability to manually trigger updating its lockfile.

Closes #2856
