### PR TITLE
plugins/hurl: init

### DIFF
--- a/plugins/by-name/hurl/default.nix
+++ b/plugins/by-name/hurl/default.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "hurl";
+  packPathName = "hurl.nvim";
+  package = "hurl-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    debug = true;
+    mode = "popup";
+    env_file = [ "vars.env" ];
+    formatters = {
+      json = [ "jq" ];
+      html = [
+        "prettier"
+        "--parser"
+        "html"
+      ];
+      xml = [
+        "tidy"
+        "-xml"
+        "-i"
+        "-q"
+      ];
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/hurl/default.nix
+++ b/tests/test-sources/plugins/by-name/hurl/default.nix
@@ -1,0 +1,86 @@
+{
+  empty = {
+    plugins.hurl.enable = true;
+  };
+
+  defaults = {
+    plugins.hurl = {
+      enable = true;
+
+      settings = {
+        debug = false;
+        mode = "split";
+        show_notification = false;
+        auto_close = true;
+        split_position = "right";
+        split_size = "50%";
+        popup_position = "50%";
+        popup_size = {
+          width = 80;
+          height = 40;
+        };
+        env_file = [ "vars.env" ];
+        fixture_vars = [
+          {
+            name = "random_int_number";
+            callback.__raw = ''
+              function()
+                return math.random(1, 1000)
+              end
+            '';
+          }
+          {
+            name = "random_float_number";
+            callback.__raw = ''
+              function()
+                local result = math.random() * 10
+                return string.format('%.2f', result)
+              end
+            '';
+          }
+        ];
+        find_env_files_in_folders.__raw = "require('hurl.utils').find_env_files_in_folders";
+        formatters = {
+          json = [ "jq" ];
+          html = [
+            "prettier"
+            "--parser"
+            "html"
+          ];
+          xml = [
+            "tidy"
+            "-xml"
+            "-i"
+            "-q"
+          ];
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.hurl = {
+      enable = true;
+
+      settings = {
+        debug = true;
+        mode = "popup";
+        env_file = [ "vars.env" ];
+        formatters = {
+          json = [ "jq" ];
+          html = [
+            "prettier"
+            "--parser"
+            "html"
+          ];
+          xml = [
+            "tidy"
+            "-xml"
+            "-i"
+            "-q"
+          ];
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [hurl.nvim](https://github.com/jellydn/hurl.nvim), plugin designed to run HTTP requests directly from `.hurl` files.

Fixes #3131
