### PR TITLE
Port lsp-format to use non-deprecated setup instructions

### DIFF
--- a/tests/test-sources/plugins/by-name/lsp-format/default.nix
+++ b/tests/test-sources/plugins/by-name/lsp-format/default.nix
@@ -1,10 +1,10 @@
 {
-  empty = {
+  legacy-empty = {
     plugins.lsp.enable = true;
     plugins.lsp-format.enable = true;
   };
 
-  example = {
+  legacy-example = {
     plugins = {
       lsp = {
         enable = true;
@@ -16,6 +16,45 @@
           '';
         };
       };
+
+      lsp-format = {
+        enable = true;
+
+        settings = {
+          go = {
+            exclude = [ "gopls" ];
+            order = [
+              "gopls"
+              "efm"
+            ];
+            sync = true;
+            force = true;
+
+            # Test the ability to provide extra options for each filetype
+            someRandomOption = 42;
+          };
+        };
+      };
+    };
+  };
+
+  empty = {
+    plugins.lspconfig.enable = true;
+    plugins.lsp-format.enable = true;
+  };
+
+  none = {
+    plugins.lspconfig.enable = true;
+    plugins.lsp-format = {
+      enable = true;
+      lspServersToEnable = "none";
+    };
+  };
+
+  example = {
+    plugins = {
+      lspconfig.enable = true;
+      lsp.servers.gopls.enable = true;
 
       lsp-format = {
         enable = true;


### PR DESCRIPTION
Upstream still documents the now-deprecated
`require("lspconfig").<name>.setup` mechanism. I believe the modern alternative is to register a `LspAttach` autocmd. For more context, see:

- https://github.com/lukas-reineke/lsp-format.nvim/issues/98
- https://github.com/lukas-reineke/lsp-format.nvim/pull/99