### PR TITLE
ci/update-other: generate branch list from version-info

### DIFF
--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   update:
     name: Trigger updates for nixvim's stable branches
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.repository == 'nix-community/nixvim'
     strategy:
       matrix:

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -6,6 +6,7 @@ on:
 
 # Allow running workflows
 permissions:
+  contents: read
   actions: write
 
 jobs:

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -15,17 +15,21 @@ jobs:
     runs-on: ubuntu-24.04-arm
     if: github.repository == 'nix-community/nixvim'
     outputs:
-      branches: ${{ steps.list-branches.outputs.branches }}
+      branches: ${{ steps.list-branches.outputs.result }}
     steps:
+      - name: Checkout version-info
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: version-info.toml
+          sparse-checkout-cone-mode: false
       - name: List stable branches
         id: list-branches
-        run: |
-          echo 'branches<<EOF
-          [
-            "nixos-25.05",
-            "nixos-24.11"
-          ]
-          EOF' >> "$GITHUB_OUTPUT"
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq --no-colors --output-format=json \
+              '[ .versions[].branch | select(. != "main") ]' \
+              version-info.toml
   update:
     name: Trigger update on ${{ matrix.branch }}
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.prepare.outputs.branches) }}
     steps:

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -10,20 +10,20 @@ permissions:
 
 jobs:
   update:
-    name: Trigger updates for nixvim's stable branches
+    name: Trigger update on ${{ matrix.branch }}
     runs-on: ubuntu-24.04-arm
     if: github.repository == 'nix-community/nixvim'
     strategy:
       matrix:
-        branches:
+        branch:
           - nixos-25.05
           - nixos-24.11
     steps:
-      - name: Update ${{ matrix.branches }}
+      - name: workflow dispatch
         env:
           GH_TOKEN: ${{ github.token }}
           repo: ${{ github.repository }}
-          branch: ${{ matrix.branches }}
+          branch: ${{ matrix.branch }}
         run: |
           gh --repo "$repo" workflow run \
             update.yml --ref "$branch"

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -10,15 +10,29 @@ permissions:
   actions: write
 
 jobs:
+  prepare:
+    name: Compute list of branches
+    runs-on: ubuntu-24.04-arm
+    if: github.repository == 'nix-community/nixvim'
+    outputs:
+      branches: ${{ steps.list-branches.outputs.branches }}
+    steps:
+      - name: List stable branches
+        id: list-branches
+        run: |
+          echo 'branches<<EOF
+          [
+            "nixos-25.05",
+            "nixos-24.11"
+          ]
+          EOF' >> "$GITHUB_OUTPUT"
   update:
     name: Trigger update on ${{ matrix.branch }}
     runs-on: ubuntu-24.04-arm
-    if: github.repository == 'nix-community/nixvim'
+    needs: prepare
     strategy:
       matrix:
-        branch:
-          - nixos-25.05
-          - nixos-24.11
+        branch: ${{ fromJSON(needs.prepare.outputs.branches) }}
     steps:
       - name: workflow dispatch
         env:


### PR DESCRIPTION
 Uses a [sparse-checkout](https://github.com/actions/checkout#scenarios) to download only the `version-info.toml` file, then uses the [`yq-go`](https://github.com/mikefarah/yq) action to extract the "other" branches as a JSON array.

This means we no longer need to manually update the workflow file when adding/removing stable branches. 🎉

Fixes #3432

---

This can be seen running on my fork in this workflow run: https://github.com/MattSturgeon/nixvim/actions/runs/15597236191

Notice that the branch matrix was created correctly, and both updates attempted. Each update failed because my fork doesn't have the relevant branches.

I created one of the branches on my fork and ran it again: https://github.com/MattSturgeon/nixvim/actions/runs/15597329168

This time notice that the `nixos-25.05` branch's `update.yml` was triggered successfully, and ran here: https://github.com/MattSturgeon/nixvim/actions/runs/15597337865

---

This doubles as a proof-of-concept for a similar change planned in the docs workflow: https://github.com/nix-community/nixvim/issues/3433

---

If it turns out we only use the "other versions" info in CI, then this could be refactored to run a script that directly parses NixOS/infra's `channels.nix` without needing to write that info to `version-info.toml`.

I believe the only other place we'll need this info will be building the multi-version docs, so perhaps a CI script is better?

Let's see as time goes on; this idea is already documented as part of #3434.
