### PR TITLE
modules/dependencies: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -40,6 +40,7 @@ lib.makeExtensible (
     inherit (self.deprecation)
       getOptionRecursive
       mkDeprecatedSubOptionModule
+      mkRemovedPackageOptionModule
       mkSettingsRenamedOptionModules
       transitionType
       ;

--- a/lib/deprecation.nix
+++ b/lib/deprecation.nix
@@ -129,7 +129,10 @@ rec {
       packageName,
       oldPackageName ? packageName,
     }:
-    lib.mkRemovedOptionModule [ "plugins" plugin "${oldPackageName}Package" ] ''
+    let
+      optionPath = [ "plugins" ] ++ (lib.toList plugin) ++ [ "${oldPackageName}Package" ];
+    in
+    lib.mkRemovedOptionModule optionPath ''
       Please use the `dependencies.${packageName}` top-level option instead:
       - `dependencies.${packageName}.enable = false` to disable installing `${packageName}`
       - `dependencies.${packageName}.package` to choose which package to install for `${packageName}`.

--- a/lib/deprecation.nix
+++ b/lib/deprecation.nix
@@ -122,4 +122,16 @@ rec {
       nestedTypes.coercedType = oldType;
       nestedTypes.finalType = newType;
     };
+
+  mkRemovedPackageOptionModule =
+    {
+      plugin,
+      packageName,
+      oldPackageName ? packageName,
+    }:
+    lib.mkRemovedOptionModule [ "plugins" plugin "${oldPackageName}Package" ] ''
+      Please use the `dependencies.${packageName}` top-level option instead:
+      - `dependencies.${packageName}.enable = false` to disable installing `${packageName}`
+      - `dependencies.${packageName}.package` to choose which package to install for `${packageName}`.
+    '';
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -9,6 +9,7 @@
     ./clipboard.nix
     ./colorscheme.nix
     ./commands.nix
+    ./dependencies.nix
     ./diagnostics.nix
     ./doc.nix
     ./editorconfig.nix

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -44,6 +44,7 @@ let
     typst.default = "typst";
     ueberzug.default = "ueberzugpp";
     websocat.default = "websocat";
+    wezterm.default = "wezterm";
     which.default = "which";
     yazi.default = "yazi";
     yq.default = "yq";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -27,6 +27,7 @@ let
       default = "nodejs";
       example = "pkgs.nodejs_22";
     };
+    plantuml.default = "plantuml";
     ripgrep.default = "ripgrep";
     sd.default = "sd";
     sed.default = "gnused";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -49,6 +49,10 @@ let
     websocat.default = "websocat";
     wezterm.default = "wezterm";
     which.default = "which";
+    xxd.default = [
+      "unixtools"
+      "xxd"
+    ];
     yazi.default = "yazi";
     yq.default = "yq";
     zk.default = "zk";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -46,6 +46,7 @@ let
     websocat.default = "websocat";
     which.default = "which";
     yazi.default = "yazi";
+    zk.default = "zk";
   };
 
   mkDependencyOption = name: properties: {

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -9,6 +9,7 @@ let
 
   packages = {
     curl.default = "curl";
+    gcc.default = "gcc";
     git = {
       default = "git";
       example = [ "gitMinimal" ];

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -18,6 +18,7 @@ let
     };
     go.default = "go";
     lean.default = "lean4";
+    ledger.default = "ledger";
     nodejs = {
       default = "nodejs";
       example = "pkgs.nodejs_22";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -28,6 +28,7 @@ let
     };
     glow.default = "glow";
     go.default = "go";
+    godot.default = "godot_4";
     lazygit.default = "lazygit";
     lean.default = "lean4";
     ledger.default = "ledger";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -27,6 +27,7 @@ let
       default = "nodejs";
       example = "pkgs.nodejs_22";
     };
+    ripgrep.default = "ripgrep";
     texpresso.default = "texpresso";
     tinymist.default = "tinymist";
     tree-sitter.default = "tree-sitter";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -46,6 +46,7 @@ let
     websocat.default = "websocat";
     which.default = "which";
     yazi.default = "yazi";
+    yq.default = "yq";
     zk.default = "zk";
   };
 

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -41,6 +41,7 @@ let
     sed.default = "gnused";
     texpresso.default = "texpresso";
     tinymist.default = "tinymist";
+    tmux.default = "tmux";
     tree-sitter.default = "tree-sitter";
     typst.default = "typst";
     ueberzug.default = "ueberzugpp";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -8,6 +8,7 @@ let
   cfg = config.dependencies;
 
   packages = {
+    ctags.default = "ctags";
     curl.default = "curl";
     gcc.default = "gcc";
     git = {

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -32,6 +32,7 @@ let
     tree-sitter.default = "tree-sitter";
     typst.default = "typst";
     ueberzug.default = "ueberzugpp";
+    websocat.default = "websocat";
     which.default = "which";
     yazi.default = "yazi";
   };

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -26,6 +26,7 @@ let
       example = [ "gitMinimal" ];
     };
     go.default = "go";
+    lazygit.default = "lazygit";
     lean.default = "lean4";
     ledger.default = "ledger";
     manix.default = "manix";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -31,6 +31,7 @@ let
     typst.default = "typst";
     ueberzug.default = "ueberzugpp";
     which.default = "which";
+    yazi.default = "yazi";
   };
 
   mkDependencyOption = name: properties: {

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -19,6 +19,7 @@ let
       default = "nodejs";
       example = "pkgs.nodejs_22";
     };
+    texpresso.default = "texpresso";
     tree-sitter.default = "tree-sitter";
     typst.default = "typst";
     ueberzug.default = "ueberzugpp";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -13,6 +13,7 @@ let
       default = "git";
       example = [ "gitMinimal" ];
     };
+    tree-sitter.default = "tree-sitter";
     ueberzug.default = "ueberzugpp";
     which.default = "which";
   };

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -14,6 +14,10 @@ let
     direnv.default = "direnv";
     distant.default = "distant";
     fish.default = "fish";
