### PR TITLE
plugins/schemastore: adapt to new lsp module

### DIFF
--- a/tests/test-sources/plugins/by-name/schemastore/default.nix
+++ b/tests/test-sources/plugins/by-name/schemastore/default.nix
@@ -1,5 +1,94 @@
 {
   empty = {
+    lsp = {
+      servers = {
+        jsonls.enable = true;
+        yamlls.enable = true;
+      };
+    };
+
+    plugins.schemastore.enable = true;
+  };
+
+  example = {
+    lsp = {
+      servers = {
+        jsonls.enable = true;
+        yamlls.enable = true;
+      };
+    };
+
+    plugins.schemastore = {
+      enable = true;
+
+      json = {
+        enable = true;
+        settings = {
+          replace."package.json" = {
+            description = "package.json overridden";
+            fileMatch = [ "package.json" ];
+            name = "package.json";
+            url = "https://example.com/package.json";
+          };
+          extra = [
+            {
+              description = "My custom JSON schema";
+              fileMatch = "foo.json";
+              name = "foo.json";
+              url = "https://example.com/schema/foo.json";
+            }
+            {
+              description = "My other custom JSON schema";
+              fileMatch = [
+                "bar.json"
+                ".baar.json"
+              ];
+              name = "bar.json";
+              url = "https://example.com/schema/bar.json";
+            }
+          ];
+        };
+      };
+      yaml = {
+        enable = true;
+        settings = { };
+      };
+    };
+  };
+
+  withJson = {
+    lsp = {
+      servers.jsonls.enable = true;
+    };
+
+    plugins.schemastore = {
+      enable = true;
+
+      json = {
+        enable = true;
+        settings = { };
+      };
+      yaml.enable = false;
+    };
+  };
+
+  withYaml = {
+    lsp = {
+      servers.yamlls.enable = true;
+    };
+
+    plugins.schemastore = {
+      enable = true;
+
+      json.enable = false;
+      yaml = {
+        enable = true;
+        settings = { };
+      };
+    };
+  };
+
+  emptyOld = {
     plugins = {
       lsp = {
         enable = true;
@@ -14,57 +103,7 @@
     };
   };
 
-  example = {
-    plugins = {
-      lsp = {
-        enable = true;
-
-        servers = {
-          jsonls.enable = true;
-          yamlls.enable = true;
-        };
-      };
-
-      schemastore = {
-        enable = true;
-
-        json = {
-          enable = true;
-          settings = {
-            replace."package.json" = {
-              description = "package.json overridden";
-              fileMatch = [ "package.json" ];
-              name = "package.json";
-              url = "https://example.com/package.json";
-            };
-            extra = [
-              {
-                description = "My custom JSON schema";
-                fileMatch = "foo.json";
-                name = "foo.json";
-                url = "https://example.com/schema/foo.json";
-              }
-              {
-                description = "My other custom JSON schema";
-                fileMatch = [
-                  "bar.json"
-                  ".baar.json"
-                ];
-                name = "bar.json";
-                url = "https://example.com/schema/bar.json";
-              }
-            ];
-          };
-        };
-        yaml = {
-          enable = true;
-          settings = { };
-        };
-      };
-    };
-  };
-
-  withJson = {
+  withJsonOld = {
     plugins = {
       lsp = {
         enable = true;
@@ -83,7 +122,7 @@
     };
   };
 
-  withYaml = {
+  withYamlOld = {
     plugins = {
       lsp = {
         enable = true;
@@ -101,4 +140,5 @@
       };
     };
   };
+
 }


### PR DESCRIPTION
I have been seeing these warnings 

```
evaluation warning: Nixvim (plugins.schemastore): You have enabled `json` schemas, but `plugins.lsp.servers.jsonls` is not enabled.
evaluation warning: Nixvim (plugins.schemastore): You have enabled `yaml` schemas, but `plugins.lsp.servers.yamlls` is not enabled.
```

when using the new lsp module. This PR adapts the schemastore module to work with the new lsp module as well and updates the tests to include testing against the new lsp module.