### PR TITLE
plugins/ansiesc: init

### DIFF
--- a/plugins/by-name/ansiesc/default.nix
+++ b/plugins/by-name/ansiesc/default.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkVimPlugin {
+  name = "ansiesc";
+  package = "vim-plugin-AnsiEsc";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+}

--- a/tests/test-sources/plugins/by-name/ansiesc/default.nix
+++ b/tests/test-sources/plugins/by-name/ansiesc/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.ansiesc.enable = true;
+  };
+}


### PR DESCRIPTION
Add support for [AnsiEsc](https://github.com/powerman/vim-plugin-AnsiEsc), a plugin to visualize ansi escape sequences.

Closes #3441
