### PR TITLE
contributing: reduce emphasis on `settingsOptions`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,8 @@ list-plugins -k vim
 > Declaring `settings`-options is **not required**, because the `settings` option is a freeform type.
 >
 > While `settings` options can be helpful for documentation and type-checking purposes, this is a double-edged sword because we have to ensure the options are correctly typed and documented to avoid unnecessary restrictions or confusion.
+>
+> We usually recommend **not** declaring `settings` options, however there are exceptions where the trade-off is worth it.
 
 > [!TIP]
 > Learn more about the [RFC 42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) which motivated this new approach.

--- a/plugins/TEMPLATE.nix
+++ b/plugins/TEMPLATE.nix
@@ -1,7 +1,4 @@
 { lib, ... }:
-let
-  inherit (lib.nixvim) defaultNullOpts;
-in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "my-plugin";
   moduleName = "my-plugin"; # TODO replace (or remove entirely if it is the same as `name`)
@@ -10,18 +7,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.MyName ]; # TODO replace with your name
 
-  # Optionally, explicitly declare some options. You don't have to.
-  settingsOptions = {
-    foo = defaultNullOpts.mkUnsignedInt 97 ''
-      The best birth year.
-    '';
-
-    great_feature = defaultNullOpts.mkBool false ''
-      Whether to enable the great feature.
-    '';
-  };
-
-  # Optionally, provide an example for the `settings` option.
+  # TODO provide an example for the `settings` option (or remove entirely if there is no useful example)
+  # NOTE you can use `lib.literalExpression` or `lib.literalMD` if needed
   settingsExample = {
     foo = 42;
     bar.__raw = "function() print('hello') end";


### PR DESCRIPTION
Seeing as we are (now) often advising contributors to remove the `settingsOptions` they have already spent time and effort writing, I think we should reduce the emphasis on this in our contributing guide & plugin template.

- Add an additional caution in `CONTRIBUTING.md#declaring-plugin-options`
- Remove `settingsOptions` from `plugins/TEMPLATE.nix`

