### PR TITLE
ci/docs: fix build ref

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ matrix.ref }}
 
         # Uses the build-docs action from the checked-out nixvim branch
       - name: Build docs


### PR DESCRIPTION
Fix typo in #3466: `inputs.ref` → `matrix.ref`.

This caused an empty string to be assigned to the checkout action's `ref` input, meaning it used its default value `github.ref`.

Therefore all "versions" of the docs were actually building `main` 😂

If you look closely at [the logs](https://github.com/nix-community/nixvim/actions/runs/15667598257/job/44133783630#step:4:66), you can see that the 25.05 job's "checkout" step actually checked out `main`.

Instead, we actually want to checkout the ref from the job's `matrix`.

Ironically, I noticed the issue because the [workflow run](https://github.com/nix-community/nixvim/actions/runs/15667598257) was _successful_, when I expected it to fail as the backports haven't been merged yet. Those backports will be queued shortly, so let's merge this after so we don't end up failing to call the `build-docs` action.
