### PR TITLE
plugins/mini-bufremove: init

### DIFF
--- a/plugins/by-name/mini-bufremove/default.nix
+++ b/plugins/by-name/mini-bufremove/default.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "mini-bufremove";
+  moduleName = "mini.bufremove";
+  packPathName = "mini.bufremove";
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  settingsExample = {
+    silent = true;
+  };
+}

--- a/tests/test-sources/plugins/by-name/mini-bufremove/default.nix
+++ b/tests/test-sources/plugins/by-name/mini-bufremove/default.nix
@@ -1,0 +1,14 @@
+{
+  empty = {
+    plugins.mini-bufremove.enable = true;
+  };
+
+  example = {
+    plugins.mini-bufremove = {
+      enable = true;
+      settings = {
+        silent = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This pull request introduces a new Neovim plugin module for the `mini.bufremove`, along with corresponding test cases.