### PR TITLE
flake: use the same treefmt package throughout

### DIFF
--- a/flake/dev/default.nix
+++ b/flake/dev/default.nix
@@ -13,6 +13,7 @@
   perSystem =
     {
       pkgs,
+      config,
       system,
       ...
     }:
@@ -84,7 +85,10 @@
               edit = true;
             };
           };
-          treefmt.enable = true;
+          treefmt = {
+            enable = true;
+            package = config.formatter;
+          };
           typos = {
             enable = true;
             excludes = [ "generated/*" ];

--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -81,7 +81,7 @@
             {
               name = "format";
               help = "Format the entire codebase";
-              command = "nix fmt";
+              command = lib.getExe config.formatter;
             }
             {
               name = "docs";

--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -16,6 +16,10 @@
       devshells.default = {
         devshell.startup.pre-commit.text = config.pre-commit.installationScript;
 
+        devshell.packages = [
+          config.formatter
+        ];
+
         commands =
           let
             # Thanks to this, the user can choose to use `nix-output-monitor` (`nom`) instead of plain `nix`


### PR DESCRIPTION
- **flake: use pre-configured treefmt package in git-hooks**
- **flake/devshell: run treefmt directly in `format` command**
- **flake/devshell: add treefmt to shell**

Avoid running `nix fmt` within the shell; we already have evaluated and built our wrapped `treefmt`, so use that instead of re-evaluating the flake by calling `nix fmt`.
