### PR TITLE
modules/lsp/servers: Fix lua_ls example

### DIFF
--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -103,7 +103,7 @@ in
             multilineTokenSupport = true;
           };
         };
-        luals.enable = true;
+        lua_ls.enable = true;
         clangd = {
           enable = true;
           settings = {


### PR DESCRIPTION
Example was referring to `luals` instead of `lua_ls`

Minor example fix, done in the Github UI, did not run tests locally.