### PR TITLE
modules/lsp: add `onAttach` option

### DIFF
--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -20,6 +20,7 @@ in
   imports = [
     ./servers
     ./keymaps.nix
+    ./on-attach.nix
   ];
 
   config = {

--- a/modules/lsp/on-attach.nix
+++ b/modules/lsp/on-attach.nix
@@ -1,0 +1,48 @@
+{ lib, config, ... }:
+let
+  cfg = config.lsp;
+in
+{
+  options.lsp = {
+    onAttach = lib.mkOption {
+      type = lib.types.lines;
+      description = ''
+        Lines of lua to be run when a language server is attached.
+
+        > [!TIP]
+        > The variables `client` and `bufnr` are made available in scope.
+
+        This is a global equivialent to the per-server `on_attach` callback,
+        which can be defined via `lsp.servers.<name>.settings.on_attach`.
+
+        Unlike the per-server callback, which should be defined as a lua
+        callback function, this option should be defined as the function body.
+      '';
+      default = "";
+    };
+  };
+
+  config = lib.mkIf (cfg.onAttach != "") {
+    autoGroups.nixvim_lsp_on_attach.clear = false;
+
+    autoCmd = [
+      {
+        event = "LspAttach";
+        group = "nixvim_lsp_on_attach";
+        callback = lib.nixvim.mkRaw ''
+          function(args)
+            do
+              -- client and bufnr are supplied to the builtin `on_attach` callback,
+              -- so make them available in scope for our global `onAttach` impl
+              local client = vim.lsp.get_client_by_id(args.data.client_id)
+              local bufnr = args.bufnr
+
+              ${cfg.onAttach}
+            end
+          end
+        '';
+        desc = "Run LSP onAttach";
+      }
+    ];
+  };
+}

--- a/tests/test-sources/plugins/by-name/lsp-format/default.nix
+++ b/tests/test-sources/plugins/by-name/lsp-format/default.nix
@@ -76,4 +76,19 @@
       };
     };
   };
+
+  listed-servers = {
+    plugins = {
+      lspconfig.enable = true;
+
+      lsp-format = {
+        enable = true;
+        lspServersToEnable = [
+          "foo"
+          "bar"
+          "baz"
+        ];
+      };
+    };
+  };
 }


### PR DESCRIPTION
Similar to `plugins.lsp.onAttach`, implement a "global" equivalent to the per-server `on_attach` callback.

The implementation is simpler than `plugins.lsp.onAttach`, by using a `LspAttach` autocmd. The old impl was to propagate the global _onAttach_ lines into each server's `on_attach` callback.

The old impl should be able to migrate to using the new option under the hood, or even become an alias of it.

Alternatively, we might decide we don't want this at all? Although it seems convenient.

Perhaps in future it'd be nice to have a similar per-server `onAttach` option? When the per-server `onAttach` option is defined, `settings.on_attach` would be derived from it, using it as the function body.
