### PR TITLE
dev/tests: add `--attr` option to print full attrpath of tests

### DIFF
--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -61,8 +61,8 @@
                         checkName:
                         map (testName: {
                           name = testName;
-                          value = "${checkName}.passthru.entries.${testName}";
-                        }) (builtins.attrNames checks'.${checkName}.passthru.entries)
+                          value = "${checkName}.entries.${testName}";
+                        }) (builtins.attrNames checks'.${checkName}.entries)
                       ) names
                     );
                 in


### PR DESCRIPTION
Allows using the `tests` devshell command to discover the full attrpath of a test.

e.g.

```
$ tests --attr modules-lsp plugins-by-name-lazygit
Printing 2 tests: modules-lsp plugins-by-name-lazygit

Full attr paths:
- checks.x86_64-linux.test-2.entries.modules-lsp
- checks.x86_64-linux.test-18.entries.plugins-by-name-lazygit
```
