### PR TITLE
plugins/kitty-navigator: init

### DIFF
--- a/plugins/by-name/kitty-navigator/default.nix
+++ b/plugins/by-name/kitty-navigator/default.nix
@@ -1,0 +1,13 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkVimPlugin {
+  name = "kitty-navigator";
+  package = "vim-kitty-navigator";
+
+  globalPrefix = "kitty_navigator_";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    enable_stack_layout = 1;
+  };
+}

--- a/tests/test-sources/plugins/by-name/kitty-navigator/default.nix
+++ b/tests/test-sources/plugins/by-name/kitty-navigator/default.nix
@@ -1,0 +1,25 @@
+{
+  empty = {
+    plugins.kitty-navigator.enable = true;
+  };
+
+  defaults = {
+    plugins.kitty-navigator = {
+      enable = true;
+
+      settings = {
+        enable_stack_layout = 0;
+      };
+    };
+  };
+
+  example = {
+    plugins.kitty-navigator = {
+      enable = true;
+
+      settings = {
+        enable_stack_layout = 1;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [vim-kitty-navigator](https://github.com/knubie/vim-kitty-navigator), a plugin offering seamless navigation between kitty panes and vim splits.

Closes #3438
