### PR TITLE
plugins/spider: include luautf8

### DIFF
--- a/plugins/by-name/spider/default.nix
+++ b/plugins/by-name/spider/default.nix
@@ -70,6 +70,7 @@ in
     in
     mkIf cfg.enable {
       extraPlugins = [ cfg.package ];
+      extraLuaPackages = luaPkgs: [ luaPkgs.luautf8 ];
 
       keymaps = mappings;
 


### PR DESCRIPTION
spider [needs luautf8](https://github.com/chrisgrieser/nvim-spider?tab=readme-ov-file#utf-8-support) for UTF-8 support. this has been driving me nuts with german umlauts :smile: 