### PR TITLE
ci/tag-maintainers: don't remove review requests

### DIFF
--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -135,45 +135,6 @@ jobs:
           echo "new_reviewers=${NEW_REVIEWERS_LIST% }" >> "$GITHUB_OUTPUT"
           echo "New reviewers to add: ${NEW_REVIEWERS_LIST% }"
 
-      # Remove reviewers who are no longer maintainers of the changed files.
-      - name: Remove outdated reviewers
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          MAINTAINERS: ${{ steps.extract-maintainers.outputs.maintainers }}
-          PENDING_REVIEWERS: ${{ steps.current-reviewers.outputs.pending_reviewers }}
-          REPO: ${{ github.repository }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-        run: |
-          remove_reviewers() {
-            local reviewers_to_remove="$1"
-            local reason="$2"
-            for REVIEWER in $reviewers_to_remove; do
-              echo "Removing review request from $REVIEWER ($reason)"
-              REVIEWER_JSON=$(jq -n -c --arg r "$REVIEWER" '{reviewers: [$r]}')
-              gh api --method DELETE "/repos/$REPO/pulls/$PR_NUM/requested_reviewers" \
-                --input - <<< "$REVIEWER_JSON" > /dev/null
-            done
-          }
-
-          # If no maintainers were found for the current set of files, remove all pending reviewers.
-          if [[ -z "$MAINTAINERS" ]]; then
-            if [[ -n "$PENDING_REVIEWERS" ]]; then
-              echo "No plugin maintainers found, removing all pending reviewers."
-              remove_reviewers "$PENDING_REVIEWERS" "no longer a maintainer of changed files"
-            fi
-            exit 0
-          fi
-
-          # Find reviewers who are in the pending list but NOT in the current maintainer list.
-          CURRENT_MAINTAINERS=$(echo "$MAINTAINERS" | tr ' ' '\n' | sort -u)
-          OUTDATED_REVIEWERS=$(comm -23 <(echo "$PENDING_REVIEWERS" | tr ' ' '\n' | sort -u) <(echo "$CURRENT_MAINTAINERS"))
-
-          if [[ -n "$OUTDATED_REVIEWERS" ]]; then
-            remove_reviewers "$OUTDATED_REVIEWERS" "no longer a maintainer of changed files"
-          else
-            echo "No outdated reviewers to remove."
-          fi
-
       # Add the new, filtered list of maintainers as reviewers to the PR.
       - name: Add new reviewers
         env:


### PR DESCRIPTION
We can't distinguish between manual review requests and requests created by CI, so let's avoid removing any review requests.

So far there's been a few examples of PRs with no matching maintainers (or no touched plugin files) having review requests removed the next time the PR is updated.

<img width="735" height="240" alt="image" src="https://github.com/user-attachments/assets/3d1082a4-6acd-4db1-8b95-fb326d36e4f6" />

