### PR TITLE
plugins/yaml-companion: init

### DIFF
--- a/plugins/by-name/yaml-companion/default.nix
+++ b/plugins/by-name/yaml-companion/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  config,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "yaml-companion";
+  packPathName = "yaml-companion.nvim";
+  package = "yaml-companion-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    schemas = [
+      {
+        name = "Argo CD Application";
+        uri = "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/argoproj.io/application_v1alpha1.json";
+      }
+      {
+        name = "SealedSecret";
+        uri = "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/bitnami.com/sealedsecret_v1alpha1.json";
+      }
+    ];
+    lspconfig = {
+      settings = {
+        yaml = {
+          format.enable = false;
+          schemaStore = {
+            enable = false;
+            url = "";
+          };
+          schemas = lib.nixvim.nestedLiteralLua "require('schemastore').yaml.schemas()";
+        };
+      };
+    };
+  };
+
+  callSetup = false;
+  extraConfig = cfg: {
+    warnings = lib.nixvim.mkWarnings "plugins.yaml-companion" [
+      {
+        when = !config.plugins.lsp.enable;
+        message = "This plugin requires the `plugins.lsp.servers.yamlls` module to be enabled.";
+      }
+    ];
+
+    plugins = {
+      lsp.servers.yamlls.extraOptions = lib.nixvim.mkRaw "require('yaml-companion').setup(${lib.nixvim.toLuaObject cfg.settings})";
+
+      telescope.enabledExtensions = [ "yaml_schema" ];
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/yaml-companion/default.nix
+++ b/tests/test-sources/plugins/by-name/yaml-companion/default.nix
@@ -1,0 +1,93 @@
+{ lib, pkgs, ... }:
+{
+  empty = {
+    plugins = {
+      lsp = {
+        enable = true;
+        servers.yamlls.enable = true;
+      };
+
+      yaml-companion.enable = true;
+    };
+  };
+
+  defaults = {
+    plugins = {
+      lsp = {
+        enable = true;
+        servers.yamlls.enable = true;
+      };
+
+      yaml-companion = {
+        enable = true;
+
+        settings = {
+          builtin_matchers = {
+            kubernetes.enabled = true;
+            cloud_init.enabled = true;
+          };
+          schemas = [ ];
+          lspconfig = {
+            flags = {
+              debounce_text_changes = 150;
+            };
+            settings = {
+              redhat.telemetry.enabled = false;
+              yaml = {
+                validate = true;
+                format.enable = true;
+                hover = true;
+                schemaStore = {
+                  enable = true;
+                  url = "https://www.schemastore.org/api/json/catalog.json";
+                };
+                schemaDownload.enable = true;
+                schemas = [ ];
+                trace.server = "debug";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    extraPlugins = [ pkgs.vimPlugins.SchemaStore-nvim ];
+    plugins = {
+      lsp = {
+        enable = true;
+        servers.yamlls.enable = true;
+      };
+
+      yaml-companion = {
+        enable = true;
+
+        settings = {
+          schemas = [
+            {
+              name = "Argo CD Application";
+              uri = "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/argoproj.io/application_v1alpha1.json";
+            }
+            {
+              name = "SealedSecret";
+              uri = "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/bitnami.com/sealedsecret_v1alpha1.json";
+            }
+          ];
+          lspconfig = {
+            settings = {
+              yaml = {
+                format.enable = false;
+                schemaStore = {
+                  enable = false;
+                  url = "";
+                };
+                schemas = lib.nixvim.mkRaw "require('schemastore').yaml.schemas()";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [yaml-companion.nvim](https://github.com/someone-stole-my-name/yaml-companion.nvim), a plugin to get, set and autodetect YAML schemas in buffers.

Closes #3328
