### PR TITLE
ci/update: drop dependency on peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,6 +39,7 @@ jobs:
       repo: ${{ github.repository }}
       base_branch: ${{ github.ref_name }}
       pr_branch: update/${{ github.ref_name }}
+      team: nix-community/nixvim
 
     steps:
       - name: Checkout repository
@@ -56,6 +57,11 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Create update branch
+        run: |
+          git branch -D "$pr_branch" || echo "Nothing to delete"
+          git switch -c "$pr_branch"
 
       - name: Get info on the current PR
         id: open_pr_info
@@ -161,14 +167,11 @@ jobs:
             echo "EOF" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create Pull Request
-        id: pr
+      - name: Create or Update Pull Request
+        id: updated_pr
         if: (!steps.changes.outputs.cancelled)
-        uses: peter-evans/create-pull-request@v6
-        with:
-          add-paths: "!**"
-          pr_branch: update/${{ github.ref_name }}
-          delete-branch: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           title: |
             [${{ github.ref_name }}] Update flake.lock & generated files
           body: |
@@ -179,15 +182,57 @@ jobs:
 
             ## Generate
             ${{ steps.generate.outputs.body || 'No changes' }}
+        run: |
+          # TODO:
+          # - cherry-pick additional commits from already open PR
+          # - avoid pushing if there are no changes
+          echo "Pushing to remote branch $pr_branch"
+          git push --force --set-upstream origin "$pr_branch"
+
+          if [[ -n "$pr_num" ]]; then
+            echo "Editing existing PR #$pr_num"
+            operation=updated
+            gh pr edit "$pr_num" \
+              --body "$body" \
+              --add-assignee "$team" \
+              --add-reviewer "$team"
+          else
+            echo "Creating new PR"
+            operation=created
+            gh pr create \
+              --base "$base_branch" \
+              --title "$title" \
+              --body "$body" \
+              --assignee "$team" \
+              --reviewer "$team"
+          fi
+
+          pr_info=$(
+            # Get info from `gh pr view`
+            gh pr view --json 'headRefName,number,url' --jq '
+              to_entries[]
+              | .key |=
+                  # Rename headRefName -> branch
+                  if . == "headRefName" then "branch"
+                  else . end
+              | "\(.key)=\(.value)"
+            '
+            # Get additional info locally
+            echo "head=$(git rev-parse HEAD)"
+            echo "operation=$operation"
+          )
+          echo "PR Info:"
+          echo "$pr_info"
+          echo "$pr_info" >> $GITHUB_OUTPUT
 
       - name: Print summary
-        if: steps.pr.outputs.pull-request-number
+        if: steps.updated_pr.outputs.number
         env:
-          pr_num: ${{ steps.pr.outputs.pull-request-number }}
-          pr_url: ${{ steps.pr.outputs.pull-request-url }}
-          pr_branch: ${{ steps.pr.outputs.pull-request-branch }}
-          head: ${{ steps.pr.outputs.pull-request-head-sha }}
-          operation: ${{ steps.pr.outputs.pull-request-operation }}
+          pr_num: ${{ steps.updated_pr.outputs.number }}
+          pr_url: ${{ steps.updated_pr.outputs.url }}
+          pr_branch: ${{ steps.updated_pr.outputs.branch }}
+          head: ${{ steps.updated_pr.outputs.head }}
+          operation: ${{ steps.updated_pr.outputs.operation }}
         run: |
           short=${head:0:6}
           # stdout
@@ -203,7 +248,7 @@ jobs:
           ) >> $GITHUB_STEP_SUMMARY
 
       - name: Print cancellation summary
-        if: (!steps.pr.outputs.pull-request-number)
+        if: (!steps.updated_pr.outputs.number)
         env:
           pr_num: ${{ steps.open_pr_info.outputs.number }}
           pr_url: ${{ steps.open_pr_info.outputs.url }}


### PR DESCRIPTION
We can create/update PRs using the `gh pr` command, no need for a third party dependency.
