### PR TITLE
flake: add overridable `systems` input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,7 +22,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -106,10 +106,26 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "nuschtosSearch": "nuschtosSearch"
+        "nuschtosSearch": "nuschtosSearch",
+        "systems": "systems"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
+    systems.url = "github:nix-systems/default";
+
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
@@ -26,13 +28,7 @@
   outputs =
     inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [
-        "x86_64-linux"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
-      ];
-
+      systems = import inputs.systems;
       imports = [ ./flake ];
     };
 }


### PR DESCRIPTION
Users can specify which systems to use by having our `systems` input follow a different file or flake:

```nix
{
  inputs = {
    # Here we list systems in a local file
    inputs.systems.url = "path:./systems.nix";
    inputs.systems.flake = false;

    inputs.nixvim.url = "github:nix-community/nixvim";
    # Here we override the list of systems with only our own
    inputs.nixvim.inputs.systems.follows = "systems";

    # ...
  };

  outputs = inputs: {
    # ...
  };
}
```

```nix
# systems.nix
[
  "x86_64-linux"
]
```

Alternatively, instead of users listing systems in a local file, they
can use an external flake, e.g.:

- `github:nix-systems/default`
  - Exposes aarch64 and x86_64 for linux and darwin
- `github:nix-systems/default-linux`
  - Exposes aarch64 and x86_64 for linux
- `github:nix-systems/default-darwin`
  - Exposes aarch64 and x86_64 for darwin
- `github:nix-systems/aarch64-darwin`
- `github:nix-systems/aarch64-linux`
- `github:nix-systems/x86_64-darwin`
- `github:nix-systems/x86_64-linux`

See https://github.com/nix-systems/nix-systems
