### PR TITLE
modules: add env option

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -28,6 +28,26 @@ let
 in
 {
   options = {
+    env = mkOption {
+      type =
+        with types;
+        lazyAttrsOf (oneOf [
+          str
+          path
+          int
+          float
+        ]);
+      description = "Environment variables to set in the neovim wrapper.";
+      default = { };
+      example = {
+        FOO = 1;
+        PI = 3.14;
+        BAR_PATH = "/home/me/.local/share/bar";
+        INFER_MODE = "local";
+        BAZ_MAX_COUNT = 1000;
+      };
+    };
+
     extraPlugins = mkOption {
       type = with types; listOf (nullOr (either package pluginWithConfigType));
       default = [ ];

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -339,7 +339,16 @@ in
           initSource;
 
       extraWrapperArgs = builtins.concatStringsSep " " (
-        (optional (
+        # Setting environment variables in the wrapper
+        (lib.mapAttrsToList (
+          name: value:
+          lib.escapeShellArgs [
+            "--set"
+            name
+            value
+          ]
+        ) config.env)
+        ++ (optional (
           config.extraPackages != [ ]
         ) ''--prefix PATH : "${lib.makeBinPath config.extraPackages}"'')
         ++ (optional config.wrapRc ''--add-flags -u --add-flags "${initFile}"'')

--- a/tests/test-sources/env.nix
+++ b/tests/test-sources/env.nix
@@ -1,0 +1,42 @@
+{
+  env-variables = {
+    env = {
+      FOO = "1";
+      FOO_INT = 42;
+      FOO_FLOAT = 3.14;
+      STRING_PATH = "/home/me/.local/share/bar";
+      REAL_PATH = ./env.nix;
+      BAZ_MAX_COUNT = "1000";
+      MUST_BE_ESCAPED = "esc'ape\nme";
+    };
+
+    extraConfigLua = ''
+      assert(
+        os.getenv("FOO") == "1"
+      )
+      assert(
+        tonumber(os.getenv("FOO_INT")) == 42
+      )
+      assert(
+        tonumber(os.getenv("FOO_FLOAT")) == 3.14
+      )
+
+      assert(
+        os.getenv("STRING_PATH") == "/home/me/.local/share/bar"
+      )
+
+      local file_path = os.getenv("REAL_PATH")
+      assert(
+        vim.fn.filereadable(file_path)
+      )
+
+      assert(
+        os.getenv("BAZ_MAX_COUNT") == "1000"
+      )
+
+      assert(
+        os.getenv("MUST_BE_ESCAPED") == "esc'ape\nme"
+      )
+    '';
+  };
+}


### PR DESCRIPTION
Add a top-level `env` option that allows to propagate environment variables in the wrapped neovim package.

```nix
env = {
  FOO = "1";
  BAR_PATH = "/home/me/.local/share/bar";
  BAZ_MAX_COUNT = "1000";
}
```

Fixes #3055
