### PR TITLE
flake/dev: rename `nixpkgs` input to avoid shadowing

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -126,7 +126,7 @@ jobs:
           root_nixpkgs=$(nix eval --raw --file . 'inputs.nixpkgs.rev')
           old=$(git show --no-patch --format=%h)
           nix flake update --commit-lock-file \
-              --override-input nixpkgs "github:NixOS/nixpkgs/$root_nixpkgs" \
+              --override-input 'dev-nixpkgs' "github:NixOS/nixpkgs/$root_nixpkgs" \
               --flake './flake/dev'
           new=$(git show --no-patch --format=%h)
           if [ "$old" != "$new" ]; then

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -2,33 +2,36 @@
   description = "Private inputs for development purposes. These are used by the top level flake in the `dev` partition, but do not appear in consumers' lock files.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # NOTE: Use a different name to the root flake's inputs.nixpkgs to avoid shadowing it.
+    # NOTE: The only reason we specify a nixpkgs input at all here, is so the other inputs can follow it.
+    # TODO: Once nix 2.26 is more prevalent, follow the root flake's inputs using a "path:../.." input.
+    dev-nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     home-manager = {
       url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "dev-nixpkgs";
     };
 
     nix-darwin = {
       url = "github:lnl7/nix-darwin";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "dev-nixpkgs";
     };
 
     devshell = {
       url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "dev-nixpkgs";
     };
 
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "dev-nixpkgs";
     };
 
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
 
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "dev-nixpkgs";
       inputs.flake-compat.follows = "flake-compat";
     };
   };


### PR DESCRIPTION
Rename `inputs.nixpkgs` to `inputs.dev-nixpkgs` to avoid shadowing the root flake's `inputs.nixpkgs`.

Having the dev flake shadow an input can be confusing, since overriding the root flake's input will have no effect when evaluating outputs that depend on the dev partition (i.e. outputs listed in [`partitionedAttrs`](https://flake.parts/options/flake-parts-partitions.html#opt-partitionedAttrs)).

The only reason we specify a nixpkgs input in the dev flake at all, is so the other inputs can follow it.

---

Once nix 2.26 is more prevalent, we can follow the root flake's inputs using a `"path:../.."` input. See [2.26 release notes](https://discourse.nixos.org/t/nix-2-26-released/59211) and https://github.com/NixOS/nix/pull/10089.

This may also require changes in [flake-compat](https://github.com/edolstra/flake-compat), since that is used by flake-parts to load the partition flake, see https://github.com/edolstra/flake-compat/pull/18. The nix-community [fork](https://github.com/nix-community/flake-compat) has [support for `path:` references](https://github.com/nix-community/flake-compat/commit/d1a6788892881f2d15836d0ac1849d844d7b01de), however idk if it is compatible with https://github.com/NixOS/nix/pull/10089 which introduced lockfile changes in nix 2.26. I'm also unsure exactly which version of flake-compat is in use by flake-parts.


