### PR TITLE
[test] nvim 0.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
+        "lastModified": 1743001004,
+        "narHash": "sha256-SA0T7o7KFZvxi/WiNFvmBdLNu5Fz1YlmIfktQzjwfms=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "rev": "2b876ec04bb832b10a0bcaa1584da251cafdf884",
         "type": "github"
       },
       "original": {

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "dev-nixpkgs": {
       "locked": {
-        "lastModified": 1742800061,
-        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
+        "lastModified": 1743001004,
+        "narHash": "sha256-SA0T7o7KFZvxi/WiNFvmBdLNu5Fz1YlmIfktQzjwfms=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "rev": "2b876ec04bb832b10a0bcaa1584da251cafdf884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
#3117 was ineffective, so retry.

Testing https://github.com/NixOS/nixpkgs/pull/393390.

```sh
nix flake lock --commit-lock-file --override-input nixpkgs 'github:NixOS/nixpkgs/2b876ec04bb832b10a0bcaa1584da251cafdf884'
nix flake lock ./flake/dev --commit-lock-file --override-input dev-nixpkgs 'github:NixOS/nixpkgs/2b876ec04bb832b10a0bcaa1584da251cafdf884'
```
