### PR TITLE
plugins/mini-surround: init

### DIFF
--- a/plugins/by-name/mini-surround/default.nix
+++ b/plugins/by-name/mini-surround/default.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "mini-surround";
+  moduleName = "mini.surround";
+  packPathName = "mini.surround";
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  settingsExample = {
+    n_lines = 50;
+    respect_selection_type = true;
+    search_method = "cover_or_next";
+  };
+}

--- a/tests/test-sources/plugins/by-name/mini-surround/default.nix
+++ b/tests/test-sources/plugins/by-name/mini-surround/default.nix
@@ -1,0 +1,17 @@
+{
+  empty = {
+    plugins.mini-surround.enable = true;
+  };
+
+  example = {
+    plugins.mini-surround = {
+      enable = true;
+
+      settings = {
+        n_lines = 50;
+        respect_selection_type = true;
+        search_method = "cover_or_next";
+      };
+    };
+  };
+}


### PR DESCRIPTION
This pull request introduces a new Neovim plugin module for the `mini.surround`, along with corresponding test cases.