### PR TITLE
lib/keymaps: add abbreviation support to `modes` enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,8 +427,13 @@ You can provide several modes to a single mapping by using a list of strings.
 | `"o"`  |  -   |  -  |  -  |  -  |  -  | yes |  -   |  -   | Operator-pending mode |
 | `"t"`  |  -   |  -  |  -  |  -  |  -  |  -  | yes  |  -   | Terminal mode |
 | `"l"`  |  -   | yes | yes |  -  |  -  |  -  |  -   | yes  | Insert, command-line and lang-arg mode |
+| `"!a"` |  -   | abr | abr |  -  |  -  |  -  |  -   |  -   | [Abbreviation] in insert and command-line mode |
+| `"ia"` |  -   | abr |  -  |  -  |  -  |  -  |  -   |  -   | [Abbreviation] in insert mode |
+| `"ca"` |  -   |  -  | abr |  -  |  -  |  -  |  -   |  -   | [Abbreviation] in command-line mode |
 
 Each keymap can specify the following settings in the `options` attrs.
+
+[Abbreviation]: https://neovim.io/doc/user/usr_24.html#_abbreviations
 
 | NixVim  | Default | VimScript                                         |
 |---------|---------|---------------------------------------------------|

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -37,6 +37,9 @@ rec {
     "o" # operator-pending
     "t" # terminal
     "l" # insert, command-line and lang-arg
+    "!a" # abbreviation in insert and command-line
+    "ia" # abbreviation in insert
+    "ca" # abbreviation in command
   ];
 
   modeEnum = lib.types.enum modes;


### PR DESCRIPTION
See https://neovim.io/doc/user/usr_24.html#_abbreviations
and https://learnvimscriptthehardway.stevelosh.com/chapters/08.html

Fixes #3012
