### PR TITLE
plugins/neotest: allow raw lua for `quickfix.open` setting

### DIFF
--- a/plugins/by-name/neotest/settings-options.nix
+++ b/plugins/by-name/neotest/settings-options.nix
@@ -180,7 +180,7 @@ in
   quickfix = {
     enabled = defaultNullOpts.mkBool true "Enable quickfix.";
 
-    open = defaultNullOpts.mkNullable (with types; either bool str) false ''
+    open = defaultNullOpts.mkNullableWithRaw (with types; either bool str) false ''
       Set to true to open quickfix on startup, or a function to be called when the quickfix
       results are set.
     '';

--- a/tests/test-sources/plugins/by-name/neotest/quickfix_open_raw.nix
+++ b/tests/test-sources/plugins/by-name/neotest/quickfix_open_raw.nix
@@ -1,0 +1,12 @@
+{
+  example = {
+    plugins.neotest = {
+      settings = {
+        quickfix.open.__raw = ''
+          function()
+          end
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
Noticed that `quickfix.open` in the `neotest` plugin says it can be a function, but the option type didn’t actually support that — if you tried setting a Lua function with string, just got treated as a string. And if you tried setting it a `__raw` it would fail to build.

This just switches the option to use `mkNullableWithRaw` so it actually accepts raw Lua like the docs suggest.
Also added a quick test to make sure it works.