### PR TITLE
ci/tag-maintainers: split nix into separate file + minor tweaks

### DIFF
--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -65,7 +65,7 @@ jobs:
         id: extract-maintainers
         env:
           PR_AUTHOR: "${{ github.event.pull_request.user.login }}"
-          CHANGED_FILES: '${{ steps.changed-files.outputs.changed_files }}'
+          CHANGED_FILES: "${{ steps.changed-files.outputs.changed_files }}"
         run: |
           MAINTAINERS_LIST=$(./ci/tag-maintainers/extract-maintainers.py \
             --changed-files "$CHANGED_FILES" \

--- a/ci/tag-maintainers/extract-maintainers.nix
+++ b/ci/tag-maintainers/extract-maintainers.nix
@@ -1,0 +1,31 @@
+{
+  nixvim ? import ../..,
+  lib ? nixvim.inputs.nixpkgs.lib,
+  changedFilesJson ? throw "provide either changedFiles or changedFilesJson",
+  changedFiles ? builtins.fromJSON changedFilesJson,
+}:
+let
+  emptyConfig = nixvim.lib.nixvim.evalNixvim {
+    modules = [ { _module.check = false; } ];
+    extraSpecialArgs.pkgs = null;
+  };
+  inherit (emptyConfig.config.meta) maintainers;
+
+  # Find maintainers for files that match changed plugin directories
+  relevantMaintainers = lib.concatLists (
+    lib.mapAttrsToList (
+      path: maintainerList:
+      let
+        matchingFiles = lib.filter (file: lib.hasSuffix (dirOf file) path) changedFiles;
+      in
+      if matchingFiles != [ ] then maintainerList else [ ]
+    ) maintainers
+  );
+
+  # Extract GitHub usernames
+  githubUsers = lib.concatMap (
+    maintainer: if maintainer ? github then [ maintainer.github ] else [ ]
+  ) relevantMaintainers;
+
+in
+lib.unique githubUsers

--- a/ci/tag-maintainers/extract-maintainers.py
+++ b/ci/tag-maintainers/extract-maintainers.py
@@ -37,7 +37,7 @@ def extract_maintainers(changed_files: List[str], pr_author: str) -> List[str]:
 
     print("Finding maintainers for changed files...", file=sys.stderr)
 
-    changed_files_nix = '[ ' + ' '.join(f'"{f}"' for f in changed_files) + ' ]'
+    changed_files_nix = "[ " + " ".join(f'"{f}"' for f in changed_files) + " ]"
 
     nix_expr = f"""
     let
@@ -83,10 +83,16 @@ def extract_maintainers(changed_files: List[str], pr_author: str) -> List[str]:
     filtered_maintainers = [m for m in maintainers if m != pr_author]
 
     if not filtered_maintainers:
-        print("No maintainers found for changed files (or only the PR author is a maintainer).", file=sys.stderr)
+        print(
+            "No maintainers found for changed files (or only the PR author is a maintainer).",
+            file=sys.stderr,
+        )
         return []
     else:
-        print(f"Found maintainers to notify: {' '.join(filtered_maintainers)}", file=sys.stderr)
+        print(
+            f"Found maintainers to notify: {' '.join(filtered_maintainers)}",
+            file=sys.stderr,
+        )
         return filtered_maintainers
 
 
@@ -107,9 +113,9 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    changed_files = [f.strip() for f in args.changed_files.split('\n') if f.strip()]
+    changed_files = [f.strip() for f in args.changed_files.split("\n") if f.strip()]
     maintainers = extract_maintainers(changed_files, args.pr_author)
-    print(' '.join(maintainers))
+    print(" ".join(maintainers))
 
 
 if __name__ == "__main__":

--- a/ci/tag-maintainers/extract-maintainers.py
+++ b/ci/tag-maintainers/extract-maintainers.py
@@ -39,8 +39,9 @@ def extract_maintainers(changed_files: List[str], pr_author: str) -> List[str]:
     print("Finding maintainers for changed files...", file=sys.stderr)
 
     file = Path(__file__).parent / "extract-maintainers.nix"
-    changed_files_nix = "[ " + " ".join(f'"{f}"' for f in changed_files) + " ]"
-    result = run_nix_eval(file, "--arg", "changedFiles", changed_files_nix)
+    result = run_nix_eval(
+        file, "--argstr", "changedFilesJson", json.dumps(changed_files)
+    )
 
     try:
         maintainers = json.loads(result)

--- a/flake/dev/generate-all-maintainers/generate-all-maintainers.py
+++ b/flake/dev/generate-all-maintainers/generate-all-maintainers.py
@@ -104,7 +104,8 @@ class MetaMaintainerGenerator:
         print(f"📦 Nixpkgs maintainers: {len(nixpkgs_maintainers)}")
 
         with open(self.output_file, "w") as f:
-            f.write(inspect.cleandoc("""
+            f.write(
+                inspect.cleandoc("""
               # Nixvim all maintainers list.
               #
               # This file lists all referenced maintainers in Nixvim.
@@ -114,7 +115,8 @@ class MetaMaintainerGenerator:
               #
               # To regenerate: nix run .#generate-all-maintainers
               #
-            """))
+            """)
+            )
 
             # Use the formatted maintainers from Nix evaluation
             print(


### PR DESCRIPTION
- **ci: run treefmt**
- **ci/tag-maintainers: split nix into separate file**
- **ci/tag-maintainers: pass changed file to nix as json**
- **ci/tag-maintainers: minor cleanup**

Two issues I've spotted but not resolved:

The `hasSuffix` check assumes that the "changed file" has a `/default.nix` component on the end that is not present in the `maintainers` file key; which is usually true but isn't guaranteed. Maybe it'd be best to always import `default.nix` files explicitly? That way docs links would also correctly link to the actual file...

If the number of changed files gets too large, the _changed files_ JSON might exceed the shell arg length limit. It might be worth writing the changed files list to a file and passing that in instead.
