### PR TITLE
plugins/telescope/zoxide: init

### DIFF
--- a/flake/dev/list-plugins/list-plugins.py
+++ b/flake/dev/list-plugins/list-plugins.py
@@ -87,6 +87,7 @@ for telescope_extension_name, has_depr_warnings in {
     "project": False,
     "ui-select": False,
     "undo": True,
+    "zoxide": False,
 }.items():
     KNOWN_PATHS[
         f"plugins/by-name/telescope/extensions/{telescope_extension_name}.nix"

--- a/plugins/by-name/telescope/extensions/default.nix
+++ b/plugins/by-name/telescope/extensions/default.nix
@@ -10,5 +10,6 @@
     ./project.nix
     ./ui-select.nix
     ./undo.nix
+    ./zoxide.nix
   ];
 }

--- a/plugins/by-name/telescope/extensions/zoxide.nix
+++ b/plugins/by-name/telescope/extensions/zoxide.nix
@@ -1,0 +1,21 @@
+let
+  mkExtension = import ./_mk-extension.nix;
+in
+mkExtension {
+  name = "zoxide";
+  package = "telescope-zoxide";
+
+  settingsExample = {
+    prompt_title = "Zoxide Folder List";
+    mappings = {
+      "<C-b>" = {
+        keepinsert = true;
+        action.__raw = ''
+          function(selection)
+            file_browser.file_browser({ cwd = selection.path })
+          end
+        '';
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/telescope/zoxide.nix
+++ b/tests/test-sources/plugins/by-name/telescope/zoxide.nix
@@ -1,0 +1,88 @@
+{
+  empty = {
+    plugins = {
+      telescope = {
+        enable = true;
+        extensions.zoxide.enable = true;
+      };
+      web-devicons.enable = true;
+    };
+  };
+
+  defaults = {
+    plugins = {
+      web-devicons.enable = true;
+      telescope = {
+        enable = true;
+
+        extensions.zoxide = {
+          enable = true;
+
+          settings = {
+            prompt_title = "[ Zoxide List ]";
+            list_command = "zoxide query -ls";
+            mappings = {
+              default = {
+                action.__raw = ''
+                  function(selection)
+                    vim.cmd.cd(selection.path)
+                  end
+                '';
+                after_action.__raw = ''
+                  function(selection)
+                    vim.notify("Directory changed to " .. selection.path)
+                  end
+                '';
+              };
+              "<C-s>".action.__raw =
+                "require('telescope._extensions.zoxide.utils').create_basic_command('split')";
+              "<C-v>".action.__raw =
+                "require('telescope._extensions.zoxide.utils').create_basic_command('vsplit')";
+              "<C-e>".action.__raw = "require('telescope._extensions.zoxide.utils').create_basic_command('edit')";
+              "<C-f>" = {
+                keepinsert = true;
+                action.__raw = ''
+                  function(selection)
+                    builtin.find_files({ cwd = selection.path })
+                  end
+                '';
+              };
+              "<C-t>".action.__raw = ''
+                function(selection)
+                  vim.cmd.tcd(selection.path)
+                end
+              '';
+            };
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins = {
+      web-devicons.enable = true;
+      telescope = {
+        enable = true;
+
+        extensions.zoxide = {
+          enable = true;
+
+          settings = {
+            prompt_title = "Zoxide Folder List";
+            mappings = {
+              "<C-b>" = {
+                keepinsert = true;
+                action.__raw = ''
+                  function(selection)
+                    file_browser.file_browser({ cwd = selection.path })
+                  end
+                '';
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/typos.toml
+++ b/typos.toml
@@ -16,6 +16,7 @@ tro = "tro"                   # ./plugins/utils/spectre.nix
 protols = "protols"           # ./plugins/lsp/lsp-packages.nix
 compatibilty = "compatibilty" # ./plugins/by-name/visual-multi/default.nix
 Maco = "Maco"                 # ./plugins/by-name/femaco
+Typ = "Typ"                   # ./flake/dev/list-plugins/list-plugins.py
 
 [type.patch]
 extend-glob = ["*.patch"]


### PR DESCRIPTION
Add [telescope-zoxide](https://github.com/jvgrootveld/telescope-zoxide), a telescope extension that allows you operate zoxide within Neovim.

Fixes #3051
