### PR TITLE
docs/mdbook: install directly to `$out`

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -110,7 +110,7 @@ jobs:
 
             # Copy the result to the install dir
             mkdir -p "$installDir"
-            cp -r result/share/doc/* "$installDir"
+            cp -r result/* "$installDir"
           }
 
           # For each version of the docs...

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -349,8 +349,7 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
   contributing = finalAttrs.passthru.fix-links ../../CONTRIBUTING.md;
 
   buildPhase = ''
-    dest=$out/share/doc
-    mkdir -p $dest
+    mkdir -p $out
 
     # Copy (and flatten) src into the build directory
     cp -r --no-preserve=all $src/* ./
@@ -397,9 +396,9 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
       --replace-fail "@USER_CONFIGS@" "$(cat ${finalAttrs.passthru.user-configs})"
 
     mdbook build
-    cp -r ./book/* $dest
-    mkdir -p $dest/search
-    cp -r ${finalAttrs.passthru.search}/* $dest/search
+    cp -r ./book/* $out
+    mkdir -p $out/search
+    cp -r ${finalAttrs.passthru.search}/* $out/search
   '';
 
   inherit baseHref;


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/nix-community/nixvim/pull/3349; that PR serves the docs from the root of the docs derivation, however docs are actually installed to `$out/share/doc`.

IMO there's no reason to put a MDBook website in `share/doc/`, so rather than fixing `serve-docs`' `--chdir` I've instead changed the docs to install to the root of `$out`.
