### PR TITLE
plugins/lightline: fix formatting of code example

### DIFF
--- a/plugins/by-name/lightline/default.nix
+++ b/plugins/by-name/lightline/default.nix
@@ -17,13 +17,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
   description = ''
     ### Example of defining your own component_function
 
+    ```nix
     plugins.lightline = {
        enable = true;
        settings.component_function = {
          readonly = "LightlineReadonly";
        };
 
-       luaConfig.pre= '''
+       luaConfig.pre = '''
          function LightlineReadonly()
            local is_readonly = vim.bo.readonly == 1
            local filetype = vim.bo.filetype
@@ -36,6 +37,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
          end
        ''';
      };
+    ```
   '';
 
   # TODO: Added 2024-08-23, remove after 24.11


### PR DESCRIPTION
Found another small problem in the docs. 