### PR TITLE
modules: refactor plugins code in top-level

### DIFF
--- a/modules/top-level/default.nix
+++ b/modules/top-level/default.nix
@@ -9,6 +9,7 @@
     ./files
     ./nixpkgs.nix
     ./output.nix
+    ./plugins
     ./readonly-renames.nix
     ./test.nix
   ];

--- a/modules/top-level/plugins/byte-compile-plugins.nix
+++ b/modules/top-level/plugins/byte-compile-plugins.nix
@@ -1,0 +1,17 @@
+/*
+  Byte compiling of normalized plugin list
+
+  Inputs: List of normalized plugins
+  Outputs: List of normalized (compiled) plugins
+*/
+{ lib, pkgs }:
+let
+  builders = lib.nixvim.builders.withPkgs pkgs;
+
+  byteCompile =
+    p:
+    (builders.byteCompileLuaDrv p).overrideAttrs (
+      prev: lib.optionalAttrs (prev ? dependencies) { dependencies = map byteCompile prev.dependencies; }
+    );
+in
+map (p: p // { plugin = byteCompile p.plugin; })

--- a/modules/top-level/plugins/combine-plugins.nix
+++ b/modules/top-level/plugins/combine-plugins.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  pkgs,
+  pathsToLink,
+  standalonePlugins,
+}:
+let
+  inherit (import ./utils.nix lib)
+    getAndNormalizeDeps
+    removeDeps
+    ;
+  mkPluginPack = import ./mk-plugin-pack.nix { inherit lib pkgs; };
+
+in
+/*
+  *combinePlugins* function
+
+  Take a list of combined plugins, combine the relevant ones and return the resulting list of plugins
+*/
+normalizedPlugins:
+let
+  # Plugin list extended with dependencies
+  allPlugins =
+    let
+      pluginWithItsDeps = p: [ p ] ++ builtins.concatMap pluginWithItsDeps (getAndNormalizeDeps p);
+    in
+    lib.unique (builtins.concatMap pluginWithItsDeps normalizedPlugins);
+
+  # Separated start and opt plugins
+  partitionedOptStartPlugins = builtins.partition (p: p.optional) allPlugins;
+  startPlugins = partitionedOptStartPlugins.wrong;
+  # Remove opt plugin dependencies since they are already available in start plugins
+  optPlugins = removeDeps partitionedOptStartPlugins.right;
+
+  # Test if plugin shouldn't be included in plugin pack
+  isStandalone =
+    p:
+    builtins.elem p.plugin standalonePlugins || builtins.elem (lib.getName p.plugin) standalonePlugins;
+
+  # Separated standalone and combined start plugins
+  partitionedStandaloneStartPlugins = builtins.partition isStandalone startPlugins;
+  pluginsToCombine = partitionedStandaloneStartPlugins.wrong;
+  # Remove standalone plugin dependencies since they are already available in start plugins
+  standaloneStartPlugins = removeDeps partitionedStandaloneStartPlugins.right;
+
+  # Combine start plugins into a single pack
+  pluginPack = mkPluginPack { inherit pluginsToCombine pathsToLink; };
+in
+# Combined plugins
+[ pluginPack ] ++ standaloneStartPlugins ++ optPlugins

--- a/modules/top-level/plugins/default.nix
+++ b/modules/top-level/plugins/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (import ./utils.nix lib)
+    normalizedPluginType
+    normalizePlugins
+    ;
+  byteCompileCfg = config.performance.byteCompileLua;
+in
+{
+  options = {
+    build.plugins = lib.mkOption {
+      visible = false;
+      internal = true;
+      readOnly = true;
+      type = lib.types.listOf normalizedPluginType;
+      description = ''
+        Final list of (normalized) plugins that will be passed to the wrapper.
+
+        It notably implements:
+        - byte-compilation (performance.byteCompileLua) -> ./byte-compile-plugins.nix
+        - plugins combining (performance.combinePlugins) -> ./combine-plugins.nix
+      '';
+    };
+  };
+
+  config = {
+    build.plugins =
+      let
+        shouldCompilePlugins = byteCompileCfg.enable && byteCompileCfg.plugins;
+        byteCompilePlugins = import ./byte-compile-plugins.nix { inherit lib pkgs; };
+
+        shouldCombinePlugins = config.performance.combinePlugins.enable;
+        combinePlugins = import ./combine-plugins.nix {
+          inherit lib pkgs;
+          inherit (config.performance.combinePlugins)
+            standalonePlugins
+            pathsToLink
+            ;
+        };
+      in
+
+      lib.pipe config.extraPlugins (
+        [ normalizePlugins ]
+        ++ lib.optionals shouldCompilePlugins [ byteCompilePlugins ]
+        ++ lib.optionals shouldCombinePlugins [ combinePlugins ]
+      );
+  };
+}

