### PR TITLE
plugins/telescope: add defaultText for highlightTheme

### DIFF
--- a/plugins/by-name/telescope/default.nix
+++ b/plugins/by-name/telescope/default.nix
@@ -77,6 +77,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       type = types.nullOr types.str;
       description = "The colorscheme to use for syntax highlighting";
       default = config.colorscheme;
+      defaultText = literalExpression "config.colorscheme";
     };
 
     enabledExtensions = mkOption {


### PR DESCRIPTION
without this change, the docs just show `null` as the default for this option.