### PR TITLE
lib/deprecation: implement aliases for `mkRemovedPackageOptionModule`

### DIFF
--- a/tests/test-sources/modules/dependencies.nix
+++ b/tests/test-sources/modules/dependencies.nix
@@ -47,4 +47,48 @@
         ))
       ];
     };
+
+  # Integration test for `lib.nixvim.deprecation.mkRemovedPackageOptionModule`
+  removed-package-options =
+    {
+      lib,
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      test = {
+        buildNixvim = false;
+        warnings = expect: [
+          (expect "count" 2)
+
+          (expect "any" "The option `plugins.chatgpt.curlPackage' defined in `")
+          (expect "any" "has been replaced by `dependencies.curl.enable' and `dependencies.curl.package'.")
+
+          (expect "any" "The option `plugins.glow.glowPackage' defined in `")
+        ];
+      };
+
+      plugins.chatgpt.curlPackage = null;
+      plugins.glow.glowPackage = pkgs.hello;
+
+      assertions = [
+        {
+          assertion = !lib.elem pkgs.curl config.extraPackages;
+          message = "Expected curl not to be installed.";
+        }
+        {
+          assertion = config.dependencies.glow.enable;
+          message = "Expected `dependencies.glow` to be enabled.";
+        }
+        {
+          assertion = lib.elem pkgs.hello config.extraPackages;
+          message = "Expected hello to be installed.";
+        }
+        {
+          assertion = !lib.elem pkgs.glow config.extraPackages;
+          message = "Expected glow not to be installed.";
+        }
+      ];
+    };
 }


### PR DESCRIPTION
Follow up to https://github.com/nix-community/nixvim/pull/3162, in particular https://github.com/nix-community/nixvim/pull/3162#discussion_r2031191608.

Allows most existing configs to continue building; defining or reading the old `plugins.*.*Package` options will now continue to work, but result in a warning.

An error is still possible when definitions cannot be merged. E.g: \
`plugins.a.fooPackage = null` and `plugins.b.fooPackage = pkgs.foo` would effectively result in `dependencies.foo.enable = mkMerge [ true false ]`.

Generally, `plugins.a.fooPackage = null` will be an alias for `dependencies.foo.enable = false` while `plugins.a.fooPackage = pkgs.foo` is an alias for `dpendencies.foo.enable = true` and `dependencies.foo.package = pkgs.foo`.

The alias is two-way; if a user _reads_ `plugins.a.fooPackage` they will actually see `if config.dependencies.foo.enable then config.dependencies.foo.package else null` (with a warning).

The alias respects override priority; if a user has `plugins.a.fooPackage = lib.mkDefault null` and `dependencies.foo.enable = true` the final value will be `true`. There may be some edge-cases I missed here, due to the alias involving three options instead of two; test case ideas welcome.


For reference, the implementation is based on [`lib.modules.doRename`](https://github.com/NixOS/nixpkgs/blob/9b78090fc935666a67fd6d2313b08bfa4ae6f8de/lib/modules.nix#L1748-L1855) _(the underlying impl used by `mkRenamedOptionModule`)_ and is conceptually similar to [`lib.modules.mkChangedOptionModule`](https://github.com/NixOS/nixpkgs/blob/9b78090fc935666a67fd6d2313b08bfa4ae6f8de/lib/modules.nix#L1649-L1689).

