### PR TITLE
modules/performance/combinePlugins: propagate lua dependencies

### DIFF
--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -1,12 +1,6 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib) types;
-  cfg = config.performance;
 
   pathsToLink = [
     # :h rtp
@@ -94,17 +88,6 @@ in
       };
     };
   };
-
-  # FIXME: The performance options do not correctly propagate lua module dependencies.
-  # We can explicitly specify 'plenary-nvim', as it is a very common dependency.
-  # While this is enough for our test suite to pass, end-users may be affected by other dependencies not covered by our test suite.
-  #
-  # See https://github.com/nix-community/nixvim/pull/3099
-  config.extraPlugins =
-    lib.mkIf (cfg.combinePlugins.enable || (cfg.byteCompileLua.enable && cfg.byteCompileLua.plugins))
-      [
-        pkgs.vimPlugins.plenary-nvim
-      ];
 
   # Set option value with default priority so that values are appended by default
   config.performance.combinePlugins = { inherit pathsToLink; };

--- a/tests/test-sources/modules/performance/byte-compile-lua.nix
+++ b/tests/test-sources/modules/performance/byte-compile-lua.nix
@@ -248,8 +248,8 @@ in
 
       extraPlugins = with pkgs.vimPlugins; [
         nvim-lspconfig
-        # Depends on plenary-nvim
-        telescope-nvim
+        # Depends on nui-nvim
+        noice-nvim
         # buildCommand plugin with python3 dependency
         ((pkgs.writeTextDir "/plugin/test.lua" "vim.opt.tabstop = 2").overrideAttrs {
           passthru.python3Dependencies = ps: [ ps.pyyaml ];
@@ -263,8 +263,8 @@ in
 
         -- Plugins are loadable
         require("lspconfig")
-        require("telescope")
-        require("plenary")
+        require("noice")
+        require("nui.popup")
         require("nvim-treesitter")
 
         -- Python modules are importable
@@ -276,16 +276,13 @@ in
         test_rtp_file("plugin/lspconfig.lua", true)
         test_rtp_file("doc/lspconfig.txt", false)
 
-        -- telescope-nvim
-        test_rtp_file("lua/telescope/init.lua", true)
-        test_rtp_file("lua/telescope/builtin/init.lua", true)
-        test_rtp_file("plugin/telescope.lua", true)
-        test_rtp_file("autoload/health/telescope.vim", false)
-        test_rtp_file("doc/telescope.txt", false)
+        -- noice-nvim
+        test_rtp_file("lua/noice/init.lua", true)
+        test_rtp_file("lua/noice/config/init.lua", true)
+        test_rtp_file("doc/noice.nvim.txt", false)
 
-        -- Dependency of telescope-nvim (plenary-nvim)
-        test_rtp_file("lua/plenary/init.lua", true)
-        test_rtp_file("plugin/plenary.vim", false)
+        -- Dependency of noice-nvim (nui-nvim)
+        test_rtp_file("lua/nui/popup/init.lua", true)
 
         -- Test plugin
         test_rtp_file("plugin/test.lua", true)

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -62,17 +62,17 @@ in
     {
       performance.combinePlugins.enable = true;
       extraPlugins = with pkgs.vimPlugins; [
-        # Depends on nvim-cmp
-        cmp-dictionary
-        # Depends on telescope-nvim which itself depends on plenary-nvim
-        telescope-undo-nvim
+        # Depends on nui-nvim
+        noice-nvim
+        # Depends on null-ls-nvim which itself depends on plenary-nvim
+        mason-null-ls-nvim
       ];
       extraConfigLuaPost = ''
         -- Plugins and its dependencies are loadable
-        require("cmp_dictionary")
-        require("cmp")
-        require("telescope-undo")
-        require("telescope")
+        require("noice")
+        require("nui.popup")
+        require("mason-null-ls.settings") -- Avoid calling deprecated functions
+        require("null-ls.helpers") -- Avoid calling deprecated functions
         require("plenary")
       '';
       assertions = [
@@ -155,7 +155,7 @@ in
         # Optional plugin with dependency on plenary-nvim
         # Dependencies should not be duplicated
         {
-          plugin = telescope-nvim;
+          plugin = none-ls-nvim;
           optional = true;
         }
       ];
@@ -167,16 +167,16 @@ in
         -- Opt plugins are not loadable
         local ok = pcall(require, "nvim-treesitter")
         assert(not ok, "nvim-treesitter plugin is loadable")
-        ok = pcall(require, "telescope")
-        assert(not ok, "telescope-nvim plugin is loadable")
+        ok = pcall(require, "null-ls")
+        assert(not ok, "null-ls-nvim plugin is loadable")
 
         -- Load plugins
         vim.cmd.packadd("nvim-treesitter")
-        vim.cmd.packadd("telescope.nvim")
+        vim.cmd.packadd("none-ls.nvim")
 
         -- Now opt plugins are loadable
         require("nvim-treesitter")
-        require("telescope")
+        require("null-ls")
 
         -- Only one copy of plenary-nvim should be available
         assert(
@@ -321,17 +321,17 @@ in
           # By package itself
           nvim-lspconfig
           # Its dependency, plenary-nvim, not in this list, so will be combined
-          telescope-nvim
+          none-ls-nvim
           # Dependency of other plugin
-          "nvim-cmp"
+          "nui.nvim"
         ];
       };
       extraPlugins = with pkgs.vimPlugins; [
         nvim-treesitter
         nvim-lspconfig
-        telescope-nvim
-        # Only its dependency (nvim-cmp) won't be combined, but not the plugin itself
-        cmp-dictionary
+        none-ls-nvim
+        # Only its dependency (nui-nvim) won't be combined, but not the plugin itself
+        noice-nvim
         # More plugins
         gitsigns-nvim
         luasnip
@@ -340,10 +340,10 @@ in
         -- Plugins are loadable
         require("nvim-treesitter")
         require("lspconfig")
-        require("telescope")
+        require("null-ls")
         require("plenary")
-        require("cmp_dictionary")
-        require("cmp")
+        require("noice")
+        require("nui.popup")
         require("gitsigns")
         require("luasnip")
 
@@ -357,18 +357,17 @@ in
         -- Standalone plugins
         assert(is_standalone("nvim-treesitter"), "nvim-treesitter is combined, expected standalone")
         assert(is_standalone("lspconfig"), "nvim-lspconfig is combined, expected standalone")
-        assert(is_standalone("telescope"), "telescope-nvim is combined, expected standalone")
-        -- Add trailing slash to ensure that it doesn't match cmp_dictionary
-        assert(is_standalone("cmp/", "nvim-cmp"), "nvim-cmp is combined, expected standalone")
+        assert(is_standalone("null-ls", "none-ls.nvim"), "none-ls-nvim is combined, expected standalone")
+        assert(is_standalone("nui"), "nui-nvim is combined, expected standalone")
         -- Combined plugins
         assert(not is_standalone("plenary"), "plenary-nvim is standalone, expected combined")
-        assert(not is_standalone("cmp_dictionary", "cmp-dictionary"), "cmp-dictionary is standalone, expected combined")
+        assert(not is_standalone("noice"), "noice-nvim is standalone, expected combined")
         assert(not is_standalone("gitsigns"), "gitsigns-nvim is standalone, expected combined")
         assert(not is_standalone("luasnip"), "luasnip is standalone, expected combined")
       '';
       assertions = [
         {
-          # plugin-pack, nvim-treesitter, nvim-lspconfig, telescope-nvim, nvim-cmp
+          # plugin-pack, nvim-treesitter, nvim-lspconfig, none-ls-nvim, nui-nvim
           assertion = pluginCount config.build.nvimPackage config.build.extraFiles "start" == 5;
           message = "Wrong number of plugins in packpathDirs";
         }

--- a/tests/test-sources/modules/performance/combine-plugins.nix
+++ b/tests/test-sources/modules/performance/combine-plugins.nix
@@ -64,8 +64,6 @@ in
       extraPlugins = with pkgs.vimPlugins; [
         # Depends on nvim-cmp
         cmp-dictionary
-        # We have to manually add cmp-dictionary's dependence: nvim-cmp
-        nvim-cmp
         # Depends on telescope-nvim which itself depends on plenary-nvim
         telescope-undo-nvim
       ];
@@ -334,8 +332,6 @@ in
         telescope-nvim
         # Only its dependency (nvim-cmp) won't be combined, but not the plugin itself
         cmp-dictionary
-        # We have to manually add cmp-dictionary's dependence: nvim-cmp
-        nvim-cmp
         # More plugins
         gitsigns-nvim
         luasnip


### PR DESCRIPTION
Alternative to #3099.

Fixes #3140
Closes #3099

Plugins from luarocks (e.g. telescope-nvim) have dependencies specified in propagatedBuildInputs. These dependencies are not added as plugins in Nvim runtime. They are added to LUA_PATH env var for wrapped neovim. This PR collects all propagatedBuildInputs from input plugin list and puts them in the combined plugin.

Note that such dependencies are never combined or byte-compiled, because they are not plugins. Also it can lead to double plugins (e.g. one plenary-nvim as plugin dependency and another one in LUA_PATH). This is not nixvim issue, this is how it works in nixpkgs at this moment.

Most of the work for this PR was done to tests. Because of the changes in nixpkgs to plugin dependencies (especially to plenary.nvim) many tests weren't doing what was intended. To avoid such cases in the future, I'm not using plugins from nixpkgs anymore. I created dummy plugins with dependencies that should be tested (combinePlugins only for now). I hope this will avoid some of the unexpected breakages.