### PR TITLE
flake: add `ci.buildbot` output

### DIFF
--- a/buildbot-nix.toml
+++ b/buildbot-nix.toml
@@ -1,0 +1,1 @@
+attribute = "ci.buildbot"

--- a/flake/ci.nix
+++ b/flake/ci.nix
@@ -1,0 +1,43 @@
+{ lib, config, ... }:
+let
+  inherit (lib)
+    mapAttrs
+    types
+    ;
+
+  buildbotOpt = lib.mkOption {
+    type = types.lazyAttrsOf types.package;
+    default = { };
+    description = ''
+      A set of tests for [buildbot] to run.
+
+      [buildbot]: https://buildbot.nix-community.org
+    '';
+  };
+in
+{
+  perSystem = {
+    # Declare per-system CI options
+    options.ci = {
+      buildbot = buildbotOpt;
+    };
+  };
+
+  flake = {
+    # Declare top-level CI options
+    options.ci = {
+      buildbot = lib.mkOption {
+        type = types.lazyAttrsOf buildbotOpt.type;
+        default = { };
+        description = ''
+          See `perSystem.ci.buildbot` for description and examples.
+        '';
+      };
+    };
+
+    # Transpose per-system CI outputs to the top-level
+    config.ci = {
+      buildbot = mapAttrs (_: sysCfg: sysCfg.ci.buildbot) config.allSystems;
+    };
+  };
+}

--- a/flake/default.nix
+++ b/flake/default.nix
@@ -8,6 +8,7 @@
 {
   imports = [
     ./flake-modules
+    ./ci.nix
     ./lib.nix
     ./legacy-packages.nix
     ./nixvim-configurations.nix
@@ -31,6 +32,7 @@
 
   # Specify which outputs are defined by which partitions
   partitionedAttrs = {
+    ci = "dev";
     checks = "dev";
     devShells = "dev";
     formatter = "dev";

--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -29,6 +29,7 @@
             {
               name = "checks";
               help = "Run all nixvim checks";
+              # TODO: run tests from the `ci` flake output too?
               command = ''
                 echo "=> Running all nixvim checks..."
 

--- a/flake/dev/package-tests.nix
+++ b/flake/dev/package-tests.nix
@@ -4,5 +4,9 @@
     {
       # Test that all packages build fine when running `nix flake check`.
       checks = config.packages;
+
+      # Test that all packages build when running buildbot
+      # TODO: only test the docs on x86_64-linux
+      ci.buildbot = config.packages;
     };
 }

--- a/flake/dev/tests.nix
+++ b/flake/dev/tests.nix
@@ -7,8 +7,15 @@
   perSystem =
     { pkgs, ... }:
     {
+      # TODO: consider whether all these tests are needed in the `checks` output
       checks = pkgs.callPackages ../../tests {
         inherit helpers self;
+      };
+
+      # TODO: consider whether all these tests are needed to be built by buildbot
+      ci.buildbot = pkgs.callPackages ../../tests {
+        inherit helpers self;
+        allSystems = false;
       };
     };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -5,6 +5,7 @@
   linkFarm,
   self, # The flake instance
   system ? pkgs.stdenv.hostPlatform.system,
+  allSystems ? true,
 }:
 let
   autoArgs = pkgs // {
@@ -31,8 +32,15 @@ let
   callTests = lib.callPackagesWith autoArgs;
 
   selfPackages = self.packages.${system};
+
+  # For tests that CI should only build on one system,
+  # This is true when on that system.
+  #
+  # TODO: consider refactoring tests/default.nix so that some tests are
+  # defined by it, while others are defined elsewhere...
+  buildForThisSystem = allSystems || system == "x86_64-linux";
 in
-{
+lib.optionalAttrs buildForThisSystem {
   extra-args-tests = callTest ./extra-args.nix { };
   extend = callTest ./extend.nix { };
   extra-files = callTest ./extra-files.nix { };
@@ -47,10 +55,12 @@ in
   lsp-all-servers = callTest ./lsp-servers.nix { };
 }
 # Expose some tests from the docs as flake-checks too
-// lib.optionalAttrs (selfPackages ? docs) {
+// lib.optionalAttrs (selfPackages ? docs && buildForThisSystem) {
   # Individual tests can be run using: nix build .#docs.user-configs.tests.<test>
   docs-user-configs = linkFarm "user-configs-tests" selfPackages.docs.user-configs.tests;
 }
+
+# These are always built on all systems, even when `allSystems = false`
 // callTests ./platforms { }
 # Tests generated from ./test-sources
 # Grouped as a number of link-farms in the form { test-1, test-2, ... test-N }


### PR DESCRIPTION
### Background

I've long complained that buildbot is too tightly coupled to our flake's `checks` output; the same one used by `nix flake check`. Being unable to customise what buildbot builds has been a pain point for a while.

Turns out around seven months ago buildbot added a per-repo config file in https://github.com/nix-community/buildbot-nix/pull/318.

The available options are documented on its readme, [here](https://github.com/nix-community/buildbot-nix#per-repository-configuration). Currently only `lock_file` and `attribute`, but the latter enables this PR!

### Core change

This PR adds an explicit `ci.buildbot` output to the flake, which we configure buildbot to use instead of the default `checks` output via a `buildbot-nix.toml` file.

This allows us to specify a different set of tests for `nix flake check` and buildbot.

### Additional changes

This PR is **not** focused on _fully_ taking advantage of the new separation, however it does make some minor tweaks:

- ~~`packages` are now only built on x86_64-linux, but are built by `nix flake check` on all systems~~ :rocket:
  - _Dropped for now due to [feedback](https://github.com/nix-community/nixvim/pull/3410#discussion_r2116552870). Will address docs packages specifically in future work._
- Many tests imported by `tests/default.nix` are also only built on x86_64-linux.
  - "Platform" tests and "module" tests (generated by `fetch-tests`) are still built on all platforms.

Without this PR buildbot had 288 builds, with just tests it has 205, with tests and packages it has 214, with tests (mostly single system) and packages (all systems), it has 235.

### Future work:

- Some builds may be better off done by a GitHub Actions workflow instead of buildbot. This will further reduce the load on buildbot while also improving the UX of how other tests get displayed in PR status checks.
  - The `ci.buildbot` option/output has been designed to accommodate `ci.*` sibling options, such as [GitHub Actions job matrices](https://github.com/nix-community/nixvim/blob/1b25700ae36df1da162020abf3a39416235815ef/.github/workflows/check.yml#L26-L31).
- We can further iterate on deciding _which_ tests should/shouldn't be built by CI and/or `nix flake check`
  - E.g., do we really need `packages` to be built by `nix flake check`?

### Related:

- https://github.com/nix-community/nixvim/issues/3238