### PR TITLE
modules/lsp: avoid empty config & enable `servers."*"` by default

### DIFF
--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -93,6 +93,8 @@ in
             type = types.submodule (
               lib.modules.importApply ./server-base.nix {
                 displayName = "all servers";
+                enable.name = "the `*` server config";
+                enable.default = true;
                 settings.extraDescription = ''
                   Will be merged by neovim using the behaviour of [`vim.tbl_deep_extend()`](https://neovim.io/doc/user/lua.html#vim.tbl_deep_extend()).
                 '';
@@ -123,13 +125,10 @@ in
       '';
       default = { };
       example = {
-        "*" = {
-          enable = true;
-          settings = {
-            root_markers = [ ".git" ];
-            capabilities.textDocument.semanticTokens = {
-              multilineTokenSupport = true;
-            };
+        "*".settings = {
+          root_markers = [ ".git" ];
+          capabilities.textDocument.semanticTokens = {
+            multilineTokenSupport = true;
           };
         };
         luals.enable = true;

--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -179,16 +179,14 @@ in
               luaName = toLuaObject server.name;
               luaSettings = toLuaObject server.settings;
             in
-            ''
-              vim.lsp.config(${luaName}, ${luaSettings})
-            ''
-            + lib.optionalString (server.activate or false) ''
-              vim.lsp.enable(${luaName})
-            '';
+            [
+              (lib.mkIf (server.settings != { }) "vim.lsp.config(${luaName}, ${luaSettings})")
+              (lib.mkIf (server.activate or false) "vim.lsp.enable(${luaName})")
+            ];
         in
         lib.mkMerge (
           lib.optional cfg.inlayHints.enable "vim.lsp.inlay_hint.enable(true)"
-          ++ builtins.map mkServerConfig enabledServers
+          ++ builtins.concatMap mkServerConfig enabledServers
         );
 
       extraConfigLua = lib.mkIf (cfg.luaConfig.content != "") ''

--- a/modules/lsp/server-base.nix
+++ b/modules/lsp/server-base.nix
@@ -2,6 +2,7 @@
 {
   displayName ? "the language server",
   settings ? null,
+  enable ? null,
 }:
 { lib, ... }:
 let
@@ -9,7 +10,12 @@ let
 in
 {
   options = {
-    enable = lib.mkEnableOption displayName;
+    enable = lib.mkOption rec {
+      type = types.bool;
+      description = "Whether to enable ${enable.name or displayName}. ${enable.extraDescription or ""}";
+      default = enable.default or false;
+      example = enable.example or (!default);
+    };
 
     settings = lib.mkOption {
       type = with types; attrsOf anything;

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -1,14 +1,11 @@
 {
   example = {
     lsp.servers = {
-      "*" = {
+      "*".settings = {
         enable = true;
-        settings = {
-          enable = true;
-          root_markers = [ ".git" ];
-          capabilities.textDocument.semanticTokens = {
-            multilineTokenSupport = true;
-          };
+        root_markers = [ ".git" ];
+        capabilities.textDocument.semanticTokens = {
+          multilineTokenSupport = true;
         };
       };
       luals.enable = true;


### PR DESCRIPTION
- **modules/lsp: check if server `settings` is empty**

Avoid writing `vim.lsp.config(...)` to `init.lua` when `server.settings == {}`

- **modules/lsp: enable `servers."*"` by default**

Change the `lsp.servers."*".enable` to default to true.

- Extracted from https://github.com/nix-community/nixvim/pull/3258
- Fixes https://github.com/nix-community/nixvim/issues/3256