+    fzf = {
+      default = "fzf";
+      example = "pkgs.skim";
+    };
     gcc.default = "gcc";
     gh.default = "gh";
     git = {

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -15,6 +15,7 @@ let
     direnv.default = "direnv";
     distant.default = "distant";
     fish.default = "fish";
+    flutter.default = "flutter";
     fzf = {
       default = "fzf";
       example = "pkgs.skim";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -8,6 +8,7 @@ let
   cfg = config.dependencies;
 
   packages = {
+    bat.default = "bat";
     ctags.default = "ctags";
     curl.default = "curl";
     direnv.default = "direnv";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -30,6 +30,7 @@ let
     lazygit.default = "lazygit";
     lean.default = "lean4";
     ledger.default = "ledger";
+    llm-ls.default = "llm-ls";
     manix.default = "manix";
     nodejs = {
       default = "nodejs";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -28,6 +28,8 @@ let
       example = "pkgs.nodejs_22";
     };
     ripgrep.default = "ripgrep";
+    sd.default = "sd";
+    sed.default = "gnused";
     texpresso.default = "texpresso";
     tinymist.default = "tinymist";
     tree-sitter.default = "tree-sitter";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -15,6 +15,7 @@ let
       default = "git";
       example = [ "gitMinimal" ];
     };
+    go.default = "go";
     nodejs = {
       default = "nodejs";
       example = "pkgs.nodejs_22";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -9,6 +9,7 @@ let
 
   packages = {
     curl.default = "curl";
+    ueberzug.default = "ueberzugpp";
   };
 
   mkDependencyOption = name: properties: {

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -9,6 +9,7 @@ let
 
   packages = {
     bat.default = "bat";
+    cornelis.default = "cornelis";
     ctags.default = "ctags";
     curl.default = "curl";
     direnv.default = "direnv";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -13,6 +13,10 @@ let
       default = "git";
       example = [ "gitMinimal" ];
     };
+    nodejs = {
+      default = "nodejs";
+      example = "pkgs.nodejs_22";
+    };
     tree-sitter.default = "tree-sitter";
     ueberzug.default = "ueberzugpp";
     which.default = "which";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -17,6 +17,7 @@ let
       example = [ "gitMinimal" ];
     };
     go.default = "go";
+    lean.default = "lean4";
     nodejs = {
       default = "nodejs";
       example = "pkgs.nodejs_22";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dependencies;
+
+  packages = {
+    curl.default = "curl";
+  };
+
+  mkDependencyOption = name: properties: {
+    enable = lib.mkEnableOption "Add ${name} to dependencies.";
+
+    package = lib.mkPackageOption pkgs name properties;
+  };
+in
+{
+  options.dependencies = lib.mapAttrs mkDependencyOption packages;
+
+  config = {
+    extraPackages = lib.pipe cfg [
+      builtins.attrValues
+      (builtins.filter (p: p.enable))
+      (builtins.map (p: p.package))
+    ];
+  };
+}

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -12,6 +12,7 @@ let
     curl.default = "curl";
     direnv.default = "direnv";
     distant.default = "distant";
+    fish.default = "fish";
     gcc.default = "gcc";
     gh.default = "gh";
     git = {

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -11,6 +11,7 @@ let
     ctags.default = "ctags";
     curl.default = "curl";
     direnv.default = "direnv";
+    distant.default = "distant";
     gcc.default = "gcc";
     gh.default = "gh";
     git = {

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -25,6 +25,7 @@ let
       default = "git";
       example = [ "gitMinimal" ];
     };
+    glow.default = "glow";
     go.default = "go";
     lazygit.default = "lazygit";
     lean.default = "lean4";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -40,6 +40,7 @@ let
     };
     plantuml.default = "plantuml";
     ripgrep.default = "ripgrep";
+    rust-analyzer.default = "rust-analyzer";
     sd.default = "sd";
     sed.default = "gnused";
     texpresso.default = "texpresso";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -12,6 +12,7 @@ let
     curl.default = "curl";
     direnv.default = "direnv";
     gcc.default = "gcc";
+    gh.default = "gh";
     git = {
       default = "git";
       example = [ "gitMinimal" ];

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -21,6 +21,7 @@ let
     go.default = "go";
     lean.default = "lean4";
     ledger.default = "ledger";
+    manix.default = "manix";
     nodejs = {
       default = "nodejs";
       example = "pkgs.nodejs_22";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -19,6 +19,7 @@ let
       example = "pkgs.nodejs_22";
     };
     tree-sitter.default = "tree-sitter";
+    typst.default = "typst";
     ueberzug.default = "ueberzugpp";
     which.default = "which";
   };

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -10,6 +10,7 @@ let
   packages = {
     ctags.default = "ctags";
     curl.default = "curl";
+    direnv.default = "direnv";
     gcc.default = "gcc";
     git = {
       default = "git";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -28,6 +28,7 @@ let
       example = "pkgs.nodejs_22";
     };
     texpresso.default = "texpresso";
+    tinymist.default = "tinymist";
     tree-sitter.default = "tree-sitter";
     typst.default = "typst";
     ueberzug.default = "ueberzugpp";

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -9,6 +9,10 @@ let
 
   packages = {
     curl.default = "curl";
+    git = {
+      default = "git";
+      example = [ "gitMinimal" ];
+    };
     ueberzug.default = "ueberzugpp";
   };
 

--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -14,6 +14,7 @@ let
       example = [ "gitMinimal" ];
     };
     ueberzug.default = "ueberzugpp";
+    which.default = "which";
   };
 
   mkDependencyOption = name: properties: {

--- a/plugins/by-name/chatgpt/default.nix
+++ b/plugins/by-name/chatgpt/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -12,13 +11,15 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ maintainers.GaetanLepage ];
 
-  extraOptions = {
-    curlPackage = lib.mkPackageOption pkgs "curl" {
-      nullable = true;
-    };
-  };
+  # TODO: added 2025-04-06, remove after 25.05
+  imports = [
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "chatgpt";
+      packageName = "curl";
+    })
+  ];
 
-  extraConfig = cfg: { extraPackages = [ cfg.curlPackage ]; };
+  extraConfig = cfg: { dependencies.curl.enable = lib.mkDefault true; };
 
   settingsOptions = {
     api_key_cmd = helpers.defaultNullOpts.mkStr null ''

--- a/plugins/by-name/committia/default.nix
+++ b/plugins/by-name/committia/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -13,6 +12,14 @@ lib.nixvim.plugins.mkVimPlugin {
   globalPrefix = "committia_";
 
   maintainers = [ lib.maintainers.alisonjenkins ];
+
+  imports = [
+    # TODO: added 2025-04-06, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "committia";
+      packageName = "git";
+    })
+  ];
 
   settingsOptions = {
     open_only_vim_starting = defaultNullOpts.mkFlagInt 1 ''
@@ -49,13 +56,7 @@ lib.nixvim.plugins.mkVimPlugin {
     '';
   };
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-  };
-
   extraConfig = cfg: {
-    extraPackages = [ cfg.gitPackage ];
+    dependencies.git.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/cornelis/default.nix
+++ b/plugins/by-name/cornelis/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
@@ -8,14 +8,16 @@ lib.nixvim.plugins.mkVimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    cornelisPackage = lib.mkPackageOption pkgs "cornelis" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "cornelis";
+      packageName = "cornelis";
+    })
+  ];
 
-  extraConfig = cfg: {
-    extraPackages = [ cfg.cornelisPackage ];
+  extraConfig = {
+    dependencies.cornelis.enable = lib.mkDefault true;
   };
 
   settingsOptions = {

--- a/plugins/by-name/direnv/default.nix
+++ b/plugins/by-name/direnv/default.nix
@@ -1,5 +1,4 @@
 {
-  pkgs,
   lib,
   ...
 }:
@@ -13,6 +12,14 @@ lib.nixvim.plugins.mkVimPlugin {
   globalPrefix = "direnv_";
 
   maintainers = [ lib.maintainers.alisonjenkins ];
+
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "direnv";
+      packageName = "direnv";
+    })
+  ];
 
   settingsOptions = {
     direnv_auto = defaultNullOpts.mkFlagInt 1 ''
@@ -37,13 +44,7 @@ lib.nixvim.plugins.mkVimPlugin {
     '';
   };
 
-  extraOptions = {
-    direnvPackage = lib.mkPackageOption pkgs "direnv" {
-      nullable = true;
-    };
-  };
-
-  extraConfig = cfg: {
-    extraPackages = [ cfg.direnvPackage ];
+  extraConfig = {
+    dependencies.direnv.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/distant/default.nix
+++ b/plugins/by-name/distant/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 let
   inherit (lib) types;
   inherit (lib.nixvim)
@@ -17,14 +17,16 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   setup = ":setup";
 
-  extraOptions = {
-    distantPackage = lib.mkPackageOption pkgs "distant" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "distant";
+      packageName = "distant";
+    })
+  ];
 
-  extraConfig = cfg: {
-    extraPackages = [ cfg.distantPackage ];
+  extraConfig = {
+    dependencies.distant.enable = lib.mkDefault true;
   };
 
   settingsOptions = {

--- a/plugins/by-name/flutter-tools/default.nix
+++ b/plugins/by-name/flutter-tools/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   config,
   ...
 }:
@@ -11,13 +10,16 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.khaneliman ];
 
-  extraOptions = {
-    flutterPackage = lib.mkPackageOption pkgs "flutter" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "flutter-tools";
+      packageName = "flutter";
+    })
+  ];
+
   extraConfig = cfg: {
-    extraPackages = [ cfg.flutterPackage ];
+    dependencies.flutter.enable = lib.mkDefault true;
 
     warnings = lib.nixvim.mkWarnings "plugins.flutter-tools" {
       when =

--- a/plugins/by-name/fugitive/default.nix
+++ b/plugins/by-name/fugitive/default.nix
@@ -1,7 +1,5 @@
 {
   lib,
-  helpers,
-  pkgs,
   ...
 }:
 lib.nixvim.plugins.mkVimPlugin {
@@ -11,14 +9,17 @@ lib.nixvim.plugins.mkVimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  # In typical tpope fashion, this plugin has no config options
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "fugitive";
+      packageName = "git";
+    })
+  ];
 
-  extraConfig = cfg: {
-    extraPackages = [ cfg.gitPackage ];
+  # In typical tpope fashion, this plugin has no config options
+
+  extraConfig = {
+    dependencies.git.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/fzf-lua/default.nix
+++ b/plugins/by-name/fzf-lua/default.nix
@@ -2,8 +2,6 @@
   config,
   lib,
   helpers,
-  options,
-  pkgs,
   ...
 }:
 with lib;
@@ -38,12 +36,15 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   inherit settingsOptions settingsExample;
 
-  extraOptions = {
-    fzfPackage = lib.mkPackageOption pkgs "fzf" {
-      nullable = true;
-      example = "pkgs.skim";
-    };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "fzf-lua";
+      packageName = "fzf";
+    })
+  ];
 
+  extraOptions = {
     # TODO: deprecated 2024-08-29 remove after 24.11
     iconsEnabled = mkOption {
       type = types.bool;
@@ -129,7 +130,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
           enable = lib.mkOverride 1490 true;
         };
 
-    extraPackages = [ cfg.fzfPackage ];
+    dependencies.fzf.enable = lib.mkDefault true;
 
     plugins.fzf-lua.settings.__unkeyed_profile = cfg.profile;
 

--- a/plugins/by-name/git-conflict/default.nix
+++ b/plugins/by-name/git-conflict/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -11,13 +10,17 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ maintainers.GaetanLepage ];
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "git-conflict";
+      packageName = "git";
+    })
+  ];
 
-  extraConfig = cfg: { extraPackages = [ cfg.gitPackage ]; };
+  extraConfig = {
+    dependencies.git.enable = lib.mkDefault true;
+  };
 
   settingsOptions = {
     default_mappings =

--- a/plugins/by-name/git-worktree/default.nix
+++ b/plugins/by-name/git-worktree/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   config,
-  pkgs,
   ...
 }:
 let
@@ -13,6 +12,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "git-worktree-nvim";
 
   maintainers = [ lib.maintainers.khaneliman ];
+
+  # TODO: added 2025-04-06, remove after 25.05
+  imports = [
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "git-worktree";
+      packageName = "git";
+    })
+  ];
 
   settingsOptions = {
     change_directory_command = defaultNullOpts.mkStr "cd" ''
@@ -50,10 +57,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraOptions = {
     enableTelescope = lib.mkEnableOption "telescope integration";
-
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
   };
 
   callSetup = false;
@@ -67,7 +70,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       '';
     };
 
-    extraPackages = [ cfg.gitPackage ];
+    dependencies.git.enable = lib.mkDefault true;
 
     plugins.telescope.enabledExtensions = lib.mkIf cfg.enableTelescope [ "git_worktree" ];
 

