### PR TITLE
modules/performance: update runtimepath `pathsToLink`

### DIFF
--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -7,6 +7,39 @@
 let
   inherit (lib) types;
   cfg = config.performance;
+
+  pathsToLink = [
+    # :h rtp
+    # TODO: "/filetype.lua" # filetypes (:h new-filetype)
+    "/autoload" # automatically loaded scripts (:h autoload-functions)
+    "/colors" # color scheme files (:h :colorscheme)
+    "/compiler" # compiler files (:h :compiler)
+    "/doc" # documentation (:h write-local-help)
+    "/ftplugin" # filetype plugins (:h write-filetype-plugin)
+    "/indent" # indent scripts (:h indent-expression)
+    "/keymap" # key mapping files (:h mbyte-keymap)
+    "/lang" # menu translations (:h :menutrans)
+    "/lsp" # LSP client configurations (:h lsp-config)
+    "/lua" # Lua plugins (:h lua)
+    # TODO: "/menu.vim" # GUI menus (:h menu.vim)
+    "/pack" # packages (:h :packadd)
+    "/parser" # treesitter syntax parsers (:h treesitter)
+    "/plugin" # plugin scripts (:h write-plugin)
+    "/queries" # treesitter queries (:h treesitter)
+    "/rplugin" # remote-plugin scripts (:h remote-plugin)
+    "/spell" # spell checking files (:h spell)
+    "/syntax" # syntax files (:h mysyntaxfile)
+    "/tutor" # tutorial files (:h :Tutor)
+
+    # after
+    "/after"
+
+    # ftdetect
+    "/ftdetect"
+
+    # plenary.nvim
+    "/data/plenary/filetypes"
+  ];
 in
 {
   options.performance = {
@@ -48,6 +81,8 @@ in
       pathsToLink = lib.mkOption {
         type = with types; listOf str;
         default = [ ];
+        # We set this default below in `config` because we want to use default priority
+        defaultText = pathsToLink;
         example = [ "/data" ];
         description = "List of paths to link into a combined plugin pack.";
       };
@@ -71,39 +106,6 @@ in
         pkgs.vimPlugins.plenary-nvim
       ];
 
-  config.performance = {
-    # Set option value with default priority so that values are appended by default
-    combinePlugins.pathsToLink = [
-      # :h rtp
-      # TODO: "/filetype.lua" # filetypes (:h new-filetype)
-      "/autoload" # automatically loaded scripts (:h autoload-functions)
-      "/colors" # color scheme files (:h :colorscheme)
-      "/compiler" # compiler files (:h :compiler)
-      "/doc" # documentation (:h write-local-help)
-      "/ftplugin" # filetype plugins (:h write-filetype-plugin)
-      "/indent" # indent scripts (:h indent-expression)
-      "/keymap" # key mapping files (:h mbyte-keymap)
-      "/lang" # menu translations (:h :menutrans)
-      "/lsp" # LSP client configurations (:h lsp-config)
-      "/lua" # Lua plugins (:h lua)
-      # TODO: "/menu.vim" # GUI menus (:h menu.vim)
-      "/pack" # packages (:h :packadd)
-      "/parser" # treesitter syntax parsers (:h treesitter)
-      "/plugin" # plugin scripts (:h write-plugin)
-      "/queries" # treesitter queries (:h treesitter)
-      "/rplugin" # remote-plugin scripts (:h remote-plugin)
-      "/spell" # spell checking files (:h spell)
-      "/syntax" # syntax files (:h mysyntaxfile)
-      "/tutor" # tutorial files (:h :Tutor)
-
-      # after
-      "/after"
-
-      # ftdetect
-      "/ftdetect"
-
-      # plenary.nvim
-      "/data/plenary/filetypes"
-    ];
-  };
+  # Set option value with default priority so that values are appended by default
+  config.performance.combinePlugins = { inherit pathsToLink; };
 }

--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -75,26 +75,33 @@ in
     # Set option value with default priority so that values are appended by default
     combinePlugins.pathsToLink = [
       # :h rtp
-      "/autoload"
-      "/colors"
-      "/compiler"
-      "/doc"
-      "/ftplugin"
-      "/indent"
-      "/keymap"
-      "/lang"
-      "/lua"
-      "/pack"
-      "/parser"
-      "/plugin"
-      "/queries"
-      "/rplugin"
-      "/spell"
-      "/syntax"
-      "/tutor"
+      # TODO: "/filetype.lua" # filetypes (:h new-filetype)
+      "/autoload" # automatically loaded scripts (:h autoload-functions)
+      "/colors" # color scheme files (:h :colorscheme)
+      "/compiler" # compiler files (:h :compiler)
+      "/doc" # documentation (:h write-local-help)
+      "/ftplugin" # filetype plugins (:h write-filetype-plugin)
+      "/indent" # indent scripts (:h indent-expression)
+      "/keymap" # key mapping files (:h mbyte-keymap)
+      "/lang" # menu translations (:h :menutrans)
+      "/lsp" # LSP client configurations (:h lsp-config)
+      "/lua" # Lua plugins (:h lua)
+      # TODO: "/menu.vim" # GUI menus (:h menu.vim)
+      "/pack" # packages (:h :packadd)
+      "/parser" # treesitter syntax parsers (:h treesitter)
+      "/plugin" # plugin scripts (:h write-plugin)
+      "/queries" # treesitter queries (:h treesitter)
+      "/rplugin" # remote-plugin scripts (:h remote-plugin)
+      "/spell" # spell checking files (:h spell)
+      "/syntax" # syntax files (:h mysyntaxfile)
+      "/tutor" # tutorial files (:h :Tutor)
+
+      # after
       "/after"
+
       # ftdetect
       "/ftdetect"
+
       # plenary.nvim
       "/data/plenary/filetypes"
     ];

--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -182,12 +182,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
       ++ mkMaps "vim.lsp.buf." "Lsp buf" cfg.keymaps.lspBuf
       ++ cfg.keymaps.extra;
 
-    # Since https://github.com/nix-community/nixvim/pull/3204, we are now using the native vim.lsp
-    # API for configuring language servers with nvim-lspconfig.
-    # For some mysterious reason, `performance.combinePlugins` now prevent language servers from
-    # being properly configured (missing some keys: `cmd`, `filetypes`, `root_markers` etc.)
-    performance.combinePlugins.standalonePlugins = [ cfg.package ];
-
     plugins.lsp.luaConfig.content =
       let
         runWrappers =


### PR DESCRIPTION
- **modules/performance: update runtimepath `pathsToLink`**
- **modules/performance: document `pathsToLink` default**
- **plugins/lsp: remove `standalonePlugins` default**

See https://github.com/nix-community/nixvim/issues/3211#issuecomment-2831943140

This should be tested by someone who has LSP and `combinePlugins` in their config:
- [ ] `:checkhealth vim.lsp` has no issues
- [ ] `:checkhealth vim.lsp` shows defaults from nvim-lspconfig are configured
- [ ] LSPs attach correctly

You can test by updating your nixvim input to point at this PR:

```sh
nix flake lock --override-input nixvim 'github:nix-community/nixvim?ref=pull/3223/head'
```

Fixes #3211 :crossed_fingers: 

cc @jolars