### PR TITLE
plugins/devdocs: init

### DIFF
--- a/plugins/by-name/devdocs/default.nix
+++ b/plugins/by-name/devdocs/default.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "devdocs";
+  packPathName = "devdocs.nvim";
+  package = "devdocs-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    ensure_installed = [
+      "go"
+      "html"
+      "http"
+      "lua~5.1"
+    ];
+  };
+}

--- a/tests/test-sources/plugins/by-name/devdocs/default.nix
+++ b/tests/test-sources/plugins/by-name/devdocs/default.nix
@@ -1,0 +1,39 @@
+{
+  empty = {
+    # Tries to download metadata
+    test.runNvim = false;
+
+    plugins.devdocs.enable = true;
+  };
+
+  defaults = {
+    # Tries to download metadata
+    test.runNvim = false;
+
+    plugins.devdocs = {
+      enable = true;
+
+      settings = {
+        ensure_installed = [ ];
+      };
+    };
+  };
+
+  example = {
+    # Tries to download metadata
+    test.runNvim = false;
+
+    plugins.devdocs = {
+      enable = true;
+
+      settings = {
+        ensure_installed = [
+          "go"
+          "html"
+          "http"
+          "lua~5.1"
+        ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [devdocs.nvim](https://github.com/maskudo/devdocs.nvim), a neovim client for devdocs.io.

Fixes #3053
