### PR TITLE
modules/performance: fix issues with combining standalonePlugins and byte compilation

### DIFF
--- a/modules/top-level/plugins/combine-plugins.nix
+++ b/modules/top-level/plugins/combine-plugins.nix
@@ -33,9 +33,8 @@ let
   optPlugins = removeDeps partitionedOptStartPlugins.right;
 
   # Test if plugin shouldn't be included in plugin pack
-  isStandalone =
-    p:
-    builtins.elem p.plugin standalonePlugins || builtins.elem (lib.getName p.plugin) standalonePlugins;
+  standaloneNames = map (p: if builtins.isString p then p else lib.getName p) standalonePlugins;
+  isStandalone = p: builtins.elem (lib.getName p.plugin) standaloneNames;
 
   # Separated standalone and combined start plugins
   partitionedStandaloneStartPlugins = builtins.partition isStandalone startPlugins;


### PR DESCRIPTION
Previously, specifying plugins as packages in the
`performance.combinePlugins.standalonePlugins` option did not work when
the `performance.byteCompileLua` option was also enabled. This issue was
due to several package transformations performed by the
`byteCompileLua`.

There are at least three methods to fix the issue:

- Change transformation order: combine plugins first, then byte-compile
  them.
- Compare every possible transformation when determining if plugins are
  standalone.
- Get the name of the package and use it for comparison.

The first method did not work because the current `byteCompileLuaDrv`
implementation does not support symlinks to directories. The second
method appears too fragile. This commit implements the third method, as
it requires minimal code changes and is straightforward. The downside is
that it might exclude multiple packages with the same name, although
this should be rare.
