### PR TITLE
plugins/mini-colors: init

### DIFF
--- a/plugins/by-name/mini-colors/default.nix
+++ b/plugins/by-name/mini-colors/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "mini-colors";
+  moduleName = "mini.colors";
+  packPathName = "mini.colors";
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  hasSettings = false;
+}

--- a/tests/test-sources/plugins/by-name/mini-colors/default.nix
+++ b/tests/test-sources/plugins/by-name/mini-colors/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.mini-colors.enable = true;
+  };
+}


### PR DESCRIPTION
This pull request introduces a new Neovim plugin module for the `mini.colors`, along with corresponding test cases.