### PR TITLE
docs/fix-links: handle `#anchor` targets on the same page

### DIFF
--- a/docs/fix-links/filter.lua
+++ b/docs/fix-links/filter.lua
@@ -18,9 +18,13 @@ function Link(link)
 	local target = link.target
 	-- Check for relative links
 	-- TODO: handle ../
-	if hasPrefix("./", target) then
-		link.target = githubUrl .. sub(target, 3)
-		return link
+	while hasPrefix("./", target) do
+		-- strip leading ./
+		target = sub(target, 3)
+	end
+	if hasPrefix("#", target) then
+		-- No-op for anchor targets on the same page
+		return nil
 	end
 	if not hasPrefix("https://", target) then
 		link.target = githubUrl .. target


### PR DESCRIPTION
Follow up to https://github.com/nix-community/nixvim/pull/3010, in particular it resolves https://github.com/nix-community/nixvim/pull/3010#discussion_r1955547292.