--- a/plugins/by-name/gitblame/default.nix
+++ b/plugins/by-name/gitblame/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -25,6 +24,13 @@ lib.nixvim.plugins.mkNeovimPlugin {
     "ignoredFiletypes"
     "delay"
     "virtualTextColumn"
+  ];
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "gitblame";
+      packageName = "git";
+    })
   ];
 
   settingsOptions = {
@@ -127,11 +133,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     use_blame_commit_file_urls = true;
   };
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
+  extraConfig = {
+    dependencies.git.enable = lib.mkDefault true;
   };
-
-  extraConfig = cfg: { extraPackages = [ cfg.gitPackage ]; };
 }

--- a/plugins/by-name/gitgutter/default.nix
+++ b/plugins/by-name/gitgutter/default.nix
@@ -35,6 +35,12 @@ lib.nixvim.plugins.mkVimPlugin {
           "modifiedAbove"
         ]
       ) "This option has been removed from upstream")
+
+      # TODO: added 2025-04-06, remove after 25.05
+      (lib.nixvim.mkRemovedPackageOptionModule {
+        plugin = "gitgutter";
+        packageName = "git";
+      })
     ];
 
   extraOptions = {
@@ -44,10 +50,6 @@ lib.nixvim.plugins.mkVimPlugin {
       description = ''
         Set recommended neovim option.
       '';
-    };
-
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
     };
 
     grepPackage = lib.mkPackageOption pkgs "gnugrep" {
@@ -61,8 +63,9 @@ lib.nixvim.plugins.mkVimPlugin {
       foldtext = "gitgutter#fold#foldtext";
     };
 
+    dependencies.git.enable = lib.mkDefault true;
+
     extraPackages = [
-      cfg.gitPackage
       cfg.grepPackage
     ];
   };

--- a/plugins/by-name/gitlab/default.nix
+++ b/plugins/by-name/gitlab/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -14,15 +13,17 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    nodePackage = lib.mkPackageOption pkgs "nodejs" {
-      nullable = true;
-      default = null;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "gitlab";
+      packageName = "nodejs";
+      oldPackageName = "node";
+    })
+  ];
 
-  extraConfig = cfg: {
-    extraPackages = [ cfg.nodePackage ];
+  extraConfig = {
+    dependencies.nodejs.enable = lib.mkDefault true;
   };
 
   settingsOptions = {

--- a/plugins/by-name/gitmessenger/default.nix
+++ b/plugins/by-name/gitmessenger/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -15,14 +14,8 @@ lib.nixvim.plugins.mkVimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-  };
-
-  extraConfig = cfg: {
-    extraPackages = [ cfg.gitPackage ];
+  extraConfig = {
+    dependencies.git.enable = lib.mkDefault true;
   };
 
   # TODO: Added 2024-12-16; remove after 25.05
@@ -41,6 +34,13 @@ lib.nixvim.plugins.mkVimPlugin {
     "concealWordDiffMarker"
     "floatingWinOps"
     "popupContentMargins"
+  ];
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "gitmessenger";
+      packageName = "git";
+    })
   ];
 
   settingsOptions = {

--- a/plugins/by-name/gitsigns/default.nix
+++ b/plugins/by-name/gitsigns/default.nix
@@ -74,13 +74,13 @@ lib.nixvim.plugins.mkNeovimPlugin {
           "enable"
         ]
       ) "yadm support was removed upstream.")
-    ];
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-  };
+      # TODO: added 2025-04-06, remove after 25.05
+      (lib.nixvim.mkRemovedPackageOptionModule {
+        plugin = "gitsigns";
+        packageName = "git";
+      })
+    ];
 
   settingsOptions = import ./settings-options.nix lib;
 
@@ -112,6 +112,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
       '';
     };
 
-    extraPackages = [ cfg.gitPackage ];
+    dependencies.git.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/glow/default.nix
+++ b/plugins/by-name/glow/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -13,19 +12,27 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.getchoo ];
 
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "glow";
+      packageName = "glow";
+    })
+  ];
+
   settingsOptions = {
     glow_path = defaultNullOpts.mkStr (lib.nixvim.mkRaw "vim.fn.exepath('glow')") ''
       Path to `glow` binary.
 
       If null or `""`, `glow` in your `$PATH` with be used if available.
 
-      Using `glowPackage` is the recommended way to make `glow` available in your `$PATH`.
+      Using `dependencies.glow` is the recommended way to make `glow` available in your `$PATH`.
     '';
 
     install_path = defaultNullOpts.mkStr "~/.local/bin" ''
       Path for installing `glow` binary if one is not found at `glow_path` or in your `$PATH`.
 
-      Consider using `glowPackage` instead.
+      Consider using `dependencies.glow` instead.
     '';
 
     border = defaultNullOpts.mkEnumFirstDefault [
@@ -76,11 +83,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     height_ratio = 0.7;
   };
 
-  extraOptions = {
-    glowPackage = lib.mkPackageOption pkgs "glow" {
-      nullable = true;
-    };
+  extraConfig = {
+    dependencies.glow.enable = lib.mkDefault true;
   };
-
-  extraConfig = cfg: { extraPackages = [ cfg.glowPackage ]; };
 }

--- a/plugins/by-name/godot/default.nix
+++ b/plugins/by-name/godot/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -13,12 +12,13 @@ lib.nixvim.plugins.mkVimPlugin {
 
   maintainers = [ maintainers.GaetanLepage ];
 
-  extraOptions = {
-    godotPackage = lib.mkPackageOption pkgs "godot" {
-      nullable = true;
-      default = "godot_4";
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "godot";
+      packageName = "godot";
+    })
+  ];
 
   settingsOptions = {
     executable = helpers.defaultNullOpts.mkStr "godot" ''
@@ -30,5 +30,7 @@ lib.nixvim.plugins.mkVimPlugin {
     executable = "godot";
   };
 
-  extraConfig = cfg: { extraPackages = [ cfg.godotPackage ]; };
+  extraConfig = {
+    dependencies.godot.enable = lib.mkDefault true;
+  };
 }

--- a/plugins/by-name/hex/default.nix
+++ b/plugins/by-name/hex/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts mkNullOrLuaFn;
 in
@@ -9,14 +9,17 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    xxdPackage = lib.mkPackageOption pkgs [
-      "unixtools"
-      "xxd"
-    ] { nullable = true; };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "hex";
+      packageName = "xxd";
+    })
+  ];
 
-  extraConfig = cfg: { extraPackages = [ cfg.xxdPackage ]; };
+  extraConfig = {
+    dependencies.xxd.enable = lib.mkDefault true;
+  };
 
   settingsOptions = {
     dump_cmd = defaultNullOpts.mkStr "xxd -g 1 -u" ''

--- a/plugins/by-name/image/default.nix
+++ b/plugins/by-name/image/default.nix
@@ -14,7 +14,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  # TODO: Added 2025-03-20. Remove after 25.05
+  # TODO: option deprecations added 2025-03-20. Remove after 25.05
+  # TODO: curlPackage deprecation added 2025-04-06. Remove after 25.05
   inherit (import ./deprecations.nix lib)
     deprecateExtraOptions
     optionsRenamedToSettings
@@ -22,10 +23,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
     ;
 
   extraOptions = {
-    curlPackage = lib.mkPackageOption pkgs "curl" {
-      nullable = true;
-    };
-
     ueberzugPackage = lib.mkOption {
       type = with types; nullOr package;
       default = pkgs.ueberzugpp;
@@ -140,11 +137,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    extraPackages = [
-      # In theory, we could remove that if the user explicitly disables `downloadRemoteImages` for
-      # all integrations but shipping `curl` is not too heavy.
-      cfg.curlPackage
+    # In theory, we could remove that if the user explicitly disables `downloadRemoteImages` for
+    # all integrations but shipping `curl` is not too heavy.
+    dependencies.curl.enable = lib.mkDefault true;
 
-    ] ++ lib.optional (cfg.settings.backend == "ueberzug") cfg.ueberzugPackage;
+    extraPackages = lib.optional (cfg.settings.backend == "ueberzug") cfg.ueberzugPackage;
   };
 }

--- a/plugins/by-name/image/default.nix
+++ b/plugins/by-name/image/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -15,23 +14,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.GaetanLepage ];
 
   # TODO: option deprecations added 2025-03-20. Remove after 25.05
-  # TODO: curlPackage deprecation added 2025-04-06. Remove after 25.05
+  # TODO: curlPackage and ueberzugPackage deprecations added 2025-04-06. Remove after 25.05
   inherit (import ./deprecations.nix lib)
     deprecateExtraOptions
     optionsRenamedToSettings
     imports
     ;
-
-  extraOptions = {
-    ueberzugPackage = lib.mkOption {
-      type = with types; nullOr package;
-      default = pkgs.ueberzugpp;
-      defaultText = lib.literalExpression "pkgs.ueberzugpp";
-      description = ''
-        Package to automatically install if `settings.backend.backend` is set to `"ueberzug"`.
-      '';
-    };
-  };
 
   settingsOptions = {
     backend =
@@ -139,8 +127,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
   extraConfig = cfg: {
     # In theory, we could remove that if the user explicitly disables `downloadRemoteImages` for
     # all integrations but shipping `curl` is not too heavy.
-    dependencies.curl.enable = lib.mkDefault true;
-
-    extraPackages = lib.optional (cfg.settings.backend == "ueberzug") cfg.ueberzugPackage;
+    dependencies = {
+      curl.enable = lib.mkDefault true;
+      ueberzug.enable = lib.mkIf (cfg.settings.backend == "ueberzug") (lib.mkDefault true);
+    };
   };
 }

