### PR TITLE
plugins/linediff: init

### DIFF
--- a/plugins/by-name/linediff/default.nix
+++ b/plugins/by-name/linediff/default.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkVimPlugin {
+  name = "linediff";
+  packPathName = "linediff.vim";
+  package = "linediff-vim";
+
+  globalPrefix = "linediff_";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    modify_statusline = 0;
+    first_buffer_command = "topleft new";
+    second_buffer_command = "vertical new";
+  };
+}

--- a/tests/test-sources/plugins/by-name/linediff/default.nix
+++ b/tests/test-sources/plugins/by-name/linediff/default.nix
@@ -1,0 +1,33 @@
+{
+  empty = {
+    plugins.linediff.enable = true;
+  };
+
+  defaults = {
+    plugins.linediff = {
+      enable = true;
+
+      settings = {
+        indent = 0;
+        buffer_type = "tempfile";
+        first_buffer_command = "tabnew";
+        further_buffer_command = "rightbelow vertical new";
+        diffopt = "builtin";
+        modify_statusline = 0;
+        sign_highlight_group = "Search";
+      };
+    };
+  };
+
+  example = {
+    plugins.linediff = {
+      enable = true;
+
+      settings = {
+        modify_statusline = 0;
+        first_buffer_command = "topleft new";
+        second_buffer_command = "vertical new";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add support for [linediff.vim](https://github.com/AndrewRadev/linediff.vim), a vim plugin to perform diffs on blocks of code.

Closes #3520
