### PR TITLE
plugins/mini-keymap: init

### DIFF
--- a/plugins/by-name/mini-keymap/default.nix
+++ b/plugins/by-name/mini-keymap/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "mini-keymap";
+  moduleName = "mini.keymap";
+  packPathName = "mini.keymap";
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  hasSettings = false;
+}

--- a/tests/test-sources/plugins/by-name/mini-keymap/default.nix
+++ b/tests/test-sources/plugins/by-name/mini-keymap/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.mini-keymap.enable = true;
+  };
+}


### PR DESCRIPTION
This pull request introduces a new Neovim plugin module for the `mini.keymap`, along with corresponding test cases.