### PR TITLE
treewide: Disable fixup phase for builds

### DIFF
--- a/ci/nvim-lspconfig/default.nix
+++ b/ci/nvim-lspconfig/default.nix
@@ -19,7 +19,10 @@ let
     ];
   };
 
-  nvim = wrapNeovimUnstable neovim-unwrapped nvimConfig;
+  nvim = (wrapNeovimUnstable neovim-unwrapped nvimConfig).overrideAttrs {
+    dontFixup = true;
+  };
+
 in
 runCommand "lspconfig-servers"
   {

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -220,7 +220,13 @@ in
         }
       );
 
-      wrappedNeovim = pkgs.wrapNeovimUnstable package neovimConfig;
+      # TODO: 2025-01-06
+      # Wait for user feedback on disabling the fixup phase.
+      # Ideally this will be upstreamed to nixpkgs.
+      # See https://github.com/nix-community/nixvim/pull/3660#discussion_r2326250439
+      wrappedNeovim = (pkgs.wrapNeovimUnstable package neovimConfig).overrideAttrs {
+        dontFixup = true;
+      };
 
       customRC = helpers.concatNonEmptyLines [
         (helpers.wrapVimscriptForLua wrappedNeovim.initRc)


### PR DESCRIPTION
This implements the change suggested in https://github.com/nix-community/nixvim/issues/3518

It skips the fixup phase on our nixvim deriviations which almost halves build times.
I've been running this setup myself for a week or so, and did not spot any issues related to it.

This could also be implemented as an overlay instead of overriding on each call.