### PR TITLE
ci: init `pr.yml` and `merge-queue.yml` workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,11 @@
 name: lint
 
 on:
-  pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.svg"
-      - ".gitignore"
-      - "LICENSE"
-      - "flake.lock"
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -18,6 +16,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,39 @@
+name: Merge Queue
+
+on:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+    with:
+      ref: ${{ github.event.merge_group.head_sha }}
+
+  # This job posts the "Required Status Checks" to satisfy our ruleset.
+  required-checks:
+    # It "needs" all the jobs that should block the Merge Queue.
+    # Modify this list to add or remove jobs from required status checks.
+    needs:
+      - lint
+
+    name: Required checks
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { serverUrl, repo, runId, payload } = context
+            await github.rest.repos.createCommitStatus({
+              ...repo,
+              sha: payload.merge_group.head_sha,
+              target_url: `${serverUrl}/${repo.owner}/${repo.repo}/actions/runs/${runId}`,
+              // WARNING:
+              // Do NOT change the context name or it will not match the ruleset.
+              // This would prevent all PRs from merging.
+              context: 'PR checks successful',
+              state: 'success',
+            })

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,43 @@
+name: PR
+
+on:
+  pull_request_target:
+
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  # This job posts the "Required Status Checks" to satisfy our ruleset.
+  required-checks:
+    # It "needs" all the jobs that should block merging a PR.
+    # Modify this list to add or remove jobs from required status checks.
+    needs:
+      - lint
+
+    name: Required checks
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { serverUrl, repo, runId, payload } = context
+            await github.rest.repos.createCommitStatus({
+              ...repo,
+              sha: payload.pull_request.head.sha,
+              target_url: `${serverUrl}/${repo.owner}/${repo.repo}/actions/runs/${runId}`,
+              // WARNING:
+              // Do NOT change the context name or it will not match the ruleset.
+              // This would prevent all PRs from merging.
+              context: 'PR checks successful',
+              state: 'success',
+            })


### PR DESCRIPTION
These workflows will serve as top-level entry points for running GHA jobs against PRs and merge groups in the merge queue.

This allows us to have a meta-job "no PR failures" that "needs" all merge requirements. This makes it easier to maintain the "required status checks" ruleset.

Additionally, by having separate workflows for `pull_request` and `merge_group`, we can have different "needs" for each.

This is related to #3611, which is adding the first GHA-based check that will need to be "required".

This is based on @wolfgangwalther's excellent work in nixpkgs: [merge-group.yml](https://github.com/NixOS/nixpkgs/blob/master/.github/workflows/merge-group.yml) and [pr.yml](https://github.com/NixOS/nixpkgs/blob/master/.github/workflows/pr.yml)

The PR workflow ran Successfully here: https://github.com/nix-community/nixvim/actions/runs/17108993910/job/48525322498?pr=3628

We won't see the Merge Queue workflow run until this PR enters the queue.

@GaetanLepage you will need to add `PR checks successful` to the required status checks list in our ruleset. EDIT: the actual status check name may change throughout this PR.

<img width="352" height="371" alt="image" src="https://github.com/user-attachments/assets/7c057ec5-a7d4-432b-b2e0-ce6ccba9ecb8" />
