### PR TITLE
tests: remove `type` passthrough

### DIFF
--- a/tests/main.nix
+++ b/tests/main.nix
@@ -37,9 +37,13 @@ let
     configuration.config.build.test.overrideAttrs (old: {
       passthru =
         old.passthru or { }
-        // builtins.removeAttrs configuration [ "_type" ]
+        // builtins.removeAttrs configuration [
+          "_type"
+          "type"
+        ]
         // {
           inherit file module;
+          optionType = configuration.type;
         };
     });
 


### PR DESCRIPTION
Nix can only build attrsets with a `type = "derivation"` attr.

Having the configuration's option-type as a passthru attr breaks the ability to build specific test entries, since they are no longer `type = "derivation"`.

Renamed `passthru.type` -> `passthru.optionType` to work around this.
