### PR TITLE
plugins/image: add resolveImagePath option

### DIFF
--- a/plugins/by-name/image/default.nix
+++ b/plugins/by-name/image/default.nix
@@ -66,6 +66,20 @@ in
           filetypes = helpers.defaultNullOpts.mkListOf types.str filetypesDefault ''
             Markdown extensions (ie. quarto) can go here.
           '';
+
+          resolveImagePath = helpers.mkNullOrLuaFn' {
+            description = "Configures how to resolve image paths.";
+            example = lib.literalExpression ''
+              lib.nixvim.mkRaw '''
+                function(document_path, image_path, fallback)
+                  -- document_path is the path to the file that contains the image
+                  -- image_path is the potentially relative path to the image. For markdown, it's `![](this text)`
+                  -- fallback is the default behavior
+                  return fallback(document_path, image_path)
+                end
+              ''';
+            '';
+          };
         };
       in
       mapAttrs mkIntegrationOptions {
@@ -150,6 +164,7 @@ in
                   download_remote_images = v.downloadRemoteImages;
                   only_render_image_at_cursor = v.onlyRenderImageAtCursor;
                   inherit (v) filetypes;
+                  resolve_image_path = v.resolveImagePath;
                 };
               in
               mapAttrs (_: processIntegrationOptions) integrations;


### PR DESCRIPTION
Hi there! First of all, thanks for providing and maintaining Nixvim! This tiny contribution updates the _image_ plugin to expose the [resolve_image_path](https://github.com/3rd/image.nvim?tab=readme-ov-file#integrations) options, enabling users to modify how images path are resolved within their projects (typical use case: when using obsidian.nvim with a custom directory for images).