### PR TITLE
ci/update: fix `inputs.nixpkgs.rev` eval

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -121,7 +121,7 @@ jobs:
         id: dev_flake_lock
         if: inputs.dev_lock || github.event_name == 'schedule'
         run: |
-          root_nixpkgs=$(nix eval -f . 'inputs.nixpkgs.rev')
+          root_nixpkgs=$(nix eval --raw --file . 'inputs.nixpkgs.rev')
           old=$(git show --no-patch --format=%h)
           nix flake update --commit-lock-file \
               --override-input nixpkgs "github:NixOS/nixpkgs/$root_nixpkgs" \


### PR DESCRIPTION
Need to use raw output to avoid having a quoted string, otherwise we end up with a malformed flakeref:

```
error: in URL 'github:NixOS/nixpkgs/"2d068ae5c6516b2d04562de50a58c682540de9bf"',
'"2d068ae5c6516b2d04562de50a58c682540de9bf"' is not a commit hash or branch/tag name
```
