### PR TITLE
tests/plugins-by-name: general cleanup

### DIFF
--- a/tests/plugins-by-name.nix
+++ b/tests/plugins-by-name.nix
@@ -92,10 +92,10 @@ linkFarmFromDrvs "plugins-by-name" [
     {
       __structuredAttrs = true;
       missingPlugins = builtins.filter (
-        name: !(builtins.pathExists "${by-name}/${name}/default.nix")
+        name: !(builtins.pathExists (by-name + "/${name}/default.nix"))
       ) children.directory;
       missingTests = builtins.filter (
-        name: !(builtins.pathExists "${./test-sources/plugins/by-name}/${name}/default.nix")
+        name: !(builtins.pathExists ./test-sources/plugins/by-name/${name}/default.nix)
       ) children.directory;
     }
     ''


### PR DESCRIPTION
- **tests/plugins-by-name: remove unnecessary copy-to-store**
- **tests/plugins-by-name: simplify namespace assertion**
- **tests/plugins-by-name: simplify by-name-enable-opts impl**

I was experimenting locally with expanding by-name support to `plugins/colorschemes`, and realised that this test would need some refactoring to ensure we correctly validate those plugins too.

This PR has some preliminary cleanup that would also make those refactors easier.
