### PR TITLE
plugins/clangd-extensions: adapt to new lsp module

### DIFF
--- a/plugins/by-name/clangd-extensions/default.nix
+++ b/plugins/by-name/clangd-extensions/default.nix
@@ -76,18 +76,27 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   extraConfig = cfg: {
     warnings = lib.nixvim.mkWarnings "plugins.clangd-extensions" {
-      when = !config.plugins.lsp.enable;
+      when = !(config.plugins.lsp.enable || config.lsp.servers.clangd.enable);
 
       message = ''
-        You have enabled `clangd-extensions` but not the lsp (`plugins.lsp`).
-        You should set `plugins.lsp.enable = true` to make use of the clangd-extensions' features.
+        You have enabled `clangd-extensions` but not the lsp (`plugins.lsp` or `lsp.servers.clangd`).
+        You should set `plugins.lsp.enable = true` or `lsp.servers.clangd.enable = true` to make use of the clangd-extensions' features.
       '';
+    };
+
+    lsp = {
+      servers.clangd = {
+        settings = lib.mkIf cfg.enableOffsetEncodingWorkaround {
+          capabilities = {
+            offsetEncoding = [ "utf-16" ];
+          };
+        };
+      };
     };
 
     plugins.lsp = {
       servers.clangd = {
         enable = lib.mkDefault true;
-
         extraOptions = lib.mkIf cfg.enableOffsetEncodingWorkaround {
           capabilities.__raw = ''
             vim.tbl_deep_extend(

--- a/tests/test-sources/plugins/by-name/clangd-extensions/default.nix
+++ b/tests/test-sources/plugins/by-name/clangd-extensions/default.nix
@@ -1,15 +1,16 @@
 {
   empty = {
+    lsp.servers.clangd.enable = true;
+
     plugins = {
-      lsp.enable = true;
       clangd-extensions.enable = true;
     };
   };
 
   default = {
-    plugins = {
-      lsp.enable = true;
+    lsp.servers.clangd.enable = true;
 
+    plugins = {
       clangd-extensions = {
         enable = true;
 
@@ -50,8 +51,9 @@
   };
 
   example = {
+    lsp.servers.clangd.enable = true;
+
     plugins = {
-      lsp.enable = true;
       clangd-extensions = {
         enable = true;
 
@@ -68,6 +70,13 @@
           };
         };
       };
+    };
+  };
+
+  emptyOld = {
+    plugins = {
+      lsp.enable = true;
+      clangd-extensions.enable = true;
     };
   };
 }


### PR DESCRIPTION
Adapt warnings, default settings, and tests to the new lsp module. Also change the previous warning, which I think should target the clangd server directly, and just not `plugins.lsp`, since the clangd server is necessary for clangd-extensions to function and a user might have disabled it on their end.

I made `lsp.servers.clangd` true by default now, but maybe it would be better to retain having `plugins.lsp.clangd` being set to default while the module matures?