### PR TITLE
plugins/spider: migrate to mkNeovimPlugin

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -127,6 +127,11 @@
     githubId = 2750775;
     name = "Refael Sheinker";
   };
+  saygo-png = {
+    github = "saygo-png";
+    githubId = 131687037;
+    name = "Saygo";
+  };
   sheemap = {
     github = "sheemap";
     githubId = 1442292;

--- a/plugins/by-name/spider/deprecations.nix
+++ b/plugins/by-name/spider/deprecations.nix
@@ -1,0 +1,19 @@
+lib: {
+  deprecateExtraOptions = true;
+  imports =
+    let
+      basePluginPath = [
+        "plugins"
+        "spider"
+      ];
+    in
+    [
+      (lib.mkRenamedOptionModule (basePluginPath ++ [ "skipInsignificantPunctuation" ]) (
+        basePluginPath
+        ++ [
+          "settings"
+          "skipInsignificantPunctuation"
+        ]
+      ))
+    ];
+}

--- a/tests/test-sources/plugins/by-name/spider/default.nix
+++ b/tests/test-sources/plugins/by-name/spider/default.nix
@@ -7,7 +7,7 @@
     plugins.spider = {
       enable = true;
 
-      skipInsignificantPunctuation = true;
+      settings.skipInsignificantPunctuation = true;
       keymaps = {
         silent = true;
         motions = {


### PR DESCRIPTION
Related tracking issue: https://github.com/nix-community/nixvim/issues/2638

I moved `skipInsignificantPunctuation` under settings since it is not a nixvim related option.

I kept the keymap option the same because i'm not sure if it should be removed or not.
A similar option existed for harpoon and was removed on migration, should the same happen here?

This is my first (substantial) pr to a major repo. Sorry for any stupid mistakes.