### PR TITLE
plugins/cutlass-nvim: init

### DIFF
--- a/plugins/by-name/cutlass/default.nix
+++ b/plugins/by-name/cutlass/default.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "cutlass-nvim";
+  moduleName = "cutlass";
+  packPathName = "cutlass.nvim";
+
+  maintainers = [ lib.maintainers.saygo-png ];
+
+  settingsExample = {
+    override_del = true;
+    exclude = [
+      "ns"
+      "nS"
+      "nx"
+      "nX"
+      "nxx"
+      "nX"
+    ];
+    registers = {
+      select = "s";
+      delete = "d";
+      change = "c";
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/cutlass/default.nix
+++ b/tests/test-sources/plugins/by-name/cutlass/default.nix
@@ -1,0 +1,43 @@
+{
+  empty = {
+    plugins.cutlass-nvim.enable = true;
+  };
+
+  defaults = {
+    plugins.cutlass-nvim = {
+      enable = true;
+      settings = {
+        cut_key = "nil";
+        override_del = "nil";
+        exclude.__empty = { };
+        registers = {
+          select = "_";
+          delete = "_";
+          change = "_";
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.cutlass-nvim = {
+      enable = true;
+      settings = {
+        override_del = true;
+        exclude = [
+          "ns"
+          "nS"
+          "nx"
+          "nX"
+          "nxx"
+          "nX"
+        ];
+        registers = {
+          select = "s";
+          delete = "d";
+          change = "c";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
https://github.com/gbprod/cutlass.nvim

Plugin that stops `d` and `c` from copying things and a bit more.

defaults: https://github.com/gbprod/cutlass.nvim/blob/1ac7e4b53d79410be52a9e464d44c60556282b3e/lua/cutlass.lua#L13-L23

Naming it `cutlass-nvim` because there is a vimscript version which I think still works, maybe someone would want to add that in the future.