### PR TITLE
flake.nix: follow nixpkgs-unstable instead of nixos-unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you have any question, please use the [discussions page](https://github.com/n
 
 > [!WARNING]
 > NixVim needs to be installed with a compatible nixpkgs version.
-> This means that the `main` branch of NixVim requires to be installed with `nixos-unstable`.
+> This means that the `main` branch of NixVim requires to be installed with `nixpkgs-unstable`.
 >
 > If you want to use NixVim with nixpkgs 24.11 you should use the `nixos-24.11` branch.
 

--- a/flake.lock
+++ b/flake.lock
@@ -22,12 +22,12 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -185,16 +185,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1737525964,
+        "narHash": "sha256-3wFonKmNRWKq1himW9N3TllbeGIHFACI5vmLpk6moF8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "5757bbb8bd7c0630a0cc4bb19c47e588db30b97c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A neovim configuration system for NixOS";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -2,7 +2,7 @@
   description = "A nixvim configuration";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixvim.url = "github:nix-community/nixvim";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -37,8 +37,7 @@ in
   extend = callTest ./extend.nix { };
   extra-files = callTest ./extra-files.nix { };
   enable-except-in-tests = callTest ./enable-except-in-tests.nix { };
-  # TODO: re-enable when https://github.com/NixOS/nixpkgs/pull/375585 lands in nixos-unstable
-  # failing-tests = callTest ./failing-tests.nix { };
+  failing-tests = callTest ./failing-tests.nix { };
   no-flake = callTest ./no-flake.nix { };
   lib-tests = callTest ./lib-tests.nix { };
   maintainers = callTest ./maintainers.nix { };


### PR DESCRIPTION
Since #2862, `useGlobalPackages` defaults to `false`.
This will hopefully significantly reduce the number of 'out-of-sync' issues for users.
It also allows us to move to a _fresher_ channel without disrupting the workflow of users.

Hence, I propose to switch our reference channel from `nixos-unstable` to `nixpkgs-unstable`.
This proposition is motivated by two reasons:
1. `nixpkgs-unstable` makes more sense as our reference channel as the job set required for its bump involves building a bunch of packages **on all four platforms**.
    Conversely, `nixos-unstable`'s job set is linux-only and include additional NixOS-related tests that do not really matter for us.
2. `nixpkgs-unstable` is fresher in average compared to `nixos-unstable`.
    In conjunction to increasing our _bump frequency_ (to be done in a follow-up PR), choosing this channel will allow us to follow `nixpkgs`'s `master` channel from closer.
    Thus, we will be able to upstream eventual fixes faster and reduce the average length of the cycle.
