### PR TITLE
colorschemes/moonfly: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -7,6 +7,12 @@
 # Nixpkgs maintainers: https://github.com/NixOS/nixpkgs/blob/0212bde005b3335b2665c1476c36b3936e113b15/maintainers/maintainer-list.nix
 {
   # keep-sorted start block=yes newline_separated=no
+  AidanWelch = {
+    email = "aidan@freedwave.com";
+    github = "AidanWelch";
+    githubId = 35280359;
+    name = "Aidan Welch";
+  };
   AndresBermeoMarinelli = {
     email = "andres_bermeo@outlook.com";
     github = "theabm";

--- a/plugins/colorschemes/moonfly.nix
+++ b/plugins/colorschemes/moonfly.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  ...
+}:
+lib.nixvim.plugins.mkVimPlugin {
+  name = "moonfly";
+  colorscheme = "moonfly";
+  packPathName = "vim-moonfly-colors";
+  package = "vim-moonfly-colors";
+  isColorscheme = true;
+
+  maintainers = [ lib.maintainers.AidanWelch ];
+
+  globalPrefix = "moonfly";
+  settingsExample = {
+    Italics = true;
+    NormalFloat = false;
+    TerminalColors = true;
+    Transparent = false;
+    Undercurls = true;
+    UnderlineMatchParen = false;
+    VirtualTextColor = false;
+    WinSeparator = 1;
+  };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -17,6 +17,7 @@
     ./colorschemes/melange.nix
     ./colorschemes/modus.nix
     ./colorschemes/monokai-pro.nix
+    ./colorschemes/moonfly.nix
     ./colorschemes/nightfox.nix
     ./colorschemes/nord.nix
     ./colorschemes/one.nix

--- a/tests/test-sources/plugins/colorschemes/moonfly.nix
+++ b/tests/test-sources/plugins/colorschemes/moonfly.nix
@@ -1,0 +1,22 @@
+{
+  empty = {
+    colorschemes.moonfly.enable = true;
+  };
+
+  defaults = {
+    colorschemes.moonfly = {
+      enable = true;
+
+      settings = {
+        Italics = false;
+        NormalFloat = true;
+        TerminalColors = true;
+        Transparent = true;
+        Undercurls = true;
+        UnderlineMatchParen = true;
+        VirtualTextColor = true;
+        WinSeparator = 1;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for the [moonfly](https://github.com/bluz71/vim-moonfly-colors) colorscheme.

This relies on https://github.com/NixOS/nixpkgs/pull/417405

Also, sorry to GaetanLepage with the presumption of them maintaining this.  I copied to from another colorscheme and didn't know what I am supposed fill for the maintainer(if I need to fill anything)