### PR TITLE
plugins/schemastore: set the correct jsonls option

### DIFF
--- a/plugins/by-name/schemastore/default.nix
+++ b/plugins/by-name/schemastore/default.nix
@@ -145,7 +145,7 @@ lib.nixvim.plugins.mkVimPlugin {
 
         # The plugin recommends to enable this option in its README.
         # Learn more: https://github.com/b0o/SchemaStore.nvim/issues/8
-        validate = mkDefault true;
+        validate.enable = mkDefault true;
       };
 
       yamlls.settings = mkIf cfg.yaml.enable {


### PR DESCRIPTION
The JSON language server has the following [configuration structure](https://github.com/microsoft/vscode/blob/6fef251f8f0e9f74b7adb4ed310e35eabb97afdf/extensions/json-language-features/server/src/jsonServer.ts#L167-L179):
```ts
    // The settings interface describes the server relevant settings part
    interface Settings {
        json?: {
            schemas?: JSONSchemaSettings[];
            format?: { enable?: boolean };
            validate?: { enable?: boolean };
            resultLimit?: number;
        };
        http?: {
            proxy?: string;
            proxyStrictSSL?: boolean;
        };
    }
```
So, we should be mkDefault'ing `validate.enable` instead of `validate`, as `validate` is expected to be an `Object` containing `enable` as a boolean.
This is also reflected in the schemastore readme, which offers this configuration example:
```lua
require('lspconfig').jsonls.setup {
  settings = {
    json = {
      schemas = require('schemastore').json.schemas(),
      validate = { enable = true },
    },
  },
}
```
Whereas nixvim currently does the following:
![image](https://github.com/user-attachments/assets/7a1bf6c2-194e-4951-864f-4f5f808145b4)
