### PR TITLE
ci/update: schedule main branch daily, other branches weekly

### DIFF
--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -1,0 +1,23 @@
+name: update
+on:
+  # Runs every Saturday at noon
+  schedule:
+    - cron: "0 12 * * SAT"
+
+# Allow running workflows
+permissions:
+  actions: write
+
+jobs:
+  update:
+    name: Trigger updates for nixvim's stable branches
+    runs-on: ubuntu-latest
+    steps:
+      # NOTE: If additional "inputs" are added, copy this step
+      # Drop the `github.event_name` condition when a branch reaches end-of-life
+      - name: Update nixos-24.11
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run update.yml --ref nixos-24.11

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,8 @@
 name: update
 on:
-  # Runs every Saturday at noon
+  # Runs everyday at noon
   schedule:
-    - cron: "0 12 * * SAT"
+    - cron: "0 12 * * *"
   # Allow manual triggering
   workflow_dispatch:
     inputs:
@@ -14,18 +14,14 @@ on:
         type: boolean
         default: true
         description: Update generated files
-      nixos-24.11:
-        type: boolean
-        description: Also update nixos-24.11
 
 # Allow one concurrent update per branch
 concurrency:
   group: "update-${{ github.ref_name }}"
   cancel-in-progress: true
 
-# Allow running workflows, pushing and creating PRs
+# Allow pushing and creating PRs
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -41,15 +37,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.CI_UPDATE_SSH_KEY }}
-
-      # NOTE: If additional "inputs" are added, copy this step
-      # Drop the `github.event_name` condition when a branch reaches end-of-life
-      - name: Update nixos-24.11
-        if: inputs['nixos-24.11'] || github.event_name == 'schedule'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run update.yml --ref nixos-24.11
 
       - name: Install Nix
         uses: cachix/install-nix-action@v30


### PR DESCRIPTION
Split scheduling other branches into a dedicated workflow. The main update workflow is no longer responsible for triggering the workflow on _other_ branches.

It may also be nice to have the workflow stop when nixpks is not one of the inputs being bumped, to reduce force-push spam to the update branches. That is not part of this PR.