### PR TITLE
top-level/output: add enablePrintInit option

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -81,6 +81,17 @@ in
       '';
     };
 
+    enablePrintInit = mkOption {
+      type = types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Install a tool that shows the content of the generated `init.lua` file.
+
+        Run it using `${config.build.printInitPackage.meta.mainProgram}`.
+      '';
+    };
+
     build = {
       # TODO: `standalonePackage`; i.e. package + printInitPackage + man-docs bundled together
 
@@ -287,10 +298,12 @@ in
             with config.build;
             [
               nvimPackage
-              printInitPackage
             ]
             ++ lib.optionals config.enableMan [
               manDocsPackage
+            ]
+            ++ lib.optionals config.enablePrintInit [
+              printInitPackage
             ];
           meta.mainProgram = "nvim";
         };


### PR DESCRIPTION
This PR works towards https://github.com/nix-community/nixvim/issues/3518

When not including `printInitPackage`, evaluation time and build time gets a small boost

I ran a small benchmark of changing some Nixvim config then building it, 5 times for each scenario. On my "dev" nixvim package (which includes the tweaks in the aforementioned PR) this improved the time from 12.97s to 12.30s (-5.16%) and my "prod" nixvim package (which is likely what most people use) it goes down from 33.91s to 33.06s (-2.5%)