### PR TITLE
colorschemes/github-theme: init

### DIFF
--- a/plugins/colorschemes/github-theme.nix
+++ b/plugins/colorschemes/github-theme.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "github-theme";
+  packPathName = "github-nvim-theme";
+  package = "github-nvim-theme";
+  isColorscheme = true;
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    options = {
+      transparent = true;
+      dim_inactive = true;
+      styles = {
+        comments = "italic";
+        keywords = "bold";
+      };
+    };
+  };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -9,6 +9,7 @@
     ./colorschemes/dracula-nvim.nix
     ./colorschemes/dracula.nix
     ./colorschemes/everforest.nix
+    ./colorschemes/github-theme.nix
     ./colorschemes/gruvbox.nix
     ./colorschemes/kanagawa.nix
     ./colorschemes/melange.nix

--- a/tests/test-sources/plugins/colorschemes/github-theme.nix
+++ b/tests/test-sources/plugins/colorschemes/github-theme.nix
@@ -1,0 +1,70 @@
+{
+  empty = {
+    colorscheme = "github_dark";
+    colorschemes.github-theme.enable = true;
+  };
+
+  defaults = {
+    colorscheme = "github_dark";
+    colorschemes.github-theme = {
+      enable = true;
+
+      settings = {
+        options = {
+          compile_path.__raw = "vim.fn.stdpath('cache') .. '/github-theme'";
+          compile_file_suffix = "_compiled";
+          hide_end_of_buffer = true;
+          hide_nc_statusline = true;
+          transparent = false;
+          terminal_colors = true;
+          dim_inactive = false;
+          module_default = true;
+          styles = {
+            comments = "NONE";
+            functions = "NONE";
+            keywords = "NONE";
+            variables = "NONE";
+            conditionals = "NONE";
+            constants = "NONE";
+            numbers = "NONE";
+            operators = "NONE";
+            strings = "NONE";
+            types = "NONE";
+          };
+          inverse = {
+            match_paren = false;
+            visual = false;
+            search = false;
+          };
+          darken = {
+            floats = true;
+            sidebars = {
+              enable = true;
+              list = [ ];
+            };
+          };
+          modules = [ ];
+        };
+        palettes = [ ];
+        specs = [ ];
+        groups = [ ];
+      };
+    };
+  };
+
+  example = {
+    colorscheme = "github_light";
+    colorschemes.github-theme = {
+      enable = true;
+
+      settings = {
+        transparent = true;
+        dim_inactive = true;
+        styles = {
+          comments = "italic";
+          keywords = "bold";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for the [github-nvim-theme](https://github.com/projekt0n/github-nvim-theme) colorscheme.

Fixes #3006
