### PR TITLE
plugins/typst-preview: init

### DIFF
--- a/plugins/by-name/typst-preview/default.nix
+++ b/plugins/by-name/typst-preview/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "typst-preview";
+  packPathName = "typst-preview.nvim";
+  package = "typst-preview-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  extraOptions = {
+    tinymistPackage = lib.mkPackageOption pkgs "tinymist" {
+      nullable = true;
+    };
+    websocatPackage = lib.mkPackageOption pkgs "websocat" {
+      nullable = true;
+    };
+  };
+  extraConfig = cfg: {
+    extraPackages = [
+      cfg.tinymistPackage
+      cfg.websocatPackage
+    ];
+
+    plugins.typst-preview.settings = {
+      # Disable automatic downloading of binary dependencies
+      dependencies_bin = {
+        tinymist = lib.mkIf (cfg.tinymistPackage != null) (lib.mkDefault (lib.getExe cfg.tinymistPackage));
+        websocat = lib.mkIf (cfg.websocatPackage != null) (lib.mkDefault (lib.getExe cfg.websocatPackage));
+      };
+    };
+  };
+
+  settingsExample = {
+    debug = true;
+    port = 8000;
+    dependencies_bin = {
+      tinymist = "tinymist";
+      websocat = "websocat";
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/typst-preview/default.nix
+++ b/tests/test-sources/plugins/by-name/typst-preview/default.nix
@@ -1,0 +1,49 @@
+{
+  empty = {
+    plugins.typst-preview.enable = true;
+  };
+
+  defaults = {
+    plugins.typst-preview = {
+      enable = true;
+
+      settings = {
+        debug = false;
+        open_cmd = null;
+        port = 0;
+        invert_colors = "never";
+        follow_cursor = true;
+        extra_args = null;
+        get_root.__raw = ''
+          function(path_of_main_file)
+            local root = os.getenv 'TYPST_ROOT'
+            if root then
+              return root
+            end
+            return vim.fn.fnamemodify(path_of_main_file, ':p:h')
+          end
+        '';
+        get_main_file.__raw = ''
+          function(path_of_buffer)
+            return path_of_buffer
+          end
+        '';
+      };
+    };
+  };
+
+  example = {
+    plugins.typst-preview = {
+      enable = true;
+
+      settings = {
+        debug = true;
+        port = 8000;
+        dependencies_bin = {
+          tinymist = "tinymist";
+          websocat = "websocat";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [typst-preview.nvim](https://github.com/chomosuke/typst-preview.nvim), providing low latency typst preview to Neovim.

Fixes #3080
