### PR TITLE
flake: add `auto` flake-parts module

### DIFF
--- a/flake/flake-modules/auto.nix
+++ b/flake/flake-modules/auto.nix
@@ -1,0 +1,62 @@
+{ lib, config, ... }:
+let
+  cfg = config.nixvim;
+in
+{
+  options.nixvim = {
+    packages = {
+      enable = lib.mkEnableOption "automatically installing packages for each nixvimConfigurations";
+      nameFunction = lib.mkOption {
+        type = lib.types.functionTo lib.types.str;
+        description = ''
+          A function to convert a nixvimConfiguration's name into a package name.
+
+          **Type**
+
+          ```
+          String -> String
+          ```
+        '';
+        default = name: "nixvim-" + name;
+        defaultText = lib.literalExpression ''name: "nixvim-" + name'';
+        example = lib.literalExpression ''name: name + "-nvim"'';
+      };
+    };
+    checks = {
+      enable = lib.mkEnableOption "automatically installing checks for each nixvimConfigurations";
+      nameFunction = lib.mkOption {
+        type = lib.types.functionTo lib.types.str;
+        description = ''
+          A function to convert a nixvimConfiguration's name into a check name.
+
+          **Type**
+
+          ```
+          String -> String
+          ```
+        '';
+        default = name: "nixvim-" + name;
+        defaultText = lib.literalExpression ''name: "nixvim-" + name'';
+        example = lib.literalExpression ''name: "nixvim-" + name + "-test"'';
+      };
+    };
+  };
+  config = {
+    perSystem =
+      { config, ... }:
+      {
+        packages = lib.mkIf cfg.packages.enable (
+          lib.mapAttrs' (name: configuration: {
+            name = cfg.packages.nameFunction name;
+            value = configuration.config.build.package;
+          }) config.nixvimConfigurations
+        );
+        checks = lib.mkIf cfg.checks.enable (
+          lib.mapAttrs' (name: configuration: {
+            name = cfg.checks.nameFunction name;
+            value = configuration.config.build.test;
+          }) config.nixvimConfigurations
+        );
+      };
+  };
+}

--- a/flake/flake-modules/default.nix
+++ b/flake/flake-modules/default.nix
@@ -4,6 +4,7 @@ let
   defaultModules = {
     nixvimModules = ./nixvimModules.nix;
     nixvimConfigurations = ./nixvimConfigurations.nix;
+    auto = ./auto.nix;
   };
 
   # Modules for the flakeModules output, but not the default module


### PR DESCRIPTION
When enabled, automatically sets up packages and/or checks for all `nixvimConfigurations`

Both options currently default to false. See https://github.com/nix-community/nixvim/pull/2854#discussion_r1921623854

A `nameFunction` can be configured for transforming nixvimConfiguration names into package/check names. Maybe prefix & suffix string options would be simpler?

Originally from #2854 