### PR TITLE
plugins/img-clip: init

### DIFF
--- a/plugins/by-name/img-clip/default.nix
+++ b/plugins/by-name/img-clip/default.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "img-clip";
+  packPathName = "img-clip.nvim";
+  package = "img-clip-nvim";
+  description = "Embed images into any markup language, like LaTeX, Markdown or Typst";
+  maintainers = [ lib.maintainers.saygo-png ];
+
+  settingsExample = {
+    default = {
+      dir_path = "assets";
+      file_name = "%y-%m-%d-%h-%m-%s";
+      use_absolute_path = false;
+      relative_to_current_file = false;
+      template = "$file_path";
+    };
+    filetypes = {
+      markdown = {
+        download_images = true;
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/img-clip/default.nix
+++ b/tests/test-sources/plugins/by-name/img-clip/default.nix
@@ -1,0 +1,25 @@
+{
+  empty = {
+    plugins.img-clip.enable = true;
+  };
+
+  example = {
+    plugins.img-clip = {
+      enable = true;
+      settings = {
+        default = {
+          dir_path = "assets";
+          file_name = "%y-%m-%d-%h-%m-%s";
+          use_absolute_path = false;
+          relative_to_current_file = false;
+          template = "$file_path";
+        };
+        filetypes = {
+          markdown = {
+            download_images = true;
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Closes https://github.com/nix-community/nixvim/issues/3469

I'm not sure if i wrote the test properly.

There is room for improvement here, as [upstream offers snippets for integrating](https://github.com/HakonHarnes/img-clip.nvim/?tab=readme-ov-file#-integrations) with telescope, oil.nvim and snacks.
We could provide these integrations as options. I'm planning to add this in the future.