### PR TITLE
lib/keymaps: make mode type description more readable

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -44,6 +44,15 @@ rec {
 
   modeEnum = lib.types.enum modes;
 
+  modeType =
+    with lib.types;
+    either modeEnum (nonEmptyListOf modeEnum)
+    // {
+      description =
+        "one of or non-empty list of" + lib.strings.removePrefix "one of" modeEnum.description;
+      descriptionClass = "conjunction";
+    };
+
   mapOptionSubmodule = mkMapOptionSubmodule { };
 
   # NOTE: options that have the deprecated `lua` sub-option must use `removeDeprecatedMapAttrs`
@@ -55,7 +64,7 @@ rec {
   mkModeOption =
     default:
     lib.mkOption {
-      type = with lib.types; either modeEnum (listOf modeEnum);
+      type = modeType;
       description = ''
         One or several modes.
         Use the short-names (`"n"`, `"v"`, ...).

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -59,7 +59,9 @@ rec {
       description = ''
         One or several modes.
         Use the short-names (`"n"`, `"v"`, ...).
-        See `:h map-modes` to learn more.
+        See [`:h map-modes`] to learn more.
+
+        [`:h map-modes`]: https://neovim.io/doc/user/map.html#%3Amap-modes
       '';
       inherit default;
       example = [


### PR DESCRIPTION
- **lib/keymaps: add a link to `:h map-modes`**
  
- **lib/keymaps: make `mode` type's description more readable**
  Only list the enum values once, instead of twice.
  
![image](https://github.com/user-attachments/assets/946c5264-d3ef-4201-acb2-2141a7f657f2)

