### PR TITLE
Update to gruvbox-material example configuration due to changes in plugin

### DIFF
--- a/plugins/colorschemes/gruvbox-material.nix
+++ b/plugins/colorschemes/gruvbox-material.nix
@@ -24,7 +24,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       force_background = false;
     };
     signs = {
-      highlight = true;
+      force_background = false;
     };
     customize = lib.nixvim.nestedLiteralLua ''
       function(g, o)

--- a/tests/test-sources/plugins/colorschemes/gruvbox-material.nix
+++ b/tests/test-sources/plugins/colorschemes/gruvbox-material.nix
@@ -22,7 +22,8 @@
           background_color = null;
         };
         signs = {
-          highlight = true;
+          force_background = false;
+          background_color = null;
         };
         customize = null;
       };
@@ -46,7 +47,8 @@
           force_background = false;
         };
         signs = {
-          highlight = true;
+          force_background = false;
+          background_color = null;
         };
         customize = lib.nixvim.mkRaw ''
           function(g, o)


### PR DESCRIPTION
The gruvbox-material plugin deprecated the `signs.highlight` option and introduced other options in its stead (see https://github.com/f4z3r/gruvbox-material.nvim/releases/tag/v1.7.0).