### PR TITLE
ci/buildbot: build treefmt checks

### DIFF
--- a/flake/dev/default.nix
+++ b/flake/dev/default.nix
@@ -19,6 +19,10 @@
       ...
     }:
     {
+      ci.buildbot = {
+        inherit (config.checks) treefmt;
+      };
+
       treefmt.config = {
         projectRootFile = "flake.nix";
         flakeCheck = true;


### PR DESCRIPTION
- **ci/tag-maintainers: run treefmt**
- **ci/buildbot: build treefmt checks**

This got missed when we added the `ci.buildbot` flake output. The treefmt flake-parts module adds its check to the `checks` output, but we also want it added to `ci.buildbot`.

This means we haven't been enforcing formatting since we split flakecheck and buildbot tests.
