### PR TITLE
modules/lsp: declare a stripped down `*` option

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -216,7 +216,10 @@ let
       name: opts:
       let
         isBranch = if (lib.hasSuffix "index" opts.index.path) then true else opts.hasComponents;
-        path = if isBranch then "${opts.index.path}/index.md" else "${opts.index.path}.md";
+        # Ensure `path` is escaped because we use it in a shell script
+        path = lib.strings.escapeShellArg (
+          if isBranch then "${opts.index.path}/index.md" else "${opts.index.path}.md"
+        );
       in
       (lib.optionalString isBranch "mkdir -p ${opts.index.path}\n")
       + (

--- a/modules/lsp/server-base.nix
+++ b/modules/lsp/server-base.nix
@@ -1,0 +1,55 @@
+# Usage: lib.importApply ./server-base.nix { /*args*/ }
+{
+  displayName ? "the language server",
+  settings ? null,
+}:
+{ lib, ... }:
+let
+  inherit (lib) types;
+in
+{
+  options = {
+    enable = lib.mkEnableOption displayName;
+
+    settings = lib.mkOption {
+      type = with types; attrsOf anything;
+      description = ''
+        Configurations for ${displayName}. ${settings.extraDescription or ""}
+      '';
+      default = { };
+      example =
+        settings.example or {
+          cmd = [
+            "clangd"
+            "--background-index"
+          ];
+          root_markers = [
+            "compile_commands.json"
+            "compile_flags.txt"
+          ];
+          filetypes = [
+            "c"
+            "cpp"
+          ];
+        };
+    };
+
+    # NOTE: we need a warnings option for `mkRenamedOptionModule` to warn about unexpected definitions
+    # This can be removed when all rename aliases are gone
+    warnings = lib.mkOption {
+      type = with types; listOf str;
+      description = "Warnings to propagate to nixvim's `warnings` option.";
+      default = [ ];
+      internal = true;
+      visible = false;
+    };
+  };
+
+  imports = [
+    # TODO: rename added 2025-04-30 (during the 25.05 cycle)
+    # The previous name `config` was introduced 2025-04-28 (during the 25.05 cycle)
+    # Because the previous name `config` never made it into a stable release,
+    # we could consider dropping this alias sooner than normal.
+    (lib.mkRenamedOptionModule [ "config" ] [ "settings" ])
+  ];
+}

--- a/modules/lsp/server.nix
+++ b/modules/lsp/server.nix
@@ -1,6 +1,6 @@
 # Usage: lib.importApply ./server.nix { /*args*/ }
 {
-  name ? null,
+  name ? "the language server",
   package ? null,
   settings ? null,
   pkgs ? { },
@@ -18,8 +18,6 @@ let
 in
 {
   options = {
-    enable = lib.mkEnableOption displayName;
-
     name = lib.mkOption {
       type = types.maybeRaw types.str;
       description = ''
@@ -53,46 +51,11 @@ in
         Alternatively, ${displayName} should be installed on your `$PATH`.
       '';
     };
-
-    settings = lib.mkOption {
-      type = with types; attrsOf anything;
-      description = ''
-        Configurations for ${displayName}. ${settings.extraDescription or ""}
-      '';
-      default = { };
-      example =
-        settings.example or {
-          cmd = [
-            "clangd"
-            "--background-index"
-          ];
-          root_markers = [
-            "compile_commands.json"
-            "compile_flags.txt"
-          ];
-          filetypes = [
-            "c"
-            "cpp"
-          ];
-        };
-    };
-
-    # NOTE: we need a warnings option for `mkRenamedOptionModule` to warn about unexpected definitions
-    # This can be removed when all rename aliases are gone
-    warnings = lib.mkOption {
-      type = with types; listOf str;
-      description = "Warnings to propagate to nixvim's `warnings` option.";
-      default = [ ];
-      internal = true;
-      visible = false;
-    };
   };
 
   imports = [
-    # TODO: rename added 2025-04-30 (during the 25.05 cycle)
-    # The previous name `config` was introduced 2025-04-28 (during the 25.05 cycle)
-    # Because the previous name `config` never made it into a stable release,
-    # we could consider dropping this alias sooner than normal.
-    (lib.mkRenamedOptionModule [ "config" ] [ "settings" ])
+    (lib.modules.importApply ./server-base.nix {
+      inherit displayName settings;
+    })
   ];
 }


### PR DESCRIPTION
- **docs: ensure path is escaped when copying module docs**
  Found this bug in the docs when declaring the `*` option

- **modules/lsp: declare a stripped down `servers."*"` option**
  Split the `server.nix` module into `server.nix` and `server-base.nix`. \
  The latter is used by the `server.nix` module internally, and also used directly by the new `lsp.servers."*"` option's type.
  This allows us to omit the options that only relate to "real" servers from the `lsp.servers."*"` option, while keeping them in the freeform options and the known-server options.


EDIT: This last part will be done in a follow-up:

- **modules/lsp: enable `servers."*"` by default**
  Change the `lsp.servers."*".enable` to default to true. \
  ~~Fixes~~ https://github.com/nix-community/nixvim/issues/3256
