### PR TITLE
ci/update: also check base branch, +cleanup

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         default: true
         description: Update generated files
+      check_for_changes:
+        type: boolean
+        default: false
+        description: Cancel if there are no changes to the `nixpkgs` input
 
 # Allow one concurrent update per branch
 concurrency:
@@ -99,8 +103,7 @@ jobs:
           fi
 
       - name: Check if nixpkgs input was changed
-        # The check is run only on scheduled runs
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || inputs.check_for_changes
         env:
           pr_num: ${{ steps.open_pr_info.outputs.number }}
           pr_url: ${{ steps.open_pr_info.outputs.url }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,7 +33,8 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'nix-community/nixvim'
     env:
       repo: ${{ github.repository }}
-      branch: update/${{ github.ref_name }}
+      base_branch: ${{ github.ref_name }}
+      pr_branch: update/${{ github.ref_name }}
 
     steps:
       - name: Checkout repository
@@ -59,7 +60,7 @@ jobs:
         run: |
           # Query for info about the already open update PR
           info=$(
-            gh api graphql -F owner='{owner}' -F repo='{repo}' -F branch="$branch" -f query='
+            gh api graphql -F owner='{owner}' -F repo='{repo}' -F branch="$pr_branch" -f query='
               query($owner:String!, $repo:String!, $branch:String!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequests(first: 1, states: OPEN, headRefName: $branch) {
@@ -98,8 +99,8 @@ jobs:
           fi
 
       - name: Check if nixpkgs input was changed
-        # The check is run only on scheduled runs & when there is a PR already open
-        if: github.event_name == 'schedule' && steps.open_pr_info.outputs.number
+        # The check is run only on scheduled runs
+        if: github.event_name == 'schedule'
         env:
           pr_num: ${{ steps.open_pr_info.outputs.number }}
           pr_url: ${{ steps.open_pr_info.outputs.url }}
@@ -113,8 +114,15 @@ jobs:
           getNixpkgsRev() {
             getAttr "$1" 'inputs.nixpkgs.rev'
           }
-          old=$(getNixpkgsRev "github:$repo/$branch")
+
+          if [[ -n "$pr_num" ]]; then
+            old_branch=$pr_branch
+          else
+            old_branch=$base_branch
+          fi
+          old=$(getNixpkgsRev "github:$repo/$old_branch")
           new=$(getNixpkgsRev "$PWD")
+
           if [[ "$old" = "$new" ]]; then
             (
               echo "nixpkgs rev has not changed ($new). Stopping..."
@@ -123,8 +131,13 @@ jobs:
             (
               echo '## Update cancelled'
               echo
-              echo -n 'The `nixpkgs` input has not changed compared to the already open PR: '
-              echo -n "[#$pr_num]($pr_url) (\`nixpkgs.rev: $new\`)."
+              if [[ -n "$pr_num" ]]; then
+                echo -n 'The `nixpkgs` input has not changed compared to the already open PR: '
+                echo "[#$pr_num]($pr_url) (\`nixpkgs.rev: $new\`)."
+              else
+                echo -n 'The `nixpkgs` input has not changed compared to the base branch: '
+                echo "\`$base_branch\`"
+              fi
               echo
               echo 'The following changes would have been made:'
               echo '```'
@@ -165,7 +178,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: "!**"
-          branch: update/${{ github.ref_name }}
+          pr_branch: update/${{ github.ref_name }}
           delete-branch: true
           title: |
             [${{ github.ref_name }}] Update flake.lock & generated files

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -103,11 +103,11 @@ jobs:
           fi
 
       - name: Check if nixpkgs input was changed
+        id: changes
         if: github.event_name == 'schedule' || inputs.check_for_changes
         env:
           pr_num: ${{ steps.open_pr_info.outputs.number }}
           pr_url: ${{ steps.open_pr_info.outputs.url }}
-          changes: ${{ steps.flake_lock.outputs.body || 'No changes' }}
         run: |
           getAttr() {
             nix eval --raw --impure \
@@ -126,36 +126,15 @@ jobs:
           old=$(getNixpkgsRev "github:$repo/$old_branch")
           new=$(getNixpkgsRev "$PWD")
 
-          if [[ "$old" = "$new" ]]; then
-            (
-              echo "nixpkgs rev has not changed ($new). Stopping..."
-              echo 'You can re-run the workflow manually to update anyway.'
-            ) >&2
-            (
-              echo '## Update cancelled'
-              echo
-              if [[ -n "$pr_num" ]]; then
-                echo -n 'The `nixpkgs` input has not changed compared to the already open PR: '
-                echo "[#$pr_num]($pr_url) (\`nixpkgs.rev: $new\`)."
-              else
-                echo -n 'The `nixpkgs` input has not changed compared to the base branch: '
-                echo "\`$base_branch\`"
-              fi
-              echo
-              echo 'The following changes would have been made:'
-              echo '```'
-              echo "$changes"
-              echo '```'
-              echo
-              echo 'You can re-run the workflow manually to update anyway.'
-              echo
-            ) >> $GITHUB_STEP_SUMMARY
-            exit 1
-          fi
+          (
+            echo "old_rev=$old"
+            echo "new_rev=$new"
+            [[ "$old" = "$new" ]] && echo 'cancelled=1'
+          ) >> $GITHUB_OUTPUT
 
       - name: Update generated files
         id: generate
-        if: inputs.generate || github.event_name == 'schedule'
+        if: (!steps.changes.outputs.cancelled) && (inputs.generate || github.event_name == 'schedule')
         run: |
           old=$(git show --no-patch --format=%h)
           nix-build ./update-scripts -A generate
@@ -178,6 +157,7 @@ jobs:
 
       - name: Create Pull Request
         id: pr
+        if: (!steps.changes.outputs.cancelled)
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: "!**"
@@ -195,7 +175,7 @@ jobs:
             ${{ steps.generate.outputs.body || 'No changes' }}
 
       - name: Print summary
-        if: ${{ steps.pr.outputs.pull-request-number }}
+        if: steps.pr.outputs.pull-request-number
         run: |
           num="${{ steps.pr.outputs.pull-request-number }}"
           pr_url="${{ steps.pr.outputs.pull-request-url }}"
@@ -214,3 +194,50 @@ jobs:
           echo >> $GITHUB_STEP_SUMMARY
           echo "[#${num}](${pr_url}) was ${operation}." >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
+
+      - name: Print cancellation summary
+        if: (!steps.pr.outputs.pull-request-number)
+        env:
+          pr_num: ${{ steps.open_pr_info.outputs.number }}
+          pr_url: ${{ steps.open_pr_info.outputs.url }}
+          changes: ${{ steps.flake_lock.outputs.body || 'No changes' }}
+          cancelled: ${{ steps.changes.outputs.cancelled || '' }}
+          rev: ${{ steps.changes.outputs.new_rev || '' }}
+        run: |
+          if [[ -n "$cancelled" ]]; then
+            ( # stdout
+              echo "nixpkgs rev has not changed ($rev)."
+              echo 'You can re-run the workflow manually to update anyway.'
+            ) >&2
+            ( # markdown summary
+              echo '## Update cancelled'
+              echo
+              if [[ -n "$pr_num" ]]; then
+                echo -n 'The `nixpkgs` input has not changed compared to the already open PR: '
+                echo "[#$pr_num]($pr_url) (\`nixpkgs.rev: ${rev:0:6}\`)."
+              else
+                echo -n 'The `nixpkgs` input has not changed compared to the base branch: '
+                echo "\`$base_branch\`"
+              fi
+              echo
+              echo 'You can re-run the workflow manually to update anyway.'
+              echo
+            ) >> $GITHUB_STEP_SUMMARY
+          else
+            ( #stdout
+              echo "No PR was opened"
+            ) >&2
+            (
+              echo "## Not updated"
+              echo
+            ) >> $GITHUB_STEP_SUMMARY
+          fi
+          ( # markdown summary
+            echo
+            echo 'The following changes would have been made:'
+            echo
+            echo '```'
+            echo "$changes"
+            echo '```'
+            echo
+          ) >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -176,24 +176,25 @@ jobs:
 
       - name: Print summary
         if: steps.pr.outputs.pull-request-number
+        env:
+          pr_num: ${{ steps.pr.outputs.pull-request-number }}
+          pr_url: ${{ steps.pr.outputs.pull-request-url }}
+          pr_branch: ${{ steps.pr.outputs.pull-request-branch }}
+          head: ${{ steps.pr.outputs.pull-request-head-sha }}
+          operation: ${{ steps.pr.outputs.pull-request-operation }}
         run: |
-          num="${{ steps.pr.outputs.pull-request-number }}"
-          pr_url="${{ steps.pr.outputs.pull-request-url }}"
-          pr_branch="${{ steps.pr.outputs.pull-request-branch }}"
-          head="${{ steps.pr.outputs.pull-request-head-sha }}"
-          operation="${{ steps.pr.outputs.pull-request-operation }}"
-
+          short=${head:0:6}
           # stdout
-          echo "${head:0:6} pushed to ${pr_branch}"
-          echo "${pr} was ${operation}."
-
-          # markdown summary
-          echo "## ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo >> $GITHUB_STEP_SUMMARY
-          echo "\`${head:0:6}\` pushed to \`${pr_branch}\`" >> $GITHUB_STEP_SUMMARY
-          echo >> $GITHUB_STEP_SUMMARY
-          echo "[#${num}](${pr_url}) was ${operation}." >> $GITHUB_STEP_SUMMARY
-          echo >> $GITHUB_STEP_SUMMARY
+          echo "${short} pushed to ${pr_branch}"
+          echo "#${pr_num} was ${operation}: ${pr_url}"
+          ( # markdown summary
+            echo "## ${{ github.ref_name }}"
+            echo
+            echo "\`${short}\` pushed to \`${pr_branch}\`"
+            echo
+            echo "[#${pr_num}](${pr_url}) was ${operation}."
+            echo
+          ) >> $GITHUB_STEP_SUMMARY
 
       - name: Print cancellation summary
         if: (!steps.pr.outputs.pull-request-number)


### PR DESCRIPTION

As discussed https://github.com/nix-community/nixvim/pull/2921#issuecomment-2618861242, it'd be good for the CI to check for differences against the base branch when there is no PR currently open.

Additionally, I've cleaned up some stuff:

- Added a checkbox for manually enabling the "check for `nixpkgs` changes" (previously enabled only on scheduled runs)
- Replaced `exit 1` with a graceful cancellation
- Improved the "print summary" steps
