### PR TITLE
lsp-packages: add package pyrefly

### DIFF
--- a/plugins/lsp/lsp-packages.nix
+++ b/plugins/lsp/lsp-packages.nix
@@ -335,6 +335,7 @@
       "python-lsp-server"
     ];
     pylyzer = "pylyzer";
+    pyrefly = "pyrefly";
     pyright = "pyright";
     qmlls = [
       "kdePackages"


### PR DESCRIPTION
basically adding the pyrefly package which can be used as an lsp for python: https://pyrefly.org/