### PR TITLE
plugins/comment: fix lazy loading

### DIFF
--- a/plugins/by-name/comment/default.nix
+++ b/plugins/by-name/comment/default.nix
@@ -6,7 +6,7 @@
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "comment";
-  packPathName = "Comment.nvim";
+  packPathName = "comment.nvim";
   moduleName = "Comment";
   package = "comment-nvim";
   description = "Smart and powerful comment plugin for Neovim.";


### PR DESCRIPTION
case sensitive path name so that lz.n finds it on case sensitive file systems

Closes https://github.com/nix-community/nixvim/issues/3594