### PR TITLE
plugins/hlchunk: init

### DIFF
--- a/plugins/by-name/hlchunk/default.nix
+++ b/plugins/by-name/hlchunk/default.nix
@@ -1,0 +1,42 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "hlchunk";
+  packPathName = "hlchunk.nvim";
+  package = "hlchunk-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    chunk = {
+      enable = true;
+      use_treesitter = true;
+      style.fg = "#91bef0";
+      exclude_filetypes = {
+        neo-tree = true;
+        lazyterm = true;
+      };
+      chars = {
+        horizontal_line = "─";
+        vertical_line = "│";
+        left_top = "╭";
+        left_bottom = "╰";
+        right_arrow = "─";
+      };
+    };
+    indent = {
+      chars = [ "│" ];
+      use_treesitter = false;
+
+      style.fg = "#45475a";
+      exclude_filetypes = {
+        neo-tree = true;
+        lazyterm = true;
+      };
+    };
+    blank.enable = false;
+    line_num = {
+      use_treesitter = true;
+      style = "#91bef0";
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/hlchunk/default.nix
+++ b/tests/test-sources/plugins/by-name/hlchunk/default.nix
@@ -1,0 +1,73 @@
+{
+  empty = {
+    plugins.hlchunk.enable = true;
+  };
+
+  defaults = {
+    plugins.hlchunk = {
+      enable = true;
+
+      # https://github.com/shellRaining/hlchunk.nvim/tree/main?tab=readme-ov-file#setup
+      settings =
+        let
+          modDefaultConfig = {
+            enable = false;
+            style = { };
+            notify = false;
+            priority = 0;
+            exclude_filetypes = {
+              aerial = true;
+              dashboard = true;
+              # ...
+            };
+          };
+        in
+        {
+          chunk = modDefaultConfig;
+          indent = modDefaultConfig;
+          line_num = modDefaultConfig;
+          blank = modDefaultConfig;
+        };
+    };
+  };
+
+  example = {
+    plugins.hlchunk = {
+      enable = true;
+
+      settings = {
+        chunk = {
+          enable = true;
+          use_treesitter = true;
+          style.fg = "#91bef0";
+          exclude_filetypes = {
+            neo-tree = true;
+            lazyterm = true;
+          };
+          chars = {
+            horizontal_line = "─";
+            vertical_line = "│";
+            left_top = "╭";
+            left_bottom = "╰";
+            right_arrow = "─";
+          };
+        };
+        indent = {
+          chars = [ "│" ];
+          use_treesitter = false;
+
+          style.fg = "#45475a";
+          exclude_filetypes = {
+            neo-tree = true;
+            lazyterm = true;
+          };
+        };
+        blank.enable = false;
+        line_num = {
+          use_treesitter = true;
+          style = "#91bef0";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [hlchunk.nvim](https://github.com/shellRaining/hlchunk.nvim), a plugin to highlight the indent and the code chunk according to the current cursor position.

Fixes #2894
