### PR TITLE
plugins/highlight-colors: init

### DIFF
--- a/plugins/by-name/highlight-colors/default.nix
+++ b/plugins/by-name/highlight-colors/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  config,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "highlight-colors";
+  packPathName = "nvim-highlight-colors";
+  package = "nvim-highlight-colors";
+  moduleName = "nvim-highlight-colors";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    render = "virtual";
+    virtual_symbol = "■";
+    enable_named_colors = true;
+  };
+
+  extraOptions = {
+    cmpIntegration = lib.mkEnableOption "cmp-integration for nvim-highlight-colors.";
+  };
+
+  extraConfig = cfg: {
+    opts.termguicolors = lib.mkDefault true;
+
+    plugins.cmp.settings.formatting.format = lib.mkIf cfg.cmpIntegration (
+      lib.nixvim.mkRaw "require('nvim-highlight-colors').format"
+    );
+
+    warnings = lib.nixvim.mkWarnings "plugins.highlight-colors" {
+      when = cfg.cmpIntegration && !config.plugins.cmp.enable;
+      message = ''
+        You have enabled the cmp integration with highlight-colors but `plugins.highlight-colors` is not enabled.
+      '';
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/highlight-colors/default.nix
+++ b/tests/test-sources/plugins/by-name/highlight-colors/default.nix
@@ -1,0 +1,44 @@
+{
+  empty = {
+    plugins.highlight-colors.enable = true;
+  };
+
+  defaults = {
+    plugins.highlight-colors = {
+      enable = true;
+
+      settings = {
+        render = "background";
+        enable_hex = true;
+        enable_rgb = true;
+        enable_hsl = true;
+        enable_hsl_without_function = true;
+        enable_var_usage = true;
+        enable_named_colors = true;
+        enable_short_hex = true;
+        enable_tailwind = false;
+        enable_ansi = false;
+        custom_colors = null;
+        virtual_symbol = "■";
+        virtual_symbol_prefix = "";
+        virtual_symbol_suffix = " ";
+        virtual_symbol_position = "inline";
+        exclude_filetypes = { };
+        exclude_buftypes = { };
+        exclude_buffer.__raw = "function(bufnr) end";
+      };
+    };
+  };
+
+  example = {
+    plugins.highlight-colors = {
+      enable = true;
+
+      settings = {
+        render = "virtual";
+        virtual_symbol = "■";
+        enable_named_colors = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [nvim-highlight-colors](https://github.com/brenoprata10/nvim-highlight-colors), highlight colors for Neovim.

Fixes #3127
