### PR TITLE
plugins/treesitter: fix `treesitterPackage` deprecation message; modules/deprecation: improve mkRemovedPackageOptionModule impl

### DIFF
--- a/lib/deprecation.nix
+++ b/lib/deprecation.nix
@@ -129,12 +129,23 @@ rec {
       packageName,
       oldPackageName ? packageName,
     }:
+    { options, ... }:
     let
-      optionPath = [ "plugins" ] ++ (lib.toList plugin) ++ [ "${oldPackageName}Package" ];
+      oldOptionPath = builtins.concatMap lib.toList [
+        "plugins"
+        plugin
+        "${oldPackageName}Package"
+      ];
+      depOption = options.dependencies.${packageName};
+      depOptionLoc = lib.dropEnd 1 depOption.enable.loc;
+
+      instructions = ''
+        Please use the `${lib.showOption depOptionLoc}` top-level option instead:
+        - `${depOption.enable} = false` to disable installing `${packageName}`
+        - `${depOption.package}` to choose which package to install for `${packageName}`.
+      '';
     in
-    lib.mkRemovedOptionModule optionPath ''
-      Please use the `dependencies.${packageName}` top-level option instead:
-      - `dependencies.${packageName}.enable = false` to disable installing `${packageName}`
-      - `dependencies.${packageName}.package` to choose which package to install for `${packageName}`.
-    '';
+    {
+      imports = [ (lib.mkRemovedOptionModule oldOptionPath instructions) ];
+    };
 }

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -240,7 +240,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
       })
       (lib.nixvim.mkRemovedPackageOptionModule {
         plugin = "treesitter";
-        packageName = "treesitter";
+        packageName = "tree-sitter";
+        oldPackageName = "treesitter";
       })
     ];
 


### PR DESCRIPTION
- **plugins/treesitter: fix `treesitterPackage` deprecation warning**
  Fix the issue reported by @SuperSandro2000 [on matrix](https://matrix.to/#/!iBrKeqhFRZaBBGodLH:matrix.org/$9eSGQIDaa0a4Wx5_cTh6sXxcBkPM2wH6t-C-0wTdVvI?via=matrix.org&via=vhack.eu&via=familleboyer.net).
  `dependencies.treesitter` should be `dependencies.tree-sitter`.

- **plugins/treesitter: cleanup build-grammar deps impl**
  Minor improvements to the impl.

- **lib/deprecations: use real option paths in `mkRemovedPackageOptionModule`**
  Minor improvements to the deprecation notice; use the actual option `loc`s that include `prefix` etc.

- **lib/deprecations: assert option is correct in `mkRemovedPackageOptionModule`**
  109f47f561cd08473da53205c2d06f9c0fc9dd06
  This commit ~~can be~~ _(has been)_ dropped, it was included to ensure there are no other issues treewide. It seems unlikely we'll introduce new uses of `mkRemovedPackageOptionModule`, so no need to keep the regression-check assertion.
