### PR TITLE
ci/update: don't request review on the PR

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,7 +39,6 @@ jobs:
       repo: ${{ github.repository }}
       base_branch: ${{ github.ref_name }}
       pr_branch: update/${{ github.ref_name }}
-      team: nix-community/nixvim
 
     steps:
       - name: Checkout repository
@@ -192,17 +191,14 @@ jobs:
           if [[ -n "$pr_num" ]]; then
             echo "Editing existing PR #$pr_num"
             operation=updated
-            gh pr edit "$pr_num" \
-              --body "$body" \
-              --add-reviewer "$team"
+            gh pr edit "$pr_num" --body "$body"
           else
             echo "Creating new PR"
             operation=created
             gh pr create \
               --base "$base_branch" \
               --title "$title" \
-              --body "$body" \
-              --reviewer "$team"
+              --body "$body"
           fi
 
           pr_info=$(


### PR DESCRIPTION
@github-actions doesn't have access to nix-community teams, so it can't request @nix-community/nixvim review the PR.

See failed run: https://github.com/nix-community/nixvim/actions/runs/13059569225/job/36438936010#step:10:71
