### PR TITLE
modules/nixpkgs: `useGlobalPackages` default to false

### DIFF
--- a/docs/mdbook/index.md
+++ b/docs/mdbook/index.md
@@ -8,6 +8,14 @@ Documentation is currently available for the following versions:
 
 @DOCS_VERSIONS@
 
+## Recent Breaking Changes
+
+> [!CAUTION]
+> By default, Nixvim now constructs its own instance of nixpkgs, using the revision from our flake.lock.
+> This change was largely motivated by: [How do I solve "`<name>` cannot be found in `pkgs`"](./user-guide/faq.html#how-do-i-solve-name-cannot-be-found-in-pkgs)
+>
+> The old behaviour can be restored by enabling `nixpkgs.useGlobalPackages`.
+
 ## What is it?
 NixVim is a [Neovim](https://neovim.io) distribution built around
 [Nix](https://nixos.org) modules. It is distributed as a Nix flake, and

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -50,9 +50,8 @@ in
         so user-provided configuration can override it without using `lib`.
         E.g. Nixvim's home-manager module can re-use the `pkgs` instance from the "host" modules.
 
-        > [!NOTE]
-        > Using a distinct version of Nixpkgs with Nixvim may be an unexpected source of problems.
-        > Use this option with care.
+        > [!CAUTION]
+        > Changing this option can lead to issues that may be difficult to debug.
       '';
     };
 
@@ -198,6 +197,9 @@ in
         The path to import Nixpkgs from.
 
         Ignored when `nixpkgs.pkgs` is set.
+
+        > [!CAUTION]
+        > Changing this option can lead to issues that may be difficult to debug.
       '';
     };
   };

--- a/wrappers/modules/nixpkgs.nix
+++ b/wrappers/modules/nixpkgs.nix
@@ -40,6 +40,9 @@ in
       description = ''
         Whether Nixvim should use the ${config.meta.wrapper.name} configuration's `pkgs`,
         instead of constructing its own instance.
+
+        > [!CAUTION]
+        > Changing this option can lead to issues that may be difficult to debug.
       '';
     };
   };

--- a/wrappers/modules/nixpkgs.nix
+++ b/wrappers/modules/nixpkgs.nix
@@ -36,8 +36,7 @@ in
   options = {
     nixpkgs.useGlobalPackages = lib.mkOption {
       type = lib.types.bool;
-      default = true; # TODO: Added 2025-01-15; switch to false one release after adding a deprecation warning
-      defaultText = lib.literalMD ''`true`, but will change to `false` in a future version.'';
+      default = false;
       description = ''
         Whether Nixvim should use the ${config.meta.wrapper.name} configuration's `pkgs`,
         instead of constructing its own instance.


### PR DESCRIPTION

Rather than waiting for a technically impossible migration strategy, let's just bite the bullet and change the default.

This PR also adds a "breaking changes" notice to the docs homepage, since we don't have a better way to inform users.

