### PR TITLE
modules/dependencies: refactor `all-examples` test

### DIFF
--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -18,13 +18,13 @@ let
     flutter.default = "flutter";
     fzf = {
       default = "fzf";
-      example = "pkgs.skim";
+      example = "skim";
     };
     gcc.default = "gcc";
     gh.default = "gh";
     git = {
       default = "git";
-      example = [ "gitMinimal" ];
+      example = "gitMinimal";
     };
     glow.default = "glow";
     go.default = "go";
@@ -36,7 +36,7 @@ let
     manix.default = "manix";
     nodejs = {
       default = "nodejs";
-      example = "pkgs.nodejs_22";
+      example = "nodejs_22";
     };
     plantuml.default = "plantuml";
     ripgrep.default = "ripgrep";
@@ -64,7 +64,21 @@ let
   mkDependencyOption = name: properties: {
     enable = lib.mkEnableOption "Add ${name} to dependencies.";
 
-    package = lib.mkPackageOption pkgs name properties;
+    package =
+      lib.mkPackageOption pkgs name properties
+      # Handle example manually so that we can embed the original attr-path within
+      # the literalExpression object. This simplifies testing the examples.
+      // lib.optionalAttrs (properties ? example) {
+        example =
+          if properties.example._type or null == "literalExpression" then
+            properties.example
+          else
+            rec {
+              _type = "literalExpression";
+              text = "pkgs.${lib.showAttrPath path}";
+              path = lib.toList properties.example;
+            };
+      };
   };
 in
 {

--- a/tests/test-sources/modules/dependencies.nix
+++ b/tests/test-sources/modules/dependencies.nix
@@ -30,12 +30,14 @@
     }:
     {
       dependencies = lib.pipe options.dependencies [
-        (lib.filterAttrs (_: depOption: depOption.package ? example))
+        # We use a literalExpression example, with an additional `path` attr.
+        # This means we don't have to convert human readable paths back to list-paths for this test.
+        (lib.filterAttrs (_: depOption: depOption.package ? example.path))
         (lib.mapAttrs (
           _: depOption:
           let
-            packageName = depOption.package.example.text;
-            packagePath = lib.splitString "." packageName;
+            packagePath = depOption.package.example.path;
+            packageName = lib.showAttrPath packagePath;
             package = lib.attrByPath packagePath (throw "${packageName} not found in pkgs") pkgs;
           in
           {


### PR DESCRIPTION
Follow up to #3174

Embed the actual package as an attr in the `example`'s literal expression, so that we don't need to convert to and from human-readable attr paths in the test.

This also fixes the "foo not found in pkgs" error from incorrectly saying "pkgs.foo not found in pkgs" and looking up `pkgs.pkgs.foo` for the actual package.

Additionally, this means that weird edge-cases (like packages with non-alphabetic chars in their attr-path) will be handled correctly.
