### PR TITLE
colorschemes/gruvbox-material: rename to gruvbox-material-nvim

### DIFF
--- a/plugins/colorschemes/gruvbox-material-nvim.nix
+++ b/plugins/colorschemes/gruvbox-material-nvim.nix
@@ -1,11 +1,9 @@
-{
-  lib,
-  config,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
-  name = "gruvbox-material";
+  name = "gruvbox-material-nvim";
   isColorscheme = true;
+  colorscheme = "gruvbox-material";
+  moduleName = "gruvbox-material";
   packPathName = "gruvbox-material.nvim";
   package = "gruvbox-material-nvim";
 

--- a/plugins/default.nix
+++ b/plugins/default.nix
@@ -13,7 +13,7 @@
     ./colorschemes/github-theme.nix
     ./colorschemes/gruvbox.nix
     ./colorschemes/gruvbox-baby.nix
-    ./colorschemes/gruvbox-material.nix
+    ./colorschemes/gruvbox-material-nvim.nix
     ./colorschemes/kanagawa.nix
     ./colorschemes/kanagawa-paper.nix
     ./colorschemes/melange.nix

--- a/plugins/deprecation.nix
+++ b/plugins/deprecation.nix
@@ -23,6 +23,12 @@ let
       It is recommended to use `plugins.pckr` or `plugins.lazy` instead.
     '';
   };
+  renamed.colorschemes = {
+    # Added 2025-08-06
+    # NOTE: The old name is not in a stable version and was only in unstable for a few weeks,
+    # so we can remove this alias more quickly than usual.
+    gruvbox-material = "gruvbox-material-nvim";
+  };
   renamed.plugins = {
     # Added 2024-09-17
     surround = "vim-surround";

--- a/plugins/deprecation.nix
+++ b/plugins/deprecation.nix
@@ -7,7 +7,7 @@ let
       It is recommended to use `rustaceanvim` instead.
     '';
   };
-  removed = {
+  removed.plugins = {
     # Added 2023-08-29
     treesitter-playground = ''
       The `treesitter-playground` plugin has been deprecated since the functionality is included in Neovim.
@@ -23,7 +23,7 @@ let
       It is recommended to use `plugins.pckr` or `plugins.lazy` instead.
     '';
   };
-  renamed = {
+  renamed.plugins = {
     # Added 2024-09-17
     surround = "vim-surround";
   };
@@ -46,18 +46,8 @@ in
 {
 
   imports =
-    (lib.mapAttrsToList (
-      name:
-      lib.mkRemovedOptionModule [
-        "plugins"
-        name
-      ]
-    ) removed)
-    ++ (lib.mapAttrsToList (
-      old: new: lib.mkRenamedOptionModule [ "plugins" old ] [ "plugins" new ]
-    ) renamed)
     # TODO: introduced 2025-04-19
-    ++ [
+    [
       (lib.mkRenamedOptionModule
         [ "plugins" "codeium-nvim" "enable" ]
         [ "plugins" "windsurf-nvim" "enable" ]
@@ -67,6 +57,14 @@ in
         [ "plugins" "windsurf-vim" "enable" ]
       )
     ]
+    ++ lib.foldlAttrs (
+      acc: scope: removed':
+      acc ++ lib.mapAttrsToList (name: msg: lib.mkRemovedOptionModule [ scope name ] msg) removed'
+    ) [ ] removed
+    ++ lib.foldlAttrs (
+      acc: scope: renamed':
+      acc ++ lib.mapAttrsToList (old: new: lib.mkRenamedOptionModule [ scope old ] [ scope new ]) renamed'
+    ) [ ] renamed
     ++ builtins.map (
       name:
       lib.mkRemovedOptionModule [ "plugins" name "iconsPackage" ] ''

--- a/plugins/deprecation.nix
+++ b/plugins/deprecation.nix
@@ -59,28 +59,12 @@ in
     # TODO: introduced 2025-04-19
     ++ [
       (lib.mkRenamedOptionModule
-        [
-          "plugins"
-          "codeium-nvim"
-          "enable"
-        ]
-        [
-          "plugins"
-          "windsurf-nvim"
-          "enable"
-        ]
+        [ "plugins" "codeium-nvim" "enable" ]
+        [ "plugins" "windsurf-nvim" "enable" ]
       )
       (lib.mkRenamedOptionModule
-        [
-          "plugins"
-          "codeium-vim"
-          "enable"
-        ]
-        [
-          "plugins"
-          "windsurf-vim"
-          "enable"
-        ]
+        [ "plugins" "codeium-vim" "enable" ]
+        [ "plugins" "windsurf-vim" "enable" ]
       )
     ]
     ++ builtins.map (

--- a/tests/test-sources/plugins/colorschemes/gruvbox-material-nvim.nix
+++ b/tests/test-sources/plugins/colorschemes/gruvbox-material-nvim.nix
@@ -1,11 +1,11 @@
 { lib, ... }:
 {
   empty = {
-    colorschemes.gruvbox-material.enable = true;
+    colorschemes.gruvbox-material-nvim.enable = true;
   };
 
   defaults = {
-    colorschemes.gruvbox-material = {
+    colorschemes.gruvbox-material-nvim = {
       enable = true;
 
       settings = {
@@ -31,7 +31,7 @@
   };
 
   example = {
-    colorschemes.gruvbox-material = {
+    colorschemes.gruvbox-material-nvim = {
       enable = true;
 
       settings = {


### PR DESCRIPTION
- **plugins/deprecation: reformat**
- **plugins/deprecation: allow renaming/removing different plugin scopes**
- **colorschemes/gruvbox-material: rename to gruvbox-material-nvim**

As discussed in https://github.com/nix-community/nixvim/pull/3495#issuecomment-3066706409, this is to allow adding a `colorschemes.gruvbox-material` that uses the non-lua plugin [`vimPlugins.gruvbox-material`](https://search.nixos.org/packages?channel=unstable&show=vimPlugins.gruvbox-material).

Included some cleanup and refactoring to enable deprecating colourschemes in `plugins/deprecation.nix`.
