### PR TITLE
modules/lsp/keymaps: init

### DIFF
--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -137,6 +137,10 @@ in
     };
   };
 
+  imports = [
+    ./keymaps.nix
+  ];
+
   config =
     let
       enabledServers = lib.pipe cfg.servers [

--- a/modules/lsp/keymaps.nix
+++ b/modules/lsp/keymaps.nix
@@ -1,0 +1,123 @@
+{ lib, config, ... }:
+let
+  inherit (lib) types;
+  inherit (lib.nixvim.keymaps) mkMapOptionSubmodule;
+
+  cfg = config.lsp;
+
+  # An extra module to include in the keymap option submodule
+  # Declares and implements a specialised `lspBufAction` option
+  extraKeymapModule =
+    { config, options, ... }:
+    {
+      options.lspBufAction = lib.mkOption {
+        type = types.nullOr types.str;
+        description = ''
+          LSP buffer action to use for `action`.
+
+          If non-null, the keymap's `action` will be defined as `vim.lsp.buf.<action>`.
+
+          See [`:h lsp-buf`](https://neovim.io/doc/user/lsp.html#lsp-buf)
+        '';
+        default = null;
+        example = "hover";
+      };
+
+      config.action = lib.mkIf (config.lspBufAction != null) (
+        lib.mkDerivedConfig options.lspBufAction (
+          action: lib.nixvim.mkRaw "vim.lsp.buf[${lib.nixvim.toLuaObject action}]"
+        )
+      );
+    };
+in
+{
+  options.lsp = {
+    keymaps = lib.mkOption {
+      type = types.listOf (mkMapOptionSubmodule {
+        action.example = "<CMD>LspRestart<Enter>";
+        extraModules = [ extraKeymapModule ];
+      });
+      description = ''
+        Keymaps to register when a language server is attached.
+      '';
+      default = [ ];
+      example = [
+        {
+          key = "gd";
+          lspBufAction = "definition";
+        }
+        {
+          key = "gD";
+          lspBufAction = "references";
+        }
+        {
+          key = "gt";
+          lspBufAction = "type_definition";
+        }
+        {
+          key = "gi";
+          lspBufAction = "implementation";
+        }
+        {
+          key = "K";
+          lspBufAction = "hover";
+        }
+
+        {
+          key = "<leader>k";
+          action = lib.nixvim.nestedLiteralLua "function() vim.diagnostic.jump({ count=-1, float=true }) end";
+        }
+        {
+          key = "<leader>j";
+          action = lib.nixvim.nestedLiteralLua "function() vim.diagnostic.jump({ count=1, float=true }) end";
+        }
+        {
+          key = "<leader>lx";
+          action = "<CMD>LspStop<Enter>";
+        }
+        {
+          key = "<leader>ls";
+          action = "<CMD>LspStart<Enter>";
+        }
+        {
+          key = "<leader>lr";
+          action = "<CMD>LspRestart<Enter>";
+        }
+        {
+          key = "gd";
+          action = lib.nixvim.nestedLiteralLua "require('telescope.builtin').lsp_definitions";
+        }
+        {
+          key = "K";
+          action = "<CMD>Lspsaga hover_doc<Enter>";
+        }
+      ];
+    };
+  };
+
+  config = lib.mkIf (cfg.keymaps != [ ]) {
+    autoGroups.nixvim_lsp_binds.clear = false;
+
+    autoCmd = [
+      {
+        event = "LspAttach";
+        group = "nixvim_lsp_binds";
+        callback = lib.nixvim.mkRaw ''
+          function(args)
+            ${lib.concatMapStringsSep "\n" (
+              keymap:
+              # lua
+              ''
+                do
+                  local map = ${lib.nixvim.toLuaObject keymap}
+                  local options = vim.tbl_extend("keep", map.options or {}, { buffer = args.buf })
+                  vim.keymap.set(map.mode, map.key, map.action, options)
+                end
+              '') cfg.keymaps}
+          end
+        '';
+        desc = "Load LSP keymaps";
+      }
+    ];
+  };
+}


### PR DESCRIPTION
Initial LSP keymaps option, inspired by `keymapsOnEvent` and `plugins.lsp.keymaps`.

Users can define `lspBufAction` instead of `action` if they wish to use a `vim.lsp.buf.<action>` callback.

---

I initially had a `diagnosticAction` option too, however looking at the manual there aren't many `vim.diagnostic.<action>` functions that'd be useful here.
Previously, `goto_prev` and `goto_next` fit well here, however 0.11 [deprecated](https://neovim.io/doc/user/deprecated.html#deprecated-0.11) those in favour of passing `count=1` or `count=-1` to `jump`, which can't easily be represented by a `diagnosticAction` option.

<details><summary><code>diagnosticAction</code></summary>

```nix
{ config, options, ... }:
{
  options = {
    lspBufAction = lib.mkOption {
      type = types.nullOr types.str;
      description = ''
        LSP buffer action to use for `action`.

        If non-null, the keymap's `action` will be defined as `vim.lsp.buf.<action>`.

        See [`:h lsp-buf`](https://neovim.io/doc/user/lsp.html#lsp-buf)
      '';
      default = null;
      example = "hover";
    };

    diagnosticsAction = lib.mkOption {
      type = types.nullOr types.str;
      description = ''
        Diagnostic action to use for `action`.

        If non-null, the keymap's `action` will be defined as `vim.diagnostic.<action>`.

        See [`:h diagnostic-api`](https://neovim.io/doc/user/diagnostic.html#diagnostic-api)
      '';
      default = null;
      example = "goto_next";
    };
  };

  config.action = lib.mkMerge [
    (lib.mkIf (config.lspBufAction != null) (
      lib.mkDerivedConfig options.lspBufAction (
        action: lib.nixvim.mkRaw "vim.lsp.buf[${lib.nixvim.toLuaObject action}]"
      )
    ))
    (lib.mkIf (config.diagnosticsAction != null) (
      lib.mkDerivedConfig options.diagnosticsAction (
        action: lib.nixvim.mkRaw "vim.diagnostic[${lib.nixvim.toLuaObject action}]"
      )
    ))
  ];
}
```

</details>

Maybe `vim.diagnostic.hide`, `show`, `enable`, etc could be useful, but many of those are often called with arguments too. 🤔

---

I'm on the fence with whether it is better to use `keymapsOnEvent.LspAttach` or to define a dedicated autocmd. I think it's neater to have a separate dedicated autocmd with its own dedicated group.

---

Fixes #3252
