### PR TITLE
treewide: use boolean comparison to simplify the code base

### DIFF
--- a/flake/dev/default.nix
+++ b/flake/dev/default.nix
@@ -34,7 +34,13 @@
             check = true;
             format = true;
           };
-          statix.enable = true;
+          statix = {
+            enable = true;
+            disabled-lints = [
+              # We often use `nullable == true`
+              "bool_comparison"
+            ];
+          };
           stylua.enable = true;
           shfmt.enable = true;
           # FIXME: re-enable on darwin, currently broken: taplo with options '[format]' failed to apply: exit status 101

--- a/plugins/by-name/blink-cmp-copilot/default.nix
+++ b/plugins/by-name/blink-cmp-copilot/default.nix
@@ -48,18 +48,17 @@ lib.nixvim.plugins.mkNeovimPlugin {
     warnings =
       let
         copilot-lua-cfg = config.plugins.copilot-lua.settings;
-        isEnabled = b: builtins.isBool b && b;
       in
       lib.nixvim.mkWarnings "plugins.blink-cmp-copilot" [
         {
-          when = isEnabled copilot-lua-cfg.suggestion.enabled;
+          when = copilot-lua-cfg.suggestion.enabled == true;
           message = ''
             It is recommended to disable copilot's `suggestion` module, as it can interfere with
             completions properly appearing in blink-cmp-copilot.
           '';
         }
         {
-          when = isEnabled copilot-lua-cfg.panel.enabled;
+          when = copilot-lua-cfg.panel.enabled == true;
           message = ''
             It is recommended to disable copilot's `panel` module, as it can interfere with completions
             properly appearing in blink-cmp-copilot.

--- a/plugins/by-name/copilot-cmp/default.nix
+++ b/plugins/by-name/copilot-cmp/default.nix
@@ -58,18 +58,17 @@ lib.nixvim.plugins.mkNeovimPlugin {
     warnings =
       let
         copilot-lua-cfg = config.plugins.copilot-lua.settings;
-        isEnabled = b: (lib.isBool b && b);
       in
       lib.nixvim.mkWarnings "plugins.copilot-cmp" [
         {
-          when = isEnabled copilot-lua-cfg.suggestion.enabled;
+          when = copilot-lua-cfg.suggestion.enabled == true;
           message = ''
             It is recommended to disable copilot's `suggestion` module, as it can interfere with
             completions properly appearing in copilot-cmp.
           '';
         }
         {
-          when = isEnabled copilot-lua-cfg.panel.enabled;
+          when = copilot-lua-cfg.panel.enabled == true;
           message = ''
             It is recommended to disable copilot's `panel` module, as it can interfere with completions
             properly appearing in copilot-cmp.

--- a/plugins/by-name/fidget/default.nix
+++ b/plugins/by-name/fidget/default.nix
@@ -471,10 +471,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "plugins.fidget" {
-      when =
-        (builtins.isBool cfg.settings.integration.nvim-tree.enable)
-        && cfg.settings.integration.nvim-tree.enable
-        && !config.plugins.nvim-tree.enable;
+      when = (cfg.settings.integration.nvim-tree.enable == true) && !config.plugins.nvim-tree.enable;
 
       message = ''
         You have set `plugins.fidget.settings.integrations.nvim-tree.enable` to true but have not enabled `plugins.nvim-tree`.

--- a/plugins/by-name/flutter-tools/default.nix
+++ b/plugins/by-name/flutter-tools/default.nix
@@ -22,8 +22,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     warnings = lib.nixvim.mkWarnings "plugins.flutter-tools" {
       when =
         (cfg.settings ? debugger.enable)
-        && (lib.isBool cfg.settings.debugger.enable)
-        && cfg.settings.debugger.enable
+        && (cfg.settings.debugger.enable == true)
         && (!config.plugins.dap.enable);
 
       message = ''

--- a/plugins/by-name/gitsigns/default.nix
+++ b/plugins/by-name/gitsigns/default.nix
@@ -104,7 +104,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "plugins.gitsigns" {
-      when = (lib.isBool cfg.settings.trouble && cfg.settings.trouble) && !config.plugins.trouble.enable;
+      when = (cfg.settings.trouble == true) && !config.plugins.trouble.enable;
 
       message = ''
         You have enabled `plugins.gitsigns.settings.trouble` but `plugins.trouble.enable` is `false`.

--- a/plugins/by-name/glance/default.nix
+++ b/plugins/by-name/glance/default.nix
@@ -19,8 +19,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     warnings = lib.nixvim.mkWarnings "plugins.glance" {
       when =
         cfg.settings ? use_trouble_qf
-        && builtins.isBool cfg.settings.use_trouble_qf
-        && cfg.settings.use_trouble_qf
+        && (cfg.settings.use_trouble_qf == true)
         && !config.plugins.trouble.enable;
 
       message = ''

--- a/plugins/by-name/lazydev/default.nix
+++ b/plugins/by-name/lazydev/default.nix
@@ -137,24 +137,15 @@ lib.nixvim.plugins.mkNeovimPlugin {
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "plugins.lazydev" [
       {
-        when =
-          builtins.isBool cfg.settings.integrations.cmp
-          && !config.plugins.cmp.enable
-          && cfg.settings.integrations.cmp;
+        when = (cfg.settings.integrations.cmp == true) && !config.plugins.cmp.enable;
         message = "You have enabled nvim-cmp integration but plugins.cmp is not enabled.";
       }
       {
-        when =
-          builtins.isBool cfg.settings.integrations.lspconfig
-          && !config.plugins.lsp.enable
-          && cfg.settings.integrations.lspconfig;
+        when = (cfg.settings.integrations.lspconfig == true) && !config.plugins.lsp.enable;
         message = "You have enabled lspconfig integration but plugins.lsp is not enabled.";
       }
       {
-        when =
-          builtins.isBool cfg.settings.integrations.coq
-          && !config.plugins.coq-nvim.enable
-          && cfg.settings.integrations.coq;
+        when = (cfg.settings.integrations.coq == true) && !config.plugins.coq-nvim.enable;
         message = "You have enabled coq integration but plugins.coq-nvim is not enabled.";
       }
     ];

--- a/plugins/by-name/lean/default.nix
+++ b/plugins/by-name/lean/default.nix
@@ -236,11 +236,8 @@ in
         !(
           # leanls lsp server is disabled in nvim-lspconfig
           config.plugins.lsp.servers.leanls.enable
-          # lsp is not (!) disabled in the lean.nvim plugin
-          && !(
-            # lsp is explicitly set to `false`.
-            (isBool cfg.lsp.enable) && !cfg.lsp.enable
-          )
+          # lsp is not explicitly disabled in the lean.nvim plugin
+          && (cfg.lsp.enable != false)
         );
       message = ''
         You have not explicitly set `plugins.lean.lsp` to `false` while having `plugins.lsp.servers.leanls.enable` set to `true`.

--- a/plugins/by-name/lir/default.nix
+++ b/plugins/by-name/lir/default.nix
@@ -22,8 +22,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     warnings = lib.nixvim.mkWarnings "plugins.lir" {
       when =
         (cfg.settings ? devicons.enable)
-        && (lib.isBool cfg.settings.devicons.enable)
-        && cfg.settings.devicons.enable
+        && (cfg.settings.devicons.enable == true)
         && (!config.plugins.web-devicons.enable);
 
       message = ''

--- a/plugins/by-name/lspsaga/default.nix
+++ b/plugins/by-name/lspsaga/default.nix
@@ -469,9 +469,7 @@ in
         };
     warnings = lib.nixvim.mkWarnings "plugins.ltex-extra" {
       # https://nvimdev.github.io/lspsaga/implement/#default-options
-      when =
-        (isBool cfg.implement.enable && cfg.implement.enable)
-        && (isBool cfg.symbolInWinbar.enable && !cfg.symbolInWinbar.enable);
+      when = (cfg.implement.enable == true) && (cfg.symbolInWinbar.enable == false);
 
       message = ''
         You have enabled the `implement` module but it requires `symbolInWinbar` to be enabled.

--- a/plugins/by-name/neoclip/default.nix
+++ b/plugins/by-name/neoclip/default.nix
@@ -240,8 +240,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     plugins.sqlite-lua.enable = mkOverride 1490 true;
     warnings = lib.nixvim.mkWarnings "plugins.neoclip" {
       when =
-        isBool cfg.settings.enable_persistent_history
-        && cfg.settings.enable_persistent_history
+        (cfg.settings.enable_persistent_history == true)
         && options.plugins.sqlite-lua.enable.highestPrio == 1490;
 
       message = ''
@@ -250,9 +249,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     };
 
     assertions = lib.nixvim.mkAssertions "plugins.neoclip" {
-      assertion =
-        isBool cfg.settings.enable_persistent_history && cfg.settings.enable_persistent_history
-        -> config.plugins.sqlite-lua.enable;
+      assertion = (cfg.settings.enable_persistent_history == true) -> config.plugins.sqlite-lua.enable;
       message = ''
         The persistent history sqlite storage backend needs `sqlite-lua` to function as intended.
         You can enable it by setting `plugins.sqlite-lua.enable` to `true`.

--- a/plugins/by-name/neogit/default.nix
+++ b/plugins/by-name/neogit/default.nix
@@ -116,10 +116,11 @@ lib.nixvim.plugins.mkNeovimPlugin {
         (name: {
           assertion =
             let
-              enabled = cfg.settings.integrations.${name};
-              isEnabled = (isBool enabled) && enabled;
+              extensionEnabled = cfg.settings.integrations.${name} == true;
+              pluginEnabled = config.plugins.${name}.enable;
             in
-            isEnabled -> config.plugins.${name}.enable;
+            extensionEnabled -> pluginEnabled;
+
           message = ''
             You have enabled the `${name}` integration, but `plugins.${name}.enable` is `false`.
           '';

--- a/plugins/by-name/nvim-autopairs/default.nix
+++ b/plugins/by-name/nvim-autopairs/default.nix
@@ -190,7 +190,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "plugins.nvim-autopairs" {
-      when = (isBool cfg.settings.check_ts) && cfg.settings.check_ts && !config.plugins.treesitter.enable;
+      when = (cfg.settings.check_ts == true) && !config.plugins.treesitter.enable;
       message = ''
         You have set `settings.check_ts` to `true` but have not enabled the treesitter plugin.
         We suggest you to set `plugins.treesitter.enable` to `true`.

--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -250,11 +250,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "plugins.obsidian" {
-      when =
-        let
-          nvimCmpEnabled = isBool cfg.settings.completion.nvim_cmp && cfg.settings.completion.nvim_cmp;
-        in
-        nvimCmpEnabled && (!config.plugins.cmp.enable);
+      when = (cfg.settings.completion.nvim_cmp == true) && (!config.plugins.cmp.enable);
       message = ''
         You have enabled `completion.nvim_cmp` but `plugins.cmp.enable` is `false`.
         You should probably enable `nvim-cmp`.

--- a/plugins/by-name/twilight/default.nix
+++ b/plugins/by-name/twilight/default.nix
@@ -71,8 +71,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "plugins.twilight" {
-      when =
-        (isBool cfg.settings.treesitter) && cfg.settings.treesitter && (!config.plugins.treesitter.enable);
+      when = (cfg.settings.treesitter == true) && (!config.plugins.treesitter.enable);
       message = ''
         You have set `plugins.twilight.treesitter` to `true` but `plugins.treesitter.enable` is false.
       '';

--- a/plugins/colorschemes/monokai-pro.nix
+++ b/plugins/colorschemes/monokai-pro.nix
@@ -117,10 +117,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "colorschemes.monokai-pro" {
-      when =
-        (lib.isBool cfg.settings.devicons)
-        && cfg.settings.devicons
-        && (!config.plugins.web-devicons.enable);
+      when = (cfg.settings.devicons == true) && (!config.plugins.web-devicons.enable);
       message = ''
         You have enabled `settings.devicons` but `plugins.web-devicons.enable` is `false`.
         Consider enabling the plugin for proper devicons support.

--- a/plugins/lsp/language-servers/hls.nix
+++ b/plugins/lsp/language-servers/hls.nix
@@ -32,6 +32,6 @@ in
       '';
     };
 
-    extraPackages = lib.optional ((lib.isBool cfg.installGhc) && cfg.installGhc) cfg.ghcPackage;
+    extraPackages = lib.optional (cfg.installGhc == true) cfg.ghcPackage;
   };
 }

--- a/plugins/lsp/language-servers/rust-analyzer.nix
+++ b/plugins/lsp/language-servers/rust-analyzer.nix
@@ -73,11 +73,8 @@ in
     ];
 
     extraPackages =
-      let
-        isEnabled = x: lib.isBool x && x;
-      in
-      lib.optional (isEnabled cfg.installCargo) cfg.cargoPackage
-      ++ lib.optional (isEnabled cfg.installRustc) cfg.rustcPackage
-      ++ lib.optional (isEnabled cfg.installRustfmt) cfg.rustfmtPackage;
+      lib.optional (cfg.installCargo == true) cfg.cargoPackage
+      ++ lib.optional (cfg.installRustc == true) cfg.rustcPackage
+      ++ lib.optional (cfg.installRustfmt == true) cfg.rustfmtPackage;
   };
 }


### PR DESCRIPTION
Alternative to #2929

- **misc/statix: disable the "bool_comparison" lint**
- **treewide: use boolean comparison to simplify the code base**

Closes #2929