### PR TITLE
treewide: re-enable darwin sandbox disablements

### DIFF
--- a/generated/efmls-configs.nix
+++ b/generated/efmls-configs.nix
@@ -1,48 +1,6 @@
 # WARNING: DO NOT EDIT
 # This file is generated with packages.<system>.efmls-configs-sources, which is run automatically by CI
 {
-  HTML = {
-    formatter = {
-      lang = "HTML";
-      possible = [ ];
-    };
-    linter = {
-      lang = "HTML";
-      possible = [
-        "markuplint"
-        "alex"
-        "codespell"
-        "cspell"
-        "languagetool"
-        "proselint"
-        "redpen"
-        "textlint"
-        "vale"
-        "write_good"
-      ];
-    };
-  };
-  JSON = {
-    formatter = {
-      lang = "JSON";
-      possible = [ ];
-    };
-    linter = {
-      lang = "JSON";
-      possible = [
-        "jsonlint"
-        "alex"
-        "codespell"
-        "cspell"
-        "languagetool"
-        "proselint"
-        "redpen"
-        "textlint"
-        "vale"
-        "write_good"
-      ];
-    };
-  };
   all = {
     formatter = {
       lang = "all languages";
@@ -557,6 +515,7 @@
     linter = {
       lang = "html";
       possible = [
+        "markuplint"
         "djlint"
         "alex"
         "codespell"
@@ -670,6 +629,7 @@
     linter = {
       lang = "json";
       possible = [
+        "jsonlint"
         "jq"
         "alex"
         "codespell"

--- a/tests/test-sources/plugins/by-name/claude-code/default.nix
+++ b/tests/test-sources/plugins/by-name/claude-code/default.nix
@@ -1,6 +1,4 @@
-{ pkgs, ... }:
-# TODO: Failing to compile on darwin CI atm
-pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+{
   empty = {
     plugins.claude-code.enable = true;
   };

--- a/tests/test-sources/plugins/by-name/efmls-configs/default.nix
+++ b/tests/test-sources/plugins/by-name/efmls-configs/default.nix
@@ -20,6 +20,11 @@
       toolOptions = builtins.removeAttrs (setup.type.getSubOptions setup.loc) [
         "_freeformOptions"
         "_module"
+
+        # Rename aliases added 2025-06-25 in https://github.com/nix-community/nixvim/pull/3503
+        "warnings"
+        "HTML"
+        "JSON"
       ];
 
       brokenTools =

--- a/tests/test-sources/plugins/by-name/none-ls/default.nix
+++ b/tests/test-sources/plugins/by-name/none-ls/default.nix
@@ -100,8 +100,7 @@
     in
     {
       plugins.none-ls = {
-        # sandbox-exec: pattern serialization length 159032 exceeds maximum (65535)
-        enable = !hostPlatform.isDarwin;
+        enable = true;
 
         sources =
           let
@@ -125,6 +124,21 @@
               ++ lib.optionals hostPlatform.isDarwin [
                 # TODO 2025-04-20 build failure
                 "ansiblelint"
+                # TODO 2025-06-24 build failure
+                "elm_format"
+                # TODO 2025-06-24 marked broken / unsupported platform
+                "clazy"
+                "haml_lint"
+                "racket_fixw"
+                "raco_fmt"
+                "rubyfmt"
+              ]
+              ++ lib.optionals (hostPlatform.isDarwin && hostPlatform.isx86_64) [
+                # TODO: 2025-06-24 build failure
+                "gleam_format"
+                "ptop"
+                # NOTE: No hash for x86 darwin
+                "verible_verilog_format"
               ];
           in
           # Enable every none-ls source that has an option

--- a/tests/test-sources/plugins/by-name/vimtex/default.nix
+++ b/tests/test-sources/plugins/by-name/vimtex/default.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 let
-  # CI failure: When trying to build `pkgs.texlive.combined.scheme-medium` on darwin, it fails with
-  #  > sandbox-exec: pattern serialization length 75279 exceeds maximum (65535)
+  # TODO: Added 2025-06-24 texlive dependency broken
   disableTexlivePackageOnDarwin = pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
     texlivePackage = null;
   };


### PR DESCRIPTION
This pull request introduces several changes to improve configuration handling, simplify code, and remove platform-specific restrictions. The most notable updates include restructuring language tools in `ci/efmls-configs.nix`, simplifying expressions in `docs/default.nix`, and removing Darwin-specific exceptions in plugin configurations.

### Efmls case sensitive support
* [`ci/efmls-configs.nix`](diffhunk://#diff-b23aa4e05c041b2fa0219fdee605957fc8307cfadf5595de4416fab692885459L16-R43): Refactored the handling of language tools by grouping languages by lowercase names and merging their tools. This ensures canonical naming and avoids case-sensitive duplication. Also, merged linters and formatters across case variations for better consistency.
  - [x] Backwards compatible rename of options

### Removal of Platform-Specific Restrictions:
* [`docs/default.nix`](diffhunk://#diff-eb8d49802027f9ca035129d9b6dca2489d8de2643b4114108f4966567c638806L103-R103): Removed darwin limitation to allow building and serving docs on darwin.
  - [ ] ~Limit docs to be tested only on linux~ We will handle later

* [`tests/test-sources/plugins/by-name/claude-code/default.nix`](diffhunk://#diff-2608ef3b819fc7f91a164f06d900bf224ce0ef779461684b51ccd61e5ad85161L1-R1): Removed the conditional disabling of the plugin on Darwin platforms, enabling it universally.
* [`tests/test-sources/plugins/by-name/none-ls/default.nix`](diffhunk://#diff-56b3b1b4d4e6f552d914c6da0a7dbded642a7e37717b2d23d1dd81d3e219bd72L103-R103): Removed restrictions preventing the plugin from being enabled on Darwin, making it available on all platforms.
* ~[`tests/test-sources/plugins/by-name/vimtex/default.nix`](diffhunk://#diff-f4d2100ed33860d170daab1da30d8f75dbc4c74fc3620306a537b4701ef01377L1-R9): Eliminated the workaround for disabling `texlivePackage` on Darwin, allowing the plugin to function without platform-specific exceptions. [[1]](diffhunk://#diff-f4d2100ed33860d170daab1da30d8f75dbc4c74fc3620306a537b4701ef01377L1-R9) [[2]](diffhunk://#diff-f4d2100ed33860d170daab1da30d8f75dbc4c74fc3620306a537b4701ef01377L74-R66)~ Has a different issue that requires the workaround still.