### PR TITLE
plugins/java: init

### DIFF
--- a/plugins/by-name/java/default.nix
+++ b/plugins/by-name/java/default.nix
@@ -1,0 +1,44 @@
+{ lib, config, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "java";
+  packPathName = "nvim-java";
+  package = "nvim-java";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  # `require("java").setup()` must run **BEFORE** lspconfig
+  configLocation = lib.mkOrder 900 "extraConfigLua";
+
+  settingsOptions = {
+    root_markers =
+      defaultNullOpts.mkListOf types.str
+        [
+          "settings.gradle"
+          "settings.gradle.kts"
+          "pom.xml"
+          "build.gradle"
+          "mvnw"
+          "gradlew"
+          "build.gradle"
+          "build.gradle.kts"
+          ".git"
+        ]
+        ''
+          List of files that exist in root of the project.
+        '';
+  };
+
+  extraConfig = cfg: {
+    assertions = lib.nixvim.mkAssertions "plugins.nvim-java" {
+      assertion = cfg.enable -> !config.plugins.nvim-jdtls.enable;
+      message = ''
+        You cannot use nvim-java alongside nvim-jdtls.
+        Please, disable `plugins.nvim-jdtls` if you wish to use this plugin.
+      '';
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/java/default.nix
+++ b/tests/test-sources/plugins/by-name/java/default.nix
@@ -1,0 +1,62 @@
+{
+  empty = {
+    # Tries to write to a log file
+    test.runNvim = false;
+
+    plugins.java.enable = true;
+  };
+
+  defaults = {
+    # Tries to write to a log file
+    test.runNvim = false;
+
+    plugins.java = {
+      enable = true;
+
+      settings = {
+        root_markers = [
+
+          "settings.gradle"
+          "settings.gradle.kts"
+          "pom.xml"
+          "build.gradle"
+          "mvnw"
+          "gradlew"
+          "build.gradle"
+          "build.gradle.kts"
+          ".git"
+        ];
+        jdtls = {
+          version = "v1.43.0";
+        };
+        lombok = {
+          version = "nightly";
+        };
+        java_test = {
+          enable = true;
+          version = "0.40.1";
+        };
+        java_debug_adapter = {
+          enable = true;
+          version = "0.58.1";
+        };
+        spring_boot_tools = {
+          enable = true;
+          version = "1.55.1";
+        };
+        jdk = {
+          auto_install = true;
+          version = "17.0.2";
+        };
+        notifications = {
+          dap = true;
+        };
+        verification = {
+          invalid_order = true;
+          duplicate_setup_calls = true;
+          invalid_mason_registry = false;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [nvim-java](https://github.com/nvim-java/nvim-java), a plugin for Java development.

Fixes #1780
