### PR TITLE
plugins/octo: add snacks picker to picker options

### DIFF
--- a/plugins/by-name/octo/default.nix
+++ b/plugins/by-name/octo/default.nix
@@ -124,6 +124,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
         [
           "telescope"
           "fzf-lua"
+          "snacks"
         ]
         ''
           Picker to use.
@@ -182,5 +183,11 @@ lib.nixvim.plugins.mkNeovimPlugin {
         plugins.telescope.enable = lib.mkDefault true;
       })
       (lib.mkIf (cfg.settings.picker == "fzf-lua") { plugins.fzf-lua.enable = lib.mkDefault true; })
+      (lib.mkIf (cfg.settings.picker == "snacks") {
+        plugins.snacks = {
+          enable = lib.mkDefault true;
+          settings.picker.enabled = lib.mkDefault true;
+        };
+      })
     ];
 }

--- a/tests/test-sources/plugins/by-name/octo/default.nix
+++ b/tests/test-sources/plugins/by-name/octo/default.nix
@@ -39,6 +39,17 @@
     };
   };
 
+  withSnacksPicker = {
+    # This test is flaky and fails non-deterministically
+    test.runNvim = false;
+
+    plugins.web-devicons.enable = true;
+    plugins.octo = {
+      enable = true;
+      settings.picker = "snacks";
+    };
+  };
+
   defaults = {
     # This test is flaky and fails non-deterministically
     test.runNvim = false;


### PR DESCRIPTION
The snacks picker is also a valid choice now:
https://github.com/pwntester/octo.nvim/blob/631776a36c12724ba1db5ed8549cad35f70134dc/lua/octo/config.lua#L418