### PR TITLE
user-configs: remove HeitorAugustoLN's configuration

### DIFF
--- a/docs/user-configs/list.toml
+++ b/docs/user-configs/list.toml
@@ -57,11 +57,6 @@ owner = "gwg313"
 repo = "nvim-nix"
 
 [[config]]
-owner = "HeitorAugustoLN"
-repo = "nvim-config"
-description = "HeitorAugustoLN's personal Neovim configuration made with Nixvim"
-
-[[config]]
 owner = "hbjydev"
 repo = "hvim"
 


### PR DESCRIPTION
Removes my configuration from configuration examples, since it doesn't use nixvim anymore