### PR TITLE
ci/update-maintainers: drop `issues:write` permission

### DIFF
--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -24,11 +24,9 @@ jobs:
     # Permissions required for workflow
     # `contents`: to update maintainers file
     # `pull-requests`: to create pr
-    # `issues`: to label pr
     permissions:
       contents: write
       pull-requests: write
-      issues: write
     env:
       pr_branch: update/maintainers-${{ github.ref_name }}
     steps:
@@ -41,7 +39,6 @@ jobs:
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
 
       - name: Get GitHub App user info
         id: user-info


### PR DESCRIPTION
The [update-maintainers](https://github.com/nix-community/nixvim/actions/workflows/update-maintainers.yml) workflow creates a `nixvim-ci` app token with permissions: https://github.com/nix-community/nixvim/blob/ecc7880e00a2a735074243d8a664a931d73beace/.github/workflows/update-maintainers.yml#L42-L44

However this is throwing errors that some of these permissions are not present on the app installation:

> The permissions requested are not granted to this installation. - https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app

E.g. on this run: https://github.com/nix-community/nixvim/actions/runs/17036431911

I'm guessing it's `issues: write` we're missing, as I believe the other perms are used successfully in other workflows?

We requested this permission to be able to create new labels, when labelling the PR. However that is not necessary here, because a) we don't apply any labels and b) if we did we could create them manually. https://github.com/nix-community/nixvim/blob/ecc7880e00a2a735074243d8a664a931d73beace/.github/workflows/update-maintainers.yml#L213-L215

@zowoq: am I correct that it is `issues:write` we're missing, and the others are present?
