### PR TITLE
plugins/lsp: correct motivation for `onAttach` alias impl

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -182,15 +182,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
     # `mkAliasAndWrapDefinitions` and `mkAliasAndWrapDefsWithPriority` propagates the un-merged
     # `definitions`.
     #
-    # This assumes both options have compatible merge functions, but it allows override and order
-    # priorities to be merged correctly.
-    #
-    # E.g:
-    #    lsp.onAttach = mkAfter "world";
-    #    plugins.lsp.onAttach = mkBefore "hello"
-    # ⇒
-    #    hello
-    #    world
+    # This assumes both options have compatible merge functions, but not using the final value allows
+    # implementing a two-way binding in the option's `apply` function. Using `mkDerivedConfig` for a
+    # two-way binding would result in infinite recursion.
     #
     # This is equivalent to `mkAliasOptionModule`, except predicated on `plugins.lsp.enable`.
     #


### PR DESCRIPTION
This PR has no code changes, but it corrects an incorrect and misleading comment in #3295.


Previously I said we alias the definitions instead of the value to allow `mkOrder` to work correctly. That is incorrect, as order-priorities are already sorted in `<opt>.definitions`.

The actual reason to use the definitions instead of the final value is to avoid inf-recursion. The "from" option's `apply` function reads the "to" option's value, which would be defined based on the "from" option's value, which is set by the "from" option's apply function...

For a one-way binding, `mkDerivedConfig` is best. For a two-way binding, `mkAliasAndWrapDefsWithPriority` is necessary.
