### PR TITLE
plugins/mini-statusline: init

### DIFF
--- a/plugins/by-name/mini-statusline/default.nix
+++ b/plugins/by-name/mini-statusline/default.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "mini-statusline";
+  moduleName = "mini.statusline";
+  packPathName = "mini.statusline";
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  settingsExample = {
+    use_icons = false;
+  };
+}

--- a/tests/test-sources/plugins/by-name/mini-statusline/default.nix
+++ b/tests/test-sources/plugins/by-name/mini-statusline/default.nix
@@ -1,0 +1,15 @@
+{
+  empty = {
+    plugins.mini-statusline.enable = true;
+  };
+
+  example = {
+    plugins.mini-statusline = {
+      enable = true;
+
+      settings = {
+        use_icons = false;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This pull request introduces a new Neovim plugin module for the `mini.statusline`, along with corresponding test cases.