### PR TITLE
[test] bump nixpkgs to latest master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -185,11 +185,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738797219,
-        "narHash": "sha256-KRwX9Z1XavpgeSDVM/THdFd6uH8rNm/6R+7kIbGa+2s=",
+        "lastModified": 1739375885,
+        "narHash": "sha256-vTKPxNKQ+2kU38zVFufWKh0zs7ZBqlga5poc4hPwsTo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1da52dd49a127ad74486b135898da2cef8c62665",
+        "rev": "b81ab2196372aa5b46a119bcfde7f39bc353cb96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

```
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/1da52dd49a127ad74486b135898da2cef8c62665?narHash=sha256-KRwX9Z1XavpgeSDVM/THdFd6uH8rNm/6R%2B7kIbGa%2B2s%3D' (2025-02-05)
  → 'github:NixOS/nixpkgs/b81ab2196372aa5b46a119bcfde7f39bc353cb96?narHash=sha256-vTKPxNKQ%2B2kU38zVFufWKh0zs7ZBqlga5poc4hPwsTo%3D' (2025-02-12)
```

---

### test-2

https://buildbot.nix-community.org/#/builders/2795/builds/3553/steps/1/logs/stdio

```
plugins-combined> ERROR: Error detected while processing /nix/store/a7cfg7x8vy7vl5dwyi98kdcdslkifh8w-init.lua:
plugins-combined> E5113: Error while calling lua chunk: /nix/store/a7cfg7x8vy7vl5dwyi98kdcdslkifh8w-init.lua:0: module 'plenary' not found:
plugins-combined>       no field package.preload['plenary']
plugins-combined>       no file '/nix/store/6hdb25rs5aphgnzq7ffaqp79rjyinh32-luajit-2.1.1713773202-env/share/lua/5.1/plenary.lua'
plugins-combined>       no file '/nix/store/6hdb25rs5aphgnzq7ffaqp79rjyinh32-luajit-2.1.1713773202-env/share/lua/5.1/plenary/init.lua'
plugins-combined>       no file '/nix/store/6hdb25rs5aphgnzq7ffaqp79rjyinh32-luajit-2.1.1713773202-env/lib/lua/5.1/plenary.so'
plugins-combined> stack traceback:
plugins-combined>       [C]: in function 'require'
plugins-combined>       /nix/store/a7cfg7x8vy7vl5dwyi98kdcdslkifh8w-init.lua: in function </nix/store/a7cfg7x8vy7vl5dwyi98kdcdslkifh8w-init.lua:0>
```

### test-10

https://buildbot.nix-community.org/#/builders/2789/builds/3577/steps/1/logs/stdio

```
python3.12-asn1tools> =========================== short test summary info ============================
python3.12-asn1tools> FAILED tests/test_command_line.py::Asn1ToolsCommandLineTest::test_command_line_generate_c_source_uper - SystemExit: error: string index out of range
python3.12-asn1tools> FAILED tests/test_command_line.py::Asn1ToolsCommandLineTest::test_command_line_generate_c_source_oer - IndexError: string index out of range
python3.12-asn1tools> FAILED tests/test_compile.py::Asn1ToolsCompileTest::test_missing_parameterized_value - IndexError: string index out of range
python3.12-asn1tools> FAILED tests/test_codecs_consistency.py::Asn1ToolsCodecsConsistencyTest::test_c_source - IndexError: string index out of range
python3.12-asn1tools> FAILED tests/test_parse.py::Asn1ToolsParseTest::test_parse_parameterization - IndexError: string index out of range
python3.12-asn1tools> FAILED tests/test_oer.py::Asn1ToolsOerTest::test_c_source - IndexError: string index out of range
python3.12-asn1tools> FAILED tests/test_command_line.py::Asn1ToolsCommandLineTest::test_command_line_generate_rust_source_uper - SystemExit: error: string index out of range
python3.12-asn1tools> ======================== 7 failed, 465 passed in 9.11s =========================
```

### test-24

https://buildbot.nix-community.org/#/builders/2883/builds/3566/steps/1/logs/stdio

```
default> ERROR: Error detected while processing /nix/store/qqfq2s0lsaq17g5h8w8pzm0xqmr1ndvf-init.lua:
default> E5113: Error while calling lua chunk: [orgmode] No C compiler found for installing tree-sitter grammar
default> stack traceback:
default>        [C]: in function 'error'
default>        ...s/start/orgmode/lua/orgmode/utils/treesitter/install.lua:113: in function 'run'
default>        ...NeovimPackages/start/orgmode/lua/orgmode/config/init.lua:35: in function 'install_grammar'
default>        ...pack/myNeovimPackages/start/orgmode/lua/orgmode/init.lua:126: in function 'setup'
default>        /nix/store/qqfq2s0lsaq17g5h8w8pzm0xqmr1ndvf-init.lua:9: in main chunk
copying path '/nix/store/hin40zlfbysbg70xhw4p9lf03d58yia6-curl-8.11.1-bin' from 'https://cache.nixos.org'...
```

### test-29

https://buildbot.nix-community.org/#/builders/2920/builds/3229/steps/1/logs/stdio

```
combine-plugins> ERROR: Error detected while processing /nix/store/9zsammppwr0yg5nqbb16jg28qf7blj71-init.lua:
combine-plugins> E5113: Error while calling lua chunk: ...ges/start/vimplugin-plugin-pack/lua/telescope/config.lua:1: module 'plenary.strings' not found:
combine-plugins>        no field package.preload['plenary.strings']
combine-plugins>        no file '/nix/store/6hdb25rs5aphgnzq7ffaqp79rjyinh32-luajit-2.1.1713773202-env/share/lua/5.1/plenary/strings.lua'
combine-plugins>        no file '/nix/store/6hdb25rs5aphgnzq7ffaqp79rjyinh32-luajit-2.1.1713773202-env/share/lua/5.1/plenary/strings/init.lua'
combine-plugins>        no file '/nix/store/6hdb25rs5aphgnzq7ffaqp79rjyinh32-luajit-2.1.1713773202-env/lib/lua/5.1/plenary/strings.so'
combine-plugins>        no file '/nix/store/6hdb25rs5aphgnzq7ffaqp79rjyinh32-luajit-2.1.1713773202-env/lib/lua/5.1/plenary.so'
combine-plugins> stack traceback:
combine-plugins>        [C]: in function 'require'
combine-plugins>        ...ges/start/vimplugin-plugin-pack/lua/telescope/config.lua:1: in main chunk
combine-plugins>        [C]: in function 'require'
combine-plugins>        ...kages/start/vimplugin-plugin-pack/lua/telescope/init.lua:133: in function 'setup'
combine-plugins>        /nix/store/9zsammppwr0yg5nqbb16jg28qf7blj71-init.lua:11: in main chunk
```

### test-34 (aarch64-darwin only)

https://buildbot.nix-community.org/#/builders/3545/builds/1883/steps/1/logs/stdio

```
yazi> Running phase: checkPhase
yazi> Executing cargoCheckHook
yazi> cargoCheckHook flags: -j 10 --profile release --target aarch64-apple-darwin --offline -- --test-threads=10
yazi>    Compiling cfg-if v1.0.0
yazi>    Compiling memchr v2.7.4
error: Nix daemon disconnected unexpectedly (maybe it crashed?)
error: builder for '/nix/store/bffdp5add95vlc9k663b8zxg62kdjnzn-yazi-25.2.11.drv' failed with exit code 1
```