### PR TITLE
plugins/nvim-ufo: Set lsp capabilities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
 [*.sh]
 indent_style = space
 indent_size = 2
+
+[*.nix]
+indent_size = 2

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -64,6 +64,16 @@ in
 rec {
   inherit pluginDefaultText;
 
+  # Create an option declaration with a default value of `true`, and can be defined to `false`.
+  mkEnabledOption =
+    name:
+    lib.mkOption {
+      default = true;
+      example = false;
+      description = "Whether to enable ${name}.";
+      type = types.bool;
+    };
+
   # Creates an option with a nullable type that defaults to null.
   mkNullOrOption' =
     {

--- a/plugins/by-name/nvim-ufo/default.nix
+++ b/plugins/by-name/nvim-ufo/default.nix
@@ -130,4 +130,20 @@ lib.nixvim.plugins.mkNeovimPlugin {
         end
       '';
   };
+
+  extraOptions = {
+    setupLspCapabilities = lib.nixvim.options.mkEnabledOption "setup LSP capabilities for nvim-ufo";
+  };
+
+  extraConfig = cfg: {
+    plugins.lsp.capabilities =
+      lib.mkIf cfg.setupLspCapabilities # lua
+        ''
+          -- Capabilities configuration for nvim-ufo
+          capabilities.textDocument.foldingRange = {
+            dynamicRegistration = false,
+            lineFoldingOnly = true
+          }
+        '';
+  };
 }

--- a/tests/test-sources/plugins/by-name/nvim-ufo/default.nix
+++ b/tests/test-sources/plugins/by-name/nvim-ufo/default.nix
@@ -90,4 +90,12 @@
       };
     };
   };
+
+  lsp-compat = {
+    plugins.nvim-ufo = {
+      enable = true;
+      setupLspCapabilities = true;
+    };
+    plugins.lsp.enable = true;
+  };
 }


### PR DESCRIPTION
Following the [installation procedure of `nvim-ufo`](https://github.com/kevinhwang91/nvim-ufo/blob/main/README.md#minimal-configuration), it require to configure the LSP capabilities