--- a/plugins/by-name/image/deprecations.nix
+++ b/plugins/by-name/image/deprecations.nix
@@ -22,5 +22,9 @@ lib: {
       plugin = "image";
       packageName = "curl";
     })
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "image";
+      packageName = "ueberzug";
+    })
   ];
 }

--- a/plugins/by-name/image/deprecations.nix
+++ b/plugins/by-name/image/deprecations.nix
@@ -17,5 +17,10 @@ lib: {
       Nixvim(plugins.image): The option `integrations` has been renamed to `settings.integrations`.
       Warning: sub-options now have the same name as upstream (`clear_in_insert_mode`...).
     '')
+
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "image";
+      packageName = "curl";
+    })
   ];
 }

--- a/plugins/by-name/lazygit/default.nix
+++ b/plugins/by-name/lazygit/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -20,6 +19,10 @@ lib.nixvim.plugins.mkVimPlugin {
     (lib.nixvim.mkRemovedPackageOptionModule {
       plugin = "lazygit";
       packageName = "git";
+    })
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "lazygit";
+      packageName = "lazygit";
     })
   ];
 
@@ -78,17 +81,11 @@ lib.nixvim.plugins.mkVimPlugin {
     config_file_path = [ ];
   };
 
-  extraOptions = {
-    lazygitPackage = lib.mkPackageOption pkgs "lazygit" {
-      nullable = true;
-    };
-  };
-
   extraConfig = cfg: {
-    dependencies.git.enable = lib.mkDefault true;
+    dependencies = {
+      git.enable = lib.mkDefault true;
+      lazygit.enable = lib.mkDefault true;
+    };
 
-    extraPackages = [
-      cfg.lazygitPackage
-    ];
   };
 }

--- a/plugins/by-name/lazygit/default.nix
+++ b/plugins/by-name/lazygit/default.nix
@@ -15,6 +15,14 @@ lib.nixvim.plugins.mkVimPlugin {
 
   maintainers = [ lib.maintainers.AndresBermeoMarinelli ];
 
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "lazygit";
+      packageName = "git";
+    })
+  ];
+
   settingsOptions = {
     floating_window_winblend = defaultNullOpts.mkNullable (types.ints.between 0 100) 0 ''
       Set the transparency of the floating window.
@@ -71,18 +79,15 @@ lib.nixvim.plugins.mkVimPlugin {
   };
 
   extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-
     lazygitPackage = lib.mkPackageOption pkgs "lazygit" {
       nullable = true;
     };
   };
 
   extraConfig = cfg: {
+    dependencies.git.enable = lib.mkDefault true;
+
     extraPackages = [
-      cfg.gitPackage
       cfg.lazygitPackage
     ];
   };

--- a/plugins/by-name/lean/default.nix
+++ b/plugins/by-name/lean/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -14,12 +13,13 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.khaneliman ];
 
-  extraOptions = {
-    leanPackage = lib.mkPackageOption pkgs "lean" {
-      nullable = true;
-      default = "lean4";
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "lean";
+      packageName = "lean";
+    })
+  ];
 
   settingsOptions = {
     lsp = defaultNullOpts.mkNullable (types.submodule {
@@ -184,8 +184,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
     };
   };
 
-  extraConfig = cfg: {
-    extraPackages = [ cfg.leanPackage ];
+  extraConfig = {
+    dependencies.lean.enable = lib.mkDefault true;
   };
 
   # TODO: Deprecated in 2025-01-31

--- a/plugins/by-name/ledger/default.nix
+++ b/plugins/by-name/ledger/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -28,14 +27,17 @@ mkVimPlugin {
       new = "fillstring";
     }
   ];
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "ledger";
+      packageName = "ledger";
+    })
+  ];
 
-  extraOptions = {
-    ledgerPackage = lib.mkPackageOption pkgs "ledger" {
-      nullable = true;
-    };
+  extraConfig = {
+    dependencies.ledger.enable = lib.mkDefault true;
   };
-
-  extraConfig = cfg: { extraPackages = [ cfg.ledgerPackage ]; };
 
   settingsOptions = {
     bin = helpers.mkNullOrStr ''

--- a/plugins/by-name/lualine/default.nix
+++ b/plugins/by-name/lualine/default.nix
@@ -43,7 +43,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
         "alwaysDivideMiddle"
       ];
     in
-    mkSettingsRenamedOptionModules basePluginPath optionsPath oldOptions;
+    (mkSettingsRenamedOptionModules basePluginPath optionsPath oldOptions)
+    ++ [
+      # TODO: added 2025-04-06, remove after 25.05
+      (lib.nixvim.mkRemovedPackageOptionModule {
+        plugin = "lualine";
+        packageName = "git";
+      })
+    ];
 
   settingsOptions =
     let
@@ -400,13 +407,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     };
   };
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-  };
-
-  extraConfig = cfg: {
-    extraPackages = [ cfg.gitPackage ];
+  extraConfig = {
+    dependencies.git.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -3,7 +3,6 @@
   helpers,
   config,
   pkgs,
-  options,
   ...
 }:
 with lib;
@@ -26,6 +25,12 @@ in
     (mkRemovedOptionModule (
       basePluginPath ++ [ "closeFloatsOnEscapeKey" ]
     ) "This option has been removed from upstream.")
+
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "neo-tree";
+      packageName = "git";
+    })
   ];
   options.plugins.neo-tree =
     let
@@ -61,10 +66,6 @@ in
           "vimPlugins"
           "neo-tree-nvim"
         ];
-      };
-
-      gitPackage = lib.mkPackageOption pkgs "git" {
-        nullable = true;
       };
 
       sources =
@@ -1139,6 +1140,6 @@ in
         require('neo-tree').setup(${lib.nixvim.toLuaObject setupOptions})
       '';
 
-      extraPackages = [ cfg.gitPackage ];
+      dependencies.git.enable = lib.mkDefault true;
     };
 }

--- a/plugins/by-name/neogit/default.nix
+++ b/plugins/by-name/neogit/default.nix
@@ -2,7 +2,6 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
@@ -112,12 +111,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
     };
   };
 
-  extraOptions = {
-    whichPackage = lib.mkPackageOption pkgs "which" {
-      nullable = true;
-    };
-  };
-
   extraConfig = cfg: {
     assertions = lib.nixvim.mkAssertions "plugins.neogit" (
       map
@@ -140,10 +133,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
         ]
     );
 
-    dependencies.git.enable = lib.mkDefault true;
+    dependencies = {
+      git.enable = lib.mkDefault true;
 
-    extraPackages = optional (hasInfix "which" (
-      cfg.settings.commit_view.verify_commit.__raw or ""
-    )) cfg.whichPackage;
+      which.enable =
+        let
+          autoInstallWhich = hasInfix "which" (cfg.settings.commit_view.verify_commit.__raw or "");
+        in
+        lib.mkIf autoInstallWhich (lib.mkDefault true);
+    };
   };
 }

--- a/plugins/by-name/neogit/default.nix
+++ b/plugins/by-name/neogit/default.nix
@@ -14,7 +14,18 @@ lib.nixvim.plugins.mkNeovimPlugin {
   # TODO introduced 2024-02-29: remove 2024-04-29
   deprecateExtraOptions = true;
   imports =
-    map
+    [
+      # TODO: added 2025-04-07, remove after 25.05
+      (lib.nixvim.mkRemovedPackageOptionModule {
+        plugin = "neogit";
+        packageName = "git";
+      })
+      (lib.nixvim.mkRemovedPackageOptionModule {
+        plugin = "neogit";
+        packageName = "which";
+      })
+    ]
+    ++ (map
       (
         optionPath:
         mkRemovedOptionModule
@@ -40,7 +51,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
           "sections"
           "unpulled"
         ]
-      ];
+      ]
+    );
   optionsRenamedToSettings = [
     "disableSigns"
     "disableHint"
@@ -101,10 +113,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-
     whichPackage = lib.mkPackageOption pkgs "which" {
       nullable = true;
     };
@@ -132,13 +140,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
         ]
     );
 
-    extraPackages =
-      [
-        cfg.gitPackage
-      ]
-      ++ optional (hasInfix "which" (
-        cfg.settings.commit_view.verify_commit.__raw or ""
-      )) cfg.whichPackage;
+    dependencies.git.enable = lib.mkDefault true;
 
+    extraPackages = optional (hasInfix "which" (
+      cfg.settings.commit_view.verify_commit.__raw or ""
+    )) cfg.whichPackage;
   };
 }

--- a/plugins/by-name/nvim-tree/default.nix
+++ b/plugins/by-name/nvim-tree/default.nix
@@ -35,6 +35,12 @@ in
       "view"
       "hideRootFolder"
     ] "Set `plugins.nvim-tree.renderer.rootFolderLabel` to `false` to hide the root folder.")
+
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "nvim-tree";
+      packageName = "git";
+    })
   ];
   options.plugins.nvim-tree = lib.nixvim.plugins.neovim.extraOptionsOptions // {
     enable = mkEnableOption "nvim-tree";
@@ -44,10 +50,6 @@ in
         "vimPlugins"
         "nvim-tree-lua"
       ];
-    };
-
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
     };
 
     disableNetrw = helpers.defaultNullOpts.mkBool false "Disable netrw";
