### PR TITLE
lib/lua-types: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -21,6 +21,7 @@ lib.makeExtensible (
     deprecation = call ./deprecation.nix { };
     keymaps = call ./keymap-helpers.nix { };
     lua = call ./to-lua.nix { };
+    lua-types = call ./lua-types.nix { };
     modules = call ./modules.nix { inherit flake; };
     options = call ./options.nix { };
     plugins = call ./plugins { };

--- a/lib/lua-types.nix
+++ b/lib/lua-types.nix
@@ -1,0 +1,66 @@
+{ lib }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim) lua-types;
+
+  # Primitive types that can be represented in lua
+  primitives = {
+    inherit (types)
+      bool
+      float
+      int
+      path
+      str
+      ;
+  };
+in
+{
+  anything = types.either lua-types.primitive (lua-types.tableOf lua-types.anything) // {
+    description = "lua value";
+    descriptionClass = "noun";
+  };
+
+  # TODO: support merging list+attrs -> unkeyedAttrs
+  tableOf =
+    elemType:
+    assert lib.strings.hasPrefix "lua" elemType.description;
+    types.oneOf [
+      (types.listOf elemType)
+      (types.attrsOf elemType)
+      types.luaInline
+      types.rawLua
+    ]
+    // {
+      description = "lua table of ${
+        lib.types.optionDescriptionPhrase (class: class == "noun" || class == "composite") elemType
+      }";
+      descriptionClass = "composite";
+    };
+
+  primitive =
+    types.nullOr (
+      types.oneOf (
+        [
+          types.luaInline
+          types.rawLua
+        ]
+        ++ builtins.attrValues primitives
+      )
+    )
+    // {
+      description = "lua primitive";
+      descriptionClass = "noun";
+    };
+}
+// builtins.mapAttrs (
+  _: wrappedType:
+  types.oneOf [
+    wrappedType
+    types.luaInline
+    types.rawLua
+  ]
+  // {
+    description = "lua ${wrappedType.description}";
+    descriptionClass = "noun";
+  }
+) primitives

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -114,6 +114,7 @@ rec {
     { type, ... }@args: mkNullOrOption' (args // { type = with types; either strLuaFn type; });
   mkNullOrStrLuaFnOr = type: description: mkNullOrStrLuaFnOr' { inherit type description; };
 
+  # TODO: use lib.nixvim.lua-types
   defaultNullOpts =
     let
       # Ensures that default is null and defaultText is not set


### PR DESCRIPTION
The types in `lua-types` are inspired by `pkgs.formats`, allowing for a more appropriate option type than `types.anything`.

The intention is that we will replace usage of `types.anything` in 90% of cases treewide with `lua-types.anything` (see #3208). Currently there are ~270 instances of `anything` treewide.

All types in `lua-types` support inline-lua and raw-lua.

`lua-types.tableOf` will also serve as a good place to implement merging lists defs and attrs defs into a mixed table, at some point in the future. Ideally we can upstream something similar to nixpkgs too. Again, see #3208 and also https://github.com/NixOS/nixpkgs/compare/master...MattSturgeon:nixpkgs:table.

## TODO

- [ ] Move `types.rawLua` to `lua-types`
- [ ] Use `lua-types.anything` in `mkNvimPkugin`'s `settings` option
- [ ] Use `lua-types` in `defaultNullOpts` (?)
