### PR TITLE
modules/lsp/server: rename `config` -> `settings`

### DIFF
--- a/modules/lsp/server.nix
+++ b/modules/lsp/server.nix
@@ -2,9 +2,7 @@
 {
   name ? null,
   package ? null,
-  # Avoid naming conflict with the `config` module arg
-  # TODO: consider renaming the `config` option to something like `settings`?
-  configOption ? null,
+  settings ? null,
   pkgs ? { },
 }@args:
 { lib, name, ... }:
@@ -48,14 +46,14 @@ in
       '';
     };
 
-    config = lib.mkOption {
+    settings = lib.mkOption {
       type = with types; attrsOf anything;
       description = ''
-        Configurations for ${displayName}. ${configOption.extraDescription or ""}
+        Configurations for ${displayName}. ${settings.extraDescription or ""}
       '';
       default = { };
       example =
-        configOption.example or {
+        settings.example or {
           cmd = [
             "clangd"
             "--background-index"
@@ -70,5 +68,23 @@ in
           ];
         };
     };
+
+    # NOTE: we need a warnings option for `mkRenamedOptionModule` to warn about unexpected definitions
+    # This can be removed when all rename aliases are gone
+    warnings = lib.mkOption {
+      type = with types; listOf str;
+      description = "Warnings to propagate to nixvim's `warnings` option.";
+      default = [ ];
+      internal = true;
+      visible = false;
+    };
   };
+
+  imports = [
+    # TODO: rename added 2025-04-30 (during the 25.05 cycle)
+    # The previous name `config` was introduced 2025-04-28 (during the 25.05 cycle)
+    # Because the previous name `config` never made it into a stable release,
+    # we could consider dropping this alias sooner than normal.
+    (lib.mkRenamedOptionModule [ "config" ] [ "settings" ])
+  ];
 }

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -1,7 +1,7 @@
 {
   example = {
     lsp.servers = {
-      "*".config = {
+      "*".settings = {
         root_markers = [ ".git" ];
         capabilities.textDocument.semanticTokens = {
           multilineTokenSupport = true;
@@ -10,7 +10,7 @@
       luals.enable = true;
       clangd = {
         enable = true;
-        config = {
+        settings = {
           cmd = [
             "clangd"
             "--background-index"


### PR DESCRIPTION
`config` is a loaded term within modules and options.

`settings` is the name usually used for freeform config in nixvim and most other module configurations.