@@ -1192,6 +1194,6 @@ in
           require('nvim-tree').setup(${lib.nixvim.toLuaObject setupOptions})
         '';
 
-      extraPackages = [ cfg.gitPackage ];
+      dependencies.git.enable = lib.mkDefault true;
     };
 }

--- a/plugins/by-name/octo/default.nix
+++ b/plugins/by-name/octo/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -13,6 +12,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "octo-nvim";
 
   maintainers = [ lib.maintainers.svl ];
+
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "octo";
+      packageName = "gh";
+    })
+  ];
 
   settingsOptions = {
     use_local_fs = defaultNullOpts.mkBool false ''
@@ -168,17 +175,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
     };
   };
 
-  extraOptions = {
-    ghPackage = lib.mkPackageOption pkgs "GitHub CLI" {
-      default = "gh";
-      nullable = true;
-    };
-  };
-
   extraConfig =
     cfg:
     lib.mkMerge [
-      { extraPackages = [ cfg.ghPackage ]; }
+      { dependencies.gh.enable = lib.mkDefault true; }
       (lib.mkIf (cfg.settings.picker == null || cfg.settings.picker == "telescope") {
         plugins.telescope.enable = lib.mkDefault true;
       })

--- a/plugins/by-name/papis/default.nix
+++ b/plugins/by-name/papis/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "papis";
   packPathName = "papis.nvim";
@@ -7,15 +7,18 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.GaetanLepage ];
 
   # papis.nvim is an nvim-cmp source too
-  imports = [ { cmpSourcePlugins.papis = "papis"; } ];
+  imports = [
+    { cmpSourcePlugins.papis = "papis"; }
 
-  extraOptions = {
-    yqPackage = lib.mkPackageOption pkgs "yq" {
-      nullable = true;
-    };
-  };
-  extraConfig = cfg: {
-    extraPackages = [ cfg.yqPackage ];
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "yq";
+      packageName = "yq";
+    })
+  ];
+
+  extraConfig = {
+    dependencies.yq.enable = lib.mkDefault true;
   };
 
   settingsOptions = import ./settings-options.nix lib;

--- a/plugins/by-name/pckr/default.nix
+++ b/plugins/by-name/pckr/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -13,11 +12,15 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "pckr";
+      packageName = "git";
+    })
+  ];
 
+  extraOptions = {
     plugins = lib.mkOption {
       default = [ ];
       type =
@@ -75,7 +78,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    extraPackages = [ cfg.gitPackage ];
+    dependencies.git.enable = lib.mkDefault true;
 
     plugins.pckr.luaConfig = {
       # Otherwise pckr can't find itself

--- a/plugins/by-name/plantuml-syntax/default.nix
+++ b/plugins/by-name/plantuml-syntax/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -18,14 +17,17 @@ lib.nixvim.plugins.mkVimPlugin {
     "setMakeprg"
     "executableScript"
   ];
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "plantuml-syntax";
+      packageName = "plantuml";
+    })
+  ];
 
-  extraOptions = {
-    plantumlPackage = lib.mkPackageOption pkgs "plantuml" {
-      nullable = true;
-    };
+  extraConfig = {
+    dependencies.plantuml.enable = lib.mkDefault true;
   };
-
-  extraConfig = cfg: { extraPackages = [ cfg.plantumlPackage ]; };
 
   settingsOptions = {
     set_makeprg = defaultNullOpts.mkFlagInt 1 ''

--- a/plugins/by-name/rest/default.nix
+++ b/plugins/by-name/rest/default.nix
@@ -40,6 +40,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
           Refer to the documentation for more information.
         ''
       )
+
+      # TODO: added 2025-04-06: remove after 25.05
+      (lib.nixvim.mkRemovedPackageOptionModule {
+        plugin = "rest";
+        packageName = "curl";
+      })
     ]
     ++
       map
@@ -207,10 +213,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraOptions = {
-    curlPackage = lib.mkPackageOption pkgs "curl" {
-      nullable = true;
-    };
-
     enableHttpFiletypeAssociation = lib.mkOption {
       type = types.bool;
       default = true;
@@ -300,7 +302,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
     globals.rest_nvim = cfg.settings;
 
-    extraPackages = [ cfg.curlPackage ];
+    dependencies.curl.enable = lib.mkDefault true;
 
     filetype = lib.mkIf cfg.enableHttpFiletypeAssociation {
       extension.http = "http";

--- a/plugins/by-name/rustaceanvim/default.nix
+++ b/plugins/by-name/rustaceanvim/default.nix
@@ -15,11 +15,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
   deprecateExtraOptions = true;
   optionsRenamedToSettings = import ./renamed-options.nix;
 
-  extraOptions = {
-    rustAnalyzerPackage = lib.mkPackageOption pkgs "rust-analyzer" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "godot";
+      packageName = "rust-analyzer";
+      oldPackageName = "rustAnalyzer";
+    })
+  ];
 
   settingsOptions = import ./settings-options.nix { inherit lib helpers pkgs; };
 
@@ -53,7 +56,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     cfg:
     mkMerge [
       {
-        extraPackages = [ cfg.rustAnalyzerPackage ];
+        dependencies.rust-analyzer.enable = lib.mkDefault true;
 
         globals.rustaceanvim = cfg.settings;
 

--- a/plugins/by-name/sg/default.nix
+++ b/plugins/by-name/sg/default.nix
@@ -1,4 +1,8 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  config,
+  ...
+}:
 let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts literalLua;
@@ -10,15 +14,20 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    nodePackage = lib.mkPackageOption pkgs "nodejs" {
-      nullable = true;
-      default = null;
-    };
-  };
-  extraConfig = cfg: {
-    plugins.sg.settings.node_executable = lib.mkIf (cfg.nodePackage != null) (
-      lib.mkDefault (lib.getExe cfg.nodePackage)
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "sg";
+      packageName = "nodejs";
+      oldPackageName = "node";
+    })
+  ];
+
+  extraConfig = {
+    dependencies.nodejs.enable = lib.mkDefault true;
+
+    plugins.sg.settings.node_executable = lib.mkIf config.dependencies.nodejs.enable (
+      lib.mkDefault (lib.getExe config.dependencies.nodejs.package)
     );
   };
 

--- a/plugins/by-name/tagbar/default.nix
+++ b/plugins/by-name/tagbar/default.nix
@@ -1,6 +1,4 @@
 {
-  helpers,
-  pkgs,
   lib,
   ...
 }:
@@ -12,6 +10,14 @@ lib.nixvim.plugins.mkVimPlugin {
 
   # TODO introduced 2024-02-12: remove 2024-04-12
   deprecateExtraConfig = true;
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "tagbar";
+      packageName = "ctags";
+      oldPackageName = "tags";
+    })
+  ];
 
   settingsExample = {
     position = "right";
@@ -30,13 +36,7 @@ lib.nixvim.plugins.mkVimPlugin {
     };
   };
 
-  extraOptions = {
-    tagsPackage = lib.mkPackageOption pkgs "ctags" {
-      nullable = true;
-    };
-  };
-
-  extraConfig = cfg: {
-    extraPackages = [ cfg.tagsPackage ];
+  extraConfig = {
+    dependencies.ctags.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/telescope/default.nix
+++ b/plugins/by-name/telescope/default.nix
@@ -37,6 +37,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
       ]
       "This option no longer has any effect now that the `plugin.telescope.keymaps` implementation uses `<cmd>`."
     )
+
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "telescope";
+      packageName = "bat";
+    })
   ];
 
   extraOptions = {
@@ -88,10 +94,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
         added to `extraPlugins`.
       '';
     };
-
-    batPackage = lib.mkPackageOption pkgs "bat" {
-      nullable = true;
-    };
   };
 
   callSetup = false;
@@ -109,7 +111,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       let $BAT_THEME = '${cfg.highlightTheme}'
     '';
 
