### PR TITLE
plugins/copilot-lua: bump node.js to 20.x version

### DIFF
--- a/plugins/by-name/copilot-lua/default.nix
+++ b/plugins/by-name/copilot-lua/default.nix
@@ -166,7 +166,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraOptions = {
     nodePackage = lib.mkPackageOption pkgs "nodejs" {
-      default = [ "nodejs-18_x" ];
+      default = [ "nodejs_20" ];
       example = [ "nodejs" ];
       nullable = true;
       extraDescription = ''


### PR DESCRIPTION
Got bumped in: https://github.com/zbirenbaum/copilot.lua/commit/f96d8e6d8f1a2de565657b6f4cd184c38a97e56d