### PR TITLE
tests/fetch-tests: avoid unnecessary copy-to-store

### DIFF
--- a/tests/fetch-tests.nix
+++ b/tests/fetch-tests.nix
@@ -32,7 +32,7 @@ let
       handleEntry =
         name: type:
         let
-          file = "${path}/${name}";
+          file = /${path}/${name};
         in
         if type == "regular" then
           lib.optional (lib.hasSuffix ".nix" name) (


### PR DESCRIPTION
Previously path was concatenated using string interpolation. This commit switches from string interpolation to path interpolation.

The problem is nix will copy the "${directory}" to a new store object, meaning anything outside its root won't be available.

From the nix manual:

> A path in an interpolated expression is first copied into the Nix
> store, and the resulting string is the store path of the newly created
> store object.

https://nix.dev/manual/nix/2.28/language/string-interpolation#interpolated-expression

This commit is cherry-picked from #3314, cc @stasjok

See prior discussion: https://github.com/nix-community/nixvim/pull/3314#discussion_r2083632273
