### PR TITLE
ci/update: drop empty commits on re-apply

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -170,7 +170,10 @@ jobs:
           if [[ -n "$commits" ]]; then
             echo "Applying ${#commits[@]} commits..."
             echo "count=${#commits[@]}" >> $GITHUB_OUTPUT
-            git cherry-pick --strategy-option=theirs "${commits[@]}"
+            git cherry-pick \
+              --strategy-option=theirs \
+              --empty=drop \
+              "${commits[@]}"
           else
             echo "Nothing to re-apply"
           fi


### PR DESCRIPTION
Partial fix for #3035

Tell `git cherry-pick` to drop any commits that end up being empty, instead of aborting.
