### PR TITLE
plugins/lspconfig: init

### DIFF
--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -35,7 +35,7 @@ in
         This can be installed using [`${options.plugins.lspconfig.enable}`][`plugins.lspconfig`].
 
         [nvim-lspconfig]: ${options.plugins.lspconfig.package.default.meta.homepage}
-        [`plugins.lspconfig`]: https://nix-community.github.io/nixvim/plugins/lspconfig/index.html
+        [`plugins.lspconfig`]: ../plugins/lspconfig/index.md
       '';
       default = { };
       example = {

--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -34,7 +34,7 @@ in
         You may also want to use [nvim-lspconfig] to install _default configs_ for many language servers.
         This can be installed using [`${options.plugins.lspconfig.enable}`][`plugins.lspconfig`].
 
-        [nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig
+        [nvim-lspconfig]: ${options.plugins.lspconfig.package.default.meta.homepage}
         [`plugins.lspconfig`]: https://nix-community.github.io/nixvim/plugins/lspconfig/index.html
       '';
       default = { };

--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   config,
+  options,
   ...
 }:
 let
@@ -29,7 +30,9 @@ in
         LSP servers to enable and/or configure.
 
         This option is implemented using neovim's `vim.lsp` lua API.
-        If you prefer to use [nvim-lspconfig], see [`plugins.lspconfig`].
+
+        You may also want to use [nvim-lspconfig] to install _default configs_ for many language servers.
+        This can be installed using [`${options.plugins.lspconfig.enable}`][`plugins.lspconfig`].
 
         [nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig
         [`plugins.lspconfig`]: https://nix-community.github.io/nixvim/plugins/lspconfig/index.html

--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -29,10 +29,10 @@ in
         LSP servers to enable and/or configure.
 
         This option is implemented using neovim's `vim.lsp` lua API.
-        If you prefer to use [nvim-lspconfig], see [`plugins.lsp`].
+        If you prefer to use [nvim-lspconfig], see [`plugins.lspconfig`].
 
         [nvim-lspconfig]: https://github.com/neovim/nvim-lspconfig
-        [`plugins.lsp`]: https://nix-community.github.io/nixvim/plugins/lsp/index.html
+        [`plugins.lspconfig`]: https://nix-community.github.io/nixvim/plugins/lspconfig/index.html
       '';
       default = { };
       example = {

--- a/plugins/by-name/lspconfig/default.nix
+++ b/plugins/by-name/lspconfig/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+let
+  # cfg = config.plugins.lspconfig;
+  opts = options.plugins.lspconfig;
+  oldCfg = config.plugins.lsp;
+  oldOpts = options.plugins.lsp;
+in
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "lspconfig";
+  packPathName = "nvim-lspconfig";
+  package = "nvim-lspconfig";
+
+  maintainers = with lib.maintainers; [
+    GaetanLepage
+    MattSturgeon
+    khaneliman
+    traxys
+  ];
+
+  description = ''
+    [nvim-lspconfig] provides default configs for many language servers, but it does not enable any of them.
+    You should use the [`lsp`] module to configure and enable LSP servers.
+
+    > [!NOTE]
+    > This plugin module will soon replace [`plugins.lsp`].
+    >
+    > Both `${opts.enable}` and `${oldOpts.enable}` will install nvim-lspconfig,
+    > however the older [`plugins.lsp`] module includes additional options and
+    > setup that relate to neovim's builtin LSP and are now being moved to the
+    > new [`lsp`] module.
+
+    [`lsp`]: ../../lsp/servers.md
+    [`plugins.lsp`]: ../lsp/index.md
+    [nvim-lspconfig]: ${opts.package.default.meta.homepage}
+  '';
+
+  # nvim-lspconfig provides configs for `vim.lsp.config` and requires no setup
+  # all configuration should be done via nvim's builtin `vim.lsp` API
+  callSetup = false;
+  hasLuaConfig = false;
+  hasSettings = false;
+
+  extraConfig = {
+    warnings = lib.nixvim.mkWarnings "plugins.lspconfig" [
+      {
+        when = oldCfg.enable;
+        message = ''
+          Both `${opts.enable}' and `${oldOpts.enable}' configure the same plugin (nvim-lspconfig).
+          ${lib.pipe
+            [ opts oldOpts ]
+            [
+              (builtins.catAttrs "enable")
+              (map (o: "`${o}' defined in ${lib.options.showFiles o.files}."))
+              lib.strings.concatLines
+            ]
+          }
+        '';
+      }
+    ];
+  };
+}

--- a/tests/test-sources/plugins/by-name/lspconfig/default.nix
+++ b/tests/test-sources/plugins/by-name/lspconfig/default.nix
@@ -1,0 +1,24 @@
+{
+  empty = {
+    plugins.lspconfig.enable = true;
+  };
+
+  # TODO: test integration with `vim.lsp.enable`, etc
+  # TODO: test some examples of enabling/configuring specific LSP servers
+
+  plugins-lsp-warning = {
+    plugins.lsp.enable = true;
+    plugins.lspconfig.enable = true;
+
+    test.warnings = expect: [
+      (expect "count" 1)
+      (expect "any" ''
+        Nixvim (plugins.lspconfig): Both `plugins.lspconfig.enable' and `plugins.lsp.enable' configure the same plugin (nvim-lspconfig).
+      '')
+      (expect "any" "`plugins.lspconfig.enable' defined in `/nix/store/")
+      (expect "any" "`plugins.lsp.enable' defined in `/nix/store/")
+    ];
+
+    test.buildNixvim = false;
+  };
+}


### PR DESCRIPTION
A simplified replacement for `plugins.lsp`, without any additional configuration options or initialisation.

This plugin module only has 5 options:

```nix
nix-repl> nixvimConfigurations.x86_64-linux.default.options.plugins.lspconfig
{
  autoLoad = { ... };
  enable = { ... };
  lazyLoad = { ... };
  package = { ... };
  packageDecorator = { ... }; # internal
}
```

Eventually, once the new `lsp` and `plugins.lspconfig` modules are mature, the old `plugins.lsp` module will be deprecated and/or aliased. I decided it was simpler to introduce the new plugin now and deprecate the old one in a _future_ PR to allow the new one to incubate before we instruct our users to migrate.

This is not very useful without https://github.com/nix-community/nixvim/pull/3203, although it's not technically _blocked_ by it.
