### PR TITLE
[backport nixos-25.05] ci: added treefmt workflow to gha and removed from buildbot

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: lint
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.svg"
+      - ".gitignore"
+      - "LICENSE"
+      - "flake.lock"
+
+jobs:
+  treefmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+      - name: Run treefmt check
+        run: nix build .#checks.x86_64-linux.treefmt --accept-flake-config


### PR DESCRIPTION
Manual backport of #3611

Without changes to `flake/dev/fmt.nix`, as that file is not on the 25.05 branch. More specifically, we haven't backported the explicit `ci.buildbot` flake output or buildbot config file to 25.05.

This does mean that for 25.05 we will check formatting in both buildbot **and** GHA, however I think that is not a big deal.

It is more important that this workflow exists on all active branches so that we can be consistent with things like "required status checks".
