### PR TITLE
plugins/luasnip: remove redundant jsregexp dependency

### DIFF
--- a/plugins/by-name/luasnip/default.nix
+++ b/plugins/by-name/luasnip/default.nix
@@ -399,7 +399,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
       '') cfg.filetypeExtend;
     in
     {
-      extraLuaPackages = ps: [ ps.jsregexp ];
       plugins.luasnip.luaConfig.content = lib.concatLines (loaderConfig ++ filetypeExtendConfig);
     };
 }


### PR DESCRIPTION
This dependency is already handled in nixpkgs. And now it works with `combinePlugins` enabled too.

Also this is tested in nixpkgs (this happened to be one of primary examples where lua deps were needed in the first place):

https://github.com/NixOS/nixpkgs/blob/d99c55d7c10924d671c4fd61f264c207ae75695f/pkgs/applications/editors/neovim/tests/default.nix#L399-L404