### PR TITLE
plugins/git-conflict: fix packPath name

### DIFF
--- a/plugins/by-name/git-conflict/default.nix
+++ b/plugins/by-name/git-conflict/default.nix
@@ -7,7 +7,6 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "git-conflict";
-  packPathName = "git-conflict.nvim";
   package = "git-conflict-nvim";
 
   maintainers = [ maintainers.GaetanLepage ];


### PR DESCRIPTION
Failing to lazy load because of incorrect packPathName

`git-conflict@ => /nix/store/g42jnf9f2ijmw3c124xj5kb2f1h4pwjf-vimplugin-git-conflict-2.1.0`