### PR TITLE
ci/update: fix `getFlake` expecting an absolute path

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -80,7 +80,7 @@ jobs:
             getNixpkgsRev "github:$repo/$branch" \
             || echo "" # Could fail, e.g. if the branch is deleted
           )
-          new=$(getNixpkgsRev '.')
+          new=$(getNixpkgsRev "$PWD")
           if [[ "$old" = "$new" ]]; then
             (
               echo "nixpkgs rev has not changed ($new). Stopping..."


### PR DESCRIPTION
Pass in `$PWD` instead of `.`, because `builtins.getFlake` does not permit relative paths.

See https://github.com/nix-community/nixvim/actions/runs/12928918623/job/36057233050#step:6:56