### PR TITLE
docs: fix typo

### DIFF
--- a/docs/mdbook/index.md
+++ b/docs/mdbook/index.md
@@ -20,7 +20,7 @@ Documentation is currently available for the following versions:
 
 ## Welcome to the docs!
 
-Over to the left, you'll find the sidebar. There you'll see several "User guides" (including an [FAQ](./user-guide/faq.md)]), along with pages for various "options".
+Over to the left, you'll find the sidebar. There you'll see several "User guides" (including an [FAQ](./user-guide/faq.md)), along with pages for various "options".
 
 While you can search our main docs using the <i class="fa fa-search"></i> icon, if you're looking for a specific option you may find the dedicated [Nixvim Option Search](./search/index.html) (at the bottom of the sidebar) has more relevant results.
 


### PR DESCRIPTION
## Overview

Hi folks. Thanks for the fantastic package. I was reading through the docs and on the home page there appears to be a tiny typo in the markdown link. Thought I'd just send a quick commit to fix it up.

It's just the removal of the extra `]` char.
