### PR TITLE
Revert "tests/lsp: disable golangci_lint_ls"

### DIFF
--- a/tests/lsp-servers.nix
+++ b/tests/lsp-servers.nix
@@ -38,11 +38,6 @@ let
     let
       disabled =
         [
-          # TODO: 2025-03-26 build failure
-          # https://github.com/nametake/golangci-lint-langserver/issues/51
-          # https://github.com/nametake/golangci-lint-langserver/pull/52
-          "golangci_lint_ls"
-
           # DEPRECATED SERVERS
           # See https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig.lua
           "ruff_lsp"


### PR DESCRIPTION
This reverts commit e1e0e6f0240327143d82086ccff5142b0f463685.
