### PR TITLE
docs/fix-links: init

### DIFF
--- a/docs/fix-links/default.nix
+++ b/docs/fix-links/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  runCommand,
+  pandoc,
+  githubUrl ? "https://github.com/nix-community/nixvim/blob/main/",
+  docsUrl ? "https://nix-community.github.io/nixvim/",
+}:
+src:
+runCommand (src.name or (builtins.baseNameOf src))
+  {
+    inherit src;
+    bindings =
+      lib.generators.toLua
+        {
+          asBindings = true;
+        }
+        {
+          inherit githubUrl docsUrl;
+        };
+    filter = ./filter.lua;
+    nativeBuildInputs = [ pandoc ];
+  }
+  ''
+    echo "$bindings" > filter.lua
+    cat $filter >> filter.lua
+
+    pandoc \
+        --output $out \
+        --from markdown \
+        --to markdown-raw_attribute \
+        --lua-filter filter.lua \
+        $src
+  ''

--- a/docs/fix-links/filter.lua
+++ b/docs/fix-links/filter.lua
@@ -1,0 +1,40 @@
+local len = pandoc.text.len
+local sub = pandoc.text.sub
+
+-- True if str starts with prefix
+local function hasPrefix(prefix, str)
+	local pfxLen = len(prefix)
+	local strLen = len(str)
+	if pfxLen == strLen then
+		return prefix == str
+	end
+	if pfxLen < strLen then
+		return prefix == sub(str, 1, pfxLen)
+	end
+	return false
+end
+
+function Link(link)
+	local target = link.target
+	-- Check for relative links
+	-- TODO: handle ../
+	if hasPrefix("./", target) then
+		link.target = githubUrl .. sub(target, 3)
+		return link
+	end
+	if not hasPrefix("https://", target) then
+		link.target = githubUrl .. target
+		return link
+	end
+
+	-- Check for absolute links, pointing to the docs website
+	if docsUrl == target then
+		link.target = "."
+		return link
+	end
+	if hasPrefix(docsUrl, target) then
+		local i = len(docsUrl) + 1
+		link.target = sub(target, i)
+		return link
+	end
+end


### PR DESCRIPTION
The README/CONTRIBUTING files are authored with GitHub in mind, but we re-use them for the docs website.

We can use pandoc's AST-based [lua filters](https://pandoc.org/lua-filters.html) to modify link targets.

Knowing we are dealing with a link target allows us to also handle things like relative links, meaning we can fixup links targeting the github repo such that they also work from the docs website.

- Replace README's substitution with the new impl
- Also fix links in the CONTRIBUTING file


