### PR TITLE
tests: add all-package-defaults

### DIFF
--- a/tests/all-package-defaults.nix
+++ b/tests/all-package-defaults.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  pkgsForTest,
+  linkFarmFromDrvs,
+}:
+let
+  inherit (stdenv) hostPlatform;
+
+  # Enable unfree packages
+  nixvimConfig = lib.nixvim.modules.evalNixvim {
+    extraSpecialArgs.pkgs = pkgsForTest;
+  };
+
+  disabledTests = [
+    # 2025-07-25 python313Packages.lsp-tree-sitter is marked as broken
+    "autotools-language-server"
+
+    # 2025-04-01 php-cs-fixer is marked as broken
+    "php-cs-fixer"
+  ]
+  ++ lib.optionals (hostPlatform.isLinux && hostPlatform.isAarch64) [
+    # "tabnine"
+    "cmp-tabnine"
+  ]
+  ++ lib.optionals hostPlatform.isDarwin [
+    # xdotool is not available on darwin
+    "fontpreview"
+
+    # Marked as broken
+    "akku-scheme-langserver"
+    "muon"
+    "rubyfmt"
+  ]
+  ++ lib.optionals (hostPlatform.isDarwin && hostPlatform.isAarch64) [
+    # As of 2025-07-25, zig-zlint is failing on aarch64-darwin
+    "zig-zlint"
+  ];
+
+  isEnabled = p: !(builtins.elem (lib.getName p) disabledTests);
+  isAvailable = lib.meta.availableOn hostPlatform;
+in
+/*
+  Collect all derivation-type option defaults in the top-level option set.
+
+  NOTE: This doesn't currently recurse into submodule option sets.
+*/
+lib.pipe nixvimConfig.options [
+  (lib.collect lib.isOption)
+
+  (lib.catAttrs "default")
+
+  # Some options throw when not defined
+  (builtins.filter (p: (builtins.tryEval p).success))
+
+  (builtins.filter lib.isDerivation)
+
+  (builtins.filter isEnabled)
+  (builtins.filter isAvailable)
+
+  (linkFarmFromDrvs "all-package-defaults")
+]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,7 +7,15 @@
   system ? pkgs.stdenv.hostPlatform.system,
 }:
 let
-  autoArgs = pkgs // {
+
+  # Use a single common instance of nixpkgs, with allowUnfree
+  # Having a single shared instance should speed up tests a little
+  pkgsForTest = import self.inputs.nixpkgs {
+    inherit system;
+    config.allowUnfree = true;
+  };
+
+  autoArgs = pkgsForTest // {
     inherit
       helpers
       self
@@ -25,6 +33,7 @@ let
       ;
     # Recursive:
     inherit callTest callTests;
+    inherit pkgsForTest;
   };
 
   callTest = lib.callPackageWith autoArgs;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,6 +41,7 @@ let
   selfPackages = self.packages.${system};
 
   misc = {
+    all-package-defaults = callTest ./all-package-defaults.nix { };
     extra-args-tests = callTest ./extra-args.nix { };
     extend = callTest ./extend.nix { };
     extra-files = callTest ./extra-files.nix { };

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -6,16 +6,10 @@
   pkgs,
   self,
   system,
+  pkgsForTest,
 }:
 let
   fetchTests = callTest ./fetch-tests.nix { };
-
-  # Use a single common instance of nixpkgs, with allowUnfree
-  # Having a single shared instance should speed up tests a little
-  pkgsForTest = import self.inputs.nixpkgs {
-    inherit system;
-    config.allowUnfree = true;
-  };
 
   moduleToTest =
     file: name: module:

--- a/tests/test-sources/plugins/by-name/none-ls/default.nix
+++ b/tests/test-sources/plugins/by-name/none-ls/default.nix
@@ -105,7 +105,7 @@
         sources =
           let
             disabled = [
-              #TODO Added 2025-04-01
+              # TODO Added 2025-04-01
               # php-cs-fixer is marked as broken
               "phpcsfixer"
             ]


### PR DESCRIPTION
Motivated by a future removal of the generated tests on non-`x86_64-linux` platforms, let's add a test that ensures all of our package dependencies correctly build on all platforms.

- **tests: move pkgsForTests definition to tests/default.nix**
- **tests: add all-package-defaults**
- **tests/none-ls: typo**
