### PR TITLE
ci/update: don't assign a team to the PR

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -194,7 +194,6 @@ jobs:
             operation=updated
             gh pr edit "$pr_num" \
               --body "$body" \
-              --add-assignee "$team" \
               --add-reviewer "$team"
           else
             echo "Creating new PR"
@@ -203,7 +202,6 @@ jobs:
               --base "$base_branch" \
               --title "$title" \
               --body "$body" \
-              --assignee "$team" \
               --reviewer "$team"
           fi
 


### PR DESCRIPTION
Only users can be assigned to PRs, not teams.


See failure: https://github.com/nix-community/nixvim/actions/runs/13059278606/job/36437988175#step:10:73

Testing locally:

```
$ gh pr create --assignee nix-community/nixvim

Creating pull request for MattSturgeon:ci/dont_assign_team into main in nix-community/nixvim

X operation failed. To restore: gh pr create --recover /tmp/gh565857481.json
GraphQL: Could not resolve to a User with the login of 'nix-community/nixvim'. (u000)
```

```
$ gh pr create --reviewer nix-community/nixvim --assignee MattSturgeon

Creating pull request for MattSturgeon:ci/dont_assign_team into main in nix-community/nixvim

https://github.com/nix-community/nixvim/pull/2936
```