### PR TITLE
fix(copilot-chat): fix default model to one supported

### DIFF
--- a/plugins/by-name/copilot-chat/default.nix
+++ b/plugins/by-name/copilot-chat/default.nix
@@ -31,8 +31,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
       System prompt to use.
     '';
 
-    model = defaultNullOpts.mkStr "gpt-4" ''
-      GPT model to use, 'gpt-3.5-turbo' or 'gpt-4'.
+    model = defaultNullOpts.mkStr "gpt-4.1" ''
+      GPT model to use, 'gpt-3.5-turbo' or 'gpt-4.1'.
     '';
 
     temperature = defaultNullOpts.mkProportion 0.1 ''


### PR DESCRIPTION
it seems that gpt-4 is no longer supported

https://docs.github.com/en/copilot/reference/ai-models/supported-models

using gpt-4 throws 400 Bad Request errors

fixes nix-community#3623