### PR TITLE
plugins/molten: add ipykernel python dependency

### DIFF
--- a/plugins/by-name/molten/default.nix
+++ b/plugins/by-name/molten/default.nix
@@ -224,6 +224,7 @@ mkVimPlugin {
           cairosvg
           ipython
           nbformat
+          ipykernel
         ];
       defaultText = literalExpression ''
         p: with p; [
@@ -232,6 +233,7 @@ mkVimPlugin {
           cairosvg
           ipython
           nbformat
+          ipykernel
         ]
       '';
       description = "Python packages to add to the `PYTHONPATH` of neovim.";


### PR DESCRIPTION
Without this dependency, commands like `:MoltenInit` causes the error message "[Molten] Unable to find any kernels to launch"

It seems like people (including myself) are implementing workarounds to this missing dep:

https://github.com/alisonjenkins/neovim-nix-flake/pull/51/commits/8b2b387b3d0d3fab465c81a662ed1240e99a2703

https://gitlab.com/p6s/vi/-/commit/792df862ea6f1a60683d3a870ea2593aa2533e36

Let's just include it with the default list of extra python dependencies.