### PR TITLE
maintainers: update out-of-date github usernames

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -49,7 +49,7 @@
   JanKremer = {
     email = "mail@jankremer.eu";
     matrix = "@jankremer:matrix.org";
-    github = "janurskremer";
+    github = "jukremer";
     githubId = 79042825;
     name = "Jan Kremer";
     keys = [ { fingerprint = "20AF 0A65 9F2B 93AD 9184  15D1 A7DA 689C B3B0 78EC"; } ];

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -34,7 +34,7 @@
   DanielLaing = {
     email = "daniel@daniellaing.com";
     matrix = "@bodleum:matrix.org";
-    github = "Bodleum";
+    github = "daniellaing";
     githubId = 60107449;
     name = "Daniel Laing";
     keys = [ { fingerprint = "0821 8B96 DC73 85E5 BB7C  A535 D264 3BD2 13BC 0FA8"; } ];


### PR DESCRIPTION
As per https://github.com/orgs/nix-community/discussions/1908#discussioncomment-13972992

> * nixvim
>   * `Bodleum` -> [api.github.com/user/60107449](https://api.github.com/user/60107449) -> `daniellaing`
>   * `janurskremer` -> [api.github.com/user/79042825](https://api.github.com/user/79042825) -> `jukremer`
