### PR TITLE
flake: test reverting plenary change

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
-        "owner": "NixOS",
+        "lastModified": 1742921165,
+        "narHash": "sha256-xxThT9/S/N+GObGr9AJw1k/XZcl8oiCzQC0BOR083rE=",
+        "owner": "MattSturgeon",
         "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "rev": "92097311294f7df7e69254a446a6c9724c2b0383",
         "type": "github"
       },
       "original": {

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -121,11 +121,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
-        "owner": "NixOS",
+        "lastModified": 1742921165,
+        "narHash": "sha256-xxThT9/S/N+GObGr9AJw1k/XZcl8oiCzQC0BOR083rE=",
+        "owner": "MattSturgeon",
         "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "rev": "92097311294f7df7e69254a446a6c9724c2b0383",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Test out https://github.com/NixOS/nixpkgs/pull/392471 again, but with https://github.com/NixOS/nixpkgs/commit/f9af047fc043b3ffd0b12c3eab20b2c04a41b812 reverted.

This overrides `inputs.nixpkgs` to point to https://github.com/NixOS/nixpkgs/commit/92097311294f7df7e69254a446a6c9724c2b0383