### PR TITLE
flake: partition dev dependencies

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,10 +6,14 @@ on:
   # Allow manual triggering
   workflow_dispatch:
     inputs:
-      lock:
+      root_lock:
         type: boolean
         default: true
-        description: Update flake.lock
+        description: Update root flake.lock
+      dev_lock:
+        type: boolean
+        default: true
+        description: Update dev flake.lock
       generate:
         type: boolean
         default: true
@@ -100,12 +104,28 @@ jobs:
           git fetch origin "$pr_branch"
           git branch --set-upstream-to "origin/$pr_branch"
 
-      - name: Update flake.lock
-        id: flake_lock
-        if: inputs.lock || github.event_name == 'schedule'
+      - name: Update root flake.lock
+        id: root_flake_lock
+        if: inputs.root_lock || github.event_name == 'schedule'
         run: |
           old=$(git show --no-patch --format=%h)
           nix flake update --commit-lock-file
+          new=$(git show --no-patch --format=%h)
+          if [ "$old" != "$new" ]; then
+            echo "body<<EOF" >> "$GITHUB_OUTPUT"
+            git show --no-patch --format=%b >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update dev flake.lock
+        id: dev_flake_lock
+        if: inputs.dev_lock || github.event_name == 'schedule'
+        run: |
+          root_nixpkgs=$(nix eval -f . 'inputs.nixpkgs.rev')
+          old=$(git show --no-patch --format=%h)
+          nix flake update --commit-lock-file \
+              --override-input nixpkgs "github:NixOS/nixpkgs/$root_nixpkgs" \
+              --flake './flake/dev'
           new=$(git show --no-patch --format=%h)
           if [ "$old" != "$new" ]; then
             echo "body<<EOF" >> "$GITHUB_OUTPUT"
@@ -185,9 +205,14 @@ jobs:
           title: |
             [${{ github.ref_name }}] Update flake.lock & generated files
           body: |
-            ## Flake lockfile
+            ## Root lockfile
             ```
-            ${{ steps.flake_lock.outputs.body || 'No changes' }}
+            ${{ steps.root_flake_lock.outputs.body || 'No changes' }}
+            ```
+
+            ## Dev lockfile
+            ```
+            ${{ steps.dev_flake_lock.outputs.body || 'No changes' }}
             ```
 
             ## Generate

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 (import (
   let
-    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    lock = builtins.fromJSON (builtins.readFile ./flake/dev/flake.lock);
   in
   fetchTarball {
     url =

--- a/flake.lock
+++ b/flake.lock
@@ -1,39 +1,5 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "revCount": 69,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -72,71 +38,6 @@
         "type": "github"
       }
     },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1738878603,
-        "narHash": "sha256-fmhq8B3MvQLawLbMO+LWLcdC2ftLMmwSk+P29icJ3tE=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "433799271274c9f2ab520a49527ebfe2992dcfbd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "ixx": {
       "inputs": {
         "flake-utils": [
@@ -160,26 +61,6 @@
         "owner": "NuschtOS",
         "ref": "v0.0.6",
         "repo": "ixx",
-        "type": "github"
-      }
-    },
-    "nix-darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1738743987,
-        "narHash": "sha256-O3bnAfsObto6l2tQOmQlrO6Z2kD6yKwOWfs7pA0CpOc=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "ae406c04577ff9a64087018c79b4fdc02468c87c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lnl7",
-        "repo": "nix-darwin",
         "type": "github"
       }
     },