-    extraPackages = [ cfg.batPackage ];
+    dependencies.bat.enable = lib.mkDefault true;
 
     keymaps = mapAttrsToList (
       key: mapping:

--- a/plugins/by-name/telescope/extensions/live-greps-args.nix
+++ b/plugins/by-name/telescope/extensions/live-greps-args.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -12,6 +11,19 @@ mkExtension {
   name = "live-grep-args";
   extensionName = "live_grep_args";
   package = "telescope-live-grep-args-nvim";
+
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = [
+        "telescope"
+        "extensions"
+        "live-grep-args"
+      ];
+      packageName = "ripgrep";
+      oldPackageName = "grep";
+    })
+  ];
 
   settingsOptions = {
     auto_quoting = defaultNullOpts.mkBool true ''
@@ -56,14 +68,7 @@ mkExtension {
     theme = "dropdown";
   };
 
-  extraOptions = {
-    grepPackage = lib.mkPackageOption pkgs "ripgrep" {
-      nullable = true;
-      example = "pkgs.gnugrep";
-    };
-  };
-
-  extraConfig = cfg: {
-    extraPackages = [ cfg.grepPackage ];
+  extraConfig = {
+    dependencies.ripgrep.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/telescope/extensions/manix.nix
+++ b/plugins/by-name/telescope/extensions/manix.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -11,6 +10,18 @@ in
 mkExtension {
   name = "manix";
   package = "telescope-manix";
+
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = [
+        "telescope"
+        "extensions"
+        "manix"
+      ];
+      packageName = "manix";
+    })
+  ];
 
   settingsOptions = {
     manix_args = defaultNullOpts.mkListOf lib.types.str [ ] "CLI arguments to pass to manix.";
@@ -24,13 +35,7 @@ mkExtension {
     cword = true;
   };
 
-  extraOptions = {
-    manixPackage = lib.mkPackageOption pkgs "manix" {
-      nullable = true;
-    };
-  };
-
-  extraConfig = cfg: {
-    extraPackages = [ cfg.manixPackage ];
+  extraConfig = {
+    dependencies.manix.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/texpresso/default.nix
+++ b/plugins/by-name/texpresso/default.nix
@@ -1,7 +1,5 @@
 {
   lib,
-  helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -14,11 +12,15 @@ lib.nixvim.plugins.mkVimPlugin {
 
   maintainers = [ maintainers.nickhu ];
 
-  extraOptions = {
-    texpressoPackage = lib.mkPackageOption pkgs "texpresso" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "texpresso";
+      packageName = "texpresso";
+    })
+  ];
 
-  extraConfig = cfg: { extraPackages = [ cfg.texpressoPackage ]; };
+  extraConfig = {
+    dependencies.texpresso.enable = lib.mkDefault true;
+  };
 }

--- a/plugins/by-name/tinygit/default.nix
+++ b/plugins/by-name/tinygit/default.nix
@@ -11,10 +11,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.GaetanLepage ];
 
   extraOptions = {
-    curlPackage = lib.mkPackageOption pkgs "curl" {
-      nullable = true;
-    };
-
     gitPackage = lib.mkPackageOption pkgs "git" {
       nullable = true;
     };
@@ -22,9 +18,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     extraPackages = [
-      cfg.curlPackage
       cfg.gitPackage
     ];
+    dependencies.curl.enable = lib.mkDefault true;
   };
 
   settingsExample = {

--- a/plugins/by-name/tinygit/default.nix
+++ b/plugins/by-name/tinygit/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 lib.nixvim.plugins.mkNeovimPlugin {
@@ -10,17 +9,11 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    gitPackage = lib.mkPackageOption pkgs "git" {
-      nullable = true;
-    };
-  };
-
   extraConfig = cfg: {
-    extraPackages = [
-      cfg.gitPackage
-    ];
-    dependencies.curl.enable = lib.mkDefault true;
+    dependencies = {
+      curl.enable = lib.mkDefault true;
+      git.enable = lib.mkDefault true;
+    };
   };
 
   settingsExample = {

--- a/plugins/by-name/todo-comments/default.nix
+++ b/plugins/by-name/todo-comments/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   config,
-  pkgs,
   ...
 }:
 with lib;
@@ -22,13 +21,19 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.khaneliman ];
 
-  # TODO: Added 2023-11-06, remove after 24.11
   imports = [
+    # TODO: Added 2023-11-06, remove after 24.11
     (mkRemovedOptionModule [
       "plugins"
       "todo-comments"
       "keymapsSilent"
     ] "Use `plugins.todo-comments.keymaps.<COMMAND>.options.silent`.")
+
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "todo-comments";
+      packageName = "ripgrep";
+    })
   ];
 
   # TODO: Added 2024-08-16, remove after 24.11
@@ -407,10 +412,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
           todoTrouble = "TodoTrouble";
           todoTelescope = "TodoTelescope";
         };
-
-    ripgrepPackage = lib.mkPackageOption pkgs "ripgrep" {
-      nullable = true;
-    };
   };
 
   extraConfig = cfg: {
@@ -431,7 +432,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       }
     ];
 
