### PR TITLE
plugins/blink-copilot: Mention in the description that copilot-lua is enabled by default

### DIFF
--- a/plugins/by-name/blink-copilot/default.nix
+++ b/plugins/by-name/blink-copilot/default.nix
@@ -8,6 +8,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   description = ''
     This plugin should be configured through blink-cmp's `sources.providers` settings.
 
+    `plugins.copilot-lua` will be enabled by default, to provide a working setup out-of-the-box.
+    You may disable it by explicitly adding `plugins.copilot-lua.enable = false` to your
+    configuration.
+
     For example:
 
     ```nix


### PR DESCRIPTION
`copilot-lua` is not needed by `blink-copilot` anymore.

Reference: https://github.com/fang2hou/blink-copilot/commit/bdc45bbbed2ec252b3a29f4adecf031e157b5573

Fixes #3283.