--- a/modules/top-level/plugins/mk-plugin-pack.nix
+++ b/modules/top-level/plugins/mk-plugin-pack.nix
@@ -1,0 +1,60 @@
+{ lib, pkgs }:
+let
+  inherit (import ./utils.nix lib) normalizePlugin;
+in
+{ pluginsToCombine, pathsToLink }:
+let
+
+  overridePlugin =
+    plugin:
+    plugin.plugin.overrideAttrs (prev: {
+      nativeBuildInputs = lib.remove pkgs.vimUtils.vimGenDocHook prev.nativeBuildInputs or [ ];
+      configurePhase = ''
+        ${prev.configurePhase or ""}
+        rm -vf doc/tags'';
+    });
+
+  # Every plugin has its own generated help tags (doc/tags)
+  # Remove them to avoid collisions, new help tags
+  # will be generate for the entire pack later on
+  overriddenPlugins = map overridePlugin pluginsToCombine;
+
+  # Gather python 3 dependencies from every plugins
+  python3Dependencies =
+    ps:
+    lib.pipe pluginsToCombine [
+      (builtins.catAttrs "plugin")
+      (builtins.catAttrs "python3Dependencies")
+      (builtins.concatMap (f: f ps))
+    ];
+
+  # Combined plugin
+  combinedPlugin = pkgs.vimUtils.toVimPlugin (
+    pkgs.buildEnv {
+      name = "plugin-pack";
+      paths = overriddenPlugins;
+      inherit pathsToLink;
+
+      # Remove empty directories and activate vimGenDocHook
+      # TODO: figure out why we are running the `preFixup` hook in `postBuild`
+      postBuild = ''
+        find $out -type d -empty -delete
+        runHook preFixup
+      '';
+      passthru = {
+        inherit python3Dependencies;
+      };
+    }
+  );
+
+  # Combined plugin configs
+  combinedConfig = lib.pipe pluginsToCombine [
+    (builtins.catAttrs "config")
+    (builtins.filter (config: config != null && config != ""))
+    (builtins.concatStringsSep "\n")
+  ];
+in
+normalizePlugin {
+  plugin = combinedPlugin;
+  config = combinedConfig;
+}

--- a/modules/top-level/plugins/utils.nix
+++ b/modules/top-level/plugins/utils.nix
@@ -1,0 +1,38 @@
+lib:
+lib.fix (self: {
+  normalizedPluginType = lib.types.submodule {
+    options = {
+      plugin = lib.mkOption {
+        type = lib.types.package;
+      };
+
+      config = lib.mkOption {
+        type = with lib.types; nullOr str;
+      };
+
+      optional = lib.mkOption {
+        type = lib.types.bool;
+      };
+    };
+  };
+
+  # Normalize a plugin in a standard { plugin, config, optional } attrs
+  normalizePlugin =
+    p:
+    let
+      defaultPlugin = {
+        plugin = null;
+        config = null;
+        optional = false;
+      };
+    in
+    defaultPlugin // (if p ? plugin then p else { plugin = p; });
+
+  # Normalize a list of plugins
+  normalizePlugins = builtins.map self.normalizePlugin;
+
+  getAndNormalizeDeps = p: self.normalizePlugins (p.plugin.dependencies or [ ]);
+
+  # Remove dependencies from all plugins in a list
+  removeDeps = map (p: p // { plugin = removeAttrs p.plugin [ "dependencies" ]; });
+})


### PR DESCRIPTION
This should not change anything functionally. I find that the current state (everything dumped in `top-level.nix` is not ideal.