### PR TITLE
ci/backport: init

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,45 @@
+# Based on
+# https://github.com/NixOS/nixpkgs/blob/2566f9dc/.github/workflows/backport.yml
+name: Backport
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport Pull Request
+    if: >
+      vars.CI_APP_ID
+      && github.event.pull_request.merged == true
+      && (
+        github.event.action != 'labeled'
+        || startsWith(github.event.label.name, 'backport')
+      )
+
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Create backport PRs
+        id: backport
+        uses: korthout/backport-action@v3
+        with:
+          # See https://github.com/korthout/backport-action#inputs
+          github_token: ${{ steps.app-token.outputs.token }}
+          branch_name: backport/${target_branch}/${pull_number}
+          copy_labels_pattern: .*


### PR DESCRIPTION
Adds a GitHub workflow to create backport PRs when merged PRs have a "backport" label.

This uses the very flexible https://github.com/korthout/backport-action and is based on the [workflow used by nixpkgs](https://github.com/NixOS/nixpkgs/blob/2566f9dc/.github/workflows/backport.yml), which is also [used by Stylix](https://github.com/nix-community/stylix/blob/0512b0f/.github/workflows/backport.yml). See [how it works](https://github.com/korthout/backport-action#how-it-works).

Currently, the workflow [will assume](https://github.com/korthout/backport-action#label_pattern) our backport labels follow the regex `backport ([^ ]+)$` (e.g. `backport nixos-25.05`), however we could customise that by assigning any regex we like to `with: label_pattern`.

Mergify also [has backport support](https://docs.mergify.com/workflow/actions/backport), which we've used a few times via the [`@mergifyio backport` command](https://docs.mergify.com/commands/backport). While we _could_ configure our `mergify.yml` file to look for "backport" labels, IMO it is better to use a GitHub-based solution so that we are not locked into continuing with Mergify indefinitely.

This also has the purely aesthetic[^1] advantage that it'll show as backported by `nixvim-ci[bot]` 🤩

[^1]: ok, it's not _purely_ aesthetic. This causes github workflows to be triggered by events caused by the bot. If we used `github-actions[bot]` then no workflow events would trigger. The [eter-evans/create-pull-request docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) explain this best.