### PR TITLE
ci/update-other: fix & improve

### DIFF
--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -12,11 +12,16 @@ jobs:
   update:
     name: Trigger updates for nixvim's stable branches
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branches:
+          - nixos-24.11
     steps:
-      - name: Update nixos-24.11
+      - name: Update ${{ matrix.branches }}
         env:
           GH_TOKEN: ${{ github.token }}
           repo: ${{ github.repository }}
+          branch: ${{ matrix.branches }}
         run: |
           gh --repo "$repo" workflow run \
-            update.yml --ref nixos-24.11
+            update.yml --ref "$branch"

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -17,5 +17,7 @@ jobs:
         if: github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
+          repo: ${{ github.repository }}
         run: |
-          gh workflow run update.yml --ref nixos-24.11
+          gh --repo "$repo" workflow run \
+            update.yml --ref nixos-24.11

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update nixos-24.11
-        if: github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
           repo: ${{ github.repository }}


### PR DESCRIPTION
- **ci/update-other: pass `--repo` to `gh`**
- **ci/update-other: remove redundant condition**
- **ci/update-other: use a job matrix**

I noticed [today's scheduled run](https://github.com/nix-community/nixvim/actions/runs/12964986550/job/36164270237) failed because `gh` was unable to figure out what repo it should target.

This happens when `gh` is used outside of a git repo. The workflow is affected because we don't checkout a repo.

However, we don't need to checkout one. We can just specify it using `--repo`.

While I was working on the workflow, I noticed a couple things that can be improved. E.g. the list of branches to trigger `update.yml` on can be a job-matrix.
