### PR TITLE
plugins/notify: allow raw for stages

### DIFF
--- a/plugins/by-name/notify/default.nix
+++ b/plugins/by-name/notify/default.nix
@@ -31,7 +31,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       Max number of lines for a message.
     '';
     stages =
-      defaultNullOpts.mkNullable
+      defaultNullOpts.mkNullableWithRaw
         (
           with types;
           either (enum [
@@ -39,7 +39,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
             "slide"
             "fade_in_slide_out"
             "static"
-          ]) (listOf str)
+          ]) (listOf (types.maybeRaw str))
         )
         "fade_in_slide_out"
         ''


### PR DESCRIPTION
Fix type of `plugins.notify.settings.stages` to allow to pass raw lua code.
