### PR TITLE
docs: don't remove freeform sub-options

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -24,7 +24,19 @@ let
 
   removeUnwanted =
     attrs:
-    builtins.removeAttrs attrs [
+    # FIXME: We incorrectly remove _freeformOptions here.
+    #
+    # However we can't fix the bug because we derive page names from attrnames;
+    # the correct behaviour would be to ignore attrnames and use option locs.
+    #
+    # As a workaround, merge the freeform options at the top of these attrs,
+    # however this can run into name conflicts 😢
+    #
+    # We should move this workaround to where we decide the page name and
+    # whether to nest into a sub-page, so that we can keep the original
+    # _freeformOptions attr as intended.
+    attrs._freeformOptions or { }
+    // builtins.removeAttrs attrs [
       "_module"
       "_freeformOptions"
       "warnings"


### PR DESCRIPTION
This isn't a fully correct fix, but it's much closer to the intended behaviour.

> FIXME: We incorrectly remove `_freeformOptions` here.
>
> However we can't fix the bug because we derive page names from attrnames;
> the correct behaviour would be to ignore attrnames and use option `loc`s.
>
> As a workaround, merge the freeform options at the top of these attrs,
> however this can run into name conflicts 😢
>
> We should move this workaround to where we decide the page name and
> whether to nest into a sub-page, so that we can keep the original
> `_freeformOptions` attr as intended.

From https://github.com/nix-community/nixvim/pull/3243:

> I've noticed that the freeformtype's suboptions don't seem to get documented. I haven't checked yet if this is an issue with submodule, freeformtype, or our docs impl.

It's an issue with our hand-rolled docs.

Submodules with a freeformType return the freeformType's sub-options in a `_freeformOptions` attr. We remove that [here](https://github.com/nix-community/nixvim/blob/7a6c5b48031059ace82ce90b9a279ec243999554/docs/mdbook/default.nix#L25-L33).

The reason we do that is because our current docs impl uses attr names to determine page-names, _however_ it is intended that attr names be ignored when rendering docs and _only_ option `loc` paths be used. Therefore `options.lsp.servers.type.getSubOptions options.lsp.servers.loc)._freeformOptions.enable` should render with as `lsp.servers.<name>.enable` _not_ as `lsp.servers._freeformOptions_.enable`:

```
nix-repl> (c.options.lsp.servers.type.getSubOptions c.options.lsp.servers.loc)._freeformOptions
{
  _module = { ... };
  activate = { ... };
  config = { ... };
  enable = { ... };
  name = { ... };
  package = { ... };
}

nix-repl> inputs.nixpkgs.lib.showOption (c.options.lsp.servers.type.getSubOptions c.options.lsp.servers.loc)._freeformOptions.enable.loc
"lsp.servers.<name>.enable"

```

Note that when NixOS renders option docs (and also how we do it in the [beta-docs PR](https://github.com/nix-community/nixvim/pull/2884)), all options are recursively [_collected_](https://noogle.dev/f/lib/attrsets/collect) into a list, so the attr names are discarded and the option's `loc` is all that remains.
