### PR TITLE
plugins/lsp: fix volar tsls integration location

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -170,7 +170,7 @@ let
               plugins = [
                 {
                   name = "@vue/typescript-plugin";
-                  location = "${lib.getBin cfg.package}/lib/node_modules/@vue/language-server";
+                  location = "${lib.getBin cfg.package}/lib/language-tools/packages/language-server";
                   languages = [ "vue" ];
                 }
               ];


### PR DESCRIPTION
This PR fixes the incorrect location in Volar LSP by updating it. The old location no longer exists.

- old: ${lib.getBin cfg.package}/lib/node_modules/@vue/language-server
- new: ${lib.getBin cfg.package}/lib/language-tools/packages/language-server

```sh
tree /nix/store/3h6sfwmwxl3x8vfasw5iaplzd6xjiip4-vue-language-server-3.0.4 -L 4
/nix/store/3h6sfwmwxl3x8vfasw5iaplzd6xjiip4-vue-language-server-3.0.4
├── bin
│   └── vue-language-server
└── lib
    └── language-tools
        ├── extensions
        │   └── vscode
        ├── node_modules
        │   ├── @lerna-lite
        │   ├── @tsslint
        │   ├── @typescript-eslint
        │   ├── dprint -> .pnpm/dprint@0.50.0/node_modules/dprint
        │   ├── oxlint -> .pnpm/oxlint@1.0.0/node_modules/oxlint
        │   ├── typescript -> .pnpm/typescript@5.8.3/node_modules/typescript
        │   └── vitest -> .pnpm/vitest@3.1.3_@types+node@22.15.2/node_modules/vitest
        └── packages
            ├── component-meta
            ├── component-type-helpers
            ├── language-core
            ├── language-plugin-pug
            ├── language-server
            ├── language-service
            ├── tsc
            └── typescript-plugin

23 directories, 1 file
```