### PR TITLE
output: add extraPackagesAfter option

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -58,7 +58,14 @@ in
     extraPackages = mkOption {
       type = with types; listOf (nullOr package);
       default = [ ];
-      description = "Extra packages to be made available to neovim";
+      description = "Extra packages to be made available to neovim, added to the start of `PATH`";
+      apply = builtins.filter (p: p != null);
+    };
+
+    extraPackagesAfter = mkOption {
+      type = with types; listOf (nullOr package);
+      default = [ ];
+      description = "Extra packages to be made available to neovim, added to the end of `PATH`";
       apply = builtins.filter (p: p != null);
     };
 

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -241,6 +241,9 @@ in
         ++ (optional (
           config.extraPackages != [ ]
         ) ''--prefix PATH : "${lib.makeBinPath config.extraPackages}"'')
+        ++ (optional (
+          config.extraPackagesAfter != [ ]
+        ) ''--suffix PATH : "${lib.makeBinPath config.extraPackagesAfter}"'')
         ++ (optional config.wrapRc ''--add-flags -u --add-flags "${initFile}"'')
       );
 

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -149,4 +149,16 @@
       end
     '';
   };
+
+  extraPackagesAfter =
+    { pkgs, ... }:
+    {
+      extraPackagesAfter = [ pkgs.hello ];
+
+      extraConfigLua = ''
+        if vim.fn.executable("hello") ~= 1 then
+          print("Unable to find hello package.")
+        end
+      '';
+    };
 }


### PR DESCRIPTION
Allow users to add packages to the end of `PATH` in the neovim wrapper. This is useful for LSP versions that might need to be overriden based on the environment, e.g. `haskell-language-server` versions provided by a project's devshell.