### PR TITLE
Add explanation on follow

### DIFF
--- a/docs/mdbook/index.md
+++ b/docs/mdbook/index.md
@@ -15,6 +15,8 @@ Documentation is currently available for the following versions:
 > This change was largely motivated by: [How do I solve "`<name>` cannot be found in `pkgs`"](./user-guide/faq.html#how-do-i-solve-name-cannot-be-found-in-pkgs)
 >
 > The old behaviour can be restored by enabling `nixpkgs.useGlobalPackages`.
+>
+> If your flake modifies the `nixpkgs` through `follows` this can still cause issues by changing the expected `nixpkg` `nixvim` was tested & built against.
 
 @README@
 


### PR DESCRIPTION
The use of `follows` in a flake can cause issues even if `useGlobalPackages` is set.

Highlight this in the doc.