### PR TITLE
{readme,lib/keymaps}: cleanup `modes` docs/impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,19 +412,21 @@ nnoremap <leader>m <silent> <cmd>make<CR>
 This table describes all modes for the `keymaps` option.
 You can provide several modes to a single mapping by using a list of strings.
 
-| Short | Description                                      |
-|-------|--------------------------------------------------|
-| `"n"` | Normal mode                                      |
-| `"i"` | Insert mode                                      |
-| `"v"` | Visual and Select mode                           |
-| `"s"` | Select mode                                      |
-| `"t"` | Terminal mode                                    |
-| `"" ` | Normal, visual, select and operator-pending mode |
-| `"x"` | Visual mode only, without select                 |
-| `"o"` | Operator-pending mode                            |
-| `"!"` | Insert and command-line mode                     |
-| `"l"` | Insert, command-line and lang-arg mode           |
-| `"c"` | Command-line mode                                |
+<!-- Based on `:h map-table` https://neovim.io/doc/user/map.html#map-table -->
+
+| Mode   | Norm | Ins | Cmd | Vis | Sel | Opr | Term | Lang | Description |
+|--------|------|-----|-----|-----|-----|-----|------|------|-------------|
+| `""`   | yes  |  -  |  -  | yes | yes | yes |  -   |  -   | Equivalent to `:map` |
+| `"n"`  | yes  |  -  |  -  |  -  |  -  |  -  |  -   |  -   | Normal mode |
+| `"!"`  |  -   | yes | yes |  -  |  -  |  -  |  -   |  -   | Insert and command-line mode |
+| `"i"`  |  -   | yes |  -  |  -  |  -  |  -  |  -   |  -   | Insert mode |
+| `"c"`  |  -   |  -  | yes |  -  |  -  |  -  |  -   |  -   | Command-line mode |
+| `"v"`  |  -   |  -  |  -  | yes | yes |  -  |  -   |  -   | Visual and Select mode |
+| `"x"`  |  -   |  -  |  -  | yes |  -  |  -  |  -   |  -   | Visual mode only, without select |
+| `"s"`  |  -   |  -  |  -  |  -  | yes |  -  |  -   |  -   | Select mode |
+| `"o"`  |  -   |  -  |  -  |  -  |  -  | yes |  -   |  -   | Operator-pending mode |
+| `"t"`  |  -   |  -  |  -  |  -  |  -  |  -  | yes  |  -   | Terminal mode |
+| `"l"`  |  -   | yes | yes |  -  |  -  |  -  |  -   | yes  | Insert, command-line and lang-arg mode |
 
 Each keymap can specify the following settings in the `options` attrs.
 

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -25,39 +25,21 @@ rec {
     buffer = defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
   };
 
-  modes = {
-    normal.short = "n";
-    insert.short = "i";
-    visual = {
-      desc = "visual and select";
-      short = "v";
-    };
-    visualOnly = {
-      desc = "visual only";
-      short = "x";
-    };
-    select.short = "s";
-    terminal.short = "t";
-    normalVisualOp = {
-      desc = "normal, visual, select and operator-pending (same as plain 'map')";
-      short = "";
-    };
-    operator.short = "o";
-    lang = {
-      desc = "normal, visual, select and operator-pending (same as plain 'map')";
-      short = "l";
-    };
-    insertCommand = {
-      desc = "insert and command-line";
-      short = "!";
-    };
-    command.short = "c";
-  };
+  modes = [
+    "" # normal, visual, select, and operator-pending (same as plain ':map')
+    "n" # normal
+    "!" # insert and command-line
+    "i" # insert
+    "c" # command
+    "v" # visual and select
+    "x" # visual only
+    "s" # select
+    "o" # operator-pending
+    "t" # terminal
+    "l" # insert, command-line and lang-arg
+  ];
 
-  modeEnum =
-    lib.types.enum
-      # ["" "n" "v" ...]
-      (map ({ short, ... }: short) (lib.attrValues modes));
+  modeEnum = lib.types.enum modes;
 
   mapOptionSubmodule = mkMapOptionSubmodule { };
 


### PR DESCRIPTION
- **readme: use `:h map-table` for mapping modes**
- **lib/keymaps: replace `modes` attrs with list**

Small cleanup in preparation for fixing #3012
