### PR TITLE
plugins/avante: fix incorrect option name

### DIFF
--- a/plugins/by-name/avante/default.nix
+++ b/plugins/by-name/avante/default.nix
@@ -14,7 +14,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       The LLM provider (`"claude"`, `"openai"`, `"azure"`, ...)
     '';
 
-    auto_suggestions_frequency = defaultNullOpts.mkStr "claude" ''
+    auto_suggestions_provider = defaultNullOpts.mkStr "claude" ''
       The provider for automatic suggestions.
 
       Since auto-suggestions are a high-frequency operation and therefore expensive, it is


### PR DESCRIPTION
Closes https://github.com/nix-community/nixvim/issues/3104
Looks like it was initialized incorrectly from inception. Renaming to match the option name upstream.

Wasn't a valid option before, so not even putting a rename warning in. 