### PR TITLE
plugins/zellij-nav.nvim: init

### DIFF
--- a/plugins/by-name/zellij-nav/default.nix
+++ b/plugins/by-name/zellij-nav/default.nix
@@ -1,0 +1,8 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "zellij-nav";
+  packPathName = "zellij-nav.nvim";
+  package = "zellij-nav-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+}

--- a/tests/test-sources/plugins/by-name/zellij-nav/default.nix
+++ b/tests/test-sources/plugins/by-name/zellij-nav/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.zellij-nav.enable = true;
+  };
+}


### PR DESCRIPTION
Add support for [zellij-nav.nvim](https://github.com/swaits/zellij-nav.nvim), a plugin granting seamless navigation between Neovim windows and Zellij panes.

Fixes #1915

I explicitly used `mkNeovimPlugin` although this plugin does not have any option.
It does have a `setup(opts)` function, so let's expose it just in case.
