### PR TITLE
plugins/tiny-inline-diagnostic: init

### DIFF
--- a/plugins/by-name/tiny-inline-diagnostic/default.nix
+++ b/plugins/by-name/tiny-inline-diagnostic/default.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "tiny-inline-diagnostic";
+  packPathName = "tiny-inline-diagnostic.nvim";
+  package = "tiny-inline-diagnostic-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  extraConfig = {
+    # README encourages to disable `virtual_text`, to not have all diagnostics in the buffer
+    # displayed.
+    diagnostic.settings.virtual_text = lib.mkDefault false;
+  };
+
+  settingsExample = {
+    preset = "classic";
+    virt_texts = {
+      priority = 2048;
+    };
+    multilines = {
+      enabled = true;
+    };
+    options = {
+      use_icons_from_diagnostic = true;
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/tiny-inline-diagnostic/default.nix
+++ b/tests/test-sources/plugins/by-name/tiny-inline-diagnostic/default.nix
@@ -1,0 +1,85 @@
+{ lib, ... }:
+{
+  empty = {
+    plugins.tiny-inline-diagnostic.enable = true;
+  };
+
+  defaults = {
+    plugins.tiny-inline-diagnostic = {
+      enable = true;
+
+      settings = {
+        preset = "classic";
+        virt_texts = {
+          priority = 2048;
+        };
+        multilines = {
+          enabled = true;
+        };
+        options = {
+          use_icons_from_diagnostic = true;
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.tiny-inline-diagnostic = {
+      enable = true;
+
+      settings = {
+        preset = "modern";
+        transparent_bg = false;
+        transparent_cursorline = false;
+        hi = {
+          error = "DiagnosticError";
+          warn = "DiagnosticWarn";
+          info = "DiagnosticInfo";
+          hint = "DiagnosticHint";
+          arrow = "NonText";
+          background = "CursorLine";
+          mixing_color = "None";
+        };
+        options = {
+          show_source = {
+            enabled = false;
+            if_many = false;
+          };
+          use_icons_from_diagnostic = false;
+          set_arrow_to_diag_color = false;
+          add_messages = true;
+          throttle = 20;
+          softwrap = 30;
+          multilines = {
+            enabled = false;
+            always_show = false;
+          };
+          show_all_diags_on_cursorline = false;
+          enable_on_insert = false;
+          enable_on_select = false;
+
+          overflow = {
+            mode = "wrap";
+            padding = 0;
+          };
+          break_line = {
+            enabled = false;
+            after = 30;
+          };
+          format = null;
+          virt_texts = {
+            priority = 2048;
+          };
+          severity = [
+            (lib.nixvim.mkRaw "vim.diagnostic.severity.ERROR")
+            (lib.nixvim.mkRaw "vim.diagnostic.severity.WARN")
+            (lib.nixvim.mkRaw "vim.diagnostic.severity.INFO")
+            (lib.nixvim.mkRaw "vim.diagnostic.severity.HINT")
+          ];
+          overwrite_events = null;
+        };
+        disabled_ft = [ ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [tiny-inline-diagnostic.nvim](https://github.com/rachartier/tiny-inline-diagnostic.nvim), a plugin that display prettier diagnostic messages.

Closes #3266
