### PR TITLE
plugins/dap: add pipe type adapter

### DIFF
--- a/plugins/by-name/dap/dapHelpers.nix
+++ b/plugins/by-name/dap/dapHelpers.nix
@@ -77,6 +77,25 @@ rec {
     '';
   };
 
+  pipeAdapterOption = mkAdapterType {
+    pipe = lib.nixvim.defaultNullOpts.mkStr "$\{pipe}" "Pipe name.";
+
+    executable = {
+      command = mkNullOrOption types.str "Command that spawns the adapter.";
+
+      args = mkNullOrOption (types.listOf types.str) "Command arguments.";
+
+      detached = lib.nixvim.defaultNullOpts.mkBool true "Spawn the debug adapter in detached state.";
+
+      cwd = mkNullOrOption types.str "Working directory.";
+    };
+
+    options.timeout = lib.nixvim.defaultNullOpts.mkInt 5000 ''
+      Max amount of time in ms to wait between spaning the executable and connecting to the pipe.
+      This gives the executable time to create the pipe
+    '';
+  };
+
   mkAdapterOption =
     name: type:
     mkNullOrOption (with types; attrsOf (either str type)) ''

--- a/plugins/by-name/dap/default.nix
+++ b/plugins/by-name/dap/default.nix
@@ -26,6 +26,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     adapters = lib.nixvim.mkCompositeOption "Dap adapters." {
       executables = dapHelpers.mkAdapterOption "executable" dapHelpers.executableAdapterOption;
       servers = dapHelpers.mkAdapterOption "server" dapHelpers.serverAdapterOption;
+      pipes = dapHelpers.mkAdapterOption "pipe" dapHelpers.pipeAdapterOption;
     };
 
     configurations =
@@ -70,6 +71,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
           ))
           // (lib.optionalAttrs (cfg.adapters.servers != null) (
             dapHelpers.processAdapters "server" cfg.adapters.servers
+          ))
+          // (lib.optionalAttrs (cfg.adapters.pipes != null) (
+            dapHelpers.processAdapters "pipe" cfg.adapters.pipes
           ));
 
         signs = with cfg.signs; {


### PR DESCRIPTION
These are for pipe based debuggers, that don't use stdout but rather a unix pipe. The cmake debugger is an example of this and would be configured something like this


```nix
dap = {
  adapters = {
    pipes = {
      cmake = {
        pipe = "$\{pipe}";
        executable = {
            command = "cmake";
            args = [ "--debugger" "--debugger-pipe" "$\{pipe}" "build" ];
        };
      };
    };
  };
};
```