### PR TITLE
plugins/obsidian: adapt options (now using the obsidian-nvim community fork)

### DIFF
--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -88,12 +88,21 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    warnings = lib.nixvim.mkWarnings "plugins.obsidian" {
-      when = (cfg.settings.completion.nvim_cmp == true) && (!config.plugins.cmp.enable);
-      message = ''
-        You have enabled `completion.nvim_cmp` but `plugins.cmp.enable` is `false`.
-        You should probably enable `nvim-cmp`.
-      '';
-    };
+    warnings = lib.nixvim.mkWarnings "plugins.obsidian" [
+      {
+        when = (cfg.settings.completion.nvim_cmp == true) && (!config.plugins.cmp.enable);
+        message = ''
+          You have enabled `completion.nvim_cmp` but `plugins.cmp.enable` is `false`.
+          You should probably enable `nvim-cmp`.
+        '';
+      }
+      {
+        when = (cfg.settings.completion.blink == true) && (!config.plugins.blink-cmp.enable);
+        message = ''
+          You have enabled `completion.blink` but `plugins.blink-cmp.enable` is `false`.
+          You should probably enable `blink-cmp`.
+        '';
+      }
+    ];
   };
 }

--- a/plugins/by-name/obsidian/settings-options.nix
+++ b/plugins/by-name/obsidian/settings-options.nix
@@ -215,6 +215,10 @@ in
       defaultText = lib.literalMD "`true` if `plugins.cmp.enable` is enabled (otherwise `null`).";
     };
 
+    blink = defaultNullOpts.mkBool false ''
+      Enable completion using blink.cmp.
+    '';
+
     min_chars = defaultNullOpts.mkUnsignedInt 2 ''
       Trigger completion at this many chars.
     '';
@@ -263,6 +267,7 @@ in
           "telescope.nvim"
           "fzf-lua"
           "mini.pick"
+          "snacks.pick"
         ])
         ''
           Set your preferred picker.

--- a/tests/test-sources/plugins/by-name/obsidian/default.nix
+++ b/tests/test-sources/plugins/by-name/obsidian/default.nix
@@ -32,8 +32,31 @@
           new_notes_location = "current_dir";
           completion = {
             nvim_cmp = true;
+            blink = false;
             min_chars = 2;
           };
+        };
+      };
+    };
+  };
+
+  blink-cmp = {
+    # Issue within the obsidian.nvim plugin itself:
+    # ERROR: cmp.add_provider is deprecated, use cmp.add_source_provider instead.
+    test.runNvim = false;
+
+    plugins = {
+      blink-cmp.enable = true;
+      obsidian = {
+        enable = true;
+        settings = {
+          completion.blink = true;
+          workspaces = [
+            {
+              name = "foo";
+              path = "~/";
+            }
+          ];
         };
       };
     };


### PR DESCRIPTION
Since https://github.com/nix-community/nixvim/pull/3098, `vimPlugins.obsidian-nvim` fetches the [obsidian-nvim/obsidian.nvim](https://github.com/obsidian-nvim/obsidian.nvim) repo.

This PR adapts our module to this change.

Fixes #3075
