### PR TITLE
plugins/rainbow: init

### DIFF
--- a/plugins/by-name/rainbow/default.nix
+++ b/plugins/by-name/rainbow/default.nix
@@ -1,0 +1,38 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkVimPlugin {
+  name = "rainbow";
+  package = "rainbow";
+  description = "Rainbow parentheses improved — shorter code, no level limit, smooth and fast with powerful configuration.";
+  maintainers = [ lib.maintainers.saygo-png ];
+  globalPrefix = "rainbow_";
+
+  settingsExample = {
+    active = 1;
+    conf = {
+      guifgs = [
+        "#7d8618"
+        "darkorange3"
+        "seagreen3"
+        "firebrick"
+      ];
+      operators = "_,_";
+      parentheses = [
+        "start=/(/ end=/)/ fold"
+        "start=/\\[/ end=/\\]/ fold"
+      ];
+      separately = {
+        "*" = { };
+        markdown = {
+          parentheses_options = "containedin=markdownCode contained";
+        };
+        haskell = {
+          parentheses = [
+            "start=/\\[/ end=/\\]/ fold"
+            "start=/\v\{\ze[^-]/ end=/}/ fold"
+          ];
+        };
+        css = 0;
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/rainbow/default.nix
+++ b/tests/test-sources/plugins/by-name/rainbow/default.nix
@@ -1,0 +1,112 @@
+{
+  empty = {
+    plugins.rainbow.enable = true;
+  };
+
+  defaults = {
+    plugins.rainbow = {
+      enable = true;
+      settings = {
+        conf = {
+          guifgs = [
+            "royalblue3"
+            "darkorange3"
+            "seagreen3"
+            "firebrick"
+          ];
+          ctermfgs = [
+            "lightblue"
+            "lightyellow"
+            "lightcyan"
+            "lightmagenta"
+          ];
+          guis = [ "" ];
+          cterms = [ "" ];
+          operators = "_,_";
+          contains_prefix = "TOP";
+          parentheses_options = "";
+          parentheses = [
+            "start=/(/ end=/)/ fold"
+            "start=/\\[/ end=/\\]/ fold"
+            "start=/{/ end=/}/ fold"
+          ];
+          separately = {
+            markdown = {
+              parentheses_options = "containedin=markdownCode contained";
+            };
+            lisp = {
+              guifgs = [
+                "royalblue3"
+                "darkorange3"
+                "seagreen3"
+                "firebrick"
+                "darkorchid3"
+              ];
+            };
+            haskell = {
+              parentheses = [
+                "start=/(/ end=/)/ fold"
+                "start=/\\[/ end=/\\]/ fold"
+                "start=/\v\{\ze[^-]/ end=/}/ fold"
+              ];
+            };
+            tex = {
+              parentheses_options = "containedin=texDocZone";
+              parentheses = [
+                "start=/(/ end=/)/"
+                "start=/\\[/ end=/\\]/"
+              ];
+            };
+            vim = {
+              parentheses_options = "containedin=vimFuncBody,vimExecute";
+              parentheses = [
+                "start=/(/ end=/)/"
+                "start=/\\[/ end=/\\]/"
+                "start=/{/ end=/}/ fold"
+              ];
+            };
+            perl = {
+              syn_name_prefix = "perlBlockFoldRainbow";
+            };
+            stylus = {
+              parentheses = [ "start=/{/ end=/}/ fold contains=@colorableGroup" ];
+            };
+            css = 0;
+            sh = 0;
+            vimwiki = 0;
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.rainbow = {
+      enable = true;
+      settings = {
+        active = 1;
+        conf = {
+          guifgs = [
+            "#7d8618"
+            "darkorange3"
+            "seagreen3"
+            "firebrick"
+          ];
+          parentheses = [
+            "start=/(/ end=/)/ fold"
+            "start=/\\[/ end=/\\]/ fold"
+          ];
+          separately = {
+            "*" = { };
+            haskell = {
+              parentheses = [
+                "start=/\\[/ end=/\\]/ fold"
+                "start=/\v\{\ze[^-]/ end=/}/ fold"
+              ];
+            };
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
https://github.com/luochen1990/rainbow/

Something easier to review from me this time.

This plugin adds rainbow parentheses. I'm aware that we already have rainbow-delimiters, but that uses treesitter. Not everyone likes that project. Even though I do use treesitter I find that this non TS implementation works much faster and does the same thing.

I enable the active setting by default because that is described as part of "setup" in the upstream documentation.