### PR TITLE
plugins/modicator: init

### DIFF
--- a/plugins/by-name/modicator/default.nix
+++ b/plugins/by-name/modicator/default.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "modicator";
+  packPathName = "modicator.nvim";
+  package = "modicator-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  extraConfig = {
+    opts = {
+      termguicolors = lib.mkDefault true;
+      cursorline = lib.mkDefault true;
+      number = lib.mkDefault true;
+    };
+  };
+
+  settingsExample = {
+    show_warnings = true;
+    highlights = {
+      defaults = {
+        bold = false;
+        italic = false;
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/modicator/default.nix
+++ b/tests/test-sources/plugins/by-name/modicator/default.nix
@@ -1,0 +1,45 @@
+{
+  empty = {
+    plugins.modicator.enable = true;
+  };
+
+  default = {
+    plugins.modicator = {
+      enable = true;
+
+      settings = {
+        show_warnings = false;
+        highlights = {
+          defaults = {
+            bold = false;
+            italic = false;
+          };
+          use_cursorline_background = false;
+        };
+        integration = {
+          lualine = {
+            enabled = true;
+            mode_section = null;
+            highlight = "bg";
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.modicator = {
+      enable = true;
+
+      settings = {
+        show_warnings = true;
+        highlights = {
+          defaults = {
+            bold = false;
+            italic = false;
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [modicator.nvim](https://github.com/mawkler/modicator.nvim), a cursor line number mode indicator plugin.

Closes #3135
