### PR TITLE
lib: export `evalNixvim` as top-level alias

### DIFF
--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -21,6 +21,10 @@
       overlay = lib.makeOverridable (import ../lib/overlay.nix) {
         flake = self;
       };
+      # Top-top-level aliases
+      inherit (self.lib.nixvim)
+        evalNixvim
+        ;
     }
     // lib.genAttrs config.systems (
       lib.flip withSystem (

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -44,6 +44,10 @@ lib.makeExtensible (
       transitionType
       ;
 
+    inherit (self.modules)
+      evalNixvim
+      ;
+
     inherit (self.options)
       defaultNullOpts
       mkAutoLoadOption


### PR DESCRIPTION
- `lib.nixvim.evalNixvim`
  - aka `<nixvim>.lib.nixvim.evalNixvim`
- `<nixvim>.lib.evalNixvim` (flake output)
  - Maybe this isn't needed?

Originally from #2854 