### PR TITLE
docs: add status to beta/deprecated version links

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -63,12 +63,12 @@ jobs:
                 | {
                     "branch": .value.branch,
                     "nixpkgsBranch": .value.channel,
-                    "baseHref": "/nixvim/\(.key)/"
+                    "baseHref": "/nixvim/\(.key)/",
+                    "status": .value.status
                   }
                 | select(.branch == "main").baseHref = "/nixvim/"
               ]
             ' version-info.toml
-            # TODO: add channel status
 
   build:
     name: Build ${{ matrix.name }}

--- a/docs/mdbook/book.toml
+++ b/docs/mdbook/book.toml
@@ -8,7 +8,7 @@ title = "nixvim docs"
 [output.html]
 site-url = "@SITE_URL@"
 additional-js = ["theme/pagetoc.js"]
-additional-css = ["theme/pagetoc.css"]
+additional-css = ["custom.css", "theme/pagetoc.css"]
 
 # Redirect targets must be relative to their origin;
 # absolute paths can break with different baseHrefs.

--- a/docs/mdbook/custom.css
+++ b/docs/mdbook/custom.css
@@ -1,0 +1,19 @@
+.label {
+  padding: 0.1rem 0.4em;
+  font-size: 0.8em;
+  font-weight: 600;
+  vertical-align: bottom;
+  background-color: #5a6165;
+  text-shadow: rgba(0, 0, 0, 0.25) 0px -1px 0px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+}
+
+.label-info {
+  background-color: #337798;
+}
+
+.label-warning {
+  background-color: #da8206;
+}

--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -11,7 +11,7 @@
   # The root directory of the site
   baseHref ? "/",
   # A list of all available docs that should be linked to
-  # Each element should contain { branch; nixpkgsBranch; baseHref; }
+  # Each element should contain { branch; nixpkgsBranch; baseHref; status; }
   availableVersions ? [ ],
 }:
 let
@@ -306,9 +306,9 @@ let
   # Zip the list of attrs into an attr of lists, for use as bash arrays
   zippedVersions =
     assert lib.assertMsg
-      (lib.all (o: o ? branch && o ? nixpkgsBranch && o ? baseHref) availableVersions)
+      (lib.all (o: o ? branch && o ? nixpkgsBranch && o ? baseHref && o ? status) availableVersions)
       ''
-        Expected all "availableVersions" docs entries to contain { branch, nixpkgsBranch, baseHref } attrs!
+        Expected all "availableVersions" docs entries to contain { branch, nixpkgsBranch, baseHref, status } attrs!
       '';
     lib.zipAttrs availableVersions;
 in
@@ -338,9 +338,10 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
         { type, hasExt, ... }:
         type == "regular"
         && lib.any hasExt [
+          "css"
+          "js"
           "md"
           "toml"
-          "js"
         ]
       ) ./.)
     ];
@@ -442,6 +443,7 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
           branches = zippedVersions.branch or [ ];
           nixpkgsBranches = zippedVersions.nixpkgsBranch or [ ];
           baseHrefs = zippedVersions.baseHref or [ ];
+          statuses = zippedVersions.status or [ ];
           current = baseHref;
         }
         ''
@@ -451,6 +453,7 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
             nixpkgs="''${nixpkgsBranches[i]}"
             baseHref="''${baseHrefs[i]}"
             linkText="\`$branch\` branch"
+            status="''${statuses[i]}"
 
             link=
             suffix=
@@ -462,7 +465,25 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
               link="[$linkText]($baseHref)"
             fi
 
-            echo "- The $link, for use with nixpkgs \`$nixpkgs\`$suffix" >> "$out"
+            statusClass=
+            statusText=
+            if [ "$status" = "beta" ]; then
+              statusClass="label label-info"
+              statusText=Beta
+            elif [ "$status" = "deprecated" ]; then
+              statusClass="label label-warning"
+              statusText=Deprecated
+            fi
+
+            {
+              echo -n '- '
+              if [ -n "$statusClass" ] && [ -n "$statusText" ]; then
+                echo -n '<span class="'"$statusClass"'">'"$statusText"'</span> '
+              fi
+              echo -n "The $link"
+              echo -n ", for use with nixpkgs \`$nixpkgs\`"
+              echo "$suffix"
+            } >> "$out"
           done
         '';
     user-configs = callPackage ../user-configs { };


### PR DESCRIPTION
This PR adds "channel status" to the "other docs" links, when that status is either "beta" or "deprecated". This matches the behaviour on [NixOS Search](https://search.nixos.org/packages).

> [!Caution]
> The changes to the `docs` directory will need backporting. Until then, the status will not be displayed in links back from the older docs versions.
>
> I'm unsure if this can be done automatically, or if there will be conflicts.

As the last CI-related version-info todo item, this closes #3431 :tada: 

---

The styles for the info/warning labels are based on those used by NixOS Search, although I didn't implement anything different for dark/light theme.

Frankly, I'm not sold on my UI design here. Maybe it'd be better to integrate the _status_ into the text of the line, e.g.:

- The [`main` branch](#), for use with nixpkgs `nixpkgs-unstable`
- The [`nixos-25.05` branch](#), for use with __beta__ nixpkgs `nixos-25.05`
- The [`nixos-25.05` branch](#), for use with __deprecated__ nixpkgs `nixos-24.11`

This approach would also mean we don't need HTML or CSS... Maybe it'd even look better too?

---

I tested the docs locally by patching `serve-docs` to pass in an `availableVersions` override:

```diff
diff --git a/docs/server/default.nix b/docs/server/default.nix
index c73bd1eb..e28c8088 100644
--- a/docs/server/default.nix
+++ b/docs/server/default.nix
@@ -17,6 +17,28 @@ writeShellApplication {
     "-o"
   ];
   text = ''
-    http-server ${docs} "''${server_flags[@]}"
+    http-server ${docs.override {
+      baseHref = "/nixvim/";
+      availableVersions = [
+        {
+          branch = "main";
+          nixpkgsBranch = "nixpkgs-unstable";
+          baseHref = "/nixvim/";
+          status = null;
+        }
+        {
+          branch = "nixos-25.05";
+          nixpkgsBranch = "nixos-25.05";
+          baseHref = "/nixvim/25.05";
+          status = "beta";
+        }
+        {
+          branch = "nixos-24.11";
+          nixpkgsBranch = "nixos-24.11";
+          baseHref = "/nixvim/24.11";
+          status = "deprecated";
+        }
+      ];
+    }} "''${server_flags[@]}"
   '';
 }
```

In practice, you will only ever have one of `beta` or `deprecated`, never both. I rendered both for demonstration purposes:

![Screenshot](https://github.com/user-attachments/assets/5147440b-55b0-49fa-a4bd-b19b473ded3a)


---

I tested out the new yq query locally, where it produced:

```json
[
  {
    "branch": "main",
    "nixpkgsBranch": "nixpkgs-unstable",
    "baseHref": "/nixvim/",
    "status": "rolling"
  },
  {
    "branch": "nixos-25.05",
    "nixpkgsBranch": "nixos-25.05",
    "baseHref": "/nixvim/25.05/",
    "status": "stable"
  },
  {
    "branch": "nixos-24.11",
    "nixpkgsBranch": "nixos-24.11",
    "baseHref": "/nixvim/24.11/",
    "status": "deprecated"
  }
]
```

