### PR TITLE
tests: clean up/refactor wrapper/platform tests

### DIFF
--- a/flake/wrappers.nix
+++ b/flake/wrappers.nix
@@ -14,39 +14,6 @@
           defaultSystem = system;
         };
       };
-
-      checks =
-        {
-          home-manager-module =
-            (import ../tests/modules/hm.nix {
-              inherit pkgs;
-              inherit (inputs) home-manager;
-              nixvim = self;
-            }).activationPackage;
-          home-manager-extra-files-byte-compiling =
-            import ../tests/modules/hm-extra-files-byte-compiling.nix
-              {
-                inherit pkgs;
-                inherit (inputs) home-manager;
-                nixvim = self;
-              };
-        }
-        // pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
-          nixos-module =
-            (import ../tests/modules/nixos.nix {
-              inherit system;
-              inherit (inputs) nixpkgs;
-              nixvim = self;
-            }).config.system.build.toplevel;
-        }
-        // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
-          darwin-module =
-            (import ../tests/modules/darwin.nix {
-              inherit system;
-              inherit (inputs) nix-darwin;
-              nixvim = self;
-            }).system;
-        };
     };
 
   flake = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -52,6 +52,7 @@ in
   # Individual tests can be run using: nix build .#docs.user-configs.tests.<test>
   docs-user-configs = linkFarm "user-configs-tests" selfPackages.docs.user-configs.tests;
 }
+// callTests ./platforms { }
 # Tests generated from ./test-sources
 # Grouped as a number of link-farms in the form { test-1, test-2, ... test-N }
 // callTests ./main.nix { }

--- a/tests/platforms/darwin.nix
+++ b/tests/platforms/darwin.nix
@@ -1,9 +1,8 @@
 {
-  nixvim,
+  self,
   system,
-  nix-darwin,
 }:
-nix-darwin.lib.darwinSystem {
+self.inputs.nix-darwin.lib.darwinSystem {
   modules = [
     {
       nixpkgs.hostPlatform = system;
@@ -14,6 +13,6 @@ nix-darwin.lib.darwinSystem {
 
       system.stateVersion = 5;
     }
-    nixvim.nixDarwinModules.nixvim
+    self.nixDarwinModules.nixvim
   ];
 }

--- a/tests/platforms/default.nix
+++ b/tests/platforms/default.nix
@@ -1,0 +1,21 @@
+{
+  callTest,
+  lib,
+  stdenv,
+}:
+let
+  inherit (stdenv.hostPlatform)
+    isLinux
+    isDarwin
+    ;
+in
+{
+  home-manager-module = (callTest ./hm.nix { }).activationPackage;
+  home-manager-extra-files-byte-compiling = callTest ./hm-extra-files-byte-compiling.nix { };
+}
+// lib.optionalAttrs isLinux {
+  nixos-module = (callTest ./nixos.nix { }).config.system.build.toplevel;
+}
+// lib.optionalAttrs isDarwin {
+  darwin-module = (callTest ./darwin.nix { }).system;
+}

--- a/tests/platforms/hm-extra-files-byte-compiling.nix
+++ b/tests/platforms/hm-extra-files-byte-compiling.nix
@@ -1,9 +1,12 @@
 {
-  nixvim,
+  self,
   pkgs,
-  home-manager,
 }:
 let
+  inherit (self.inputs.home-manager.lib)
+    homeManagerConfiguration
+    ;
+
   config = {
     home = {
       username = "nixvim";
@@ -32,22 +35,22 @@ let
   };
 
   homeFilesByteCompilingEnabled =
-    (home-manager.lib.homeManagerConfiguration {
+    (homeManagerConfiguration {
       inherit pkgs;
 
       modules = [
-        nixvim.homeManagerModules.nixvim
+        self.homeManagerModules.nixvim
         config
         { programs.nixvim.performance.byteCompileLua.configs = true; }
       ];
     }).config.home-files;
 
   homeFilesByteCompilingDisabled =
-    (home-manager.lib.homeManagerConfiguration {
+    (homeManagerConfiguration {
       inherit pkgs;
 
       modules = [
-        nixvim.homeManagerModules.nixvim
+        self.homeManagerModules.nixvim
         config
         { programs.nixvim.performance.byteCompileLua.configs = false; }
       ];

--- a/tests/platforms/hm.nix
+++ b/tests/platforms/hm.nix
@@ -1,9 +1,8 @@
 {
-  nixvim,
+  self,
   pkgs,
-  home-manager,
 }:
-home-manager.lib.homeManagerConfiguration {
+self.inputs.home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
 
   modules = [
@@ -19,6 +18,6 @@ home-manager.lib.homeManagerConfiguration {
 
       programs.home-manager.enable = true;
     }
-    nixvim.homeManagerModules.nixvim
+    self.homeManagerModules.nixvim
   ];
 }

--- a/tests/platforms/nixos.nix
+++ b/tests/platforms/nixos.nix
@@ -1,9 +1,8 @@
 {
-  nixvim,
-  nixpkgs,
+  self,
   system,
 }:
-nixpkgs.lib.nixosSystem {
+self.inputs.nixpkgs.lib.nixosSystem {
   inherit system;
 
   modules = [
@@ -18,6 +17,6 @@ nixpkgs.lib.nixosSystem {
         enable = true;
       };
     }
-    nixvim.nixosModules.nixvim
+    self.nixosModules.nixvim
   ];
 }


### PR DESCRIPTION
Moved the platform integration tests out of `flake/wrappers.nix`. It makes more sense to set these up within `tests/`.

Now, they are owned by `tests/platforms/default.nix`, which is included by `tests/default.nix`.

Also:
- Renamed `tests/modules` -> `tests/platforms`
- Refactored to use `callTest`
- Used `isLinux` instead of `!isDarwin`
- Used `stdenv.hostPlatform`
