### PR TITLE
ci/update: cancel scheduled runs that don't bump nixpkgs

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -62,6 +62,41 @@ jobs:
             echo "EOF" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check if nixpkgs input was changed
+        if: github.event_name == 'schedule'
+        env:
+          repo: ${{ github.repository }}
+          branch: update/${{ github.ref_name }}
+        run: |
+          getAttr() {
+            nix eval --raw --impure \
+              --expr '{ ref }: builtins.getFlake ref' \
+              --argstr ref "$1" "$2"
+          }
+          getNixpkgsRev() {
+            getAttr "$1" 'inputs.nixpkgs.rev'
+          }
+          old=$(
+            getNixpkgsRev "github:$repo/$branch" \
+            || echo "" # Could fail, e.g. if the branch is deleted
+          )
+          new=$(getNixpkgsRev '.')
+          if [[ "$old" = "$new" ]]; then
+            (
+              echo "nixpkgs rev has not changed ($new). Stopping..."
+              echo 'You can re-run the workflow manually to update anyway.'
+            ) >&2
+            (
+              echo '## Update cancelled'
+              echo
+              echo 'The `nixpkgs` rev has not changed (`'"$new"'`).'
+              echo
+              echo 'You can re-run the workflow manually to update anyway.'
+              echo
+            ) >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
       - name: Update generated files
         id: generate
         if: inputs.generate || github.event_name == 'schedule'


### PR DESCRIPTION
This should help mitigate spammy force-pushes that don't actually update the nixpkgs input.

This only affects _scheduled_ runs. Manually triggered updates will always force-push to the update branch.

I've tested out the `nix eval` commands locally with some canned examples, but as ever with CI workflows I'm unable to fully verify this works in production.

