### PR TITLE
plugins/aider: init

### DIFF
--- a/plugins/by-name/aider/default.nix
+++ b/plugins/by-name/aider/default.nix
@@ -1,0 +1,31 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "aider";
+  package = "aider-nvim";
+  packPathName = "aider.nvim";
+
+  maintainers = with lib.maintainers; [
+    c4patino
+  ];
+
+  settingsExample = {
+    auto_manage_context = false;
+    default_bindings = false;
+    debug = true;
+    vim = true;
+    ignore_buffers = [ ];
+    border = {
+      style = [
+        "╭"
+        "─"
+        "╮"
+        "│"
+        "╯"
+        "─"
+        "╰"
+        "│"
+      ];
+      color = "#fab387";
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/aider/default.nix
+++ b/tests/test-sources/plugins/by-name/aider/default.nix
@@ -1,0 +1,49 @@
+{
+  empty = {
+    plugins.aider.enable = true;
+  };
+
+  defaults = {
+    plugins.aider = {
+      enable = true;
+      settings = {
+        auto_manage_context = true;
+        default_bindings = true;
+        debug = false;
+        ignore_buffers = [
+          "^term://"
+          "NeogitConsole"
+          "NvimTree_"
+          "neo-tree filesystem"
+        ];
+      };
+    };
+  };
+
+  example = {
+    plugins.aider = {
+      enable = true;
+
+      settings = {
+        auto_manage_context = false;
+        default_bindings = false;
+        debug = true;
+        vim = true;
+        ignore_buffers = [ ];
+        border = {
+          style = [
+            "╭"
+            "─"
+            "╮"
+            "│"
+            "╯"
+            "─"
+            "╰"
+            "│"
+          ];
+          color = "#fab387";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds `aider.nvim` plugin. Example is from their README, tests are of their default `M.config` and the example.

Resolves #3570