### PR TITLE
plugins.lsp: alias `onAttach` to new `lsp.onAttach`

### DIFF
--- a/plugins/by-name/rust-tools/default.nix
+++ b/plugins/by-name/rust-tools/default.nix
@@ -173,7 +173,6 @@ in
           server = {
             inherit (cfg.server) standalone;
             settings.rust-analyzer = lib.filterAttrs (n: v: n != "standalone") cfg.server;
-            on_attach = lib.nixvim.mkRaw "__lspOnAttach";
           };
         } // cfg.extraOptions;
       in

--- a/plugins/by-name/rustaceanvim/default.nix
+++ b/plugins/by-name/rustaceanvim/default.nix
@@ -53,43 +53,30 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   callSetup = false;
   hasLuaConfig = false;
-  extraConfig =
-    cfg:
-    mkMerge [
-      {
-        globals.rustaceanvim = cfg.settings;
+  extraConfig = cfg: {
+    globals.rustaceanvim = cfg.settings;
 
-        assertions = lib.nixvim.mkAssertions "plugins.rustaceanvim" {
-          assertion = cfg.enable -> !config.plugins.lsp.servers.rust_analyzer.enable;
-          message = ''
-            Both `plugins.rustaceanvim.enable` and `plugins.lsp.servers.rust_analyzer.enable` are true.
-            Disable one of them otherwise you will have multiple clients attached to each buffer.
-          '';
-        };
+    assertions = lib.nixvim.mkAssertions "plugins.rustaceanvim" {
+      assertion = cfg.enable -> !config.plugins.lsp.servers.rust_analyzer.enable;
+      message = ''
+        Both `plugins.rustaceanvim.enable` and `plugins.lsp.servers.rust_analyzer.enable` are true.
+        Disable one of them otherwise you will have multiple clients attached to each buffer.
+      '';
+    };
 
-        # TODO: remove after 24.11
-        warnings = lib.nixvim.mkWarnings "plugins.rustaceanvim" {
-          when = hasAttrByPath [
-            "settings"
-            "server"
-            "settings"
-          ] cfg;
-          message = ''
-            The `settings.server.settings' option has been renamed to `settings.server.default_settings'.
+    # TODO: remove after 24.11
+    warnings = lib.nixvim.mkWarnings "plugins.rustaceanvim" {
+      when = hasAttrByPath [
+        "settings"
+        "server"
+        "settings"
+      ] cfg;
+      message = ''
+        The `settings.server.settings' option has been renamed to `settings.server.default_settings'.
 
-            Note that if you supplied an attrset and not a function you need to set this attr set in:
-              `settings.server.default_settings.rust-analyzer'.
-          '';
-        };
-      }
-      # If nvim-lspconfig is enabled:
-      (mkIf config.plugins.lsp.enable {
-        # Use the same `on_attach` callback as for the other LSP servers
-        plugins.rustaceanvim.settings.server.on_attach = mkDefault ''
-          function(client, bufnr)
-            return _M.lspOnAttach(client, bufnr)
-          end
-        '';
-      })
-    ];
+        Note that if you supplied an attrset and not a function you need to set this attr set in:
+          `settings.server.default_settings.rust-analyzer'.
+      '';
+    };
+  };
 }

--- a/plugins/by-name/rustaceanvim/settings-options.nix
+++ b/plugins/by-name/rustaceanvim/settings-options.nix
@@ -234,11 +234,7 @@ with lib;
       ```
     '';
 
-    on_attach = helpers.mkNullOrLuaFn ''
-      Function to call on attach.
-      If `plugins.lsp` is enabled, it defaults to the Nixvim global `__lspOnAttach` function.
-      Otherwise it defaults to `null`.
-    '';
+    on_attach = helpers.defaultNullOpts.mkLuaFn null "Function to call when rustaceanvim attaches to a buffer.";
 
     cmd = helpers.mkNullOrStrLuaFnOr (with types; listOf str) ''
       Command and arguments for starting rust-analyzer.

--- a/plugins/by-name/typescript-tools/default.nix
+++ b/plugins/by-name/typescript-tools/default.nix
@@ -19,7 +19,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   ];
 
   settingsOptions = {
-    on_attach = defaultNullOpts.mkLuaFn "__lspOnAttach" "Lua code to run when tsserver attaches to a buffer.";
+    on_attach = defaultNullOpts.mkLuaFn null "Function to call when tsserver attaches to a buffer.";
 
     handlers = lib.mkOption {
       type = with lib.types; nullOr (attrsOf strLuaFn);


### PR DESCRIPTION
Follow up to #3280

Simplify the impl by doing global on-attach logic in `lsp.onAttach` (i.e. a `LspAttach` autocmd) instead of adding lua lines to each server's individual `on_attach` callback function.

This is effectively a `mkAliasOptionModule [ "plugins" "lsp" "onAttach" ] [ "lsp" "onAttach" ]` alias, but it is only applied when `plugins.lsp.enable` is true.
