### PR TITLE
plugins/oil-git-status: improve desc; improve warning; set sane default

### DIFF
--- a/plugins/by-name/oil-git-status/default.nix
+++ b/plugins/by-name/oil-git-status/default.nix
@@ -15,7 +15,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
     Git status is added to the listing asynchronously after creating the oil directory
 
     listing so it won't slow oil down on big repositories. The plugin puts the status in two new sign columns
-
     the left being the status of the index, the right being the status of the working directory
 
     `win_options.signcolumn` needs to be configured in `plugins.oil.settings`:

--- a/plugins/by-name/oil-git-status/default.nix
+++ b/plugins/by-name/oil-git-status/default.nix
@@ -50,6 +50,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
   ];
 
   extraConfig = cfg: {
+    # Set the required default for plugins.oil's signcolumn:
+    plugins.oil.settings.win_options.signcolumn = lib.mkDefault "yes:2";
+
     warnings = lib.nixvim.mkWarnings "plugins.oil-git-status" [
       {
         when = !config.plugins.oil.enable;

--- a/plugins/by-name/oil-git-status/default.nix
+++ b/plugins/by-name/oil-git-status/default.nix
@@ -17,17 +17,27 @@ lib.nixvim.plugins.mkNeovimPlugin {
     listing so it won't slow oil down on big repositories. The plugin puts the status in two new sign columns
     the left being the status of the index, the right being the status of the working directory
 
-    `win_options.signcolumn` needs to be configured in `plugins.oil.settings`:
-    ```nix
-    plugins.oil = {
-      enable = true;
-      settings = {
-        win_options = {
-          signcolumn = "yes:2,";
-        };
-      };
-    };
-    ```
+    > [!NOTE]
+    > This plugin requires you configure `plugins.oil` to allow at least 2 sign columns:
+    >
+    > ```nix
+    > plugins.oil = {
+    >   enable = true;
+    >   settings = {
+    >     win_options = {
+    >       signcolumn = "yes:2";
+    >     };
+    >   };
+    > };
+    > ```
+    >
+    > Valid values include `yes` or `auto` with a "max" of at least `2`.
+    > E.g. `"yes:2"` or `"auto:1-2"`.
+    >
+    > See [plugin docs][readme-configuration] and [`:h 'signcolumn'`]
+
+    [readme-configuration]: https://github.com/refractalize/oil-git-status.nvim#configuration
+    [`:h 'signcolumn'`]: https://neovim.io/doc/user/options.html#'signcolumn'
   '';
 
   maintainers = [ lib.maintainers.FKouhai ];

--- a/tests/test-sources/plugins/by-name/oil-git-status/default.nix
+++ b/tests/test-sources/plugins/by-name/oil-git-status/default.nix
@@ -6,7 +6,7 @@
       enable = true;
       settings = {
         win_options = {
-          signcolumn = "yes:2,";
+          signcolumn = "yes:2";
         };
       };
     };
@@ -24,7 +24,7 @@
       enable = true;
       settings = {
         win_options = {
-          signcolumn = "yes:2,";
+          signcolumn = "yes:2";
         };
       };
     };

--- a/tests/test-sources/plugins/by-name/oil-git-status/default.nix
+++ b/tests/test-sources/plugins/by-name/oil-git-status/default.nix
@@ -31,4 +31,19 @@
     plugins.oil-git-status.enable = true;
   };
 
+  bad-signcolumn_yes = {
+    test.buildNixvim = false;
+    test.warnings = expect: [
+      (expect "count" 1)
+      (expect "any" "Nixvim (plugins.oil-git-status): This plugin requires `plugins.oil` is configured to allow at least 2 sign columns.")
+      (expect "any" "`plugins.oil.settings.win_options.signcolumn` is currently set to \"yes\".")
+    ];
+
+    plugins.oil = {
+      enable = true;
+      # Should trigger the warning
+      settings.win_options.signcolumn = "yes";
+    };
+    plugins.oil-git-status.enable = true;
+  };
 }


### PR DESCRIPTION
- **plugins/oil-git-status: fix whitespace in desc**
- **plugins/oil-git-status: update `signcolumn` instructions**
- **plugins/oil-git-status: improve `signcolumn` warning**
- **plugins/oil-git-status: set `signcolumn` sane default**

Minor follow ups to #3292, cc @FKouhai

For ease, please review one commit at a time.

This plugin requires you configure `plugins.oil` to allow at least 2 sign columns:

> Change the `oil` configuration to allow at least 2 sign columns
> ```lua
> require("oil").setup({
>  win_options = {
>    signcolumn = "yes:2",
>  },
> })
> ```
> — https://github.com/refractalize/oil-git-status.nvim#configuration

Looking at oil's docs, the `win_options` are options to apply to the oil buffer, so `signcolumn` is a vim setting (set by oil), not an actual oil setting.

The `signcolumn` docs are at [`:h 'signcolumn'`].

Notably, values can be `"no"`, `"auto"`, or `"yes"`; with an optional `:<num>` suffix specifying the number of allowed columns. Despite the confusion in https://github.com/nix-community/nixvim/pull/3292#discussion_r2080443419, there is no `,` syntax.

I'm unsure whether `"auto:2"` is an acceptable value for oil-git-status or if it _must_ be `"yes:2"`. Any idea @FKouhai ?

[`:h 'signcolumn'`]: https://neovim.io/doc/user/options.html#'signcolumn'

