### PR TITLE
plugins/neo-tree: correct contentLayout allowed options

### DIFF
--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -193,7 +193,7 @@ in
             [
               "start"
               "end"
-              "focus"
+              "center"
             ]
             ''
               Defines how the labels are placed inside a tab.


### PR DESCRIPTION
According to the docs, focus is not an accepted value for this field, it's also a pretty common wish to have tabs layout centered.

Reference: https://github.com/nvim-neo-tree/neo-tree.nvim/blob/main/doc/neo-tree.txt#L893