@@ -223,15 +104,9 @@
     },
     "root": {
       "inputs": {
-        "devshell": "devshell",
-        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "git-hooks": "git-hooks",
-        "home-manager": "home-manager",
-        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
-        "nuschtosSearch": "nuschtosSearch",
-        "treefmt-nix": "treefmt-nix"
+        "nuschtosSearch": "nuschtosSearch"
       }
     },
     "systems": {
@@ -246,26 +121,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1738680491,
-        "narHash": "sha256-8X7tR3kFGkE7WEF5EXVkt4apgaN85oHZdoTGutCFs6I=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "64dbb922d51a42c0ced6a7668ca008dded61c483",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,59 +9,9 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
 
-    /*
-      # NOTE: The inputs below this comment are optional
-      # You can remove them with `inputs.<input>.follows = ""`
-
-      For example:
-
-      ```
-      nixvim = {
-        url = "github:nix-community/nixvim";
-        inputs = {
-          nixpkgs.follows = "nixpkgs";
-          flake-parts.follows = "flake-parts";
-
-          devshell.follows = "";
-          flake-compat.follows = "";
-          git-hooks.follows = "";
-          home-manager.follows = "";
-          nix-darwin.follows = "";
-          treefmt-nix.follows = "";
-        };
-      };
-      ```
-    */
-
     nuschtosSearch = {
       url = "github:NuschtOS/search";
       inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    nix-darwin = {
-      url = "github:lnl7/nix-darwin";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    devshell = {
-      url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
-
-    git-hooks = {
-      url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-compat.follows = "flake-compat";
     };
   };
 

--- a/flake/default.nix
+++ b/flake/default.nix
@@ -1,6 +1,12 @@
 {
+  lib,
+  inputs,
+  config,
+  partitionStack,
+  ...
+}:
+{
   imports = [
-    ./dev
     ./flake-modules
     ./lib.nix
     ./legacy-packages.nix
@@ -8,7 +14,43 @@
     ./overlays.nix
     ./packages.nix
     ./templates.nix
-    ./tests.nix
     ./wrappers.nix
+    inputs.flake-parts.flakeModules.partitions
   ];
+
+  # Define flake partitions
+  # Each has a `module`, assigned to the partition's submodule,
+  # and an `extraInputsFlake`, used for its inputs.
+  # See https://flake.parts/options/flake-parts-partitions.html
+  partitions = {
+    dev = {
+      module = ./dev;
+      extraInputsFlake = ./dev;
+    };
+  };
+
+  # Specify which outputs are defined by which partitions
+  partitionedAttrs = {
+    checks = "dev";
+    devShells = "dev";
+    formatter = "dev";
+  };
+
+  # For any output attrs normally defined by the root flake configuration,
+  # any exceptions must be manually propagated from the `dev` partition.
+  #
+  # NOTE: Attrs should be explicitly propagated at the deepest level.
+  # Otherwise the partition won't be lazy, making it pointless.
+  # E.g. propagate `packages.${system}.foo` instead of `packages.${system}`
+  # See: https://github.com/hercules-ci/flake-parts/issues/258
+  perSystem =
+    { system, ... }:
+    {
+      packages = lib.optionalAttrs (partitionStack == [ ]) {
+        # Propagate `packages` from the `dev` partition:
+        inherit (config.partitions.dev.module.flake.packages.${system})
+          list-plugins
+          ;
+      };
+    };
 }

--- a/flake/dev/default.nix
+++ b/flake/dev/default.nix
@@ -1,21 +1,22 @@
-{ lib, inputs, ... }:
+{ inputs, ... }:
 {
-  imports =
-    [
-      ./devshell.nix
-      ./list-plugins
-    ]
-    ++ lib.optional (inputs.git-hooks ? flakeModule) inputs.git-hooks.flakeModule
-    ++ lib.optional (inputs.treefmt-nix ? flakeModule) inputs.treefmt-nix.flakeModule;
+  imports = [
+    ./devshell.nix
+    ./list-plugins
+    ./package-tests.nix
+    ./template-tests.nix
+    ./tests.nix
+    inputs.git-hooks.flakeModule
+    inputs.treefmt-nix.flakeModule
+  ];
 
   perSystem =
     {
-      lib,
       pkgs,
       system,
       ...
     }:
-    lib.optionalAttrs (inputs.treefmt-nix ? flakeModule) {
+    {
       treefmt.config = {
         projectRootFile = "flake.nix";
         flakeCheck = true;
@@ -66,8 +67,7 @@
           formatter.ruff-format.options = [ "--isolated" ];
         };
       };
-    }
-    // lib.optionalAttrs (inputs.git-hooks ? flakeModule) {
+
       pre-commit = {
         # We have a treefmt check already, so this is redundant.
         # We also can't run the test if it includes running `nix build`,

--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -1,17 +1,18 @@
 { lib, inputs, ... }:
 {
-  imports = lib.optional (inputs.devshell ? flakeModule) inputs.devshell.flakeModule;
+  imports = [
+    inputs.devshell.flakeModule
+  ];
 
   perSystem =
     {
-      lib,
       pkgs,
       config,
       self',
       system,
       ...
     }:
-    lib.optionalAttrs (inputs.devshell ? flakeModule) {
+    {
       devshells.default = {
         devshell.startup.pre-commit.text = config.pre-commit.installationScript;
 

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -1,0 +1,172 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1735644329,
+        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738878603,
+        "narHash": "sha256-fmhq8B3MvQLawLbMO+LWLcdC2ftLMmwSk+P29icJ3tE=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "433799271274c9f2ab520a49527ebfe2992dcfbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738743987,
+        "narHash": "sha256-O3bnAfsObto6l2tQOmQlrO6Z2kD6yKwOWfs7pA0CpOc=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "ae406c04577ff9a64087018c79b4fdc02468c87c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738797219,
+        "narHash": "sha256-KRwX9Z1XavpgeSDVM/THdFd6uH8rNm/6R+7kIbGa+2s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1da52dd49a127ad74486b135898da2cef8c62665",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "git-hooks": "git-hooks",
+        "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738680491,
+        "narHash": "sha256-8X7tR3kFGkE7WEF5EXVkt4apgaN85oHZdoTGutCFs6I=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "64dbb922d51a42c0ced6a7668ca008dded61c483",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Private inputs for development purposes. These are used by the top level flake in the `dev` partition, but do not appear in consumers' lock files.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-darwin = {
+      url = "github:lnl7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-compat.follows = "flake-compat";
+    };
+  };
+
+  # This flake is only used for its inputs.
+  outputs = inputs: { };
+}

--- a/flake/dev/list-plugins/default.nix
+++ b/flake/dev/list-plugins/default.nix
@@ -1,12 +1,8 @@
-{ inputs, self, ... }:
+{ self, ... }:
 {
   perSystem =
     {
-      self',
-      config,
       lib,
-      inputs',
-      system,
       pkgs,
       ...
     }:
@@ -33,8 +29,6 @@
             list-plugins --root-path ${self} > $out
           '';
 
-    }
-    // lib.optionalAttrs (inputs.devshell ? flakeModule) {
       devshells.default.commands = [
         {
           name = "list-plugins";

--- a/flake/dev/package-tests.nix
+++ b/flake/dev/package-tests.nix
@@ -1,0 +1,8 @@
+{
+  perSystem =
+    { config, ... }:
+    {
+      # Test that all packages build fine when running `nix flake check`.
+      checks = config.packages;
+    };
+}

--- a/flake/dev/template-tests.nix
+++ b/flake/dev/template-tests.nix
@@ -1,0 +1,51 @@
+{ self, inputs, ... }:
+{
+  # The following adds the template flake's checks to the main (current) flake's checks.
+  # It ensures that the template's own checks are successful.
+  perSystem =
+    {
+      pkgs,
+      system,
+      lib,
+      ...
+    }:
+    {
+      checks =
+        let
+          # Approximates https://github.com/NixOS/nix/blob/96e550ef/src/libexpr/call-flake.nix#L67-L85
+          callFlake =
+            flake@{
+              inputs,
+              outputs,
+              sourceInfo ? { },
+            }:
+            let
+              outputs = flake.outputs (inputs // { self = result; });
+              result =
+                outputs
+                // sourceInfo
+                // {
+                  inherit inputs outputs sourceInfo;
+                  _type = "flake";
+                };
+            in
+            result;
+
+          flakes = lib.mapAttrs (
+            name: template:
+            callFlake {
+              # Use inputs from our flake
+              inputs = {
+                inherit (inputs) flake-parts nixpkgs;
+                nixvim = self;
+              };
+              # Use outputs from the template flake
+              inherit (import "${template.path}/flake.nix") outputs;
+            }
+          ) self.templates;
+        in
+        lib.concatMapAttrs (name: flake: {
+          "template-${name}" = pkgs.linkFarm name flake.checks.${system};
+        }) flakes;
+    };
+}

--- a/flake/dev/tests.nix
+++ b/flake/dev/tests.nix
@@ -7,7 +7,7 @@
   perSystem =
     { pkgs, ... }:
     {
-      checks = pkgs.callPackages ../tests {
+      checks = pkgs.callPackages ../../tests {
         inherit helpers self;
       };
     };

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -6,7 +6,6 @@
 {
   perSystem =
     {
-      config,
       inputs',
       system,
       ...
@@ -18,8 +17,5 @@
         inherit (inputs) nixpkgs;
         inherit (inputs') nuschtosSearch;
       };
-
-      # Test that all packages build fine when running `nix flake check`.
-      checks = config.packages;
     };
 }

--- a/flake/templates.nix
+++ b/flake/templates.nix
@@ -1,4 +1,3 @@
-{ self, inputs, ... }:
 {
   flake.templates = {
     default = {
@@ -10,54 +9,4 @@
       description = "An experimental flake template for configuring nixvim using evalNixvim and flake.parts";
     };
   };
-
-  # The following adds the template flake's checks to the main (current) flake's checks.
-  # It ensures that the template's own checks are successful.
-  perSystem =
-    {
-      pkgs,
-      system,
-      lib,
-      ...
-    }:
-    {
-      checks =
-        let
-          # Approximates https://github.com/NixOS/nix/blob/7cd08ae379746749506f2e33c3baeb49b58299b8/src/libexpr/flake/call-flake.nix#L46
-          # s/flake.outputs/args.outputs/
-          callFlake =
-            args@{
-              inputs,
-              outputs,
-              sourceInfo ? { },
-            }:
-            let
-              outputs = args.outputs (inputs // { self = result; });
-              result =
-                outputs
-                // sourceInfo
-                // {
-                  inherit inputs outputs sourceInfo;
-                  _type = "flake";
-                };
-            in
-            result;
-
-          flakes = lib.mapAttrs (
-            name: template:
-            callFlake {
-              # Use inputs from our flake
-              inputs = {
-                inherit (inputs) flake-parts nixpkgs;
-                nixvim = self;
-              };
-              # Use outputs from the template flake
-              inherit (import "${template.path}/flake.nix") outputs;
-            }
-          ) self.templates;
-        in
-        lib.concatMapAttrs (name: flake: {
-          "template-${name}" = pkgs.linkFarm name flake.checks.${system};
-        }) flakes;
-    };
 }

--- a/tests/no-flake.nix
+++ b/tests/no-flake.nix
@@ -9,7 +9,7 @@ let
   nixvim' =
     (import (
       let
-        lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+        lock = builtins.fromJSON (builtins.readFile ../flake/dev/flake.lock);
       in
       fetchTarball {
         url =


### PR DESCRIPTION
## Summary

By _partitioning_ our "dev" dependencies, they will not be added to end-user's lockfiles. Instead, they will be fetched lazily when flake outputs that _actually_ need them are evaluated.

E.g. evaluating `nixvim.nixvimModules` will not fetch dev dependencies, however evaluating `nixvim.checks` or `nixvim.devShells` will.

## Motivation

This removes the need for end-users to manually set `nixvim.inputs.devshell.follows = ""` (etc). In fact, these optional inputs are no longer part of the root flake at all. I believe any user that currently has such inputs will get an error or warning notifying them that they are following a non-existent input.

## Technical explanation

We offload evaluation of some of our flake modules into a "partition" submodule. When its not needed, this submodule is not evaluated. When it is needed, it fetches extra inputs from `flake/dev/flake.nix` as part of evaluating the submodule.

The submodule extends the top-level (root) configuration, so any root inputs and configuration are also present in the submodule's `config` and `inputs` args.

We use another `flake.nix` and `flake.lock` file (in `flake/dev`). This is purely to manage inputs, so that we can run `nix flake update --commit-lock-file --flake ./flake/dev`. The dev flake does not have any outputs of its own.

See reference docs: https://flake.parts/options/flake-parts-partitions.html

## Caveats

The only disadvantage of this approach is we now have two lockfiles to keep up to date.

The dev flake (`flake/dev/flake.nix`) has inputs that transitively depend on nixpkgs. In order to avoid depending on multiple nixpkgs revisions, we therefore need to specify nixpkgs as an input in both our root and dev flakes.

This is a little awkward, as we have to be careful when updating lock files that both stay in sync.

Eventually, we may be able to use relative paths to do something like:
```nix
{
  inputs = {
    nixvim.url = "path:../..";
    nixpkgs.follows = [ "nixvim" "inputs" "nixpkgs" ];
  };
}
```

However this depends on https://github.com/NixOS/nix/pull/10089 making it to a stable nix version, ideally making it to `nixVersions.minimum` which may take some time. I'm unsure how `lix` deals with relative path flake inputs, too.

For now, we can ensure thing stay in sync by carefully using `--override-input` when updating the dev lockfile.

## Not covered

The `nuschtosSearch` input was not (and still is not) optional. I'd like to change that at some point, but it will need some restructuring of the docs package set (`./docs/default.nix`) and is not in scope for this PR. See https://github.com/hercules-ci/flake-parts/pull/272#issuecomment-2676984478

----

Fixes #3027
Resolves #2948 :crossed_fingers:, by working-around whatever issue was causing that.

cc @HeitorAugustoLN for testing