### PR TITLE
tests: refactor buildbot outputs

### DIFF
--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -59,26 +59,10 @@
 
                     text = builtins.readFile ./launch-test.sh;
                   };
-
-                  tests =
-                    let
-                      checks' = self'.checks;
-                      names = builtins.filter (n: builtins.match "test-.*" n != null) (builtins.attrNames checks');
-                    in
-                    builtins.listToAttrs (
-                      builtins.concatMap (
-                        checkName:
-                        map (testName: {
-                          name = testName;
-                          value = "${checkName}.entries.${testName}";
-                        }) (builtins.attrNames checks'.${checkName}.entries)
-                      ) names
-                    );
                 in
                 ''
                   export NIXVIM_SYSTEM=${system}
                   export NIXVIM_NIX_COMMAND=${nix}
-                  export NIXVIM_TESTS=${pkgs.writers.writeJSON "tests.json" tests}
                   ${lib.getExe launchTest} "$@"
                 '';
             }

--- a/flake/dev/tests.nix
+++ b/flake/dev/tests.nix
@@ -6,16 +6,13 @@
 {
   perSystem =
     { pkgs, ... }:
+    let
+      tests = pkgs.callPackage ../../tests {
+        inherit helpers self;
+      };
+    in
     {
-      # TODO: consider whether all these tests are needed in the `checks` output
-      checks = pkgs.callPackages ../../tests {
-        inherit helpers self;
-      };
-
-      # TODO: consider whether all these tests are needed to be built by buildbot
-      ci.buildbot = pkgs.callPackages ../../tests {
-        inherit helpers self;
-        allSystems = false;
-      };
+      checks = tests.flakeCheck;
+      ci.buildbot = tests.buildbot;
     };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -5,7 +5,6 @@
   linkFarm,
   self, # The flake instance
   system ? pkgs.stdenv.hostPlatform.system,
-  allSystems ? true,
 }:
 let
   autoArgs = pkgs // {
@@ -30,38 +29,39 @@ let
 
   callTest = lib.callPackageWith autoArgs;
   callTests = lib.callPackagesWith autoArgs;
-
   selfPackages = self.packages.${system};
 
-  # For tests that CI should only build on one system,
-  # This is true when on that system.
-  #
-  # TODO: consider refactoring tests/default.nix so that some tests are
-  # defined by it, while others are defined elsewhere...
-  buildForThisSystem = allSystems || system == "x86_64-linux";
-in
-lib.optionalAttrs buildForThisSystem {
-  extra-args-tests = callTest ./extra-args.nix { };
-  extend = callTest ./extend.nix { };
-  extra-files = callTest ./extra-files.nix { };
-  enable-except-in-tests = callTest ./enable-except-in-tests.nix { };
-  failing-tests = callTest ./failing-tests.nix { };
-  no-flake = callTest ./no-flake.nix { };
-  lib-tests = callTest ./lib-tests.nix { };
-  maintainers = callTest ./maintainers.nix { };
-  nixpkgs-module = callTest ./nixpkgs-module.nix { };
-  plugins-by-name = callTest ./plugins-by-name.nix { };
-  generated = callTest ./generated.nix { };
-  lsp-all-servers = callTest ./lsp-servers.nix { };
-}
-# Expose some tests from the docs as flake-checks too
-// lib.optionalAttrs (selfPackages ? docs && buildForThisSystem) {
-  # Individual tests can be run using: nix build .#docs.user-configs.tests.<test>
-  docs-user-configs = linkFarm "user-configs-tests" selfPackages.docs.user-configs.tests;
-}
+  misc = {
+    extra-args-tests = callTest ./extra-args.nix { };
+    extend = callTest ./extend.nix { };
+    extra-files = callTest ./extra-files.nix { };
+    enable-except-in-tests = callTest ./enable-except-in-tests.nix { };
+    failing-tests = callTest ./failing-tests.nix { };
+    no-flake = callTest ./no-flake.nix { };
+    lib-tests = callTest ./lib-tests.nix { };
+    maintainers = callTest ./maintainers.nix { };
+    nixpkgs-module = callTest ./nixpkgs-module.nix { };
+    plugins-by-name = callTest ./plugins-by-name.nix { };
+    generated = callTest ./generated.nix { };
+    lsp-all-servers = callTest ./lsp-servers.nix { };
+  };
 