-    extraPackages = [ cfg.ripgrepPackage ];
+    dependencies.ripgrep.enable = lib.mkDefault true;
 
     keymaps = lib.pipe cfg.keymaps [
       (filterAttrs (n: keymap: keymap != null && keymap.key != null))

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -232,6 +232,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
       # TODO: added 2025-04-07, remove after 25.05
       (lib.nixvim.mkRemovedPackageOptionModule {
         plugin = "treesitter";
+        packageName = "gcc";
+      })
+      (lib.nixvim.mkRemovedPackageOptionModule {
+        plugin = "treesitter";
         packageName = "nodejs";
       })
       (lib.nixvim.mkRemovedPackageOptionModule {
@@ -370,12 +374,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
   extraOptions = {
     folding = mkEnableOption "tree-sitter based folding";
 
-    gccPackage = lib.mkPackageOption pkgs "gcc" {
-      nullable = true;
-      example = "pkgs.gcc14";
-      extraDescription = ''This is required to build grammars if you are not using `nixGrammars      '';
-    };
-
     grammarPackages = mkOption {
       type = with types; listOf package;
       default = config.plugins.treesitter.package.passthru.allGrammars;
@@ -449,11 +447,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
       pkg: pkg.withPlugins (_: cfg.grammarPackages)
     );
 
-    extraPackages = [
-      cfg.gccPackage
-    ];
-
     dependencies = lib.mkIf (!cfg.nixGrammars) {
+      gcc.enable = lib.mkDefault true;
       nodejs.enable = lib.mkDefault true;
       tree-sitter.enable = lib.mkDefault true;
     };
@@ -467,6 +462,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
           '';
         })
         [
+          "gcc"
           "nodejs"
           "tree-sitter"
         ]

--- a/plugins/by-name/typst-preview/default.nix
+++ b/plugins/by-name/typst-preview/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   config,
   ...
 }:
@@ -17,19 +16,17 @@ lib.nixvim.plugins.mkNeovimPlugin {
       plugin = "typst-preview";
       packageName = "tinymist";
     })
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "typst-preview";
+      packageName = "websocat";
+    })
   ];
 
-  extraOptions = {
-    websocatPackage = lib.mkPackageOption pkgs "websocat" {
-      nullable = true;
-    };
-  };
   extraConfig = cfg: {
-    extraPackages = [
-      cfg.websocatPackage
-    ];
-
-    dependencies.tinymist.enable = lib.mkDefault true;
+    dependencies = {
+      tinymist.enable = lib.mkDefault true;
+      websocat.enable = lib.mkDefault true;
+    };
 
     plugins.typst-preview.settings = {
       # Disable automatic downloading of binary dependencies
@@ -37,7 +34,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
         tinymist = lib.mkIf config.dependencies.tinymist.enable (
           lib.mkDefault (lib.getExe config.dependencies.tinymist.package)
         );
-        websocat = lib.mkIf (cfg.websocatPackage != null) (lib.mkDefault (lib.getExe cfg.websocatPackage));
+        websocat = lib.mkIf config.dependencies.websocat.enable (
+          lib.mkDefault (lib.getExe config.dependencies.websocat.package)
+        );
       };
     };
   };

--- a/plugins/by-name/typst-preview/default.nix
+++ b/plugins/by-name/typst-preview/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   pkgs,
+  config,
   ...
 }:
 lib.nixvim.plugins.mkNeovimPlugin {
@@ -10,24 +11,32 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "typst-preview";
+      packageName = "tinymist";
+    })
+  ];
+
   extraOptions = {
-    tinymistPackage = lib.mkPackageOption pkgs "tinymist" {
-      nullable = true;
-    };
     websocatPackage = lib.mkPackageOption pkgs "websocat" {
       nullable = true;
     };
   };
   extraConfig = cfg: {
     extraPackages = [
-      cfg.tinymistPackage
       cfg.websocatPackage
     ];
+
+    dependencies.tinymist.enable = lib.mkDefault true;
 
     plugins.typst-preview.settings = {
       # Disable automatic downloading of binary dependencies
       dependencies_bin = {
-        tinymist = lib.mkIf (cfg.tinymistPackage != null) (lib.mkDefault (lib.getExe cfg.tinymistPackage));
+        tinymist = lib.mkIf config.dependencies.tinymist.enable (
+          lib.mkDefault (lib.getExe config.dependencies.tinymist.package)
+        );
         websocat = lib.mkIf (cfg.websocatPackage != null) (lib.mkDefault (lib.getExe cfg.websocatPackage));
       };
     };

--- a/plugins/by-name/typst-vim/default.nix
+++ b/plugins/by-name/typst-vim/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   helpers,
-  pkgs,
   ...
 }:
 with lib;
@@ -20,13 +19,15 @@ lib.nixvim.plugins.mkVimPlugin {
     "concealMath"
     "autoCloseToc"
   ];
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "typst-vim";
+      packageName = "typst";
+    })
+  ];
 
   extraOptions = {
-    # Add the typst compiler to nixvim packages
-    typstPackage = lib.mkPackageOption pkgs "typst" {
-      nullable = true;
-    };
-
     keymaps = {
       silent = mkOption {
         type = types.bool;
@@ -39,7 +40,7 @@ lib.nixvim.plugins.mkVimPlugin {
   };
 
   extraConfig = cfg: {
-    extraPackages = [ cfg.typstPackage ];
+    dependencies.typst.enable = lib.mkDefault true;
 
     keymaps =
       with cfg.keymaps;

--- a/plugins/by-name/vimux/default.nix
+++ b/plugins/by-name/vimux/default.nix
@@ -1,18 +1,20 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "vimux";
   globalPrefix = "Vimux";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 
-  extraOptions = {
-    tmuxPackage = lib.mkPackageOption pkgs "tmux" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "tmux";
+      packageName = "tmux";
+    })
+  ];
 
-  extraConfig = cfg: {
-    extraPackages = [ cfg.tmuxPackage ];
+  extraConfig = {
+    dependencies.tmux.enable = lib.mkDefault true;
   };
 
   settingsOptions = import ./settings-options.nix lib;

--- a/plugins/by-name/wezterm/default.nix
+++ b/plugins/by-name/wezterm/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -13,11 +12,13 @@ lib.nixvim.plugins.neovim.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.khaneliman ];
 
-  extraOptions = {
-    weztermPackage = lib.mkPackageOption pkgs "wezterm" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "wezterm";
+      packageName = "wezterm";
+    })
+  ];
 
   settingsOptions = {
     create_commands = defaultNullOpts.mkBool true ''
@@ -29,9 +30,7 @@ lib.nixvim.plugins.neovim.mkNeovimPlugin {
     create_commands = false;
   };
 
-  extraConfig = cfg: {
-    extraPackages = [
-      cfg.weztermPackage
-    ];
+  extraConfig = {
+    dependencies.wezterm.enable = lib.mkDefault true;
   };
 }

--- a/plugins/by-name/yazi/default.nix
+++ b/plugins/by-name/yazi/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pkgs,
   ...
 }:
 let
@@ -22,14 +21,16 @@ lib.nixvim.plugins.mkNeovimPlugin {
     See the [upstream docs](https://github.com/mikavilpas/yazi.nvim?tab=readme-ov-file#%EF%B8%8F-keybindings) for details.
   '';
 
-  extraOptions = {
-    yaziPackage = lib.mkPackageOption pkgs "yazi" {
-      nullable = true;
-    };
-  };
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "yazi";
+      packageName = "yazi";
+    })
+  ];
 
-  extraConfig = cfg: {
-    extraPackages = [ cfg.yaziPackage ];
+  extraConfig = {
+    dependencies.yazi.enable = lib.mkDefault true;
   };
 
   settingsOptions = {

--- a/plugins/by-name/zk/default.nix
+++ b/plugins/by-name/zk/default.nix
@@ -2,7 +2,6 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
@@ -30,6 +29,13 @@ lib.nixvim.plugins.mkNeovimPlugin {
       "autoAttach"
       "filetypes"
     ]
+  ];
+  imports = [
+    # TODO: added 2025-04-07, remove after 25.05
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "zk";
+      packageName = "zk";
+    })
   ];
 
   settingsOptions = {
@@ -107,13 +113,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   };
 
-  extraOptions = {
-    zkPackage = lib.mkPackageOption pkgs "zk" {
-      nullable = true;
-    };
-  };
   extraConfig = cfg: {
-    extraPackages = [ cfg.zkPackage ];
+    dependencies.zk.enable = lib.mkDefault true;
 
     warnings = lib.nixvim.mkWarnings "plugins.zk" (
       mapAttrsToList

--- a/plugins/cmp/sources/default.nix
+++ b/plugins/cmp/sources/default.nix
@@ -58,8 +58,16 @@ let
       pluginName = "cmp-fish";
       sourceName = "fish";
 
-      extraOptions.fishPackage = lib.mkPackageOption pkgs "fish" { nullable = true; };
-      extraConfig = cfg: { extraPackages = [ cfg.fishPackage ]; };
+      imports = [
+        # TODO: added 2025-04-07, remove after 25.05
+        (lib.nixvim.mkRemovedPackageOptionModule {
+          plugin = "cmp-fish";
+          packageName = "fish";
+        })
+      ];
+      extraConfig = {
+        dependencies.fish.enable = lib.mkDefault true;
+      };
     }
     {
       pluginName = "cmp-fuzzy-buffer";

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -14,13 +14,19 @@ let
       settings = cfg: { dart = cfg; };
     };
     gopls = {
-      extraOptions = {
-        goPackage = lib.mkPackageOption pkgs "go" {
-          nullable = true;
-        };
-      };
-      extraConfig = cfg: {
-        extraPackages = [ cfg.goPackage ];
+      imports = [
+        # TODO: added 2025-04-07, remove after 25.05
+        (lib.nixvim.mkRemovedPackageOptionModule {
+          plugin = [
+            "lsp"
+            "servers"
+            "gopls"
+          ];
+          packageName = "go";
+        })
+      ];
+      extraConfig = {
+        dependencies.go.enable = lib.mkDefault true;
       };
     };
     idris2_lsp = {

--- a/plugins/pluginmanagers/lazy.nix
+++ b/plugins/pluginmanagers/lazy.nix
@@ -37,6 +37,14 @@ let
   lazyPath = pkgs.linkFarm "lazy-plugins" processedPlugins;
 in
 {
+  # TODO: added 2025-04-06, remove after 25.05
+  imports = [
+    (lib.nixvim.mkRemovedPackageOptionModule {
+      plugin = "lazy";
+      packageName = "git";
+    })
+  ];
+
   options = {
     plugins.lazy = {
       enable = mkEnableOption "lazy.nvim";
@@ -45,10 +53,6 @@ in
         "vimPlugins"
         "lazy-nvim"
       ] { };
-
-      gitPackage = lib.mkPackageOption pkgs "git" {
-        nullable = true;
-      };
 
       plugins =
         with types;
@@ -162,7 +166,7 @@ in
   config = mkIf cfg.enable {
     extraPlugins = [ cfg.package ];
 
-    extraPackages = [ cfg.gitPackage ];
+    dependencies.git.enable = lib.mkDefault true;
 
     extraConfigLua =
       let

--- a/tests/test-sources/modules/dependencies.nix
+++ b/tests/test-sources/modules/dependencies.nix
@@ -1,0 +1,23 @@
+{
+  override =
+    { pkgs, ... }:
+    {
+      dependencies.git = {
+        enable = true;
+        package = pkgs.gitMinimal;
+      };
+    };
+
+  all =
+    {
+      lib,
+      pkgs,
+      options,
+      ...
+    }:
+    {
+      dependencies = lib.mapAttrs (_: depOption: {
+        enable = lib.meta.availableOn pkgs.stdenv.hostPlatform depOption.package.default;
+      }) options.dependencies;
+    };
+}

--- a/tests/test-sources/plugins/by-name/committia/default.nix
+++ b/tests/test-sources/plugins/by-name/committia/default.nix
@@ -21,9 +21,8 @@
   };
 
   no-packages = {
-    plugins.committia = {
-      enable = true;
-      gitPackage = null;
-    };
+    plugins.committia.enable = true;
+
+    dependencies.git.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/direnv/default.nix
+++ b/tests/test-sources/plugins/by-name/direnv/default.nix
@@ -16,9 +16,8 @@
   };
 
   no-packages = {
-    plugins.direnv = {
-      enable = true;
-      direnvPackage = null;
-    };
+    plugins.direnv.enable = true;
+
+    dependencies.direnv.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/git-worktree/default.nix
+++ b/tests/test-sources/plugins/by-name/git-worktree/default.nix
@@ -33,9 +33,8 @@
   };
 
   no-packages = {
-    plugins.git-worktree = {
-      enable = true;
-      gitPackage = null;
-    };
+    dependencies.git.enable = false;
+
+    plugins.git-worktree.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/gitgutter/default.nix
+++ b/tests/test-sources/plugins/by-name/gitgutter/default.nix
@@ -84,13 +84,15 @@
     {
       plugins.gitgutter = {
         enable = true;
-        gitPackage = null;
         grepPackage = null;
         settings = {
           git_executable = lib.getExe pkgs.git;
           grep = lib.getExe pkgs.gnugrep;
         };
       };
+
+      dependencies.git.enable = false;
+
       assertions = [
         {
           assertion = lib.all (x: x.pname or null != "git") config.extraPackages;

--- a/tests/test-sources/plugins/by-name/glow/default.nix
+++ b/tests/test-sources/plugins/by-name/glow/default.nix
@@ -1,4 +1,3 @@
-{ pkgs, ... }:
 {
   empty = {
     plugins.glow.enable = true;
@@ -7,8 +6,6 @@
   defaults = {
     plugins.glow = {
       enable = true;
-
-      glowPackage = pkgs.glow;
 
       settings = {
         glow_path.__raw = "vim.fn.exepath('glow')";

--- a/tests/test-sources/plugins/by-name/image/default.nix
+++ b/tests/test-sources/plugins/by-name/image/default.nix
@@ -92,10 +92,12 @@
   no-packages = {
     test.runNvim = false;
 
+    dependencies = {
+      curl.enable = false;
+    };
     plugins.image = {
       enable = true;
       settings.backend = "kitty";
-      curlPackage = null;
       ueberzugPackage = null;
     };
   };

--- a/tests/test-sources/plugins/by-name/image/default.nix
+++ b/tests/test-sources/plugins/by-name/image/default.nix
@@ -94,11 +94,11 @@
 
     dependencies = {
       curl.enable = false;
+      ueberzug.enable = false;
     };
     plugins.image = {
       enable = true;
       settings.backend = "kitty";
-      ueberzugPackage = null;
     };
   };
 }

--- a/tests/test-sources/plugins/by-name/llm/default.nix
+++ b/tests/test-sources/plugins/by-name/llm/default.nix
@@ -9,9 +9,9 @@
     plugins.llm = {
       enable = true;
 
-      llmLsPackage = null;
       settings.lsp.bin_path = null;
     };
+    dependencies.llm-ls.enable = false;
   };
 
   defaults = {

--- a/tests/test-sources/plugins/by-name/lualine/default.nix
+++ b/tests/test-sources/plugins/by-name/lualine/default.nix
@@ -152,9 +152,8 @@
   };
 
   no-packages = {
-    plugins.lualine = {
-      enable = true;
-      gitPackage = null;
-    };
+    plugins.lualine.enable = true;
+
+    dependencies.git.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/neo-tree/default.nix
+++ b/tests/test-sources/plugins/by-name/neo-tree/default.nix
@@ -441,11 +441,12 @@
   };
 
   no-packages = {
-    plugins.web-devicons.enable = false;
-    plugins.neo-tree = {
-      enable = true;
-      gitPackage = null;
+    plugins = {
+      web-devicons.enable = true;
+      neo-tree.enable = true;
     };
+
+    dependencies.git.enable = false;
   };
 
   no-icons = {

--- a/tests/test-sources/plugins/by-name/neogit/default.nix
+++ b/tests/test-sources/plugins/by-name/neogit/default.nix
@@ -296,8 +296,9 @@
   no-packages = {
     plugins.neogit = {
       enable = true;
-      gitPackage = null;
       whichPackage = null;
     };
+
+    dependencies.git.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/neogit/default.nix
+++ b/tests/test-sources/plugins/by-name/neogit/default.nix
@@ -294,11 +294,11 @@
   };
 
   no-packages = {
-    plugins.neogit = {
-      enable = true;
-      whichPackage = null;
-    };
+    plugins.neogit.enable = true;
 
-    dependencies.git.enable = false;
+    dependencies = {
+      git.enable = false;
+      which.enable = false;
+    };
   };
 }

--- a/tests/test-sources/plugins/by-name/nvim-tree/default.nix
+++ b/tests/test-sources/plugins/by-name/nvim-tree/default.nix
@@ -260,10 +260,11 @@
   };
 
   no-packages = {
-    plugins.web-devicons.enable = true;
-    plugins.nvim-tree = {
-      enable = true;
-      gitPackage = null;
+    plugins = {
+      web-devicons.enable = true;
+      nvim-tree.enable = true;
     };
+
+    dependencies.git.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/octo/default.nix
+++ b/tests/test-sources/plugins/by-name/octo/default.nix
@@ -103,10 +103,11 @@
   no-packages = {
     # Need to add gh executable to runtime path for plugin
     test.runNvim = false;
-    plugins.web-devicons.enable = false;
-    plugins.octo = {
-      enable = true;
-      ghPackage = null;
+
+    plugins = {
+      web-devicons.enable = false;
+      octo.enable = true;
     };
+    dependencies.gh.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/pckr/default.nix
+++ b/tests/test-sources/plugins/by-name/pckr/default.nix
@@ -118,9 +118,8 @@
   };
 
   no-packages = {
-    plugins.pckr = {
-      enable = true;
-      gitPackage = null;
-    };
+    plugins.pckr.enable = true;
+
+    dependencies.git.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/spectre/default.nix
+++ b/tests/test-sources/plugins/by-name/spectre/default.nix
@@ -1,15 +1,6 @@
-{ pkgs, ... }:
 {
   empty = {
     plugins.spectre.enable = true;
-  };
-
-  package-options-manual = {
-    plugins.spectre = {
-      enable = true;
-
-      replacePackage = pkgs.gnused;
-    };
   };
 
   package-options-from-settings = {

--- a/tests/test-sources/plugins/by-name/spectre/default.nix
+++ b/tests/test-sources/plugins/by-name/spectre/default.nix
@@ -8,7 +8,6 @@
     plugins.spectre = {
       enable = true;
 
-      findPackage = pkgs.ripgrep;
       replacePackage = pkgs.gnused;
     };
   };

--- a/tests/test-sources/plugins/by-name/tagbar/default.nix
+++ b/tests/test-sources/plugins/by-name/tagbar/default.nix
@@ -53,9 +53,8 @@
   };
 
   no-packages = {
-    plugins.tagbar = {
-      enable = true;
-      tagsPackage = null;
-    };
+    plugins.tagbar.enable = true;
+
+    dependencies.ctags.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/default.nix
+++ b/tests/test-sources/plugins/by-name/telescope/default.nix
@@ -35,11 +35,11 @@
   };
 
   no-packages = {
-    plugins.web-devicons.enable = false;
-    plugins.telescope = {
-      enable = true;
-      batPackage = null;
+    plugins = {
+      web-devicons.enable = false;
+      telescope.enable = true;
     };
+    dependencies.bat.enable = false;
   };
 
   mini-icons = {

--- a/tests/test-sources/plugins/by-name/telescope/live-grep-args.nix
+++ b/tests/test-sources/plugins/by-name/telescope/live-grep-args.nix
@@ -49,26 +49,26 @@
   };
 
   custom-packages = {
-    plugins.telescope = {
-      enable = true;
-
-      extensions.live-grep-args = {
+    plugins = {
+      telescope = {
         enable = true;
-        grepPackage = pkgs.gnugrep;
+
+        extensions.live-grep-args.enable = true;
       };
+      web-devicons.enable = true;
     };
-    plugins.web-devicons.enable = true;
+    dependencies.ripgrep.package = pkgs.gnugrep;
   };
 
   no-packages = {
-    plugins.telescope = {
-      enable = true;
-
-      extensions.live-grep-args = {
+    plugins = {
+      telescope = {
         enable = true;
-        grepPackage = null;
+
+        extensions.live-grep-args.enable = true;
       };
+      web-devicons.enable = false;
     };
-    plugins.web-devicons.enable = false;
+    dependencies.ripgrep.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/manix.nix
+++ b/tests/test-sources/plugins/by-name/telescope/manix.nix
@@ -40,14 +40,15 @@
   };
 
   no-packages = {
-    plugins.telescope = {
-      enable = true;
-
-      extensions.manix = {
+    plugins = {
+      telescope = {
         enable = true;
-        manixPackage = null;
+
+        extensions.manix.enable = true;
       };
+      web-devicons.enable = false;
     };
-    plugins.web-devicons.enable = false;
+
+    dependencies.manix.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/todo-comments/default.nix
+++ b/tests/test-sources/plugins/by-name/todo-comments/default.nix
@@ -191,11 +191,9 @@
     };
 
   without-ripgrep = {
-    plugins.todo-comments = {
-      enable = true;
+    plugins.todo-comments.enable = true;
 
-      ripgrepPackage = null;
-    };
+    dependencies.ripgrep.enable = false;
   };
 
   highlight-pattern-list = {

--- a/tests/test-sources/plugins/by-name/typst-vim/default.nix
+++ b/tests/test-sources/plugins/by-name/typst-vim/default.nix
@@ -22,9 +22,7 @@
   };
 
   no-packages = {
-    plugins.typst-vim = {
-      enable = true;
-      typstPackage = null;
-    };
+    plugins.typst-vim.enable = true;
+    dependencies.typst.enable = false;
   };
 }

--- a/tests/test-sources/plugins/by-name/wezterm/default.nix
+++ b/tests/test-sources/plugins/by-name/wezterm/default.nix
@@ -1,23 +1,15 @@
 {
-  empty =
-    { pkgs, ... }:
-    {
-      plugins.wezterm = {
-        enable = true;
-        weztermPackage = pkgs.wezterm;
+  empty = {
+    plugins.wezterm.enable = true;
+  };
+
+  defaults = {
+    plugins.wezterm = {
+      enable = true;
+
+      settings = {
+        create_commands = true;
       };
     };
-
-  defaults =
-    { pkgs, ... }:
-    {
-      plugins.wezterm = {
-        enable = true;
-        weztermPackage = pkgs.wezterm;
-
-        settings = {
-          create_commands = true;
-        };
-      };
-    };
+  };
 }

--- a/tests/test-sources/plugins/pluginmanagers/lazy.nix
+++ b/tests/test-sources/plugins/pluginmanagers/lazy.nix
@@ -91,9 +91,7 @@
   };
 
   no-packages = {
-    plugins.lazy = {
-      enable = true;
-      gitPackage = null;
-    };
+    dependencies.git.enable = false;
+    plugins.lazy.enable = true;
   };
 }


### PR DESCRIPTION
## Motivation

Currently, we manage "dependencies" (i.e. executable packages needed for certain plugins to work) by adding a `plugins.<PLUGIN>.fooPackage` `null`able option.
The issue is that we now have several of these options for the same package (`git` for instance) distributed across the code-base.

So, a user wanting to swap `pkgs.git` for `pkgs.gitMinimal` in his Nixvim closure would have to look for all instances of `gitPackage` options and set them to `pkgs.gitMinimal`.
It would be better to centralize this dependency management.

## Solution

Substitute these options for a `dependencies` top-level module.
Each attribute under `dependencies` is itself an attrs containing two options: `enable` (to install the package) and `package` to customize which package is installed:

```nix
dependencies = {
  git.package = pkgs.gitMinimal;
  curl.enable = false;
};
```

On the plugin module side, this change requires:
- Removing the declarations of the `plugins.*.fooPackage` options.
- Adding a _deprecation module_ (`mkRemovedOptionModule`) for each of the `plugins.*.fooPackage` options removed.
- Replacing `extraPackages = [ cfg.fooPackage ];` with `dependencies.foo.enable = lib.mkDefault true;`
    _Note:_ Later, we can add an argument to `mk{Neovim,Vim}Plugin`: `dependencies = ["foo"];` that would abstract this.


## PR content

- **modules/dependencies: init + add curl**
- **modules/dependencies: add ueberzug**
- **modules/dependencies: add git**
