### PR TITLE
flake/dev/flake.lock: apply changes from #3121

### DIFF
--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -1,9 +1,25 @@
 {
   "nodes": {
+    "dev-nixpkgs": {
+      "locked": {
+        "lastModified": 1742800061,
+        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "devshell": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "dev-nixpkgs"
         ]
       },
       "locked": {
@@ -41,7 +57,7 @@
         ],
         "gitignore": "gitignore",
         "nixpkgs": [
-          "nixpkgs"
+          "dev-nixpkgs"
         ]
       },
       "locked": {
@@ -82,7 +98,7 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "dev-nixpkgs"
         ]
       },
       "locked": {
@@ -102,7 +118,7 @@
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "dev-nixpkgs"
         ]
       },
       "locked": {
@@ -119,37 +135,21 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
+        "dev-nixpkgs": "dev-nixpkgs",
         "devshell": "devshell",
         "flake-compat": "flake-compat",
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }
     },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "dev-nixpkgs"
         ]
       },
       "locked": {


### PR DESCRIPTION
Apply changes from 8e732cfac1e99dd53822c4e536d09e242ef9fd2a (#3121)

I forgot to run `nix flake lock ./flake/dev` (oops)

```
Flake lock file updates:

• Added input 'dev-nixpkgs':
    'github:NixOS/nixpkgs/1750f3c1c89488e2ffdd47cab9d05454dddfb734?narHash=sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs%3D' (2025-03-24)
• Updated input 'devshell/nixpkgs':
    follows 'nixpkgs'
  → follows 'dev-nixpkgs'
• Updated input 'git-hooks/nixpkgs':
    follows 'nixpkgs'
  → follows 'dev-nixpkgs'
• Updated input 'home-manager/nixpkgs':
    follows 'nixpkgs'
  → follows 'dev-nixpkgs'
• Updated input 'nix-darwin/nixpkgs':
    follows 'nixpkgs'
  → follows 'dev-nixpkgs'
• Removed input 'nixpkgs'
• Updated input 'treefmt-nix/nixpkgs':
    follows 'nixpkgs'
  → follows 'dev-nixpkgs'
```
