### PR TITLE
plugins/telescope/advanced-git-search: init

### DIFF
--- a/flake/dev/list-plugins/list-plugins.py
+++ b/flake/dev/list-plugins/list-plugins.py
@@ -77,6 +77,7 @@ KNOWN_PATHS: dict[
     ),
 }
 for telescope_extension_name, has_depr_warnings in {
+    "advanced-git-search": False,
     "file-browser": True,
     "frecency": True,
     "fzf-native": True,

--- a/plugins/by-name/telescope/extensions/advanced-git-search.nix
+++ b/plugins/by-name/telescope/extensions/advanced-git-search.nix
@@ -1,0 +1,16 @@
+let
+  mkExtension = import ./_mk-extension.nix;
+in
+mkExtension {
+  name = "advanced-git-search";
+  extensionName = "advanced_git_search";
+  package = "advanced-git-search-nvim";
+
+  settingsExample = {
+    diff_plugin = "diffview";
+    git_flags = [
+      "-c"
+      "delta.side-by-side=false"
+    ];
+  };
+}

--- a/plugins/by-name/telescope/extensions/default.nix
+++ b/plugins/by-name/telescope/extensions/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./advanced-git-search.nix
     ./file-browser.nix
     ./frecency.nix
     ./fzf-native.nix

--- a/tests/test-sources/plugins/by-name/telescope/advanced-git-search.nix
+++ b/tests/test-sources/plugins/by-name/telescope/advanced-git-search.nix
@@ -1,0 +1,57 @@
+{
+  empty = {
+    plugins = {
+      telescope = {
+        enable = true;
+        extensions.advanced-git-search.enable = true;
+      };
+      web-devicons.enable = true;
+    };
+  };
+
+  defaults = {
+    plugins = {
+      web-devicons.enable = true;
+      telescope = {
+        enable = true;
+
+        extensions.advanced-git-search = {
+          enable = true;
+
+          settings = {
+            browse_command = "GBrowse {commit_hash}";
+            diff_plugin = "fugitive";
+            git_flags = [ ];
+            git_diff_flags = [ ];
+            git_log_flags = [ ];
+            show_builtin_git_pickers = false;
+
+            entry_default_author_or_date = "author";
+            keymaps = {
+              toggle_date_author = "<C-w>";
+              open_commit_in_browser = "<C-o>";
+              copy_commit_hash = "<C-y>";
+              show_entire_commit = "<C-e>";
+            };
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins = {
+      web-devicons.enable = true;
+      telescope = {
+        enable = true;
+
+        extensions.advanced-git-search = {
+          enable = true;
+
+          settings = {
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [advanced-git-search](https://github.com/aaronhallaert/advanced-git-search.nvim), an advanced git search extension for Telescope.

Fixes #2833
