### PR TITLE
Test NixOS/nixpkgs#380342

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738797219,
-        "narHash": "sha256-KRwX9Z1XavpgeSDVM/THdFd6uH8rNm/6R+7kIbGa+2s=",
-        "owner": "NixOS",
+        "lastModified": 1739040350,
+        "narHash": "sha256-K4K50MZHe6BhTAjMTU/YfJQ4fC6DiQtVJ75IheCQj+s=",
+        "owner": "MattSturgeon",
         "repo": "nixpkgs",
-        "rev": "1da52dd49a127ad74486b135898da2cef8c62665",
+        "rev": "ffd6dc6380eba7ef28c4c12315f65cc54cfbd0cb",
         "type": "github"
       },
       "original": {

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -39,9 +39,9 @@ let
         # Use global packages in nixvim's submodule
         pkgs = lib.mkIf config.nixpkgs.useGlobalPackages (lib.mkDefault pkgs);
 
-        # Inherit platforms
-        hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform.system;
-        buildPlatform = lib.mkOverride buildPlatformPrio pkgs.stdenv.buildPlatform.system;
+        # Inherit platform spec
+        hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform;
+        buildPlatform = lib.mkOverride buildPlatformPrio pkgs.stdenv.buildPlatform;
       };
     };
 


### PR DESCRIPTION
This PR is just for running the CI against https://github.com/NixOS/nixpkgs/pull/380342

Initially, I tested directly against https://github.com/NixOS/nixpkgs/pull/380342:

- First build: https://buildbot.nix-community.org/#/builders/26/builds/4139
- Second build (with f99264c1fb8e98e0712cdad2744afa8b40661dcc reverted): https://buildbot.nix-community.org/#/builders/26/builds/4140

However, this has several unrelated build failures.

I tried again, cherry-picking https://github.com/NixOS/nixpkgs/pull/380342 onto nixvim's current nixpkgs rev (https://github.com/NixOS/nixpkgs/commit/1da52dd49a127ad74486b135898da2cef8c62665):

- First build: https://buildbot.nix-community.org/#/builders/26/builds/4142
- Second build (with f99264c1fb8e98e0712cdad2744afa8b40661dcc reverted): https://buildbot.nix-community.org/#/builders/26/builds/4143