### PR TITLE
Add gruvbox-material colorscheme

### DIFF
--- a/plugins/colorschemes/gruvbox-material.nix
+++ b/plugins/colorschemes/gruvbox-material.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  config,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "gruvbox-material";
+  isColorscheme = true;
+  packPathName = "gruvbox-material.nvim";
+  package = "gruvbox-material-nvim";
+
+  maintainers = [ lib.maintainers.f4z3r ];
+
+  settingsExample = {
+    italics = true;
+    contrast = "medium";
+    comments = {
+      italics = true;
+    };
+    background = {
+      transparent = false;
+    };
+    float = {
+      force_background = false;
+    };
+    signs = {
+      highlight = true;
+    };
+    customize = lib.nixvim.nestedLiteralLua ''
+      function(g, o)
+        local colors = require("gruvbox-material.colors").get(vim.o.background, "medium")
+        if g == "CursorLineNr" then
+          o.link = nil            -- wipe a potential link, which would take precedence over other
+                                  -- attributes
+          o.fg = colors.orange    -- or use any color in "#rrggbb" hex format
+          o.bold = true
+        end
+        return o
+      end
+    '';
+  };
+}

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -12,6 +12,7 @@
     ./colorschemes/everforest.nix
     ./colorschemes/github-theme.nix
     ./colorschemes/gruvbox.nix
+    ./colorschemes/gruvbox-material.nix
     ./colorschemes/kanagawa.nix
     ./colorschemes/kanagawa-paper.nix
     ./colorschemes/melange.nix

--- a/tests/test-sources/plugins/colorschemes/gruvbox-material.nix
+++ b/tests/test-sources/plugins/colorschemes/gruvbox-material.nix
@@ -1,0 +1,66 @@
+{ lib, ... }:
+{
+  empty = {
+    colorschemes.gruvbox-material.enable = true;
+  };
+
+  defaults = {
+    colorschemes.gruvbox-material = {
+      enable = true;
+
+      settings = {
+        italics = true;
+        contrast = "medium";
+        comments = {
+          italics = true;
+        };
+        background = {
+          transparent = false;
+        };
+        float = {
+          force_background = false;
+          background_color = null;
+        };
+        signs = {
+          highlight = true;
+        };
+        customize = null;
+      };
+    };
+  };
+
+  example = {
+    colorschemes.gruvbox-material = {
+      enable = true;
+
+      settings = {
+        italics = true;
+        contrast = "medium";
+        comments = {
+          italics = true;
+        };
+        background = {
+          transparent = false;
+        };
+        float = {
+          force_background = false;
+        };
+        signs = {
+          highlight = true;
+        };
+        customize = lib.nixvim.mkRaw ''
+          function(g, o)
+            local colors = require("gruvbox-material.colors").get(vim.o.background, "medium")
+            if g == "CursorLineNr" then
+              o.link = nil            -- wipe a potential link, which would take precedence over other
+                                      -- attributes
+              o.fg = colors.orange    -- or use any color in "#rrggbb" hex format
+              o.bold = true
+            end
+            return o
+          end
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
Gruvbox-material is a colorscheme in pure lua: https://github.com/f4z3r/gruvbox-material.nvim. It is highly customizable and supports a wide variety of plugins.