### PR TITLE
plugins/blink-cmp: support raw lua for settings.sources.providers.enabled

### DIFF
--- a/plugins/by-name/blink-cmp/provider-config.nix
+++ b/plugins/by-name/blink-cmp/provider-config.nix
@@ -25,7 +25,7 @@ types.submodule {
     };
 
     enabled = mkNullOrOption' {
-      type = types.bool;
+      type = with types; maybeRaw bool;
       description = ''
         Whether or not to enable the provider.
       '';

--- a/tests/test-sources/plugins/by-name/blink-cmp/default.nix
+++ b/tests/test-sources/plugins/by-name/blink-cmp/default.nix
@@ -379,6 +379,13 @@
           providers = {
             buffer.score_offset = -7;
             lsp.fallbacks = [ ];
+            cmdline.enabled = {
+              __raw = ''
+                function()
+                  return true
+                end
+              '';
+            };
           };
           cmdline = [ ];
         };


### PR DESCRIPTION
Adds the raw lua type to `plugins.blink-cmp.settings.sources.providers.enabled` so that the given example in the [documentation](https://nix-community.github.io/nixvim/plugins/blink-cmp/settings/sources/providers.html) actually works.

TODO:
- [X] Add type to `enabled`.
- [x] Add test for feature.