### PR TITLE
tests: add `passthru` and drop `mkTestDerivationFromNixvimModule`

### DIFF
--- a/tests/main.nix
+++ b/tests/main.nix
@@ -34,7 +34,14 @@ let
         ];
       };
     in
-    configuration.config.build.test;
+    configuration.config.build.test.overrideAttrs (old: {
+      passthru =
+        old.passthru or { }
+        // builtins.removeAttrs configuration [ "_type" ]
+        // {
+          inherit file module;
+        };
+    });
 
   # List of files containing configurations
   testFiles = fetchTests ./test-sources;


### PR DESCRIPTION
- **tests: drop use of `mkTestDerivationFromNixvimModule`**
- **tests: add useful attrs to test passthru**

I found it annoying when debugging that I had no access to the nixvim configuration that produced the test. I've resolved that by adding all useful attrs from the configuration to the test's passthru.

It's still a little cumbersome, since you have to step through two layers of linkFarm `entries` to get to the actual test derivation:

```
nix-repl> :lf .
Added 29 variables.

nix-repl> checks.x86_64-linux.test-1.entries.env.entries.env-variables.passthru
{
  _module = { ... };
  class = null;
  config = { ... };
  extendModules = «lambda extendModules @ /nix/store/4z177m7dr7rkib4d13mn0j6sh5vvhlnc-source/lib/modules.nix:317:23»;
  file = "/nix/store/6cmww5libbnzkad096xjxh94792rxkm8-test-sources/env.nix";
  module = { ... };
  name = "env-variables";
  options = { ... };
  type = { ... };
}
```

Additionally, I dropped internal usage of the old `mkTestDerivationFromNixvimModule` function. I'd like to gradually transition away from everything in `lib/tests.nix` so that it can be deprecated in favour of a more modern approach.

This means that `enableExceptInTests` will not work anymore, however that is something we don't use internally, and is something I'd like to find a better alternative to as well.
