### PR TITLE
escape backslash

### DIFF
--- a/plugins/by-name/toggleterm/default.nix
+++ b/plugins/by-name/toggleterm/default.nix
@@ -279,7 +279,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   settingsExample = {
-    open_mapping = "[[<c-\>]]";
+    open_mapping = "[[<c-\\>]]";
     direction = "float";
     float_opts = {
       border = "curved";


### PR DESCRIPTION
single backslash is not rendered right now:
![image](https://github.com/user-attachments/assets/eb8480b4-9455-4b92-b0fc-15c36accd31e)
