### PR TITLE
flake/auto: `nameFunction` default to `lib.id`

### DIFF
--- a/flake/flake-modules/auto.nix
+++ b/flake/flake-modules/auto.nix
@@ -17,8 +17,8 @@ in
           String -> String
           ```
         '';
-        default = name: "nixvim-" + name;
-        defaultText = lib.literalExpression ''name: "nixvim-" + name'';
+        default = lib.id;
+        defaultText = lib.literalExpression "name: name";
         example = lib.literalExpression ''name: name + "-nvim"'';
       };
     };
@@ -35,8 +35,8 @@ in
           String -> String
           ```
         '';
-        default = name: "nixvim-" + name;
-        defaultText = lib.literalExpression ''name: "nixvim-" + name'';
+        default = lib.id;
+        defaultText = lib.literalExpression "name: name";
         example = lib.literalExpression ''name: "nixvim-" + name + "-test"'';
       };
     };


### PR DESCRIPTION
This seems like a simpler/saner default.

See https://github.com/khaneliman/khanelivim/pull/12#discussion_r1921824152 for prior discussion.
