### PR TITLE
modules/lsp/server: declare `package` defaults

### DIFF
--- a/modules/lsp/server.nix
+++ b/modules/lsp/server.nix
@@ -1,59 +1,74 @@
+# Usage: lib.importApply ./server.nix { /*args*/ }
+{
+  name ? null,
+  package ? null,
+  # Avoid naming conflict with the `config` module arg
+  # TODO: consider renaming the `config` option to something like `settings`?
+  configOption ? null,
+  pkgs ? { },
+}@args:
 { lib, name, ... }:
 let
   inherit (lib) types;
+  displayName = args.name or "the language server";
+  packageName = package.name or (lib.strings.removePrefix "the " displayName);
 in
 {
   options = {
-    enable = lib.mkEnableOption "the language server";
+    enable = lib.mkEnableOption displayName;
 
     name = lib.mkOption {
       type = types.maybeRaw types.str;
       description = ''
-        The name of the language server, supplied to functions like `vim.lsp.enable()`.
+        The name to use for ${displayName}.
+        Supplied to functions like `vim.lsp.enable()`.
       '';
-      default = name;
-      defaultText = lib.literalMD "the attribute name";
+      # Use the supplied attr name, or fallback to the name module-arg
+      default = args.name or name;
+      defaultText = args.name or (lib.literalMD "the attribute name");
     };
 
     activate = lib.mkOption {
       type = types.bool;
       description = ''
-        Whether to call `vim.lsp.enable()` for this server.
+        Whether to call `vim.lsp.enable()` for ${displayName}.
       '';
       default = true;
       example = false;
     };
 
-    package = lib.mkOption {
-      type = with types; nullOr package;
-      default = null;
-      description = ''
-        Package to use for this language server.
+    package = lib.mkPackageOption pkgs packageName {
+      nullable = true;
+      default = package.default or package;
+      example = package.example or null;
+      extraDescription = ''
+        ${package.extraDescription or ""}
 
-        Alternatively, the language server should be available on your `$PATH`.
+        Alternatively, ${displayName} should be installed on your `$PATH`.
       '';
     };
 
     config = lib.mkOption {
       type = with types; attrsOf anything;
       description = ''
-        Configurations for each language server.
+        Configurations for ${displayName}. ${configOption.extraDescription or ""}
       '';
       default = { };
-      example = {
-        cmd = [
-          "clangd"
-          "--background-index"
-        ];
-        root_markers = [
-          "compile_commands.json"
-          "compile_flags.txt"
-        ];
-        filetypes = [
-          "c"
-          "cpp"
-        ];
-      };
+      example =
+        configOption.example or {
+          cmd = [
+            "clangd"
+            "--background-index"
+          ];
+          root_markers = [
+            "compile_commands.json"
+            "compile_flags.txt"
+          ];
+          filetypes = [
+            "c"
+            "cpp"
+          ];
+        };
     };
   };
 }

--- a/plugins/by-name/lspconfig/default.nix
+++ b/plugins/by-name/lspconfig/default.nix
@@ -35,7 +35,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     > setup that relate to neovim's builtin LSP and are now being moved to the
     > new [`lsp`] module.
 
-    [`lsp`]: ../../lsp/servers.md
+    [`lsp`]: ../../lsp/servers/index.md
     [`plugins.lsp`]: ../lsp/index.md
     [nvim-lspconfig]: ${opts.package.default.meta.homepage}
   '';


### PR DESCRIPTION
Initial design for declaring per-server `lsp.servers.<name>.package` defaults.

- Change `lsp.servers` to a freeform submodule
- Call the `server.nix` module using [`lib.importApply`](https://noogle.dev/f/lib/modules/importApply)
  - This allows passing in server-specific info like name and package
- Declare a `lsp.servers.<name>` option for each packaged server

