### PR TITLE
colorschemes/kanagawa-paper: init

### DIFF
--- a/plugins/colorschemes/kanagawa-paper.nix
+++ b/plugins/colorschemes/kanagawa-paper.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "kanagawa-paper";
+  isColorscheme = true;
+  packPathName = "kanagawa-paper.nvim";
+  package = "kanagawa-paper-nvim";
+
+  description = ''
+    You can select the theme in two ways:
+    - Set `colorschemes.kanagawa-paper.settings.theme` AND explicitly unset `vim.o.background` (i.e. `opts.background = ""`).
+    - Set `colorschemes.kanagawa-paper.settings.background` (the active theme will depend on the value of `vim.o.background`).
+  '';
+
+  maintainers = [ lib.maintainers.FKouhai ];
+
+  settingsExample = {
+    background = "dark";
+    cache = false;
+    colors = {
+      palette = { };
+      theme = {
+        ink = { };
+        canvas = { };
+      };
+    };
+
+    undercurl = true;
+    styles = {
+      comments = {
+        italic = true;
+      };
+      functions = {
+        italic = true;
+      };
+      keywords = {
+        italic = true;
+      };
+      statement_style = {
+        bold = true;
+      };
+    };
+
+    transparent = true;
+    auto_plugins = false;
+    dim_inactive = false;
+    gutter = false;
+    compile = false;
+    overrides = lib.nixvim.nestedLiteralLua "function(colors) return {} end";
+    terminal_colors = false;
+    theme = "ink";
+  };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -12,6 +12,7 @@
     ./colorschemes/github-theme.nix
     ./colorschemes/gruvbox.nix
     ./colorschemes/kanagawa.nix
+    ./colorschemes/kanagawa-paper.nix
     ./colorschemes/melange.nix
     ./colorschemes/modus.nix
     ./colorschemes/monokai-pro.nix

--- a/tests/test-sources/plugins/colorschemes/kanagawa-paper.nix
+++ b/tests/test-sources/plugins/colorschemes/kanagawa-paper.nix
@@ -1,0 +1,48 @@
+{
+  empty = {
+    # disable test due to this error: ERROR: Cache updated: kanagawa-paper-plugins.json
+    # initial assessment was to disable cache via plugin config but that did not work
+    # then disabled the plugins loading on auto and that did not work either, might be a runtime setup
+    test.runNvim = false;
+    colorschemes.kanagawa-paper.enable = true;
+  };
+
+  defaults = {
+    test.runNvim = false;
+    colorschemes.kanagawa-paper = {
+      enable = true;
+
+      settings = {
+        cache = false;
+        colors = {
+          palette = { };
+          theme = {
+            ink = { };
+            canvas = { };
+          };
+        };
+        undercurl = true;
+        styles = {
+          comments = {
+            italic = true;
+          };
+          functions = {
+            italic = true;
+          };
+          keywords = {
+            italic = true;
+          };
+          statement_style = {
+            bold = true;
+          };
+        };
+        transparent = true;
+        auto_plugins = false;
+        dim_inactive = false;
+        terminal_colors = false;
+        gutter = false;
+        theme = "ink";
+      };
+    };
+  };
+}


### PR DESCRIPTION
this PR introduces the kanagawa-paper colorsheme config via nixvim.
the package is already on nixpkgs-unstable and nixos-unstable.
PR in nixpkgs: https://github.com/NixOS/nixpkgs/pull/403656

testing wise im encountering some issues with tests being "killed"
![image](https://github.com/user-attachments/assets/f594e903-22e7-40b2-96db-efeee9006551)
