### PR TITLE
modules/output: move `symlinkJoin` to `build.package`

### DIFF
--- a/modules/top-level/test.nix
+++ b/modules/top-level/test.nix
@@ -296,7 +296,7 @@ in
         cfg.runCommand cfg.name
           {
             nativeBuildInputs = lib.optionals cfg.buildNixvim [
-              config.build.packageUnchecked
+              config.build.nvimPackage
             ];
 
             inherit (failedExpectations) warnings assertions;

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -33,7 +33,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs, expected one plugin pack.";
         }
       ];
@@ -50,7 +50,7 @@ in
       ];
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" >= 2;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" >= 2;
           message = "Only one plugin is defined in packpathDirs, expected at least two.";
         }
       ];
@@ -79,7 +79,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -107,7 +107,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -134,7 +134,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 1;
           message = "More than one plugin is defined in packpathDirs.";
         }
       ];
@@ -188,11 +188,11 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "opt" == 2;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "opt" == 2;
           message = "Less than two opt plugins are defined in packpathDirs";
         }
       ];
@@ -235,7 +235,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
       ];
@@ -305,7 +305,7 @@ in
       '';
       assertions = [
         {
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 1;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 1;
           message = "More than one start plugin is defined in packpathDirs";
         }
       ];
@@ -373,7 +373,7 @@ in
       assertions = [
         {
           # plugin-pack, nvim-treesitter, nvim-lspconfig, telescope-nvim, nvim-cmp
-          assertion = pluginCount config.build.packageUnchecked config.build.extraFiles "start" == 5;
+          assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 5;
           message = "Wrong number of plugins in packpathDirs";
         }
       ];

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -26,7 +26,6 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [
       cfg.build.package
-      cfg.build.printInitPackage
-    ] ++ lib.optional cfg.enableMan cfg.build.manDocsPackage;
+    ];
   };
 }

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -34,8 +34,7 @@ in
   config = mkIf cfg.enable {
     home.packages = [
       cfg.build.package
-      cfg.build.printInitPackage
-    ] ++ lib.optional cfg.enableMan cfg.build.manDocsPackage;
+    ];
 
     home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
 

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -35,8 +35,7 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [
       cfg.build.package
-      cfg.build.printInitPackage
-    ] ++ lib.optional cfg.enableMan cfg.build.manDocsPackage;
+    ];
 
     environment.variables = {
       VIM = mkIf (!cfg.wrapRc) "/etc/nvim";

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -32,25 +32,19 @@ let
   mkNvim =
     mod:
     let
+      modules = lib.toList mod;
       nixvimConfig = evalNixvim {
-        modules = [
-          mod
+        modules = modules ++ [
           systemMod
         ];
         inherit extraSpecialArgs;
       };
+      extend = extension: mkNvim (modules ++ lib.toList extension);
     in
     nixvimConfig.config.build.package.overrideAttrs (old: {
-      passthru = old.passthru or { } // rec {
+      passthru = old.passthru or { } // {
         inherit (nixvimConfig) config options;
-        extend =
-          extension:
-          mkNvim {
-            imports = [
-              mod
-              extension
-            ];
-          };
+        inherit extend;
         nixvimExtend = lib.warn "<nixvim>.nixvimExtend has been renamed to <nixvim>.extend" extend;
       };
     });

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -39,28 +39,20 @@ let
         ];
         inherit extraSpecialArgs;
       };
-      inherit (nixvimConfig.config) enableMan build;
-      inherit (nixvimConfig._module.args.pkgs) symlinkJoin;
     in
-    (symlinkJoin {
-      name = "nixvim";
-      paths = [
-        build.package
-        build.printInitPackage
-      ] ++ lib.optional enableMan build.manDocsPackage;
-      meta.mainProgram = "nvim";
-    })
-    // rec {
-      inherit (nixvimConfig) config options;
-      extend =
-        extension:
-        mkNvim {
-          imports = [
-            mod
-            extension
-          ];
-        };
-      nixvimExtend = lib.warn "<nixvim>.nixvimExtend has been renamed to <nixvim>.extend" extend;
-    };
+    nixvimConfig.config.build.package.overrideAttrs (old: {
+      passthru = old.passthru or { } // rec {
+        inherit (nixvimConfig) config options;
+        extend =
+          extension:
+          mkNvim {
+            imports = [
+              mod
+              extension
+            ];
+          };
+        nixvimExtend = lib.warn "<nixvim>.nixvimExtend has been renamed to <nixvim>.extend" extend;
+      };
+    });
 in
 mkNvim module


### PR DESCRIPTION
- **modules/output: move `symlinkJoin` to `build.package`**
- **wrappers/standalone: simplify `extend`**

Should work better with #2854
