### PR TITLE
plugins/dial: init

### DIFF
--- a/plugins/by-name/dial/default.nix
+++ b/plugins/by-name/dial/default.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "dial";
+  packPathName = "dial.nvim";
+  package = "dial-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  # This plugin does not have a conventional setup function
+  hasSettings = false;
+  callSetup = false;
+}

--- a/tests/test-sources/plugins/by-name/dial/default.nix
+++ b/tests/test-sources/plugins/by-name/dial/default.nix
@@ -1,0 +1,25 @@
+{
+  empty = {
+    plugins.dial.enable = true;
+  };
+
+  example = {
+    plugins.dial = {
+      enable = true;
+
+      luaConfig.content = ''
+        local augend = require("dial.augend")
+        require("dial.config").augends:register_group({
+          default = {
+            augend.integer.alias.decimal,
+            augend.integer.alias.hex,
+            augend.date.alias["%Y/%m/%d"],
+            augend.constant.alias.bool,
+            augend.semver.alias.semver,
+            augend.constant.new({ elements = { "let", "const" } }),
+          },
+        })
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Add support for [dial.nvim](https://github.com/monaqa/dial.nvim), an extended increment/decrement plugin for Neovim.

Closes #3235
