### PR TITLE
plugins/mini-cursorword: init

### DIFF
--- a/plugins/by-name/mini-cursorword/default.nix
+++ b/plugins/by-name/mini-cursorword/default.nix
@@ -1,0 +1,21 @@
+{ lib, ... }:
+let
+  inherit (lib.nixvim) defaultNullOpts;
+in
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "mini-cursorword";
+  moduleName = "mini.cursorword";
+  packPathName = "mini.cursorword";
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  settingsOptions = {
+    delay = defaultNullOpts.mkNum 100 ''
+      Delay (in ms) between when cursor moved and when highlighting appeared.
+    '';
+  };
+
+  settingsExample = {
+    delay = 50;
+  };
+}

--- a/tests/test-sources/plugins/by-name/mini-cursorword/default.nix
+++ b/tests/test-sources/plugins/by-name/mini-cursorword/default.nix
@@ -1,0 +1,14 @@
+{
+  empty = {
+    plugins.mini-cursorword.enable = true;
+  };
+
+  example = {
+    plugins.mini-cursorword = {
+      enable = true;
+      settings = {
+        delay = 50;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This pull request introduces a new Neovim plugin module for the `mini.cursorword`, along with corresponding test cases.