### PR TITLE
plugins/telescope/media-files: use the top-level dependencies option

### DIFF
--- a/plugins/by-name/telescope/extensions/media-files.nix
+++ b/plugins/by-name/telescope/extensions/media-files.nix
@@ -13,36 +13,6 @@ mkExtension {
   extensionName = "media_files";
   package = "telescope-media-files-nvim";
 
-  # TODO: introduced 2024-03-24, remove on 2024-05-24
-  imports =
-    let
-      telescopeExtensionsPath = [
-        "plugins"
-        "telescope"
-        "extensions"
-      ];
-      oldPath = telescopeExtensionsPath ++ [ "media_files" ];
-      newPath = telescopeExtensionsPath ++ [ "media-files" ];
-    in
-    lib.nixvim.mkSettingsRenamedOptionModules oldPath newPath [
-      "enable"
-      "package"
-      {
-        old = "filetypes";
-        new = [
-          "settings"
-          "filetypes"
-        ];
-      }
-      {
-        old = "find_cmd";
-        new = [
-          "settings"
-          "find_cmd"
-        ];
-      }
-    ];
-
   extraOptions = {
     dependencies =
       let

--- a/tests/test-sources/modules/dependencies.nix
+++ b/tests/test-sources/modules/dependencies.nix
@@ -4,10 +4,12 @@
   ...
 }:
 let
-  disabledDeps = [
-  ];
-
   inherit (pkgs.stdenv) hostPlatform;
+
+  disabledDeps = lib.optionals hostPlatform.isDarwin [
+    # One of its dependencies is not available on darwin
+    "fontpreview"
+  ];
 
   isDepEnabled =
     name: package:

--- a/tests/test-sources/plugins/by-name/telescope/media-files.nix
+++ b/tests/test-sources/plugins/by-name/telescope/media-files.nix
@@ -32,23 +32,23 @@
     plugins.web-devicons.enable = true;
   };
 
-  dependencies = {
-    plugins.telescope = {
-      enable = true;
-
-      extensions.media-files = {
+  withAllDependencies = {
+    plugins = {
+      telescope = {
         enable = true;
 
-        dependencies = {
-          chafa.enable = true;
-          imageMagick.enable = true;
-          ffmpegthumbnailer.enable = true;
-          pdftoppm.enable = true;
-          epub-thumbnailer.enable = pkgs.stdenv.isLinux;
-          fontpreview.enable = pkgs.stdenv.isLinux;
-        };
+        extensions.media-files.enable = true;
       };
+      web-devicons.enable = true;
     };
-    plugins.web-devicons.enable = true;
+
+    dependencies = {
+      chafa.enable = true;
+      epub-thumbnailer.enable = true;
+      ffmpegthumbnailer.enable = true;
+      fontpreview.enable = !pkgs.stdenv.hostPlatform.isDarwin;
+      imagemagick.enable = true;
+      poppler-utils.enable = true;
+    };
   };
 }


### PR DESCRIPTION
- **plugins/telescope/media-files: remove old rename warnings**
- **plugins/telescope/media-files: use the top-level dependencies option**
