### PR TITLE
treewide: add plugin descriptions

### DIFF
--- a/plugins/by-name/aerial/default.nix
+++ b/plugins/by-name/aerial/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "aerial";
   packPathName = "aerial.nvim";
   package = "aerial-nvim";
+  description = "A code outline window for skimming and quick navigation.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/airline/default.nix
+++ b/plugins/by-name/airline/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-airline";
   package = "vim-airline";
   globalPrefix = "airline_";
+  description = "Lean & mean status/tabline for vim that's light as air.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/ansiesc/default.nix
+++ b/plugins/by-name/ansiesc/default.nix
@@ -2,6 +2,7 @@
 lib.nixvim.plugins.mkVimPlugin {
   name = "ansiesc";
   package = "vim-plugin-AnsiEsc";
+  description = "Vim plugin to conceal ANSI escape sequences in the text.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/arrow/default.nix
+++ b/plugins/by-name/arrow/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "arrow";
   packPathName = "arrow.nvim";
   package = "arrow-nvim";
+  description = "A Neovim plugin to bookmark and navigate through files.";
 
   maintainers = [ maintainers.hmajid2301 ];
 

--- a/plugins/by-name/auto-save/default.nix
+++ b/plugins/by-name/auto-save/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "auto-save";
   packPathName = "auto-save.nvim";
   package = "auto-save-nvim";
+  description = "Automatically save your changes in NeoVim.";
 
   maintainers = [ lib.maintainers.braindefender ];
 

--- a/plugins/by-name/auto-session/default.nix
+++ b/plugins/by-name/auto-session/default.nix
@@ -9,6 +9,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "auto-session";
   package = "auto-session";
+  description = "A small automated session manager for Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/autosource/default.nix
+++ b/plugins/by-name/autosource/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-autosource";
   package = "vim-autosource";
   globalPrefix = "autosource_";
+  description = "A Vim plugin that enables per project Vim configuration.";
 
   maintainers = [ lib.maintainers.refaelsh ];
 

--- a/plugins/by-name/avante/default.nix
+++ b/plugins/by-name/avante/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "avante";
   packPathName = "avante.nvim";
   package = "avante-nvim";
+  description = "A Neovim plugin designed to emulate the behaviour of the Cursor AI IDE.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/aw-watcher/default.nix
+++ b/plugins/by-name/aw-watcher/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   moduleName = "aw_watcher";
   packPathName = "aw-watcher.nvim";
   package = "aw-watcher-nvim";
+  description = "A neovim watcher for ActivityWatch time tracker.";
 
   maintainers = [ lib.maintainers.axka ];
 

--- a/plugins/by-name/bacon/default.nix
+++ b/plugins/by-name/bacon/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "bacon";
   package = "nvim-bacon";
   maintainers = [ lib.maintainers.alisonjenkins ];
+  description = "View and jump to locations found in `.bacon-locations` files.";
 
   settingsOptions = {
     quickfix = {

--- a/plugins/by-name/baleia/default.nix
+++ b/plugins/by-name/baleia/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "baleia";
   packPathName = "baleia.nvim";
   package = "baleia-nvim";
+  description = "A Neovim plugin for colorizing text with ANSI escape sequences.";
 
   maintainers = [ lib.maintainers.alisonjenkins ];
 

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -55,6 +55,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "barbar";
   packPathName = "barbar.nvim";
   package = "barbar-nvim";
+  description = "A neovim tabline plugin.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/barbecue/default.nix
+++ b/plugins/by-name/barbecue/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "barbecue";
   packPathName = "barbecue.nvim";
   package = "barbecue-nvim";
+  description = "Visual Studio Code inspired breadcrumbs plugin.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/better-escape/default.nix
+++ b/plugins/by-name/better-escape/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "better-escape.nvim";
   moduleName = "better_escape";
   package = "better-escape-nvim";
+  description = "A Neovim plugin to quickly exit insert mode without losing your typed text.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/blink-cmp-copilot/default.nix
+++ b/plugins/by-name/blink-cmp-copilot/default.nix
@@ -6,6 +6,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 
   description = ''
+    Copilot suggestions source for the blink-cmp.
+
+    ---
+
     This plugin should be configured through blink-cmp's source settings.
 
     For example:

--- a/plugins/by-name/blink-cmp-dictionary/default.nix
+++ b/plugins/by-name/blink-cmp-dictionary/default.nix
@@ -6,6 +6,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    Dictionary source for the blink-cmp.
+
+    ---
+
     This plugin should be configured through blink-cmp's `sources.providers` settings.
 
     For example:

--- a/plugins/by-name/blink-cmp-git/default.nix
+++ b/plugins/by-name/blink-cmp-git/default.nix
@@ -6,6 +6,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    Git source for the blink-cmp.
+
+    ---
+
     This plugin should be configured through blink-cmp's `sources.providers` settings.
 
     For example:

--- a/plugins/by-name/blink-cmp-spell/default.nix
+++ b/plugins/by-name/blink-cmp-spell/default.nix
@@ -6,6 +6,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    Spell checking source for the blink-cmp.
+
+    ---
+
     This plugin should be configured through blink-cmp's `sources.providers` settings.
 
     For example:

--- a/plugins/by-name/blink-compat/default.nix
+++ b/plugins/by-name/blink-compat/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "blink-compat";
   packPathName = "blink.compat";
   package = "blink-compat";
+  description = "Compatibility layer for using nvim-cmp sources on blink.cmp";
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 

--- a/plugins/by-name/blink-copilot/default.nix
+++ b/plugins/by-name/blink-copilot/default.nix
@@ -6,6 +6,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    Configurable GitHub Copilot suggestions source for the blink-cmp.
+
+    ---
+
     This plugin should be configured through blink-cmp's `sources.providers` settings.
 
     `plugins.copilot-lua` will be enabled by default, to provide a working setup out-of-the-box.

--- a/plugins/by-name/blink-emoji/default.nix
+++ b/plugins/by-name/blink-emoji/default.nix
@@ -7,6 +7,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    Emoji source for the blink-cmp.
+
+    ---
+
     This plugin should be configured through blink-cmp's `sources.providers` settings.
 
     For example:

--- a/plugins/by-name/blink-ripgrep/default.nix
+++ b/plugins/by-name/blink-ripgrep/default.nix
@@ -7,6 +7,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    Ripgrep/gitgrep source for the blink.cmp.
+
+    ---
+
     This plugin should be configured through blink-cmp's `sources.providers` settings.
 
     For example:

--- a/plugins/by-name/bufdelete/default.nix
+++ b/plugins/by-name/bufdelete/default.nix
@@ -13,6 +13,10 @@ lib.nixvim.plugins.mkVimPlugin {
   maintainers = [ maintainers.MattSturgeon ];
 
   description = ''
+    Delete Neovim buffers without losing window layout.
+
+    ---
+
     This plugin provides two commands, `:Bdelete` and `:Bwipeout`.
     They work exactly the same as `:bdelete` and `:bwipeout`,
     except they keep your window layout intact.

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -12,6 +12,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "bufferline";
   packPathName = "bufferline.nvim";
   package = "bufferline-nvim";
+  description = "A snazzy bufferline plugin for Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/ccc/default.nix
+++ b/plugins/by-name/ccc/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "ccc";
   packPathName = "ccc.nvim";
   package = "ccc-nvim";
+  description = "Color picker and highlighter plugin for Neovim.";
 
   maintainers = [ lib.maintainers.JanKremer ];
 

--- a/plugins/by-name/chatgpt/default.nix
+++ b/plugins/by-name/chatgpt/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "chatgpt";
   packPathName = "ChatGPT.nvim";
   package = "ChatGPT-nvim";
+  description = "Effortless Natural Language Generation with OpenAI's ChatGPT API";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/claude-code/default.nix
+++ b/plugins/by-name/claude-code/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "claude-code";
   packPathName = "claude-code.nvim";
   package = "claude-code-nvim";
+  description = "Seamless integration between Claude Code AI assistant and Neovim";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/cloak/default.nix
+++ b/plugins/by-name/cloak/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "cloak";
   packPathName = "cloak.nvim";
   package = "cloak-nvim";
+  description = "Cloak allows you to overlay *'s over defined patterns.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/cmake-tools/default.nix
+++ b/plugins/by-name/cmake-tools/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmake-tools";
   packPathName = "cmake-tools.nvim";
   package = "cmake-tools-nvim";
+  description = "CMake tools for Neovim, providing a set of features to work with CMake projects.";
 
   maintainers = [ lib.maintainers.NathanFelber ];
 

--- a/plugins/by-name/cmp-ai/default.nix
+++ b/plugins/by-name/cmp-ai/default.nix
@@ -7,6 +7,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-ai";
+  description = "AI completion source for the nvim-cmp, powered by various AI providers.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/cmp-git/default.nix
+++ b/plugins/by-name/cmp-git/default.nix
@@ -5,6 +5,7 @@
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-git";
   moduleName = "cmp_git";
+  description = "Git source for the nvim-cmp.";
 
   imports = [
     { cmpSourcePlugins.git = "cmp-git"; }

--- a/plugins/by-name/cmp-tabby/default.nix
+++ b/plugins/by-name/cmp-tabby/default.nix
@@ -5,6 +5,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-tabby";
+  description = "[Tabby](https://tabbyml.com) completion source for the nvim-cmp.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/cmp-tabnine/default.nix
+++ b/plugins/by-name/cmp-tabnine/default.nix
@@ -5,6 +5,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "cmp-tabnine";
+  description = "[TabNine](https://tabnine.com) completion source for the nvim-cmp.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/codecompanion/default.nix
+++ b/plugins/by-name/codecompanion/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "codecompanion";
   packPathName = "codecompanion.nvim";
   package = "codecompanion-nvim";
+  description = "AI-powered coding, seamlessly in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/codesnap/default.nix
+++ b/plugins/by-name/codesnap/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "codesnap";
   packPathName = "codesnap.nvim";
   package = "codesnap-nvim";
+  description = "Snapshot plugin with rich features that can make pretty code snapshots.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/colorful-menu/default.nix
+++ b/plugins/by-name/colorful-menu/default.nix
@@ -5,6 +5,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "colorful-menu-nvim";
 
   description = ''
+    Colorful menu for the autocompletion engines in Neovim.
+
+    ---
+
     To use this in `nvim-cmp` for example,
     ```nix
     plugins.cmp.settings.formatting.format.__raw = \'\'

--- a/plugins/by-name/colorizer/default.nix
+++ b/plugins/by-name/colorizer/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "colorizer";
   packPathName = "nvim-colorizer.lua";
   package = "nvim-colorizer-lua";
+  description = "A high-performance color highlighter for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/comment/default.nix
+++ b/plugins/by-name/comment/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "Comment.nvim";
   moduleName = "Comment";
   package = "comment-nvim";
+  description = "Smart and powerful comment plugin for Neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/commentary/default.nix
+++ b/plugins/by-name/commentary/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "commentary";
   packPathName = "vim-commentary";
   package = "vim-commentary";
+  description = "Comment stuff out.";
 
   # TODO Add support for additional filetypes. This requires autocommands!
 

--- a/plugins/by-name/committia/default.nix
+++ b/plugins/by-name/committia/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "committia.vim";
   package = "committia-vim";
   globalPrefix = "committia_";
+  description = "A Vim plugin for more pleasant editing on commit messages.";
 
   maintainers = [ lib.maintainers.alisonjenkins ];
 

--- a/plugins/by-name/competitest/default.nix
+++ b/plugins/by-name/competitest/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "competitest";
   packPathName = "competitest.nvim";
   package = "competitest-nvim";
+  description = "Competitive programming plugin for Neovim.";
 
   maintainers = [ lib.maintainers.svl ];
 

--- a/plugins/by-name/compiler/default.nix
+++ b/plugins/by-name/compiler/default.nix
@@ -10,6 +10,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    Neovim compiler for building and running your code.
+
+    ---
+
     > [!Note]
     > Some languages require you manually install their compilers in your machine, so `compiler.nvim` is able to call them.
     > Please check [here], as the packages will be different depending your operative system.

--- a/plugins/by-name/conform-nvim/default.nix
+++ b/plugins/by-name/conform-nvim/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "conform-nvim";
   moduleName = "conform";
   packPathName = "conform.nvim";
+  description = "Lightweight yet powerful formatter plugin for Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/conjure/default.nix
+++ b/plugins/by-name/conjure/default.nix
@@ -4,6 +4,7 @@
 }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "conjure";
+  description = "Conjure is an interactive environment for evaluating code within your running program.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/copilot-chat/default.nix
+++ b/plugins/by-name/copilot-chat/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "CopilotChat.nvim";
   moduleName = "CopilotChat";
   package = "CopilotChat-nvim";
+  description = "Chat with Github Copilot in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/copilot-cmp/default.nix
+++ b/plugins/by-name/copilot-cmp/default.nix
@@ -6,6 +6,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "copilot-cmp";
   moduleName = "copilot_cmp";
+  description = "Copilot completion source for the nvim-cmp.";
 
   imports = [
     { cmpSourcePlugins.copilot = "copilot-cmp"; }

--- a/plugins/by-name/copilot-lua/default.nix
+++ b/plugins/by-name/copilot-lua/default.nix
@@ -12,6 +12,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "copilot-lua";
   moduleName = "copilot";
   packPathName = "copilot.lua";
+  description = "Fully featured & enhanced replacement for copilot.vim.";
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 

--- a/plugins/by-name/copilot-vim/default.nix
+++ b/plugins/by-name/copilot-vim/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "copilot-vim";
   packPathName = "copilot.vim";
   globalPrefix = "copilot_";
+  description = "Official Neovim plugin for GitHub Copilot.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/coq-nvim/default.nix
+++ b/plugins/by-name/coq-nvim/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "coq-nvim";
   packPathName = "coq_nvim";
   package = "coq_nvim";
+  description = "A fast nvim completion engine.";
 
   maintainers = with lib.maintainers; [
     traxys

--- a/plugins/by-name/cord/default.nix
+++ b/plugins/by-name/cord/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "cord";
   packPathName = "cord.nvim";
   package = "cord-nvim";
+  description = "A Neovim plugin that displays the current activity in Discord.";
   maintainers = [ lib.maintainers.eveeifyeve ];
 
   settingsExample = {

--- a/plugins/by-name/cornelis/default.nix
+++ b/plugins/by-name/cornelis/default.nix
@@ -5,6 +5,10 @@ in
 lib.nixvim.plugins.mkVimPlugin {
   name = "cornelis";
   globalPrefix = "cornelis_";
+  description = ''
+    Agda programming language support for Neovim.
+    Emacs [agda-mode](https://agda.readthedocs.io/en/latest/tools/emacs-mode.html) for Neovim.
+  '';
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/crates/default.nix
+++ b/plugins/by-name/crates/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "crates";
   packPathName = "crates.nvim";
   package = "crates-nvim";
+  description = "A neovim plugin that helps managing crates.io dependencies.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/csvview/default.nix
+++ b/plugins/by-name/csvview/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "csvview";
   packPathName = "csvview.nvim";
   package = "csvview-nvim";
+  description = "A Neovim plugin for CSV file editing.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/dap-go/default.nix
+++ b/plugins/by-name/dap-go/default.nix
@@ -11,6 +11,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "dap-go";
   package = "nvim-dap-go";
+  description = "An extension for nvim-dap providing configurations for launching go debugger.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dap-lldb/default.nix
+++ b/plugins/by-name/dap-lldb/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dap-lldb";
   packPathName = "nvim-dap-lldb";
   package = "nvim-dap-lldb";
+  description = "An extension for nvim-dap to provide C, C++, and Rust debugging support.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dap-python/default.nix
+++ b/plugins/by-name/dap-python/default.nix
@@ -19,6 +19,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "dap-python";
   package = "nvim-dap-python";
+  description = "An extension for nvim-dap, providing default configurations for python.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dap-rr/default.nix
+++ b/plugins/by-name/dap-rr/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dap-rr";
   packPathName = "nvim-dap-rr";
   package = "nvim-dap-rr";
+  description = "Dap configuration for the record and replay debugger.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/dap-ui/default.nix
+++ b/plugins/by-name/dap-ui/default.nix
@@ -55,6 +55,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   moduleName = "dapui";
   packPathName = "nvim-dap-ui";
   package = "nvim-dap-ui";
+  description = "A UI for nvim-dap.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dap-view/default.nix
+++ b/plugins/by-name/dap-view/default.nix
@@ -4,6 +4,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "nvim-dap-view";
   moduleName = "dap-view";
   package = "nvim-dap-view";
+  description = "Visualize debugging sessions in Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dap-virtual-text/default.nix
+++ b/plugins/by-name/dap-virtual-text/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   moduleName = "nvim-dap-virtual-text";
   packPathName = "nvim-dap-virtual-text";
   package = "nvim-dap-virtual-text";
+  description = "A plugin that adds virtual text support to the nvim-dap.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dap/default.nix
+++ b/plugins/by-name/dap/default.nix
@@ -15,6 +15,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dap";
   package = "nvim-dap";
   packPathName = "nvim-dap";
+  description = "Debug Adapter Protocol client implementation for Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dashboard/default.nix
+++ b/plugins/by-name/dashboard/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dashboard";
   packPathName = "dashboard-nvim";
   package = "dashboard-nvim";
+  description = "Fancy and Blazing Fast start screen plugin for Neovim.";
 
   maintainers = [ maintainers.MattSturgeon ];
 

--- a/plugins/by-name/dbee/default.nix
+++ b/plugins/by-name/dbee/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dbee";
   packPathName = "nvim-dbee";
   package = "nvim-dbee";
+  description = "Interactive database client for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/debugprint/default.nix
+++ b/plugins/by-name/debugprint/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "debugprint";
   packPathName = "debugprint.nvim";
   package = "debugprint-nvim";
+  description = "A Neovim plugin for inserting debug print statements.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/devdocs/default.nix
+++ b/plugins/by-name/devdocs/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "devdocs";
   packPathName = "devdocs.nvim";
   package = "devdocs-nvim";
+  description = "A Neovim plugin for accessing DevDocs documentation.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/diagram/default.nix
+++ b/plugins/by-name/diagram/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "diagram";
   packPathName = "diagram.nvim";
   package = "diagram-nvim";
+  description = "A Neovim plugin for rendering diagrams, powered by [image.nvim](https://github.com/3rd/image.nvim).";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/dial/default.nix
+++ b/plugins/by-name/dial/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dial";
   packPathName = "dial.nvim";
   package = "dial-nvim";
+  description = "Extended increment/decrement plugin for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/direnv/default.nix
+++ b/plugins/by-name/direnv/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "direnv.vim";
   package = "direnv-vim";
   globalPrefix = "direnv_";
+  description = "A Neovim plugin for integrating Direnv with Neovim.";
 
   maintainers = [ lib.maintainers.alisonjenkins ];
 

--- a/plugins/by-name/distant/default.nix
+++ b/plugins/by-name/distant/default.nix
@@ -12,6 +12,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "distant";
   packPathName = "distant.nvim";
   package = "distant-nvim";
+  description = "Edit files, run programs, and work with LSP on a remote machine from the comfort of your local environment.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/dotnet/default.nix
+++ b/plugins/by-name/dotnet/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dotnet";
   packPathName = "dotnet.nvim";
   package = "dotnet-nvim";
+  description = ".NET Neovim plugin for improving the .NET dev experience.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/dressing/default.nix
+++ b/plugins/by-name/dressing/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "dressing";
   packPathName = "dressing.nvim";
   package = "dressing-nvim";
+  description = "Neovim plugin to improve the default `vim.ui` interfaces.";
 
   maintainers = [ lib.maintainers.AndresBermeoMarinelli ];
 

--- a/plugins/by-name/easy-dotnet/default.nix
+++ b/plugins/by-name/easy-dotnet/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "easy-dotnet";
   packPathName = "easy-dotnet.nvim";
   package = "easy-dotnet-nvim";
+  description = "Neovim plugin for working with .Net projects in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/easyescape/default.nix
+++ b/plugins/by-name/easyescape/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-easyescape";
   package = "vim-easyescape";
   globalPrefix = "easyescape_";
+  description = "A plugin that makes exiting insert mode easy and distraction free!";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/edgy/default.nix
+++ b/plugins/by-name/edgy/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "edgy";
   packPathName = "edgy.nvim";
   package = "edgy-nvim";
+  description = "A Neovim plugin to easily create and manage predefined window layouts.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/emmet/default.nix
+++ b/plugins/by-name/emmet/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "emmet-vim";
   package = "emmet-vim";
   globalPrefix = "user_emmet_";
+  description = "Provides support for Emmet abbreviations and snippets.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/endwise/default.nix
+++ b/plugins/by-name/endwise/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "endwise";
   packPathName = "vim-endwise";
   package = "vim-endwise";
+  description = "A Vim plugin that automatically adds `end` to Ruby blocks.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/fastaction/default.nix
+++ b/plugins/by-name/fastaction/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "fastaction";
   packPathName = "fastaction.nvim";
   package = "fastaction-nvim";
+  description = "Efficiency plugin designed to optimize code actions in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/faust/default.nix
+++ b/plugins/by-name/faust/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "faust";
   packPathName = "faust-nvim";
   package = "faust-nvim";
+  description = "NeoVim plugin for writing Faust DSP code.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/femaco/default.nix
+++ b/plugins/by-name/femaco/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "femaco";
   packPathName = "nvim-FeMaco.lua";
   package = "nvim-FeMaco-lua";
+  description = "Catalyze your Fenced Markdown Code-block editing.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/fidget/default.nix
+++ b/plugins/by-name/fidget/default.nix
@@ -114,6 +114,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "fidget";
   packPathName = "fidget.nvim";
   package = "fidget-nvim";
+  description = "Extensible UI for Neovim notifications and LSP progress messages.";
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 

--- a/plugins/by-name/firenvim/default.nix
+++ b/plugins/by-name/firenvim/default.nix
@@ -10,6 +10,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "firenvim";
+  description = "Embed Neovim in Chrome, Firefox & others.";
 
   maintainers = with lib.maintainers; [ GaetanLepage ];
 

--- a/plugins/by-name/flash/default.nix
+++ b/plugins/by-name/flash/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "flash";
   packPathName = "flash.nvim";
   package = "flash-nvim";
+  description = "`flash.nvim` lets you navigate your code with search labels, enhanced character motions, and Treesitter integration.";
 
   maintainers = with maintainers; [
     traxys

--- a/plugins/by-name/floaterm/default.nix
+++ b/plugins/by-name/floaterm/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-floaterm";
   package = "vim-floaterm";
   globalPrefix = "floaterm_";
+  description = "A Neovim plugin for floating terminal windows.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/flutter-tools/default.nix
+++ b/plugins/by-name/flutter-tools/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "flutter-tools";
   packPathName = "flutter-tools.nvim";
   package = "flutter-tools-nvim";
+  description = "Build flutter and dart applications in neovim using the native LSP.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/friendly-snippets/default.nix
+++ b/plugins/by-name/friendly-snippets/default.nix
@@ -4,6 +4,7 @@
 }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "friendly-snippets";
+  description = "Set of preconfigured snippets for different languages.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/fugit2/default.nix
+++ b/plugins/by-name/fugit2/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "fugit2";
   packPathName = "fugit2.nvim";
   package = "fugit2-nvim";
+  description = "Neovim git GUI powered by libgit2.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/fugitive/default.nix
+++ b/plugins/by-name/fugitive/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "fugitive";
   packPathName = "vim-fugitive";
   package = "vim-fugitive";
+  description = "Fugitive is the premier Vim plugin for Git management.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/fzf-lua/default.nix
+++ b/plugins/by-name/fzf-lua/default.nix
@@ -31,6 +31,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "fzf-lua";
+  description = "`fzf` powered fuzzy finder for Neovim written in Lua.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/git-conflict/default.nix
+++ b/plugins/by-name/git-conflict/default.nix
@@ -7,6 +7,7 @@ with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "git-conflict";
   package = "git-conflict-nvim";
+  description = "A plugin to visualise and resolve merge conflicts in neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/git-worktree/default.nix
+++ b/plugins/by-name/git-worktree/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "git-worktree";
   packPathName = "git-worktree.nvim";
   package = "git-worktree-nvim";
+  description = "A Neovim plugin to manage git worktrees.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/gitblame/default.nix
+++ b/plugins/by-name/gitblame/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "gitblame";
   packPathName = "git-blame.nvim";
   package = "git-blame-nvim";
+  description = "A git blame plugin for Neovim.";
 
   maintainers = with lib.maintainers; [ GaetanLepage ];
 

--- a/plugins/by-name/gitgutter/default.nix
+++ b/plugins/by-name/gitgutter/default.nix
@@ -12,6 +12,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-gitgutter";
   package = "vim-gitgutter";
   globalPrefix = "gitgutter_";
+  description = "A Vim plugin which shows a git diff in the sign column.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/gitignore/default.nix
+++ b/plugins/by-name/gitignore/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "gitignore";
   packPathName = "gitignore.nvim";
   package = "gitignore-nvim";
+  description = "A Neovim plugin for generating .gitignore files.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/gitlab/default.nix
+++ b/plugins/by-name/gitlab/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "gitlab";
   packPathName = "gitlab.vim";
   package = "gitlab-vim";
+  description = "A Neovim plugin that integrates GitLab Duo with Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/gitmessenger/default.nix
+++ b/plugins/by-name/gitmessenger/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "git-messenger.vim";
   package = "git-messenger-vim";
   globalPrefix = "git_messenger_";
+  description = "Neovim plugin to reveal the commit messages under the cursor.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/gitsigns/default.nix
+++ b/plugins/by-name/gitsigns/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "gitsigns";
   packPathName = "gitsigns.nvim";
   package = "gitsigns-nvim";
+  description = "Git integration for buffers.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/glance/default.nix
+++ b/plugins/by-name/glance/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "glance";
   packPathName = "glance.nvim";
   package = "glance-nvim";
+  description = "Peek preview window for LSP locations in Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/glow/default.nix
+++ b/plugins/by-name/glow/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "glow";
   packPathName = "glow.nvim";
   package = "glow-nvim";
+  description = "A markdown preview directly in your neovim.";
 
   maintainers = [ lib.maintainers.getchoo ];
 

--- a/plugins/by-name/godot/default.nix
+++ b/plugins/by-name/godot/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-godot";
   package = "vim-godot";
   globalPrefix = "godot_";
+  description = "A Neovim plugin for Godot game engine integration.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/goto-preview/default.nix
+++ b/plugins/by-name/goto-preview/default.nix
@@ -4,6 +4,7 @@
 }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "goto-preview";
+  description = "A small Neovim plugin for previewing definitions using floating windows.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/goyo/default.nix
+++ b/plugins/by-name/goyo/default.nix
@@ -10,6 +10,7 @@ mkVimPlugin {
   packPathName = "goyo.vim";
   package = "goyo-vim";
   globalPrefix = "goyo_";
+  description = "Distraction-free writing in Vim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/grug-far/default.nix
+++ b/plugins/by-name/grug-far/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "grug-far";
   packPathName = "grug-far.nvim";
   package = "grug-far-nvim";
+  description = "Find And Replace plugin for Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/guess-indent/default.nix
+++ b/plugins/by-name/guess-indent/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "guess-indent";
   packPathName = "guess-indent.nvim";
   package = "guess-indent-nvim";
+  description = "Automatic indentation style detection for Neovim.";
 
   maintainers = [ lib.maintainers.GGORG ];
 

--- a/plugins/by-name/hardtime/default.nix
+++ b/plugins/by-name/hardtime/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "hardtime";
   packPathName = "hardtime.nvim";
   package = "hardtime-nvim";
+  description = "A Neovim plugin that helps you to avoid repeating mistakes with key presses.";
 
   maintainers = [ lib.maintainers.refaelsh ];
 

--- a/plugins/by-name/harpoon/default.nix
+++ b/plugins/by-name/harpoon/default.nix
@@ -9,6 +9,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "harpoon";
   package = "harpoon2";
+  description = "Quickly access files and marks in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/haskell-scope-highlighting/default.nix
+++ b/plugins/by-name/haskell-scope-highlighting/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "haskell-scope-highlighting";
   packPathName = "haskell-scope-highlighting.nvim";
   package = "haskell-scope-highlighting-nvim";
+  description = "Haskell syntax highlighting that considers variable scopes.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/headlines/default.nix
+++ b/plugins/by-name/headlines/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "headlines";
   packPathName = "headlines.nvim";
   package = "headlines-nvim";
+  description = "A plugin that adds horizontal highlights for text filetypes, like markdown, orgmode, and neorg.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/helm/default.nix
+++ b/plugins/by-name/helm/default.nix
@@ -9,6 +9,10 @@ lib.nixvim.plugins.mkVimPlugin {
   package = "vim-helm";
 
   description = ''
+    A Vim plugin for editing Helm templates.
+
+    ---
+
     To ensure that `helm_ls` (and not `yamlls`) is used on helm files, add the following autocmd:
 
     ```nix

--- a/plugins/by-name/helpview/default.nix
+++ b/plugins/by-name/helpview/default.nix
@@ -14,6 +14,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    A hackable & fancy vimdoc/help file viewer for Neovim.
+
+    ---
+
     Decorations for vimdoc/help files in Neovim
 
     Supports a vast amount of rendering customization.

--- a/plugins/by-name/hex/default.nix
+++ b/plugins/by-name/hex/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "hex";
   packPathName = "hex.nvim";
   package = "hex-nvim";
+  description = "Hex editor for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/highlight-colors/default.nix
+++ b/plugins/by-name/highlight-colors/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "nvim-highlight-colors";
   package = "nvim-highlight-colors";
   moduleName = "nvim-highlight-colors";
+  description = "Highlight colors in Neovim buffers.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/hlchunk/default.nix
+++ b/plugins/by-name/hlchunk/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "hlchunk";
   packPathName = "hlchunk.nvim";
   package = "hlchunk-nvim";
+  description = "A plugin that can highlight the indent line, and highlight the code chunk according to the current cursor position.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/hmts/default.nix
+++ b/plugins/by-name/hmts/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "hmts";
   packPathName = "hmts.nvim";
   package = "hmts-nvim";
+  description = "Custom treesitter queries for Home Manager nix files, in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/hop/default.nix
+++ b/plugins/by-name/hop/default.nix
@@ -12,6 +12,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ maintainers.GaetanLepage ];
 
   description = ''
+    A plugin allowing you to jump anywhere in a document with as few keystrokes as possible.
+
+    ---
+
     Hop doesn’t set any keybindings; you will have to define them by yourself.
     If you want to create a key binding from within nixvim:
     ```nix

--- a/plugins/by-name/hunk/default.nix
+++ b/plugins/by-name/hunk/default.nix
@@ -12,6 +12,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
   description = ''
     A tool for splitting diffs in Neovim.
 
+    ---
+
      If you wish to display icons in the file tree you should enable either
      `plugins.web-devicons` or `plugins.mini`. If using `plugins.mini`, you
      must enable the `icons` module.

--- a/plugins/by-name/hurl/default.nix
+++ b/plugins/by-name/hurl/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "hurl";
   packPathName = "hurl.nvim";
   package = "hurl-nvim";
+  description = "A Neovim plugin designed to run HTTP requests directly from `.hurl` files.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/hydra/default.nix
+++ b/plugins/by-name/hydra/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "hydra";
   packPathName = "hydra.nvim";
   package = "hydra-nvim";
+  description = "Create custom submodes and menus, inspired by the Hydra Emacs package.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/idris2/default.nix
+++ b/plugins/by-name/idris2/default.nix
@@ -7,5 +7,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "idris2";
   packPathName = "idris2";
   package = "idris2-nvim";
+  description = "Idris2 support for Neovim.";
   maintainers = [ lib.maintainers.mitchmindtree ];
 }

--- a/plugins/by-name/image/default.nix
+++ b/plugins/by-name/image/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "image";
   packPathName = "image.nvim";
   package = "image-nvim";
+  description = "This plugin adds image support to Neovim using Kitty's Graphics Protocol or ueberzugpp.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/improved-search/default.nix
+++ b/plugins/by-name/improved-search/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "improved-search";
   packPathName = "improved-search.nvim";
   package = "improved-search-nvim";
+  description = "It's a Neovim plugin that improves the search experience.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/indent-blankline/default.nix
+++ b/plugins/by-name/indent-blankline/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "indent-blankline.nvim";
   moduleName = "ibl";
   package = "indent-blankline-nvim";
+  description = "This plugin adds indentation guides to Neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/indent-o-matic/default.nix
+++ b/plugins/by-name/indent-o-matic/default.nix
@@ -5,6 +5,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "indent-o-matic";
+  description = "Dumb automatic fast indentation detection for Neovim.";
   maintainers = [ lib.maintainers.alisonjenkins ];
   settingsOptions = {
     max_lines = defaultNullOpts.mkInt 2048 "Number of lines without indentation before giving up (use -1 for infinite)";

--- a/plugins/by-name/indent-tools/default.nix
+++ b/plugins/by-name/indent-tools/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "indent-tools";
   packPathName = "indent-tools.nvim";
   package = "indent-tools-nvim";
+  description = "Neovim plugin for dealing with indentations.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/instant/default.nix
+++ b/plugins/by-name/instant/default.nix
@@ -10,6 +10,7 @@ mkVimPlugin {
   packPathName = "instant.nvim";
   package = "instant-nvim";
   globalPrefix = "instant_";
+  description = "A Neovim plugin for collaborative editing.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/intellitab/default.nix
+++ b/plugins/by-name/intellitab/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "intellitab";
   packPathName = "intellitab.nvim";
   package = "intellitab-nvim";
+  description = "A neovim plugin to only press tab once.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/java/default.nix
+++ b/plugins/by-name/java/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "java";
   packPathName = "nvim-java";
   package = "nvim-java";
+  description = "Neovim plugin for Java development, providing LSP support and more.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/jdtls/default.nix
+++ b/plugins/by-name/jdtls/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "jdtls";
   packPathName = "nvim-jdtls";
   package = "nvim-jdtls";
+  description = "Neovim plugin for the Java Development Tools Language Server (JDT LS).";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/julia-cell/default.nix
+++ b/plugins/by-name/julia-cell/default.nix
@@ -40,6 +40,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-julia-cell";
   package = "vim-julia-cell";
   globalPrefix = "julia_cell_";
+  description = "A Vim plugin for executing Julia code cells.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/jupytext/default.nix
+++ b/plugins/by-name/jupytext/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "jupytext";
   packPathName = "jupytext.nvim";
   package = "jupytext-nvim";
+  description = "Jupyter notebooks on Neovim powered by Jupytext.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/kitty-navigator/default.nix
+++ b/plugins/by-name/kitty-navigator/default.nix
@@ -2,8 +2,8 @@
 lib.nixvim.plugins.mkVimPlugin {
   name = "kitty-navigator";
   package = "vim-kitty-navigator";
-
   globalPrefix = "kitty_navigator_";
+  description = "Seamless navigation between kitty panes and vim splits.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/kulala/default.nix
+++ b/plugins/by-name/kulala/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "kulala";
   packPathName = "kulala.nvim";
   package = "kulala-nvim";
+  description = "A fully-featured REST Client Interface for Neovim.";
 
   maintainers = [ lib.maintainers.BoneyPatel ];
 

--- a/plugins/by-name/lazydev/default.nix
+++ b/plugins/by-name/lazydev/default.nix
@@ -16,6 +16,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 
   description = ''
+    A plugin that properly configures LuaLS for editing your Neovim config by lazily updating your workspace libraries.
+
+    ---
+
     ### lazydev.nvim as a blink.cmp source
 
     ```nix

--- a/plugins/by-name/lazygit/default.nix
+++ b/plugins/by-name/lazygit/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "lazygit.nvim";
   package = "lazygit-nvim";
   globalPrefix = "lazygit_";
+  description = "A Neovim plugin for using lazygit, a TUI for git commands.";
 
   maintainers = [ lib.maintainers.AndresBermeoMarinelli ];
 

--- a/plugins/by-name/lean/default.nix
+++ b/plugins/by-name/lean/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "lean";
   packPathName = "lean.nvim";
   package = "lean-nvim";
+  description = "Neovim support for the Lean theorem prover.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/ledger/default.nix
+++ b/plugins/by-name/ledger/default.nix
@@ -10,6 +10,7 @@ mkVimPlugin {
   packPathName = "vim-ledger";
   package = "vim-ledger";
   globalPrefix = "ledger_";
+  description = "Filetype detection, syntax highlighting, auto-formatting, auto-completion, and other tools for working with ledger files.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/lexima/default.nix
+++ b/plugins/by-name/lexima/default.nix
@@ -4,6 +4,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "lexima.vim";
   package = "lexima-vim";
   globalPrefix = "lexima_";
+  description = "Auto close parentheses (and other pairs) by pressing \"dot\"s.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/lightline/default.nix
+++ b/plugins/by-name/lightline/default.nix
@@ -15,6 +15,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.khaneliman ];
 
   description = ''
+    A light and configurable statusline/tabline plugin for Vim.
+
+    ---
+
     ### Example of defining your own component_function
 
     ```nix

--- a/plugins/by-name/lilypond-suite/default.nix
+++ b/plugins/by-name/lilypond-suite/default.nix
@@ -4,6 +4,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "nvim-lilypond-suite";
   package = "nvim-lilypond-suite";
   moduleName = "nvls";
+  description = "Neovim plugin for writing LilyPond scores.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/lint/default.nix
+++ b/plugins/by-name/lint/default.nix
@@ -132,6 +132,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "nvim-lint";
   callSetup = false;
   hasSettings = false;
+  description = "An asynchronous linter plugin for Neovim complementary to the built-in Language Server Protocol support.";
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 

--- a/plugins/by-name/lir/default.nix
+++ b/plugins/by-name/lir/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "lir";
   packPathName = "lir.nvim";
   package = "lir-nvim";
+  description = "A simple file explorer for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/llm/default.nix
+++ b/plugins/by-name/llm/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "llm";
   packPathName = "llm.nvim";
   package = "llm-nvim";
+  description = "llm.nvim is a plugin for all things LLM. It uses `llm-ls` as a backend.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/lsp-format/default.nix
+++ b/plugins/by-name/lsp-format/default.nix
@@ -28,6 +28,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   ];
 
   description = ''
+    A wrapper around Neovims native LSP formatting.
+
+    ---
+
     ## Configuring a Language
 
     `lsp-format` uses a table defining which lsp servers to use for each language.

--- a/plugins/by-name/lsp-lines/default.nix
+++ b/plugins/by-name/lsp-lines/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   moduleName = "lsp_lines";
   packPathName = "lsp_lines.nvim";
   package = "lsp_lines-nvim";
+  description = "A simple neovim plugin that renders diagnostics using virtual lines on top of the real line of code.";
 
   # This plugin has no settings; it is configured via vim.diagnostic.config
   hasSettings = false;

--- a/plugins/by-name/lsp-signature/default.nix
+++ b/plugins/by-name/lsp-signature/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "lsp_signature.nvim";
   package = "lsp_signature-nvim";
   moduleName = "lsp_signature";
+  description = "A Neovim plugin for showing function signatures as you type.";
 
   maintainers = [ lib.maintainers.wadsaek ];
 

--- a/plugins/by-name/lsp-status/default.nix
+++ b/plugins/by-name/lsp-status/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "lsp-status";
   packPathName = "lsp-status.nvim";
   package = "lsp-status-nvim";
+  description = "Utility functions for getting diagnostic status and progress messages from LSP servers, for use in the Neovim statusline.";
   maintainers = [ lib.maintainers.b3nb5n ];
 
   settingsOptions =

--- a/plugins/by-name/ltex-extra/default.nix
+++ b/plugins/by-name/ltex-extra/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "ltex-extra";
   packPathName = "ltex_extra.nvim";
   package = "ltex_extra-nvim";
+  description = "LTeX_extra is a companion plugin for LTeX language server.";
 
   maintainers = [ maintainers.loicreynier ];
 

--- a/plugins/by-name/lualine/default.nix
+++ b/plugins/by-name/lualine/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "lualine";
   packPathName = "lualine.nvim";
   package = "lualine-nvim";
+  description = "A blazing fast and easy to configure neovim statusline written in lua.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/luasnip/default.nix
+++ b/plugins/by-name/luasnip/default.nix
@@ -47,6 +47,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "luasnip";
   package = "luasnip";
   setup = ".config.setup";
+  description = "Snippet Engine for Neovim.";
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 

--- a/plugins/by-name/magma-nvim/default.nix
+++ b/plugins/by-name/magma-nvim/default.nix
@@ -10,6 +10,7 @@ mkVimPlugin {
   packPathName = "magma-nvim";
   package = "magma-nvim";
   globalPrefix = "magma_";
+  description = "Interact with Jupyter from NeoVim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/markdown-preview/default.nix
+++ b/plugins/by-name/markdown-preview/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "markdown-preview.nvim";
   package = "markdown-preview-nvim";
   globalPrefix = "mkdp_";
+  description = "A markdown preview plugin for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/mini/default.nix
+++ b/plugins/by-name/mini/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "mini.nvim";
   # Just want it before most other plugins for the icons provider.
   configLocation = lib.mkOrder 800 "extraConfigLua";
+  description = "A collection of Neovim plugins that are small, focused, and modular. They can be used individually or together to enhance your Neovim experience.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/minuet/default.nix
+++ b/plugins/by-name/minuet/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "minuet";
   packPathName = "minuet-ai.nvim";
   package = "minuet-ai-nvim";
+  description = "A Neovim plugin that provides AI-powered code completion and suggestions.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/modicator/default.nix
+++ b/plugins/by-name/modicator/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "modicator";
   packPathName = "modicator.nvim";
   package = "modicator-nvim";
+  description = "Cursor line number mode indicator plugin for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/molten/default.nix
+++ b/plugins/by-name/molten/default.nix
@@ -11,6 +11,7 @@ mkVimPlugin {
   packPathName = "molten-nvim";
   package = "molten-nvim";
   globalPrefix = "molten_";
+  description = "A neovim plugin for interactively running code with the jupyter kernel. Fork of magma-nvim with improvements in image rendering, performance, and more.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/muren/default.nix
+++ b/plugins/by-name/muren/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "muren";
   packPathName = "muren.nvim";
   package = "muren-nvim";
+  description = "Neovim plugin for doing multiple search and replace with ease.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/nabla/default.nix
+++ b/plugins/by-name/nabla/default.nix
@@ -8,6 +8,10 @@ lib.nixvim.plugins.mkVimPlugin {
   package = "nabla-nvim";
 
   description = ''
+    An ASCII math generator from LaTeX equations.
+
+    ---
+
     You can bind the popup action like so:
     ```nix
       keymaps = [

--- a/plugins/by-name/navic/default.nix
+++ b/plugins/by-name/navic/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "nvim-navic";
   moduleName = "nvim-navic";
   package = "nvim-navic";
+  description = "Simple winbar/statusline plugin that shows your current code context.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/neoclip/default.nix
+++ b/plugins/by-name/neoclip/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "neoclip";
   packPathName = "nvim-neoclip.lua";
   package = "nvim-neoclip-lua";
+  description = "Clipboard manager neovim plugin with telescope integration.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/neoconf/default.nix
+++ b/plugins/by-name/neoconf/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "neoconf";
   packPathName = "neoconf.nvim";
   package = "neoconf-nvim";
+  description = "Neovim plugin to manage global and project-local settings.";
 
   maintainers = [ lib.maintainers.BoneyPatel ];
 

--- a/plugins/by-name/neocord/default.nix
+++ b/plugins/by-name/neocord/default.nix
@@ -6,6 +6,7 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "neocord";
+  description = "Discord Rich Presence for Neovim (Fork of presence.nvim).";
 
   maintainers = [ ];
 

--- a/plugins/by-name/neogit/default.nix
+++ b/plugins/by-name/neogit/default.nix
@@ -7,6 +7,7 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "neogit";
+  description = "An interactive and powerful Git interface for Neovim, inspired by Magit.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/neorg/default.nix
+++ b/plugins/by-name/neorg/default.nix
@@ -15,6 +15,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "neorg";
+  description = "A modular, extensible, and feature-rich note-taking and organization tool for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/neoscroll/default.nix
+++ b/plugins/by-name/neoscroll/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "neoscroll";
   packPathName = "neoscroll.nvim";
   package = "neoscroll-nvim";
+  description = "Smooth scrolling neovim plugin.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/neotest/default.nix
+++ b/plugins/by-name/neotest/default.nix
@@ -5,6 +5,7 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "neotest";
+  description = "An extensible framework for interacting with tests within NeoVim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/nerdy/default.nix
+++ b/plugins/by-name/nerdy/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "nerdy";
   packPathName = "nerdy.nvim";
   package = "nerdy-nvim";
+  description = "A Neovim plugin for searching, previewing, and inserting Nerd Font glyphs.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/netman/default.nix
+++ b/plugins/by-name/netman/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "netman";
   packPathName = "netman.nvim";
   package = "netman-nvim";
+  description = "Neovim (Lua powered) Network Resource Manager.";
 
   hasSettings = false;
   callSetup = false;

--- a/plugins/by-name/nix-develop/default.nix
+++ b/plugins/by-name/nix-develop/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "nix-develop-nvim";
   callSetup = false;
   hasSettings = false;
+  description = "Run `nix develop` without restarting Neovim.";
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 

--- a/plugins/by-name/nix/default.nix
+++ b/plugins/by-name/nix/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "nix";
   packPathName = "vim-nix";
   package = "vim-nix";
+  description = "Syntax highlighting and indenting for the Nix expression language.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/none-ls/default.nix
+++ b/plugins/by-name/none-ls/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "none-ls.nvim";
   moduleName = "null-ls";
   package = "none-ls-nvim";
+  description = "Use Neovim as a language server to inject LSP diagnostics, code actions, and more via Lua.";
 
   maintainers = [ lib.maintainers.MattSturgeon ];
 

--- a/plugins/by-name/notebook-navigator/default.nix
+++ b/plugins/by-name/notebook-navigator/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "notebook-navigator";
   packPathName = "NotebookNavigator-nvim";
   package = "NotebookNavigator-nvim";
+  description = "A Neovim plugin for navigating and managing Jupyter code cells in notebooks.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/numbertoggle/default.nix
+++ b/plugins/by-name/numbertoggle/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "numbertoggle";
   packPathName = "vim-numbertoggle";
   package = "vim-numbertoggle";
+  description = "Toggles between hybrid and absolute line numbers automatically.";
 
   maintainers = [ lib.maintainers.refaelsh ];
 }

--- a/plugins/by-name/nvim-autopairs/default.nix
+++ b/plugins/by-name/nvim-autopairs/default.nix
@@ -7,6 +7,7 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-autopairs";
+  description = "Insert and delete brackets, parens, quotes in pair automatically.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/nvim-lightbulb/default.nix
+++ b/plugins/by-name/nvim-lightbulb/default.nix
@@ -6,6 +6,7 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-lightbulb";
+  description = "The plugin shows a lightbulb in the sign column whenever a `textDocument/codeAction` is available at the current cursor position.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/nvim-snippets/default.nix
+++ b/plugins/by-name/nvim-snippets/default.nix
@@ -9,6 +9,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-snippets";
   moduleName = "snippets";
+  description = "Allow vscode style snippets to be used with native neovim snippets `vim.snippet`.";
 
   maintainers = [ lib.maintainers.psfloyd ];
 

--- a/plugins/by-name/nvim-surround/default.nix
+++ b/plugins/by-name/nvim-surround/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-surround";
   packPathName = "nvim-surround";
   package = "nvim-surround";
+  description = "Add/change/delete surrounding delimiter pairs with ease.";
 
   maintainers = with lib.maintainers; [
     khaneliman

--- a/plugins/by-name/nvim-ufo/default.nix
+++ b/plugins/by-name/nvim-ufo/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "nvim-ufo";
   moduleName = "ufo";
   package = "nvim-ufo";
+  description = "An Neovim plugin for managing folds with LSP support.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/obsidian/default.nix
+++ b/plugins/by-name/obsidian/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "obsidian";
   packPathName = "obsidian.nvim";
   package = "obsidian-nvim";
+  description = "Neovim plugin for writing and navigating Obsidian vaults.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/octo/default.nix
+++ b/plugins/by-name/octo/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "octo";
   packPathName = "octo.nvim";
   package = "octo-nvim";
+  description = "Edit and review GitHub issues and pull requests from the comfort of your favorite editor.";
 
   maintainers = [ lib.maintainers.svl ];
 

--- a/plugins/by-name/oil/default.nix
+++ b/plugins/by-name/oil/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "oil";
   packPathName = "oil.nvim";
   package = "oil-nvim";
+  description = "Neovim file explorer: edit your filesystem like a buffer.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/openscad/default.nix
+++ b/plugins/by-name/openscad/default.nix
@@ -16,6 +16,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   inherit name;
   packPathName = "openscad.nvim";
   package = "openscad-nvim";
+  description = "Syntax highlighting, cheatsheet, snippets, offline manual and fuzzy help plugin for the openscad language.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/orgmode/default.nix
+++ b/plugins/by-name/orgmode/default.nix
@@ -8,6 +8,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "orgmode";
   packPathName = "nvim-orgmode";
+  description = "Nvim orgmode is a clone of Emacs Orgmode for Neovim.";
 
   maintainers = [ lib.maintainers.refaelsh ];
 

--- a/plugins/by-name/origami/default.nix
+++ b/plugins/by-name/origami/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "origami";
   packPathName = "nvim-origami";
   package = "nvim-origami";
+  description = "A Neovim plugin for managing folds with ease.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/otter/default.nix
+++ b/plugins/by-name/otter/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "otter";
   packPathName = "otter.nvim";
   package = "otter-nvim";
+  description = "A Neovim plugin for writing and running embedded languages in your code.";
 
   maintainers = [ ];
 

--- a/plugins/by-name/overseer/default.nix
+++ b/plugins/by-name/overseer/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "overseer";
   packPathName = "overseer.nvim";
   package = "overseer-nvim";
+  description = "A task runner and job management plugin for Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/package-info/default.nix
+++ b/plugins/by-name/package-info/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "package-info";
   packPathName = "package-info.nvim";
   package = "package-info-nvim";
+  description = "A Neovim plugin to manage npm/yarn/pnpm dependencies, commands and more.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/papis/default.nix
+++ b/plugins/by-name/papis/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "papis";
   packPathName = "papis.nvim";
   package = "papis-nvim";
+  description = "Manage your bibliography from within your favourite editor.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/parinfer-rust/default.nix
+++ b/plugins/by-name/parinfer-rust/default.nix
@@ -6,6 +6,7 @@
 lib.nixvim.plugins.mkVimPlugin {
   name = "parinfer-rust";
   globalPrefix = "parinfer_";
+  description = "Infer parentheses for Clojure, Lisp and Scheme.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/parrot/default.nix
+++ b/plugins/by-name/parrot/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "parrot";
   packPathName = "parrot.nvim";
   package = "parrot-nvim";
+  description = "A Neovim plugin for LLM text generation.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/pckr/default.nix
+++ b/plugins/by-name/pckr/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "pckr";
   packPathName = "pckr.nvim";
   package = "pckr-nvim";
+  description = "A Neovim plugin manager that allows you to install plugins from various sources. Spiritual successor to packer.nvim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/peek/default.nix
+++ b/plugins/by-name/peek/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "peek";
   packPathName = "peek.nvim";
   package = "peek-nvim";
+  description = "Markdown preview plugin for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/persisted/default.nix
+++ b/plugins/by-name/persisted/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "persisted";
   packPathName = "persisted.nvim";
   package = "persisted-nvim";
+  description = "Simple session management for Neovim with git branching, autoloading and Telescope support.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/plantuml-syntax/default.nix
+++ b/plugins/by-name/plantuml-syntax/default.nix
@@ -8,6 +8,7 @@ in
 lib.nixvim.plugins.mkVimPlugin {
   name = "plantuml-syntax";
   globalPrefix = "plantuml_";
+  description = "Syntax highlighting for PlantUML files.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/precognition/default.nix
+++ b/plugins/by-name/precognition/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "precognition";
   packPathName = "precognition.nvim";
   package = "precognition-nvim";
+  description = "Precognition uses virtual text and gutter signs to show available motions.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/preview/default.nix
+++ b/plugins/by-name/preview/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "preview";
   packPathName = "Preview.nvim";
   package = "Preview-nvim";
+  description = "Neovim wrapper around MD-TUI.";
 
   hasSettings = false;
 

--- a/plugins/by-name/project-nvim/default.nix
+++ b/plugins/by-name/project-nvim/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "project-nvim";
   packPathName = "project.nvim";
   moduleName = "project_nvim";
+  description = "`project.nvim` is an all in one neovim plugin written in lua that provides superior project management.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/projections/default.nix
+++ b/plugins/by-name/projections/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "projections";
   packPathName = "projections.nvim";
   package = "projections-nvim";
+  description = "A tiny project + sessions manager for neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/qmk/default.nix
+++ b/plugins/by-name/qmk/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "qmk";
   packPathName = "qmk.nvim";
   package = "qmk-nvim";
+  description = "Format qmk and zmk keymaps in Neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/quarto/default.nix
+++ b/plugins/by-name/quarto/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "quarto";
   packPathName = "quarto-nvim";
   package = "quarto-nvim";
+  description = "Quarto-nvim provides tools for working on Quarto manuscripts in Neovim.";
 
   maintainers = [ lib.maintainers.BoneyPatel ];
 

--- a/plugins/by-name/quicker/default.nix
+++ b/plugins/by-name/quicker/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "quicker";
   packPathName = "quicker.nvim";
   package = "quicker-nvim";
+  description = "Improved UI and workflow for the Neovim quickfix.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/quickmath/default.nix
+++ b/plugins/by-name/quickmath/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "quickmath";
   packPathName = "quickmath.nvim";
   package = "quickmath-nvim";
+  description = "A simple plugin to do live calculations in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/refactoring/default.nix
+++ b/plugins/by-name/refactoring/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "refactoring";
   packPathName = "refactoring.nvim";
   package = "refactoring-nvim";
+  description = "The Refactoring library based off the Refactoring book by Martin Fowler.";
 
   maintainers = [ maintainers.MattSturgeon ];
 

--- a/plugins/by-name/remote-nvim/default.nix
+++ b/plugins/by-name/remote-nvim/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "remote-nvim";
   packPathName = "remote-nvim.nvim";
   package = "remote-nvim-nvim";
+  description = "Adds support for remote development and devcontainers to Neovim.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/render-markdown/default.nix
+++ b/plugins/by-name/render-markdown/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "render-markdown";
   packPathName = "render-markdown.nvim";
   package = "render-markdown-nvim";
+  description = "Plugin to improve viewing Markdown files in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/repeat/default.nix
+++ b/plugins/by-name/repeat/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "repeat";
   packPathName = "vim-repeat";
   package = "vim-repeat";
+  description = "Enable repeating supported plugin maps with the '.' command.";
 
   maintainers = [ lib.maintainers.refaelsh ];
 }

--- a/plugins/by-name/rest/default.nix
+++ b/plugins/by-name/rest/default.nix
@@ -13,6 +13,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "rest.nvim";
   moduleName = "rest-nvim";
   package = "rest-nvim";
+  description = "A very fast, powerful, extensible and asynchronous Neovim HTTP client.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/rustaceanvim/default.nix
+++ b/plugins/by-name/rustaceanvim/default.nix
@@ -8,6 +8,7 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "rustaceanvim";
+  description = "A Neovim plugin for Rust development, providing features like LSP support, code navigation, and more.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/sandwich/default.nix
+++ b/plugins/by-name/sandwich/default.nix
@@ -11,6 +11,11 @@ lib.nixvim.plugins.mkVimPlugin {
   globalPrefix = "sandwich_";
 
   description = ''
+    `sandwich.vim` is a plugin that makes it super easy to work with stuff that comes in
+    pairs, like brackets, quotes, and even HTML or XML tags.
+
+    ---
+
     The `settings` option will not let you define the options starting with `sandwich#`.
     For those, you can directly use the `globals` option:
     ```nix

--- a/plugins/by-name/schemastore/default.nix
+++ b/plugins/by-name/schemastore/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "schemastore";
   packPathName = "SchemaStore.nvim";
   package = "SchemaStore-nvim";
+  description = "A Neovim plugin that provides the SchemaStore catalog for use with jsonls and yamlls.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/scope/default.nix
+++ b/plugins/by-name/scope/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "scope";
   packPathName = "scope.nvim";
   package = "scope-nvim";
+  description = "Seamlessly navigate through buffers within each tab using commands like `:bnext` and `:bprev`.";
 
   maintainers = [ lib.maintainers.insipx ];
 

--- a/plugins/by-name/scrollview/default.nix
+++ b/plugins/by-name/scrollview/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "nvim-scrollview";
   package = "nvim-scrollview";
   globalPrefix = "scrollview_";
+  description = "A Neovim plugin that displays interactive vertical scrollbars and signs.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/sg/default.nix
+++ b/plugins/by-name/sg/default.nix
@@ -11,6 +11,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "sg";
   packPathName = "sg.nvim";
   package = "sg-nvim";
+  description = "Experimental Sourcegraph + Cody plugin for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/sleuth/default.nix
+++ b/plugins/by-name/sleuth/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-sleuth";
   package = "vim-sleuth";
   globalPrefix = "sleuth_";
+  description = "This plugin automatically adjusts 'shiftwidth' and 'expandtab' heuristically based on the current file.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/smart-splits/default.nix
+++ b/plugins/by-name/smart-splits/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "smart-splits";
   packPathName = "smart-splits.nvim";
   package = "smart-splits-nvim";
+  description = "Smarter and more intuitive split pane management that uses a mental model of left/right/up/down instead of wider/narrower/taller/shorter for resizing splits.";
 
   maintainers = [ lib.maintainers.foo-dogsquared ];
 

--- a/plugins/by-name/smartcolumn/default.nix
+++ b/plugins/by-name/smartcolumn/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "smartcolumn";
   packPathName = "smartcolumn.nvim";
   package = "smartcolumn-nvim";
+  description = "A Neovim plugin hiding your colorcolumn when unneeded.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/smear-cursor/default.nix
+++ b/plugins/by-name/smear-cursor/default.nix
@@ -4,6 +4,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "smear-cursor.nvim";
   package = "smear-cursor-nvim";
   moduleName = "smear_cursor";
+  description = "A Neovim plugin that adds a smear effect to the cursor when moving quickly.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/snacks/default.nix
+++ b/plugins/by-name/snacks/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "snacks";
   packPathName = "snacks.nvim";
   package = "snacks-nvim";
+  description = "A collection of small QoL plugins for Neovim.";
 
   maintainers = [ lib.maintainers.HeitorAugustoLN ];
 

--- a/plugins/by-name/sniprun/default.nix
+++ b/plugins/by-name/sniprun/default.nix
@@ -7,6 +7,7 @@ with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "sniprun";
   url = "https://github.com/michaelb/sniprun";
+  description = "A neovim plugin to run lines/blocs of code.";
 
   maintainers = with maintainers; [
     traxys

--- a/plugins/by-name/specs/default.nix
+++ b/plugins/by-name/specs/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "specs";
   packPathName = "specs.nvim";
   package = "specs-nvim";
+  description = "A fast and lightweight Neovim lua plugin to keep an eye on where your cursor has jumped.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/spectre/default.nix
+++ b/plugins/by-name/spectre/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "spectre";
   packPathName = "nvim-spectre";
   package = "nvim-spectre";
+  description = "A search panel for neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/sqlite-lua/default.nix
+++ b/plugins/by-name/sqlite-lua/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "sqlite.lua";
   moduleName = "sqlite.lua";
   package = "sqlite-lua";
+  description = "SQLite/LuaJIT binding and a highly opinionated wrapper for storing, retrieving, caching, and persisting SQLite databases.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/startify/default.nix
+++ b/plugins/by-name/startify/default.nix
@@ -10,6 +10,7 @@ mkVimPlugin {
   packPathName = "vim-startify";
   package = "vim-startify";
   globalPrefix = "startify_";
+  description = "The fancy start screen for Vim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/statuscol/default.nix
+++ b/plugins/by-name/statuscol/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "statuscol";
   packPathName = "statuscol.nvim";
   package = "statuscol-nvim";
+  description = "Status column plugin that provides a configurable `statuscolumn` and click handlers.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/supermaven/default.nix
+++ b/plugins/by-name/supermaven/default.nix
@@ -4,6 +4,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "supermaven-nvim";
   moduleName = "supermaven-nvim";
   packPathName = "supermaven-nvim";
+  description = "The official Neovim plugin for Supermaven.";
 
   maintainers = [ lib.maintainers.PoCo ];
 

--- a/plugins/by-name/tagbar/default.nix
+++ b/plugins/by-name/tagbar/default.nix
@@ -5,6 +5,7 @@
 lib.nixvim.plugins.mkVimPlugin {
   name = "tagbar";
   globalPrefix = "tagbar_";
+  description = "Vim plugin that displays tags in a window, ordered by scope.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/tailwind-tools/default.nix
+++ b/plugins/by-name/tailwind-tools/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "tailwind-tools";
   packPathName = "tailwind-tools.nvim";
   package = "tailwind-tools-nvim";
+  description = "A Neovim plugin that provides tools for working with Tailwind CSS.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/telekasten/default.nix
+++ b/plugins/by-name/telekasten/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "telekasten";
   packPathName = "telekasten.nvim";
   package = "telekasten-nvim";
+  description = "A Neovim plugin for working with a markdown zettelkasten/wiki and mixing it with a journal, based on telescope.nvim.";
 
   maintainers = [ lib.maintainers.onemoresuza ];
 

--- a/plugins/by-name/telescope/default.nix
+++ b/plugins/by-name/telescope/default.nix
@@ -16,6 +16,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "telescope";
   packPathName = "telescope.nvim";
   package = "telescope-nvim";
+  description = "Find, Filter, Preview, Pick. All lua, all the time.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/texpresso/default.nix
+++ b/plugins/by-name/texpresso/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "texpresso";
   packPathName = "texpresso.vim";
   package = "texpresso-vim";
+  description = "Neovim mode for TeXpresso.";
 
   maintainers = [ maintainers.nickhu ];
 

--- a/plugins/by-name/timerly/default.nix
+++ b/plugins/by-name/timerly/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "timerly";
   packPathName = "timerly.nvim";
   package = "timerly";
+  description = "Beautiful countdown timer plugin for Neovim.";
 
   settingsExample = {
     minutes = [

--- a/plugins/by-name/tiny-devicons-auto-colors/default.nix
+++ b/plugins/by-name/tiny-devicons-auto-colors/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "tiny-devicons-auto-colors";
   packPathName = "tiny-devicons-auto-colors.nvim";
   package = "tiny-devicons-auto-colors-nvim";
+  description = "A Neovim plugin that automatically assigns colors to devicons based on their nearest color in a predefined color palette.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/tiny-inline-diagnostic/default.nix
+++ b/plugins/by-name/tiny-inline-diagnostic/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "tiny-inline-diagnostic";
   packPathName = "tiny-inline-diagnostic.nvim";
   package = "tiny-inline-diagnostic-nvim";
+  description = "A Neovim plugin that display prettier diagnostic messages.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/tinygit/default.nix
+++ b/plugins/by-name/tinygit/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "tinygit";
   packPathName = "nvim-tinygit";
   package = "nvim-tinygit";
+  description = "A lightweight bundle of commands focused on quick and streamlined git operations.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/tmux-navigator/default.nix
+++ b/plugins/by-name/tmux-navigator/default.nix
@@ -13,6 +13,10 @@ lib.nixvim.plugins.mkVimPlugin {
   maintainers = [ maintainers.MattSturgeon ];
 
   description = ''
+    Seamless navigation between tmux panes and vim splits.
+
+    ---
+
     When combined with a set of tmux key bindings, the plugin will allow you to navigate seamlessly between vim splits and tmux panes using a consistent set of hotkeys.
 
     > [!WARNING]

--- a/plugins/by-name/todo-comments/default.nix
+++ b/plugins/by-name/todo-comments/default.nix
@@ -18,6 +18,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "todo-comments";
   packPathName = "todo-comments.nvim";
   package = "todo-comments-nvim";
+  description = "Highlight, list and search todo comments in your projects.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/toggleterm/default.nix
+++ b/plugins/by-name/toggleterm/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "toggleterm";
   packPathName = "toggleterm.nvim";
   package = "toggleterm-nvim";
+  description = "A neovim lua plugin to help easily manage multiple terminal windows.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/transparent/default.nix
+++ b/plugins/by-name/transparent/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "transparent";
   packPathName = "transparent.nvim";
   package = "transparent-nvim";
+  description = "Remove all background colors to make Neovim transparent.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/treesitter-context/default.nix
+++ b/plugins/by-name/treesitter-context/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "treesitter-context";
   packPathName = "nvim-treesitter-context";
   package = "nvim-treesitter-context";
+  description = "Show code context.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/trim/default.nix
+++ b/plugins/by-name/trim/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "trim";
   packPathName = "trim.nvim";
   package = "trim-nvim";
+  description = "This plugin trims trailing whitespace and lines.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/trouble/default.nix
+++ b/plugins/by-name/trouble/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "trouble";
   packPathName = "trouble.nvim";
   package = "trouble-nvim";
+  description = "A pretty list for showing diagnostics, references, telescope results, quickfix and location lists to help you solve all the trouble your code is causing.";
 
   maintainers = [ lib.maintainers.loicreynier ];
 

--- a/plugins/by-name/ts-autotag/default.nix
+++ b/plugins/by-name/ts-autotag/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "nvim-ts-autotag";
   moduleName = "nvim-ts-autotag";
   package = "nvim-ts-autotag";
+  description = "Use treesitter to auto close and auto rename a html tag.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/ts-comments/default.nix
+++ b/plugins/by-name/ts-comments/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "ts-comments";
   packPathName = "ts-comments.nvim";
   package = "ts-comments-nvim";
+  description = "A Neovim plugin that provides comment strings for various languages using Treesitter.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/twilight/default.nix
+++ b/plugins/by-name/twilight/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "twilight";
   packPathName = "twilight.nvim";
   package = "twilight-nvim";
+  description = "Twilight is a Lua plugin for Neovim that dims inactive portions of the code you're editing using TreeSitter.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/typescript-tools/default.nix
+++ b/plugins/by-name/typescript-tools/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "typescript-tools";
   packPathName = "typescript-tools.nvim";
   package = "typescript-tools-nvim";
+  description = "A collection of tools for working with TypeScript and JavaScript in Neovim, including LSP support, code actions, and more.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/typst-preview/default.nix
+++ b/plugins/by-name/typst-preview/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "typst-preview";
   packPathName = "typst-preview.nvim";
   package = "typst-preview-nvim";
+  description = "A Neovim plugin for previewing Typst documents in a web browser, with support for live reloading.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/typst-vim/default.nix
+++ b/plugins/by-name/typst-vim/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "typst-vim";
   packPathName = "typst.vim";
   globalPrefix = "typst_";
+  description = "A Neovim plugin for Typst, a modern typesetting system.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/undotree/default.nix
+++ b/plugins/by-name/undotree/default.nix
@@ -8,6 +8,7 @@ with lib.nixvim.plugins;
 mkVimPlugin {
   name = "undotree";
   globalPrefix = "undotree_";
+  description = "The undo history visualizer for Vim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vim-bbye/default.nix
+++ b/plugins/by-name/vim-bbye/default.nix
@@ -8,6 +8,7 @@ let
 in
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-bbye";
+  description = "Delete buffers and close files in Vim without closing your windows or messing up your layout.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vim-colemak/default.nix
+++ b/plugins/by-name/vim-colemak/default.nix
@@ -1,5 +1,6 @@
 { lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-colemak";
+  description = "Colemak key mappings for Vim.";
   maintainers = [ lib.maintainers.kalbasit ];
 }

--- a/plugins/by-name/vim-css-color/default.nix
+++ b/plugins/by-name/vim-css-color/default.nix
@@ -1,5 +1,6 @@
 { lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-css-color";
+  description = "Preview CSS colors in Vim.";
   maintainers = [ lib.maintainers.DanielLaing ];
 }

--- a/plugins/by-name/vim-dadbod-completion/default.nix
+++ b/plugins/by-name/vim-dadbod-completion/default.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-dadbod-completion";
+  description = "Database autocompletion powered by vim-dadbod.";
   maintainers = [ lib.maintainers.BoneyPatel ];
   imports = [
     { cmpSourcePlugins.vim-dadbod-completion = "vim-dadbod-completion"; }

--- a/plugins/by-name/vim-dadbod-ui/default.nix
+++ b/plugins/by-name/vim-dadbod-ui/default.nix
@@ -1,5 +1,6 @@
 { lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-dadbod-ui";
+  description = "Simple UI for vim-dadbod.";
   maintainers = [ lib.maintainers.BoneyPatel ];
 }

--- a/plugins/by-name/vim-dadbod/default.nix
+++ b/plugins/by-name/vim-dadbod/default.nix
@@ -1,5 +1,6 @@
 { lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-dadbod";
+  description = "Modern database interface for Vim.";
   maintainers = [ lib.maintainers.BoneyPatel ];
 }

--- a/plugins/by-name/vim-matchup/default.nix
+++ b/plugins/by-name/vim-matchup/default.nix
@@ -10,6 +10,7 @@ in
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-matchup";
   globalPrefix = "matchup_";
+  description = "`match-up` is a plugin that lets you highlight, navigate, and operate on sets of matching text.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vim-slime/default.nix
+++ b/plugins/by-name/vim-slime/default.nix
@@ -8,6 +8,7 @@ with lib.nixvim.plugins;
 mkVimPlugin {
   name = "vim-slime";
   globalPrefix = "slime_";
+  description = "Send text from Vim to a terminal or REPL. Inspired by Emacs' `slime`.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vim-suda/default.nix
+++ b/plugins/by-name/vim-suda/default.nix
@@ -5,6 +5,7 @@ in
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-suda";
   globalPrefix = "suda#";
+  description = "suda is a plugin to read or write files with sudo command.";
   maintainers = [ lib.maintainers.marcel ];
 
   settingsOptions = {

--- a/plugins/by-name/vim-surround/default.nix
+++ b/plugins/by-name/vim-surround/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "vim-surround";
   packPathName = "surround.vim";
   package = "vim-surround";
+  description = "Delete/change/add parentheses/quotes/XML-tags/much more with ease.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/vim-test/default.nix
+++ b/plugins/by-name/vim-test/default.nix
@@ -2,6 +2,7 @@
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-test";
   globalPrefix = "test#";
+  description = "Run your tests at the speed of thought.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vimade/default.nix
+++ b/plugins/by-name/vimade/default.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "vimade";
+  description = "Vimade let's you dim, fade, tint, animate, and customize colors in your windows and buffers for Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vimtex/default.nix
+++ b/plugins/by-name/vimtex/default.nix
@@ -8,6 +8,7 @@ with lib;
 lib.nixvim.plugins.mkVimPlugin {
   name = "vimtex";
   globalPrefix = "vimtex_";
+  description = "A modern Vim and Neovim plugin for writing LaTeX documents.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vimux/default.nix
+++ b/plugins/by-name/vimux/default.nix
@@ -2,6 +2,7 @@
 lib.nixvim.plugins.mkVimPlugin {
   name = "vimux";
   globalPrefix = "Vimux";
+  description = "Easily interact with tmux from vim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/vimwiki/default.nix
+++ b/plugins/by-name/vimwiki/default.nix
@@ -2,6 +2,7 @@
 lib.nixvim.plugins.mkVimPlugin {
   name = "vimwiki";
   globalPrefix = "vimwiki_";
+  description = "Personal Wiki for Vim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/virt-column/default.nix
+++ b/plugins/by-name/virt-column/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "virt-column";
   packPathName = "virt-column.nvim";
   package = "virt-column-nvim";
+  description = "Display a character as the colorcolumn.";
 
   maintainers = [ lib.maintainers.alisonjenkins ];
 

--- a/plugins/by-name/visual-multi/default.nix
+++ b/plugins/by-name/visual-multi/default.nix
@@ -4,6 +4,7 @@ lib.nixvim.plugins.mkVimPlugin {
   packPathName = "vim-visual-multi";
   package = "vim-visual-multi";
   globalPrefix = "VM_";
+  description = "Multiple cursors plugin for vim/neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/by-name/visual-whitespace/default.nix
+++ b/plugins/by-name/visual-whitespace/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "visual-whitespace";
   packPathName = "visual-whitespace.nvim";
   package = "visual-whitespace-nvim";
+  description = "Display white space characters in visual mode, like VSCode's `renderWhitespace: selection`.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/wakatime/default.nix
+++ b/plugins/by-name/wakatime/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "wakatime";
   packPathName = "vim-wakatime";
   package = "vim-wakatime";
+  description = "Vim plugin for WakaTime, a time tracking service for developers.";
 
   maintainers = [ maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/web-devicons/default.nix
+++ b/plugins/by-name/web-devicons/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "nvim-web-devicons";
   # Just want it before most other plugins for the icons provider.
   configLocation = lib.mkOrder 800 "extraConfigLua";
+  description = "Provides file type icons for Neovim.";
 
   maintainers = [ lib.maintainers.refaelsh ];
 

--- a/plugins/by-name/wezterm/default.nix
+++ b/plugins/by-name/wezterm/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.neovim.mkNeovimPlugin {
   name = "wezterm";
   packPathName = "wezterm.nvim";
   package = "wezterm-nvim";
+  description = "Neovim plugin for WezTerm, a GPU-accelerated terminal emulator and multiplexer.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/which-key/default.nix
+++ b/plugins/by-name/which-key/default.nix
@@ -73,6 +73,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "which-key";
   packPathName = "which-key.nvim";
   package = "which-key-nvim";
+  description = "Neovim plugin for displaying keybindings in a popup window.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/whichpy/default.nix
+++ b/plugins/by-name/whichpy/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "whichpy";
   packPathName = "whichpy.nvim";
   package = "whichpy-nvim";
+  description = "Python interpreter selector for Neovim. Switch interpreters without restarting LSP.";
 
   maintainers = [ lib.maintainers.wvffle ];
 

--- a/plugins/by-name/whitespace/default.nix
+++ b/plugins/by-name/whitespace/default.nix
@@ -4,6 +4,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   packPathName = "whitespace.nvim";
   moduleName = "whitespace-nvim";
   package = "whitespace-nvim";
+  description = "A simple neovim plugin to highlight and remove trailing whitespace.";
 
   maintainers = [ lib.maintainers.khaneliman ];
 

--- a/plugins/by-name/windsurf-nvim/default.nix
+++ b/plugins/by-name/windsurf-nvim/default.nix
@@ -13,6 +13,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   ];
 
   description = ''
+    A native neovim extension for Codeium.
+
+    ---
+
     By default, enabling this plugin will also install the `curl`, `gzip`, `coreutils`, `util-linux` and `codeium` packages (via the `dependencies.*.enable` options`).
 
     You are free to configure `dependencies.*.enable` and `dependencies.*.package` to disable or customize this behavior, respectively.

--- a/plugins/by-name/windsurf-vim/default.nix
+++ b/plugins/by-name/windsurf-vim/default.nix
@@ -38,6 +38,7 @@ lib.nixvim.plugins.mkVimPlugin {
   name = "windsurf-vim";
   packPathName = "windsurf.vim";
   globalPrefix = "codeium_";
+  description = "Free, ultrafast Copilot alternative for Vim and Neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/wrapping/default.nix
+++ b/plugins/by-name/wrapping/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "wrapping";
   packPathName = "wrapping.nvim";
   package = "wrapping-nvim";
+  description = "Plugin to make it easier to switch between 'soft' and 'hard' line wrapping in NeoVim.";
 
   maintainers = [ lib.maintainers.ZainKergaye ];
 

--- a/plugins/by-name/yanky/default.nix
+++ b/plugins/by-name/yanky/default.nix
@@ -10,6 +10,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "yanky";
   packPathName = "yanky.nvim";
   package = "yanky-nvim";
+  description = "Improved Yank and Put functionalities for Neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/zellij-nav/default.nix
+++ b/plugins/by-name/zellij-nav/default.nix
@@ -3,6 +3,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "zellij-nav";
   packPathName = "zellij-nav.nvim";
   package = "zellij-nav-nvim";
+  description = "Seamless navigation between Neovim windows and Zellij panes.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/zellij/default.nix
+++ b/plugins/by-name/zellij/default.nix
@@ -7,6 +7,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "zellij";
   packPathName = "zellij.nvim";
   package = "zellij-nvim";
+  description = "Zellij integration for Neovim.";
 
   maintainers = [ lib.maintainers.hmajid2301 ];
 

--- a/plugins/by-name/zen-mode/default.nix
+++ b/plugins/by-name/zen-mode/default.nix
@@ -8,6 +8,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "zen-mode";
   packPathName = "zen-mode.nvim";
   package = "zen-mode-nvim";
+  description = "Distraction-free coding for Neovim.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/zig/default.nix
+++ b/plugins/by-name/zig/default.nix
@@ -10,6 +10,7 @@ mkVimPlugin {
   packPathName = "zig.vim";
   package = "zig-vim";
   globalPrefix = "zig_";
+  description = "Vim plugin for the Zig programming language.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/zk/default.nix
+++ b/plugins/by-name/zk/default.nix
@@ -9,6 +9,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "zk";
   packPathName = "zk.nvim";
   package = "zk-nvim";
+  description = "Neovim extension for the [`zk`](https://github.com/zk-org/zk) plain text note-taking assistant.";
 
   maintainers = [ maintainers.GaetanLepage ];
 

--- a/plugins/by-name/zotcite/default.nix
+++ b/plugins/by-name/zotcite/default.nix
@@ -5,6 +5,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "zotcite";
+  description = "Neovim plugin for integration with Zotero.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 

--- a/plugins/cmp/default.nix
+++ b/plugins/cmp/default.nix
@@ -15,6 +15,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   maintainers = [ lib.maintainers.GaetanLepage ];
 
   description = ''
+    A completion engine for Neovim written in Lua, designed to be fast and extensible.
+
+    ---
+
     ### Completion Source Installation
 
     If `plugins.cmp.autoEnableSources` is `true` Nixivm will automatically enable the corresponding source


### PR DESCRIPTION
Related to the https://github.com/nix-community/nixvim/issues/3052

I tried to make these explanations make as much sense as possible for the uninitiated.

But there are some plugins that are defined as nix modules, and their documentation pages doesn't show any meta fields just options. So i couldn't do much about them. But these should cover  every plugin inside the `by-name` folder.

Any change request is welcome. 