### PR TITLE
plugins/lsp/servers: replace `rootDir` with `rootMarkers`

### DIFF
--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -84,12 +84,13 @@
           filetypes = [ "python" ];
           autostart = false;
         };
-        # rootDir
+        # rootMarkers
         tinymist = {
           enable = true;
-          rootDir = ''
-            require 'lspconfig.util'.root_pattern('.git', 'main.typ')
-          '';
+          rootMarkers = [
+            ".git"
+            "main.typ"
+          ];
         };
       };
     };


### PR DESCRIPTION
Users on matrix have reported issues when `rootDir` is defined.

nvim-lspconfig historically used `root_dir`, along with util functions like `root_pattern`.

Now that neovim's own LSP API is used, `root_dir` _appears_ to be subtly different and `root_markers` is introduced to replace `util.root_pattern`. _(?)_

Since we cannot easily warn about the `root_dir` differences, it can usually be replaced with `root_markers`, and can still be manually configured via `extraOptions` if needed; the simplest approach here is to remove the `rootDir` option.


```
The option definition `plugins.lsp.servers.tinymist.rootDir' in `/nix/store/via5xff0d3fbwg5nfxwpy0lijxbg9n3i-test-sources/plugins/lsp/_lsp.nix' no longer has any effect; please remove it.

nvim-lspconfig has switched from its own `root_dir` implementation to using neovim's built-in LSP API.

In most cases you can use `plugins.lsp.servers.tinymist.rootMarkers` instead. It should be a list of files that mark the root of the project.
In more complex cases you can still use `plugins.lsp.servers.tinymist.extraOptions.root_dir`.
```
