### PR TITLE
plugins/treesitter: don't exclude nvim-treesitter from combining by default

### DIFF
--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -475,10 +475,5 @@ lib.nixvim.plugins.mkNeovimPlugin {
       foldmethod = mkDefault "expr";
       foldexpr = mkDefault "nvim_treesitter#foldexpr()";
     };
-
-    # Since https://github.com/NixOS/nixpkgs/pull/321550 upstream queries are added
-    # to grammar plugins. Exclude nvim-treesitter itself from combining to avoid
-    # collisions with grammar's queries
-    performance.combinePlugins.standalonePlugins = [ cfg.package ];
   };
 }

--- a/tests/test-sources/plugins/by-name/treesitter/combine-plugins.nix
+++ b/tests/test-sources/plugins/by-name/treesitter/combine-plugins.nix
@@ -1,37 +1,38 @@
-{ pkgs, ... }:
 {
-  combine-plugins = {
-    performance.combinePlugins.enable = true;
+  combine-plugins =
+    { config, ... }:
+    {
+      performance.combinePlugins.enable = true;
 
-    plugins.treesitter = {
-      enable = true;
+      plugins.treesitter = {
+        enable = true;
 
-      # Exclude nixvim injections for test to pass
-      nixvimInjections = false;
-    };
+        # Exclude nixvim injections for test to pass
+        nixvimInjections = false;
+      };
 
-    extraConfigLuaPost = ''
-      -- Ensure that queries from nvim-treesitter are first in rtp
-      local queries_path = "${pkgs.vimPlugins.nvim-treesitter}/queries"
-      for name, type in vim.fs.dir(queries_path, {depth = 10}) do
-        if type == "file" then
-          -- Resolve all symlinks and compare nvim-treesitter's path with
-          -- whatever we've got from runtime
-          local nvim_treesitter_path = assert(vim.uv.fs_realpath(vim.fs.joinpath(queries_path, name)))
-          local rtp_path = assert(
-            vim.uv.fs_realpath(vim.api.nvim_get_runtime_file("queries/" .. name, false)[1]),
-            name .. " not found in runtime"
-          )
-          assert(
-            nvim_treesitter_path == rtp_path,
-            string.format(
-              "%s from rtp (%s) is not the same as from nvim-treesitter (%s)",
-              name,
-              rtp_path, nvim_treesitter_path
+      extraConfigLuaPost = ''
+        -- Ensure that queries from nvim-treesitter are first in rtp
+        local queries_path = "${config.plugins.treesitter.package}/queries"
+        for name, type in vim.fs.dir(queries_path, {depth = 10}) do
+          if type == "file" then
+            -- Get the file from rtp, resolve all symlinks and check
+            -- that the file is from nvim-treesitter. Only name is compared,
+            -- because 'combinePlugins' overrides packages.
+            local rtp_path = assert(
+              vim.uv.fs_realpath(vim.api.nvim_get_runtime_file("queries/" .. name, false)[1]),
+              name .. " not found in runtime"
             )
-          )
+            assert(
+              rtp_path:find("nvim-treesitter", 1, true),
+              string.format(
+                "%s from rtp (%s) is not from nvim-treesitter",
+                name,
+                rtp_path
+              )
+            )
+          end
         end
-      end
-    '';
-  };
+      '';
+    };
 }


### PR DESCRIPTION
Originally nvim-treesitter was added to standalonePlugins as workaround for https://github.com/NixOS/nixpkgs/pull/321550.
Nvim-treesitter from nixpkgs don't include queries from upstream parsers anymore since https://github.com/NixOS/nixpkgs/pull/344849.

If the user has some other plugin containing treesitter queries, this
change can cause a build failure due to collisions. But since it is
easier to add the plugin to standalonePlugins compared to removing it, I
think this should be the default.
