### PR TITLE
ci/docs: fix `base-href` in matrix

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -45,7 +45,7 @@ jobs:
                     "base-href": "/nixvim/"
                   }
                 | select(.ref != "main").sub-path = .name
-                | select(.ref != "main").base-href += .name + "/"
+                | select(.ref != "main").base-href = "\(.base-href)\(.name)/"
               ]
             ' version-info.toml
 


### PR DESCRIPTION
I noticed that since merging #3481, both stable versions of the docs "think" they are 24.11.

I.e., both render the list like this:
![image](https://github.com/user-attachments/assets/2f07525b-4073-40cd-88c7-c8fb44819339)

For some context, the docs render the `availableVersions` list into a markdown list, and compare each entry's `baseHref` against the `baseHref` supplied to the docs. When building in CI, the top-level `baseHref` comes from the job matrix, while the `availableVersions` is passed in directly.

https://github.com/nix-community/nixvim/blob/7ff884527ecbb722e3b6b9f89025d1ee2065792b/docs/mdbook/default.nix#L457-L463

https://github.com/nix-community/nixvim/blob/7ff884527ecbb722e3b6b9f89025d1ee2065792b/.github/workflows/website.yml#L104-L105

---

For some reason, when updating `base-href` using `+=`, yq updates _all_ entries matching the LHS selection. This means that all non-main branches get `"base-href": "/nixvim/24.11/"` in the job matrix.

This gets passed in as an overridden attr when building the docs, and is used to determine which list item represents the currently-being-built docs; therefore both 25.05 and 24.11 think they are 24.11...

For some reason, while `+=` does this, `=` does not. So switched to using that.

AFAICT, this is just a bug in [yq-go](https://github.com/mikefarah/yq)... But at least we have a solution.
