### PR TITLE
colorschemes/solarized-osaka: init

### DIFF
--- a/plugins/colorschemes/solarized-osaka.nix
+++ b/plugins/colorschemes/solarized-osaka.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "solarized-osaka";
+  isColorscheme = true;
+  packPathName = "solarized-osaka.nvim";
+  package = "solarized-osaka-nvim";
+  colorscheme = "solarized-osaka";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    transparent = false;
+    styles = {
+      comments.italic = true;
+      keywords.italic = false;
+      floats = "transparent";
+    };
+  };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -25,6 +25,7 @@
     ./colorschemes/palette.nix
     ./colorschemes/poimandres.nix
     ./colorschemes/rose-pine.nix
+    ./colorschemes/solarized-osaka.nix
     ./colorschemes/tokyonight.nix
     ./colorschemes/vscode.nix
 

--- a/tests/test-sources/plugins/colorschemes/solazized-osaka.nix
+++ b/tests/test-sources/plugins/colorschemes/solazized-osaka.nix
@@ -1,0 +1,50 @@
+{ lib, ... }:
+{
+  empty = {
+    colorschemes.solarized-osaka.enable = true;
+  };
+
+  defaults = {
+    colorschemes.solarized-osaka = {
+      enable = true;
+
+      settings = {
+        transparent = true;
+        terminal_colors = true;
+        styles = {
+          comments.italic = true;
+          keywords.italic = true;
+          functions = { };
+          variables = { };
+          sidebars = "dark";
+          floats = "dark";
+        };
+        sidebars = [
+          "qf"
+          "help"
+        ];
+        day_brightness = 0.3;
+        hide_inactive_statusline = false;
+        dim_inactive = false;
+        lualine_bold = false;
+        on_colors = lib.nixvim.mkRaw "function(colors) end";
+        on_highlights = lib.nixvim.mkRaw "function(highlights, colors) end";
+      };
+    };
+  };
+
+  example = {
+    colorschemes.solarized-osaka = {
+      enable = true;
+
+      settings = {
+        transparent = false;
+        styles = {
+          comments.italic = true;
+          keywords.italic = false;
+          floats = "transparent";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for the [solarized-osaka.nvim](https://github.com/craftzdog/solarized-osaka.nvim) colorscheme.

Closes #3446
