### PR TITLE
modules/diagnostics.nix: Fix nonexistent virtual line option example

### DIFF
--- a/modules/diagnostics.nix
+++ b/modules/diagnostics.nix
@@ -12,7 +12,7 @@
       description = "The configuration diagnostic options, provided to `vim.diagnostic.config`.";
       example = {
         virtual_text = false;
-        virtual_lines.only_current_line = true;
+        virtual_lines.current_line = true;
       };
     };
   };

--- a/tests/test-sources/modules/diagnostics.nix
+++ b/tests/test-sources/modules/diagnostics.nix
@@ -2,7 +2,7 @@
   example = {
     diagnostics = {
       virtual_text = false;
-      virtual_lines.only_current_line = true;
+      virtual_lines.current_line = true;
     };
   };
 }


### PR DESCRIPTION
The `only_current_line` option for `vim.diagnostic.Opts.VirtualLines` doesn't exist. This PR changes the example diagnostic configuration to use `current_line` instead.

The relevant nvim docs are [here](https://neovim.io/doc/user/diagnostic.html#vim.diagnostic.Opts.VirtualLines).