### PR TITLE
plugins/treesitter: prevent mkRaw over-injection by removing injection.combined

### DIFF
--- a/plugins/by-name/treesitter/injections.scm
+++ b/plugins/by-name/treesitter/injections.scm
@@ -23,8 +23,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "lua")))
   ]
-  (#match? @_func "(^|\\.)mkRaw$")
-  (#set! injection.combined))
+  (#match? @_func "(^|\\.)mkRaw$"))
 
 (binding
   attrpath: (attrpath


### PR DESCRIPTION
Fixes the issue I was having with wrong commenting/uncommenting with nixvim injections