### PR TITLE
modules/keymaps: add replace_keycodes keymap sub-option

### DIFF
--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -1,7 +1,7 @@
 { lib }:
 let
   inherit (lib) optionalAttrs isAttrs types;
-  inherit (lib.nixvim) defaultNullOpts;
+  inherit (lib.nixvim) defaultNullOpts mkNullOrStr;
 in
 rec {
   # These are the configuration options that change the behavior of each mapping.
@@ -20,7 +20,7 @@ rec {
 
     remap = defaultNullOpts.mkBool false "Make the mapping recursive. Inverses `noremap`.";
 
-    desc = lib.nixvim.mkNullOrOption lib.types.str "A textual description of this keybind, to be shown in which-key, if you have it.";
+    desc = mkNullOrStr "A textual description of this keybind, to be shown in which-key, if you have it.";
 
     buffer = defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
   };

--- a/lib/keymap-helpers.nix
+++ b/lib/keymap-helpers.nix
@@ -1,7 +1,7 @@
 { lib }:
 let
   inherit (lib) optionalAttrs isAttrs types;
-  inherit (lib.nixvim) defaultNullOpts mkNullOrStr;
+  inherit (lib.nixvim) defaultNullOpts mkNullOrOption mkNullOrStr;
 in
 rec {
   # These are the configuration options that change the behavior of each mapping.
@@ -23,6 +23,12 @@ rec {
     desc = mkNullOrStr "A textual description of this keybind, to be shown in which-key, if you have it.";
 
     buffer = defaultNullOpts.mkBool false "Make the mapping buffer-local. Equivalent to adding `<buffer>` to a map.";
+
+    replace_keycodes = mkNullOrOption types.bool ''
+      When `expr` is `true`, replace keycodes in the resulting string.
+
+      Returning `nil` from the Lua `callback` is equivalent to returning an empty string.
+    '';
   };
 
   modes = [

--- a/tests/test-sources/modules/keymaps.nix
+++ b/tests/test-sources/modules/keymaps.nix
@@ -48,6 +48,12 @@
             key = "<C-z>";
             action = "bar";
           }
+          {
+            mode = "n";
+            key = "<C-h>";
+            action.__raw = "function() end";
+            options.replace_keycodes = false;
+          }
         ];
   };
 


### PR DESCRIPTION
https://neovim.io/doc/user/lua.html#vim.keymap.set()

- **lib/keymap-helpers (mapConfigOptions): use mkNullOrStr for desc**
- **modules/keymaps: add replace_keycodes keymap sub-option**

Fixes #3067
