### PR TITLE
docs: use README as a source for the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - [Quick set up tutorial](https://www.youtube.com/watch?v=b641h63lqy0) (by [@Vimjoyer](https://www.youtube.com/@vimjoyer))
 - [Nixvim: How to configure Neovim with the power of Nix](https://www.youtube.com/watch?v=GOe0C7Qtypk) (NeovimConf 2023 talk by [@GaetanLepage](https://glepage.com/))
 
+<!-- START DOCS -->
+
 ## What is it?
 NixVim is a [Neovim](https://neovim.io) distribution built around
 [Nix](https://nixos.org) modules. It is distributed as a Nix flake, and
@@ -36,6 +38,8 @@ When we do this, lualine will be set up to a sensible default, and will use
 catppuccin as the colorscheme, no extra configuration required!
 
 Check out [this list of real world nixvim configs](https://nix-community.github.io/nixvim/user-guide/config-examples.html)!
+
+<!-- STOP DOCS -->
 
 ## How does it work?
 When you build the module (probably using home-manager), it will install all

--- a/docs/mdbook/index.md
+++ b/docs/mdbook/index.md
@@ -16,30 +16,7 @@ Documentation is currently available for the following versions:
 >
 > The old behaviour can be restored by enabling `nixpkgs.useGlobalPackages`.
 
-## What is it?
-NixVim is a [Neovim](https://neovim.io) distribution built around
-[Nix](https://nixos.org) modules. It is distributed as a Nix flake, and
-configured through Nix, all while leaving room for your plugins and your vimrc.
-
-## What does it look like?
-Here is a simple configuration that uses catppuccin as the colorscheme and uses the
-lualine plugin:
-
-```nix
-{
-  programs.nixvim = {
-    enable = true;
-
-    colorschemes.catppuccin.enable = true;
-    plugins.lualine.enable = true;
-  };
-}
-```
-
-When we do this, lualine will be set up to a sensible default, and will use
-catppuccin as the colorscheme, no extra configuration required!
-
-Check out [this list of real world nixvim configs](./user-guide/config-examples.md)!
+@README@
 
 ## Welcome to the docs!
 


### PR DESCRIPTION
Reduce duplication by defining a section of the README that'll be automatically included in the docs