### PR TITLE
editorconfig: set root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*.sh]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
> When opening a file, EditorConfig plugins look for a file named .editorconfig (all lowercase) in the directory of the opened file and in every parent directory. A search for .editorconfig files will stop if the root filepath is reached or an EditorConfig file with root=true is found.
>
> -- https://editorconfig.org/#file-location