### PR TITLE
update-scripts/update: fix call to `version-info` & 'has changed' when not committing

### DIFF
--- a/update-scripts/update.nix
+++ b/update-scripts/update.nix
@@ -43,7 +43,7 @@ writeShellApplication {
 
     versionInfo() {
       nix-build ./update-scripts -A version-info
-      ./result
+      ./result/bin/version-info
       if [ -n "$commit" ]; then
         git add version-info.toml
         git commit "$@"


### PR DESCRIPTION
- **update-scripts/update: fix call to `version-info`**
- **update-scripts/update: fix 'has changed' condition when not committing**

As per https://github.com/nix-community/nixvim/pull/3382/files#r2127406819, I spotted the last update failed because `./result` is not where the `version-info` script is installed. Instead it is at `./result/bin/version-info`.

```
/result/bin/update: line 41: ./result: Is a directory
```

- https://github.com/nix-community/nixvim/actions/runs/15417040422
- https://github.com/nix-community/nixvim/actions/runs/15442028271

Additionally, I've added some fixes & refactoring so that the script works properly when _not_ committing, as without this it was failing in other scenarios when testing it locally.

I've now tested locally: with and without `--commit`; and with and without `--github-output`, exporting the `GITHUB_OUTPUT` variable to a local file to validate what is written.

Additionally, I've run github actions against this branch:

- Run: https://github.com/nix-community/nixvim/actions/runs/15465504018
- Created: https://github.com/nix-community/nixvim/pull/3437

Ideas or follow-up PRs for further refactoring & simplification welcome, but I'd like to get _this_ merged soon to address the currently broken update CI workflow.
