### PR TITLE
plugins/lf: init

### DIFF
--- a/plugins/by-name/lf/default.nix
+++ b/plugins/by-name/lf/default.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "lf";
+  packPathName = "lf.nvim";
+  package = "lf-nvim";
+
+  description = ''
+    Lf file manager integration for Neovim
+  '';
+
+  maintainers = [ lib.maintainers.bpeetz ];
+
+  settingsExample = {
+    default_action = "drop";
+    default_actions = {
+      "<C-t>" = "tabedit";
+      "<C-x>" = "split";
+      "<C-v>" = "vsplit";
+      "<C-o>" = "tab drop";
+    };
+    winblend = 10;
+    dir = "";
+    direction = "float";
+    border = "rounded";
+    height.__raw = "vim.fn.float2nr(vim.fn.round(0.75 * vim.o.lines))";
+    width.__raw = "vim.fn.float2nr(vim.fn.round(0.75 * vim.o.columns))";
+    escape_quit = true;
+    focus_on_open = true;
+    tmux = false;
+    default_file_manager = true;
+    disable_netrw_warning = true;
+  };
+}

--- a/tests/test-sources/plugins/by-name/lf/default.nix
+++ b/tests/test-sources/plugins/by-name/lf/default.nix
@@ -1,0 +1,68 @@
+{
+  empty = {
+    plugins.lf.enable = true;
+  };
+
+  defaults = {
+    plugins.lf = {
+      enable = true;
+
+      settings = {
+        default_action = "drop";
+        default_actions = {
+          "<C-S>" = "tabedit";
+          "<C-V>" = "split";
+          "<C-L>" = "vsplit";
+          "<C-F>" = "tab drop";
+        };
+        winblend = 10;
+        layout_mapping = "<M-u>";
+        views = [
+          {
+            width = 0.8;
+            height = 0.8;
+          }
+          {
+            width = 0.2;
+            height = 0.9;
+            col = 0;
+            row = 0.5;
+          }
+          {
+            width = 1;
+            height = 0.8;
+            col = 1;
+            row = 0;
+          }
+        ];
+      };
+    };
+  };
+
+  example = {
+    plugins.lf = {
+      enable = true;
+
+      settings = {
+        default_action = "drop";
+        default_actions = {
+          "<C-t>" = "tabedit";
+          "<C-x>" = "split";
+          "<C-v>" = "vsplit";
+          "<C-o>" = "tab drop";
+        };
+        winblend = 10;
+        dir = "";
+        direction = "float";
+        border = "rounded";
+        height.__raw = "vim.fn.float2nr(vim.fn.round(0.75 * vim.o.lines))";
+        width.__raw = "vim.fn.float2nr(vim.fn.round(0.75 * vim.o.columns))";
+        escape_quit = true;
+        focus_on_open = true;
+        tmux = false;
+        default_file_manager = true;
+        disable_netrw_warning = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Fixes: #3124.

I went with calling this `lf` instead of `lf-nvim` because I do not think that supporting the packaging of `lf.vim` in the future is needed, as both effectively share the same features.

Unfortunately, I could not finish a run of `nix flake check --all-systems --option max-jobs 1` as it consistently OOMed my system (and that is with ~28GB of available ram), but I came rather close to finishing it and the change seems rather straight forward.