-# These are always built on all systems, even when `allSystems = false`
-// callTests ./platforms { }
-# Tests generated from ./test-sources
-# Grouped as a number of link-farms in the form { test-1, test-2, ... test-N }
-// callTests ./main.nix { }
+  docs = lib.optionalAttrs (selfPackages ? docs) {
+    # Individual tests can be run using: nix build .#docs.user-configs.tests.<test>
+    docs-user-configs = linkFarm "user-configs-tests" selfPackages.docs.user-configs.tests;
+  };
+
+  # These are always built on all systems, even when `allSystems = false`
+  platforms = callTests ./platforms { };
+
+  # Tests generated from ./test-sources
+  # Grouped as a number of link-farms in the form { test-1, test-2, ... test-N }
+  main = callTests ./main.nix { };
+in
+{
+  # TODO: consider whether all these tests are needed in the `checks` output
+  flakeCheck = misc // docs // platforms // main;
+
+  # TODO: consider whether all these tests are needed to be built by buildbot
+  buildbot = lib.optionalAttrs (system == "x86_64-linux") (misc // docs) // platforms // main;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -61,12 +61,12 @@ let
   # Combined into a single link-farm derivation
   mainDrv.tests = linkFarm "tests" main;
 
-  # Grouped as a number of link-farms in the form { test-1, test-2, ... test-N }
-  mainGrouped = lib.pipe main [
+  # Grouped as a number of link-farms in the form { tests = { group-1, group-2, ... group-N }; }
+  mainGrouped.tests = lib.pipe main [
     (helpers.groupListBySize 10)
     (lib.imap1 (
       i: group: rec {
-        name = "test-${toString i}";
+        name = "group-${toString i}";
         value = linkFarm name group;
       }
     ))

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -1,7 +1,6 @@
 # Collects the various test modules in tests/test-sources/ and groups them into a number of test derivations
 {
   callTest,
-  helpers,
   lib ? pkgs.lib,
   linkFarm,
   pkgs,
@@ -69,8 +68,8 @@ let
   };
 in
 # We attempt to build & execute all configurations
-lib.pipe (testFiles ++ [ exampleFiles ]) [
-  (builtins.map (
+{
+  tests = map (
     {
       name,
       file,
@@ -80,13 +79,5 @@ lib.pipe (testFiles ++ [ exampleFiles ]) [
       inherit name;
       path = linkFarm name (builtins.mapAttrs (moduleToTest file) cases);
     }
-  ))
-  (helpers.groupListBySize 10)
-  (lib.imap1 (
-    i: group: rec {
-      name = "test-${toString i}";
-      value = linkFarm name group;
-    }
-  ))
-  builtins.listToAttrs
-]
+  ) (testFiles ++ [ exampleFiles ]);
+}


### PR DESCRIPTION
- **tests: take responsibility for flakecheck/buildbot split**
- **tests: use a single link-farm for flake-checks**
- **tests: use a nested attrset for buildbot**


This is some of the originally planned refactoring that was kept out of the initial switch to a dedicated `buildbot` flake output.

Not using the `checks` output means a few things.

For example, we are not restricted to the "flat" package hierarchy required by `packages` and `checks`, instead we can use a recursive hierarchy similar to `legacyPackages`.

Having a recursive hierarchy means we don't need all the "test groups" at the top-level.

Since buildbot (and `nix-eval-jobs`) doesn't need to eval the `checks` output, we can simplify the user-facing tests back to a single `tests` linkFarm. This change also simplifies the `tests` command, meaning we don't need to pre-compute the attrnames.

Not pre-computing the attrnames at eval time should speed up building the devshell.