### PR TITLE
lib/utils: fix `literalLua` multiline rendering

### DIFF
--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -169,7 +169,7 @@ rec {
       # Pass the value through mkRaw for validation
       raw = mkRaw r;
       # TODO: consider switching to lib.generators.mkLuaInline ?
-      exp = "lib.nixvim.mkRaw " + builtins.toJSON raw.__raw;
+      exp = "lib.nixvim.mkRaw " + lib.generators.toPretty { } raw.__raw;
     in
     lib.literalExpression exp;
 


### PR DESCRIPTION
`lib.generators.toPretty` has bespoke handling for rendering nix strings using either the `" "` or `'' ''` syntax, based on some heuristics.

Using `toPretty` instead of `toJSON` improves how literal-lua examples render in the docs.

```
nix-repl> lib.nixvim.literalLua "hi"
{
  _type = "literalExpression";
  text = "lib.nixvim.mkRaw \"hi\"";
}

nix-repl> lib.nixvim.literalLua "hi\nthere\n"
{
  _type = "literalExpression";
  text = "lib.nixvim.mkRaw ''\n  hi\n  there\n''";
}

nix-repl> lib.nixvim.literalLua "hi\nthere"
{
  _type = "literalExpression";
  text = "lib.nixvim.mkRaw ''\n  hi\n  there''";
}
```
