### PR TITLE
docs/fix-links: pandoc `markdown` -> `gfm`

### DIFF
--- a/docs/fix-links/default.nix
+++ b/docs/fix-links/default.nix
@@ -26,8 +26,8 @@ runCommand (src.name or (builtins.baseNameOf src))
 
     pandoc \
         --output $out \
-        --from markdown \
-        --to markdown-raw_attribute \
+        --from gfm \
+        --to gfm \
         --lua-filter filter.lua \
         $src
   ''


### PR DESCRIPTION
We are essentially writing GFM e.g. inline HTML comments and GFM alerts. So tell pandoc to parse/render as such. This resolves issues such as `> [!TIP]` being escaped to `> \[!TIP\]`.

### Before:

![image](https://github.com/user-attachments/assets/8e266553-364f-41c0-aaf3-d17b1638c062)

### After:

![image](https://github.com/user-attachments/assets/27012b0c-ab1f-461c-b857-7a3f39b248cb)

Fixes #3033
