### PR TITLE
plugins/vim-test: init

### DIFF
--- a/plugins/by-name/vim-test/default.nix
+++ b/plugins/by-name/vim-test/default.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkVimPlugin {
+  name = "vim-test";
+  globalPrefix = "test#";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    preserve_screen = false;
+    "javascript#jest#options" = "--reporters jest-vim-reporter";
+    strategy = {
+      nearest = "vimux";
+      file = "vimux";
+      suite = "vimux";
+    };
+    "neovim#term_position" = "vert";
+  };
+}

--- a/tests/test-sources/plugins/by-name/vim-test/default.nix
+++ b/tests/test-sources/plugins/by-name/vim-test/default.nix
@@ -1,0 +1,22 @@
+{
+  empty = {
+    plugins.vim-test.enable = true;
+  };
+
+  example = {
+    plugins.vim-test = {
+      enable = true;
+
+      settings = {
+        preserve_screen = false;
+        "javascript#jest#options" = "--reporters jest-vim-reporter";
+        strategy = {
+          nearest = "vimux";
+          file = "vimux";
+          suite = "vimux";
+        };
+        "neovim#term_position" = "vert";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [vim-test](https://github.com/vim-test/vim-test), a plugin to run tests directly from Neovim.

Fixes #1497
