### PR TITLE
modules/lsp: don't enable wildcard server

### DIFF
--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -93,10 +93,13 @@ in
       '';
       default = { };
       example = {
-        "*".settings = {
-          root_markers = [ ".git" ];
-          capabilities.textDocument.semanticTokens = {
-            multilineTokenSupport = true;
+        "*" = {
+          enable = true;
+          settings = {
+            root_markers = [ ".git" ];
+            capabilities.textDocument.semanticTokens = {
+              multilineTokenSupport = true;
+            };
           };
         };
         luals.enable = true;

--- a/modules/lsp/server.nix
+++ b/modules/lsp/server.nix
@@ -5,7 +5,12 @@
   settings ? null,
   pkgs ? { },
 }@args:
-{ lib, name, ... }:
+{
+  lib,
+  name,
+  config,
+  ...
+}:
 let
   inherit (lib) types;
   displayName = args.name or "the language server";
@@ -31,7 +36,10 @@ in
       description = ''
         Whether to call `vim.lsp.enable()` for ${displayName}.
       '';
-      default = true;
+      default = config.name != "*";
+      defaultText = lib.literalMD ''
+        `true`, unless the server's `name` is `*`
+      '';
       example = false;
     };
 

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -1,10 +1,14 @@
 {
   example = {
     lsp.servers = {
-      "*".settings = {
-        root_markers = [ ".git" ];
-        capabilities.textDocument.semanticTokens = {
-          multilineTokenSupport = true;
+      "*" = {
+        enable = true;
+        settings = {
+          enable = true;
+          root_markers = [ ".git" ];
+          capabilities.textDocument.semanticTokens = {
+            multilineTokenSupport = true;
+          };
         };
       };
       luals.enable = true;


### PR DESCRIPTION
The wildcard server ("*") should have its config set, but not be enabled through `vim.lsp.enable()`. Calling `vim.lsp.enable("*")` causes an error.