### PR TITLE
modules/performance: add ability to byte-compile lua packages and lua dependencies

### DIFF
--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -57,6 +57,9 @@ in
       nvimRuntime = lib.mkEnableOption "nvimRuntime" // {
         description = "Whether to byte compile lua files in Nvim runtime.";
       };
+      luaLib = lib.mkEnableOption "luaLib" // {
+        description = "Whether to byte compile lua library.";
+      };
     };
 
     combinePlugins = {

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -172,9 +172,10 @@ in
   config =
     let
       # Optionally byte compile lua library
+      inherit (import ./plugins/byte-compile-lua-lib.nix { inherit lib pkgs; }) byteCompileLuaPackages;
       extraLuaPackages =
         if config.performance.byteCompileLua.enable && config.performance.byteCompileLua.luaLib then
-          ps: map builders.byteCompileLuaDrv (config.extraLuaPackages ps)
+          ps: byteCompileLuaPackages (config.extraLuaPackages ps)
         else
           config.extraLuaPackages;
 

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -172,7 +172,9 @@ in
   config =
     let
       # Optionally byte compile lua library
-      inherit (import ./plugins/byte-compile-lua-lib.nix { inherit lib pkgs; }) byteCompileLuaPackages;
+      inherit (pkgs.callPackage ./plugins/byte-compile-lua-lib.nix { inherit lib; })
+        byteCompileLuaPackages
+        ;
       extraLuaPackages =
         if config.performance.byteCompileLua.enable && config.performance.byteCompileLua.luaLib then
           ps: byteCompileLuaPackages (config.extraLuaPackages ps)

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -171,11 +171,18 @@ in
 
   config =
     let
+      # Optionally byte compile lua library
+      extraLuaPackages =
+        if config.performance.byteCompileLua.enable && config.performance.byteCompileLua.luaLib then
+          ps: map builders.byteCompileLuaDrv (config.extraLuaPackages ps)
+        else
+          config.extraLuaPackages;
+
       neovimConfig = pkgs.neovimUtils.makeNeovimConfig (
         {
+          inherit extraLuaPackages;
           inherit (config)
             extraPython3Packages
-            extraLuaPackages
             viAlias
             vimAlias
             withRuby

--- a/modules/top-level/plugins/byte-compile-lua-lib.nix
+++ b/modules/top-level/plugins/byte-compile-lua-lib.nix
@@ -9,20 +9,35 @@ let
   builders = lib.nixvim.builders.withPkgs pkgs;
   inherit (import ./utils.nix lib) mapNormalizedPlugins;
 
+  luaPackages = pkgs.neovim-unwrapped.lua.pkgs;
+
+  # Applies a function to the derivation, but only if it's a lua module,
+  # otherwise returns it as is
+  mapLuaModule = f: drv: if luaPackages.luaLib.hasLuaModule drv then f drv else drv;
+
   # Byte-compile only lua dependencies
   byteCompileDeps =
     drv:
-    drv.overrideAttrs (
-      prev:
-      lib.optionalAttrs (prev ? propagatedBuildInputs) {
-        propagatedBuildInputs = map byteCompile prev.propagatedBuildInputs;
-      }
-    );
+    lib.pipe drv [
+      (
+        drv:
+        if drv.dependencies or [ ] != [ ] then
+          drv.overrideAttrs { dependencies = map byteCompileDeps drv.dependencies; }
+        else
+          drv
+      )
+      (
+        drv:
+        if drv.propagatedBuildInputs or [ ] != [ ] then
+          drv.overrideAttrs { propagatedBuildInputs = map byteCompile drv.propagatedBuildInputs; }
+        else
+          drv
+      )
+      # 'toLuaModule' updates requiredLuaModules attr
+      # It works without it, but update it anyway for consistency
+      (mapLuaModule luaPackages.toLuaModule)
+    ];
   # Byte-compile derivation (but only if it's a lua module) and its dependencies
-  byteCompile =
-    drv:
-    byteCompileDeps (
-      if pkgs.luaPackages.luaLib.hasLuaModule drv then builders.byteCompileLuaDrv drv else drv
-    );
+  byteCompile = drv: byteCompileDeps (mapLuaModule builders.byteCompileLuaDrv drv);
 in
 mapNormalizedPlugins byteCompileDeps

--- a/modules/top-level/plugins/byte-compile-lua-lib.nix
+++ b/modules/top-level/plugins/byte-compile-lua-lib.nix
@@ -1,0 +1,28 @@
+/*
+  Byte compiling of lua dependencies of normalized plugin list
+
+  Inputs: List of normalized plugins
+  Outputs: List of normalized plugins with all the propagatedBuildInputs byte-compiled
+*/
+{ lib, pkgs }:
+let
+  builders = lib.nixvim.builders.withPkgs pkgs;
+  inherit (import ./utils.nix lib) mapNormalizedPlugins;
+
+  # Byte-compile only lua dependencies
+  byteCompileDeps =
+    drv:
+    drv.overrideAttrs (
+      prev:
+      lib.optionalAttrs (prev ? propagatedBuildInputs) {
+        propagatedBuildInputs = map byteCompile prev.propagatedBuildInputs;
+      }
+    );
+  # Byte-compile derivation (but only if it's a lua module) and its dependencies
+  byteCompile =
+    drv:
+    byteCompileDeps (
+      if pkgs.luaPackages.luaLib.hasLuaModule drv then builders.byteCompileLuaDrv drv else drv
+    );
+in
+mapNormalizedPlugins byteCompileDeps

--- a/modules/top-level/plugins/byte-compile-lua-lib.nix
+++ b/modules/top-level/plugins/byte-compile-lua-lib.nix
@@ -1,10 +1,14 @@
 # Utilities for byte compiling of lua dependencies
-{ lib, pkgs }:
+{
+  lib,
+  pkgs,
+  neovim-unwrapped,
+}:
 let
   builders = lib.nixvim.builders.withPkgs pkgs;
   inherit (import ./utils.nix lib) mapNormalizedPlugins;
 
-  luaPackages = pkgs.neovim-unwrapped.lua.pkgs;
+  luaPackages = neovim-unwrapped.lua.pkgs;
 
   # Applies a function to the derivation, but only if it's a lua module,
   # otherwise returns it as is

--- a/modules/top-level/plugins/byte-compile-lua-lib.nix
+++ b/modules/top-level/plugins/byte-compile-lua-lib.nix
@@ -1,9 +1,4 @@
-/*
-  Byte compiling of lua dependencies of normalized plugin list
-
-  Inputs: List of normalized plugins
-  Outputs: List of normalized plugins with all the propagatedBuildInputs byte-compiled
-*/
+# Utilities for byte compiling of lua dependencies
 { lib, pkgs }:
 let
   builders = lib.nixvim.builders.withPkgs pkgs;
@@ -40,4 +35,14 @@ let
   # Byte-compile derivation (but only if it's a lua module) and its dependencies
   byteCompile = drv: byteCompileDeps (mapLuaModule builders.byteCompileLuaDrv drv);
 in
-mapNormalizedPlugins byteCompileDeps
+{
+  # byteCompilePluginDeps compiles propagatedBuildInputs recursively
+  # Inputs: List of normalized plugins
+  # Outputs: List of normalized plugins with all the propagatedBuildInputs byte-compiled
+  byteCompilePluginDeps = mapNormalizedPlugins byteCompileDeps;
+
+  # byteCompileLuaPackages compiles packages and its propagatedBuildInputs
+  # Inputs: List of lua packages
+  # Outputs: List of byte-compiled packages along with all the propagatedBuildInputs
+  byteCompileLuaPackages = map byteCompile;
+}

--- a/modules/top-level/plugins/byte-compile-plugins.nix
+++ b/modules/top-level/plugins/byte-compile-plugins.nix
@@ -7,6 +7,7 @@
 { lib, pkgs }:
 let
   builders = lib.nixvim.builders.withPkgs pkgs;
+  inherit (import ./utils.nix lib) mapNormalizedPlugins;
 
   byteCompile =
     p:
@@ -14,4 +15,4 @@ let
       prev: lib.optionalAttrs (prev ? dependencies) { dependencies = map byteCompile prev.dependencies; }
     );
 in
-map (p: p // { plugin = byteCompile p.plugin; })
+mapNormalizedPlugins byteCompile

--- a/modules/top-level/plugins/combine-plugins.nix
+++ b/modules/top-level/plugins/combine-plugins.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  pkgs,
+  callPackage,
   pathsToLink,
   standalonePlugins,
 }:
@@ -9,7 +9,7 @@ let
     getAndNormalizeDeps
     removeDeps
     ;
-  mkPluginPack = import ./mk-plugin-pack.nix { inherit lib pkgs; };
+  mkPluginPack = callPackage ./mk-plugin-pack.nix { inherit lib; };
 
 in
 /*

--- a/modules/top-level/plugins/default.nix
+++ b/modules/top-level/plugins/default.nix
@@ -34,6 +34,9 @@ in
         shouldCompilePlugins = byteCompileCfg.enable && byteCompileCfg.plugins;
         byteCompilePlugins = import ./byte-compile-plugins.nix { inherit lib pkgs; };
 
+        shouldCompileLuaLib = byteCompileCfg.enable && byteCompileCfg.luaLib;
+        byteCompileLuaLib = import ./byte-compile-lua-lib.nix { inherit lib pkgs; };
+
         shouldCombinePlugins = config.performance.combinePlugins.enable;
         combinePlugins = import ./combine-plugins.nix {
           inherit lib pkgs;
@@ -47,6 +50,7 @@ in
       lib.pipe config.extraPlugins (
         [ normalizePlugins ]
         ++ lib.optionals shouldCompilePlugins [ byteCompilePlugins ]
+        ++ lib.optionals shouldCompileLuaLib [ byteCompileLuaLib ]
         ++ lib.optionals shouldCombinePlugins [ combinePlugins ]
       );
   };

--- a/modules/top-level/plugins/default.nix
+++ b/modules/top-level/plugins/default.nix
@@ -32,14 +32,14 @@ in
     build.plugins =
       let
         shouldCompilePlugins = byteCompileCfg.enable && byteCompileCfg.plugins;
-        byteCompilePlugins = import ./byte-compile-plugins.nix { inherit lib pkgs; };
+        byteCompilePlugins = pkgs.callPackage ./byte-compile-plugins.nix { inherit lib; };
 
         shouldCompileLuaLib = byteCompileCfg.enable && byteCompileCfg.luaLib;
-        inherit (import ./byte-compile-lua-lib.nix { inherit lib pkgs; }) byteCompilePluginDeps;
+        inherit (pkgs.callPackage ./byte-compile-lua-lib.nix { inherit lib; }) byteCompilePluginDeps;
 
         shouldCombinePlugins = config.performance.combinePlugins.enable;
-        combinePlugins = import ./combine-plugins.nix {
-          inherit lib pkgs;
+        combinePlugins = pkgs.callPackage ./combine-plugins.nix {
+          inherit lib;
           inherit (config.performance.combinePlugins)
             standalonePlugins
             pathsToLink

--- a/modules/top-level/plugins/default.nix
+++ b/modules/top-level/plugins/default.nix
@@ -35,7 +35,7 @@ in
         byteCompilePlugins = import ./byte-compile-plugins.nix { inherit lib pkgs; };
 
         shouldCompileLuaLib = byteCompileCfg.enable && byteCompileCfg.luaLib;
-        byteCompileLuaLib = import ./byte-compile-lua-lib.nix { inherit lib pkgs; };
+        inherit (import ./byte-compile-lua-lib.nix { inherit lib pkgs; }) byteCompilePluginDeps;
 
         shouldCombinePlugins = config.performance.combinePlugins.enable;
         combinePlugins = import ./combine-plugins.nix {
@@ -50,7 +50,7 @@ in
       lib.pipe config.extraPlugins (
         [ normalizePlugins ]
         ++ lib.optionals shouldCompilePlugins [ byteCompilePlugins ]
-        ++ lib.optionals shouldCompileLuaLib [ byteCompileLuaLib ]
+        ++ lib.optionals shouldCompileLuaLib [ byteCompilePluginDeps ]
         ++ lib.optionals shouldCombinePlugins [ combinePlugins ]
       );
   };

--- a/modules/top-level/plugins/mk-plugin-pack.nix
+++ b/modules/top-level/plugins/mk-plugin-pack.nix
@@ -1,4 +1,8 @@
-{ lib, pkgs }:
+{
+  lib,
+  buildEnv,
+  vimUtils,
+}:
 let
   inherit (import ./utils.nix lib) normalizePlugin;
 in
@@ -8,7 +12,7 @@ let
   overridePlugin =
     plugin:
     plugin.plugin.overrideAttrs (prev: {
-      nativeBuildInputs = lib.remove pkgs.vimUtils.vimGenDocHook prev.nativeBuildInputs or [ ];
+      nativeBuildInputs = lib.remove vimUtils.vimGenDocHook prev.nativeBuildInputs or [ ];
       configurePhase = ''
         ${prev.configurePhase or ""}
         rm -vf doc/tags'';
@@ -56,8 +60,8 @@ let
         };
       }
       [
-        pkgs.buildEnv
-        pkgs.vimUtils.toVimPlugin
+        buildEnv
+        vimUtils.toVimPlugin
         (drv: drv.overrideAttrs { inherit propagatedBuildInputs; })
       ];
 

--- a/modules/top-level/plugins/utils.nix
+++ b/modules/top-level/plugins/utils.nix
@@ -35,4 +35,7 @@ lib.fix (self: {
 
   # Remove dependencies from all plugins in a list
   removeDeps = map (p: p // { plugin = removeAttrs p.plugin [ "dependencies" ]; });
+
+  # Apply a map function to each 'plugin' attr of the normalized plugin list
+  mapNormalizedPlugins = f: map (p: p // { plugin = f p.plugin; });
 })

--- a/tests/platforms/hm-extra-files-byte-compiling.nix
+++ b/tests/platforms/hm-extra-files-byte-compiling.nix
@@ -57,17 +57,19 @@ let
     }).config.home-files;
 in
 pkgs.runCommand "home-manager-extra-files-byte-compiling" { } ''
-  is_binary() {
-      ! grep -qI . "$1"
+  is_byte_compiled() {
+      # LuaJIT bytecode header is: ESC L J version
+      # https://github.com/LuaJIT/LuaJIT/blob/v2.1/src/lj_bcdump.h
+      [[ $(head -c3 "$1") = $'\x1bLJ' ]]
   }
   test_byte_compiled() {
-      if ! is_binary "$home_files/.config/nvim/$1"; then
+      if ! is_byte_compiled "$home_files/.config/nvim/$1"; then
           echo "File $1 is expected to be byte compiled, but it's not"
           exit 1
       fi
   }
   test_not_byte_compiled() {
-      if is_binary "$home_files/.config/nvim/$1"; then
+      if is_byte_compiled "$home_files/.config/nvim/$1"; then
           echo "File $1 is not expected to be byte compiled, but it is"
           exit 1
       fi

--- a/tests/test-sources/modules/performance/byte-compile-lua.nix
+++ b/tests/test-sources/modules/performance/byte-compile-lua.nix
@@ -308,20 +308,17 @@ in
       luaLib = true;
     };
 
-    extraLuaPackages =
-      ps: with ps; [
-        say
-        argparse
-      ];
+    extraLuaPackages = _: pluginStubs.libPack;
 
     extraConfigLuaPost = ''
+      ${pluginStubs.libChecks}
+
       ${isByteCompiledFun}
 
-      -- Lua modules are importable and byte compiled
-      local say = require("say")
-      test_lualib_file(say.set, true)
-      local argparse = require("argparse")
-      test_lualib_file(argparse("test").parse, true)
+      -- Lua modules are byte-compiled
+      ${lib.concatMapStringsSep "\n" (
+        name: "test_lualib_file(require('${name}').name, true)"
+      ) pluginStubs.libNames}
     '';
   };
 

--- a/tests/test-sources/modules/performance/files/file.lua
+++ b/tests/test-sources/modules/performance/files/file.lua
@@ -1,1 +1,1 @@
-vim.opt.tabstop = 2
+vim.g.extra_file_path = true

--- a/tests/utils/plugin-stubs.nix
+++ b/tests/utils/plugin-stubs.nix
@@ -1,0 +1,372 @@
+/*
+  This file includes stub plugins with dependencies of various types.
+  It is primarily used in tests for the performance module.
+*/
+{
+  lib,
+  neovim-unwrapped,
+  neovimUtils,
+  runCommand,
+  vimUtils,
+  writeText,
+  writeTextDir,
+}:
+let
+  # Make plugin content
+  mkSrc =
+    name:
+    runCommand "${name}-source" { } ''
+      mkdir $out
+
+      # Add import path
+      mkdir -p $out/lua/${name}
+      echo "return '${name}'" >$out/lua/${name}/init.lua
+
+      # Add plugins
+      mkdir $out/plugin
+      echo "_G['${name}'] = true" >$out/plugin/${name}.lua
+      echo "let g:${builtins.replaceStrings [ "-" ] [ "_" ] name} = 1" >$out/plugin/${name}.vim
+
+      # Add doc
+      mkdir $out/doc
+      echo "*${name}.txt* ${name}" >$out/doc/${name}.txt
+
+      # Add colliding files (required for combinePlugins tests)
+      echo "# ${name}" >$out/README.md
+      echo "Copyright (c) ${name}" >$out/LICENSE
+      mkdir $out/tests
+      echo "return '${name}'" >$out/tests/test.lua
+    '';
+
+  # Make a classic vim plugin
+  mkPlugin =
+    name: attrs:
+    vimUtils.buildVimPlugin (
+      {
+        pname = name;
+        version = "2025-04-27";
+        src = mkSrc name;
+      }
+      // attrs
+    );
+
+  # Make a plugin built with buildCommand
+  mkBuildCommandPlugin =
+    name: attrs:
+    vimUtils.toVimPlugin (
+      (mkSrc name).overrideAttrs (
+        prev:
+        {
+          inherit name;
+          buildCommand = ''
+            ${prev.buildCommand}
+            # Activate vimGenDocHook for doc checks to pass
+            fixupPhase
+          '';
+        }
+        // attrs
+      )
+    );
+
+  # Make lua library
+  mkLuaLib =
+    name: attrs:
+    neovim-unwrapped.lua.pkgs.buildLuarocksPackage (
+      let
+        version = "0.0.1";
+      in
+      {
+        pname = name;
+        inherit version;
+        # write-rockspec appends revision
+        rockspecVersion = "${version}-1";
+        src =
+          writeTextDir "${name}/init.lua" # lua
+            ''
+              local M = {}
+              M.name = function()
+                return "${name}"
+              end
+              return M
+            '';
+        # Create a simple rockspec manifiest
+        postPatch = ''
+          luarocks write-rockspec "${name}" "${version}" .
+        '';
+      }
+      // attrs
+    );
+
+  # Make luarocks neovim plugin
+  mkLuaPlugin =
+    name: attrs:
+    neovimUtils.buildNeovimPlugin {
+      luaAttr = neovim-unwrapped.lua.pkgs.buildLuarocksPackage (
+        let
+          version = "0.0.1-1";
+        in
+        {
+          pname = name;
+          inherit version;
+          src = mkSrc name;
+          knownRockspec = writeText "${name}-${version}.rockspec" ''
+            rockspec_format = "3.0"
+            package = "${name}"
+            version = "${version}"
+            source = {
+              url = "git://github.com/nix-community/nixvim.git",
+            }
+            build = {
+              type = "builtin",
+              copy_directories = {
+                "doc",
+                "plugin",
+              },
+            }
+          '';
+        }
+        // attrs
+      );
+    };
+
+  /*
+    Dependency graph:
+
+      plugin1  plugin2  plugin3  plugin_with_dep4  plugin_with_deep_dep
+        |   \              |       /         \             /       \   \
+      lib1  pyyaml       lib3  plugin4        \   plugin_with_dep5  \  lib_with_deep_dep
+                              /   |   \        \   /       |     \   \           \
+                          lib2  numpy  pyyaml  plugin3  plugin5  lib_with_dep4  lib_with_dep5
+                                                  |        |          |      \  /     |
+                                                lib3   requests      lib4    lib3    lib5
+
+    plugin*: plugins
+    lib*: lua dependencies that are not plugins
+    pyyaml, requests, numpy: python dependencies
+
+    *_with_dep*: plugin or lua library with dependency
+    *_with_deep_dep: plugin or lua library with recursive dependencies
+
+    Basic principles:
+      * there are plugins of various types: buildVimPlugin (plugin1),
+        buildNeovimPlugin (plugin3), buildCommand (plugin2)
+      * there are standalone plugins (plugin1, plugin2)
+      * there is a multiplied plugin present on all levels (plugin3)
+      * there is a plugin with dependency (plugin_with_dep4 -> plugin4)
+      * there is a plugin with recursive dependencies
+        (plugin_with_deep_dep -> plugin_with_dep5 -> plugin5)
+      * same principles for lua libraries (lib*)
+      * there are python dependencies on various levels
+  */
+
+  # Lua libraries
+  lib1 = mkLuaLib "lib1" { };
+  lib2 = mkLuaLib "lib2" { };
+  lib3 = mkLuaLib "lib3" { };
+  lib4 = mkLuaLib "lib4" { };
+  lib5 = mkLuaLib "lib5" { };
+  libWithDep4 = mkLuaLib "lib_with_dep4" {
+    propagatedBuildInputs = [
+      lib4
+      lib3
+    ];
+  };
+  libWithDep5 = mkLuaLib "lib_with_dep5" {
+    propagatedBuildInputs = [
+      lib5
+      lib3
+    ];
+  };
+  libWithDeepDep = mkLuaLib "lib_with_deep_dep" {
+    propagatedBuildInputs = [ libWithDep5 ];
+  };
+
+  # Plugins
+  plugin1 = mkPlugin "plugin1" {
+    propagatedBuildInputs = [
+      # propagate lua to activate setup-hook
+      neovim-unwrapped.lua
+      lib1
+    ];
+    passthru.python3Dependencies = ps: [ ps.pyyaml ];
+  };
+  plugin2 = mkBuildCommandPlugin "plugin2" { };
+  plugin3 = mkLuaPlugin "plugin3" {
+    propagatedBuildInputs = [ lib3 ];
+  };
+  plugin4 = mkPlugin "plugin4" {
+    propagatedBuildInputs = [ lib2 ];
+    passthru.python3Dependencies = ps: [
+      ps.numpy
+      ps.pyyaml
+    ];
+  };
+  plugin5 = mkPlugin "plugin5" {
+    passthru.python3Dependencies = ps: [ ps.requests ];
+  };
+  pluginWithDep4 = mkPlugin "plugin_with_dep4" {
+    dependencies = [
+      plugin4
+      plugin3
+    ];
+  };
+  pluginWithDep5 = mkLuaPlugin "plugin_with_dep5" {
+    dependencies = [
+      plugin5
+      plugin3
+    ];
+    propagatedBuildInputs = [ libWithDep4 ];
+  };
+  pluginWithDeepDep = mkLuaPlugin "plugin_with_deep_dep" {
+    dependencies = [ pluginWithDep5 ];
+    propagatedBuildInputs = [
+      libWithDep4
+      libWithDeepDep
+    ];
+  };
+
+  # Names for using in loops
+  libNames = [
+    "lib1"
+    "lib2"
+    "lib3"
+    "lib_with_dep4"
+    "lib4"
+    "lib_with_deep_dep"
+    "lib_with_dep5"
+    "lib5"
+  ];
+  pluginNames = [
+    "plugin1"
+    "plugin2"
+    "plugin3"
+    "plugin_with_dep4"
+    "plugin4"
+    "plugin_with_deep_dep"
+    "plugin_with_dep5"
+    "plugin5"
+  ];
+  # Lua code to validate that everything works
+  libChecks = lib.concatMapStringsSep "\n" (
+    name:
+    # lua
+    ''
+      -- Lua dependencies require check
+      do
+        local mod = require("${name}")
+        assert(
+          mod.name() == "${name}",
+          string.format(
+            [[expected require("${name}").name() == "${name}", got %q. Invalid lua dependency?]],
+            mod.name()
+          )
+        )
+      end
+    '') libNames;
+  pluginChecks =
+    lib.concatMapStringsSep "\n" (
+      name:
+      # lua
+      ''
+        -- Require check
+        do
+          local name = require("${name}")
+          assert(
+            name == "${name}",
+            string.format([[expected require("${name}") == "${name}", got %q. Invalid plugin?]], name)
+          )
+        end
+
+        -- Lua plugin check
+        vim.cmd.runtime("plugin/${name}.lua")
+        assert(
+          _G["${name}"] == true,
+          string.format(
+            [[expected _G["${name}"] == true, got %s. File %q isn't executed?]],
+            _G["${name}"],
+            "plugin/${name}.lua"
+          )
+        )
+
+        -- Vimscript plugin check
+        vim.cmd.runtime("plugin/${name}.vim")
+        assert(
+          vim.g["${name}"] == 1,
+          string.format(
+            [[expected vim.g["${name}"] == 1, got %s. File %q isn't executed?]],
+            vim.g["${name}"],
+            "plugin/${name}.vim"
+          )
+        )
+
+        -- Doc check
+        do
+          local doc = vim.api.nvim_get_runtime_file("doc/${name}.txt", false)
+          assert(doc[1], [["doc/${name}.txt" not found in runtime]])
+          assert(vim.fn.getcompletion("${name}", "help")[1], [[no help tags for "${name}"]])
+        end
+      '') pluginNames
+    # lua
+    + ''
+
+      -- Python dependencies check
+      vim.cmd.py3("import yaml")
+      vim.cmd.py3("import requests")
+      vim.cmd.py3("import numpy")
+
+    ''
+    + libChecks;
+in
+{
+  inherit
+    # helpers
+    mkPlugin
+    mkLuaPlugin
+    mkBuildCommandPlugin
+    mkLuaLib
+
+    # individual plugins
+    plugin1
+    plugin2
+    plugin3
+    plugin4
+    plugin5
+    pluginWithDep4
+    pluginWithDep5
+    pluginWithDeepDep
+
+    # individual lua libraries
+    lib1
+    lib2
+    lib3
+    lib4
+    lib5
+    libWithDep4
+    libWithDep5
+    libWithDeepDep
+
+    # checks
+    pluginChecks
+    pluginNames
+    libChecks
+    libNames
+    ;
+
+  # a pack of top-level plugins
+  pluginPack = [
+    plugin1
+    plugin2
+    plugin3
+    pluginWithDep4
+    pluginWithDeepDep
+  ];
+
+  # a pack of top-level lua libraries
+  libPack = [
+    lib1
+    lib2
+    lib3
+    libWithDep4
+    libWithDeepDep
+  ];
+}

--- a/tests/utils/plugin-stubs.nix
+++ b/tests/utils/plugin-stubs.nix
@@ -58,6 +58,7 @@ let
         prev:
         {
           inherit name;
+          pname = name;
           buildCommand = ''
             ${prev.buildCommand}
             # Activate vimGenDocHook for doc checks to pass


### PR DESCRIPTION
This PR:

- Introduces `performance.byteCompileLua.luaLib` option. When enabled, it'll byte-compile lua libraries in LUA_PATH. Specifically: `extraLuaPackages` and plugins `propagatedBuildInputs`.
- Adds `tests/utils/plugin-stubs.nix` with a shared plugin stubs and generated lua code for using in performance tests.
- Once again refactors performance tests using shared plugin stubs.