### PR TITLE
Typo fix at blink-cmp 

### DIFF
--- a/plugins/by-name/blink-cmp/settings-options.nix
+++ b/plugins/by-name/blink-cmp/settings-options.nix
@@ -263,7 +263,7 @@ in
       '';
 
       max_height = defaultNullOpts.mkUnsignedInt 10 ''
-        Maximum width of the completion menu.
+        Maximum height of the completion menu.
       '';
 
       border = defaultNullOpts.mkNullable types.anything "none" ''


### PR DESCRIPTION
"max_height" parameter had maximum width in description 