### PR TITLE
Fix example for option `extraFiles` on file `ftplugin/nix.lua`

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -102,10 +102,10 @@ in
       default = { };
       example = lib.literalExpression ''
         {
-          "ftplugin/nix.lua".text = '''
-            vim.opt.tabstop = 2
-            vim.opt.shiftwidth = 2
-            vim.opt.expandtab = true
+          "after/ftplugin/nix.lua".text = '''
+            vim.opt_local.tabstop = 2
+            vim.opt_local.shiftwidth = 2
+            vim.opt_local.expandtab = true
           ''';
         }
       '';


### PR DESCRIPTION
Following https://github.com/nix-community/nixvim/issues/2418#issuecomment-2413714276
https://vi.stackexchange.com/questions/26169/difference-between-adding-vim-after-ftplugin-vs-vim-ftplugin/26170#26170