### PR TITLE
docs/mdbook: add page ToC

### DIFF
--- a/docs/mdbook/book.toml
+++ b/docs/mdbook/book.toml
@@ -7,9 +7,13 @@ title = "nixvim docs"
 
 [output.html]
 site-url = "@SITE_URL@"
+additional-js = ["theme/pagetoc.js"]
+additional-css = ["theme/pagetoc.css"]
 
 [output.html.fold]
 enable = true
 level = 0
 
 [preprocessor.alerts]
+
+[preprocessor.pagetoc]

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -323,6 +323,7 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     pkgs.mdbook
     pkgs.mdbook-alerts
+    pkgs.mdbook-pagetoc
   ];
 
   # Build a source from the fileset containing the following paths,


### PR DESCRIPTION
Adds a ToC for all headings on the page.

https://github.com/slowsage/mdbook-pagetoc

![image](https://github.com/user-attachments/assets/49550898-c571-477a-b42d-d654fa5c4506)

