### PR TITLE
ci/update-other: don't run on forks

### DIFF
--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -12,6 +12,7 @@ jobs:
   update:
     name: Trigger updates for nixvim's stable branches
     runs-on: ubuntu-latest
+    if: github.repository == 'nix-community/nixvim'
     strategy:
       matrix:
         branches:


### PR DESCRIPTION
The update CI(s) shouldn't run _scheduled_ runs on forks; i.e. repos that aren't `nix-community/nixvim`.

The main `update` workflow [already has a check](https://github.com/nix-community/nixvim/blob/73c1a755f0ac6d09d312daffd13c1ce6572d6fe5/.github/workflows/update.yml#L37), however the newer `update-other` workflow doesn't.

This fixes the annoying emails I get each week when the `update-other` workflow tries to run on my fork :grin:
