### PR TITLE
ci: build all-packages-defaults on all platforms

### DIFF
--- a/tests/all-package-defaults.nix
+++ b/tests/all-package-defaults.nix
@@ -32,6 +32,27 @@ let
     "muon"
     "rubyfmt"
   ]
+  ++ lib.optionals (hostPlatform.isDarwin && hostPlatform.isx86_64) [
+    # As of 2024-07-31, dmd is broken on x86_64-darwin
+    # https://github.com/NixOS/nixpkgs/pull/331373
+    "dmd"
+
+    # Marked as broken
+    "mesonlsp"
+
+    # No hash for system
+    "verible"
+
+    # 2025-06-24 build failure
+    "gleam"
+
+    # 2024-01-04 build failure
+    "texlive-combined-medium"
+    "texlive"
+
+    # python3Packages.sentence-transformers hangs forever
+    "vectorcode"
+  ]
   ++ lib.optionals (hostPlatform.isDarwin && hostPlatform.isAarch64) [
     # As of 2025-07-25, zig-zlint is failing on aarch64-darwin
     "zig-zlint"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,7 +41,6 @@ let
   selfPackages = self.packages.${system};
 
   misc = {
-    all-package-defaults = callTest ./all-package-defaults.nix { };
     extra-args-tests = callTest ./extra-args.nix { };
     extend = callTest ./extend.nix { };
     extra-files = callTest ./extra-files.nix { };
@@ -59,6 +58,11 @@ let
   docs = lib.optionalAttrs (selfPackages ? docs) {
     # Individual tests can be run using: nix build .#docs.user-configs.tests.<test>
     docs-user-configs = linkFarm "user-configs-tests" selfPackages.docs.user-configs.tests;
+  };
+
+  packages = {
+    # Checks that all package defaults we specify can actually be built
+    all-package-defaults = callTest ./all-package-defaults.nix { };
   };
 
   # These are always built on all systems, even when `allSystems = false`
@@ -85,8 +89,9 @@ let
 in
 {
   # TODO: consider whether all these tests are needed in the `checks` output
-  flakeCheck = misc // docs // platforms // mainDrv;
+  flakeCheck = misc // docs // platforms // packages // mainDrv;
 
   # TODO: consider whether all these tests are needed to be built by buildbot
-  buildbot = lib.optionalAttrs (system == "x86_64-linux") (misc // docs) // platforms // mainGrouped;
+  buildbot =
+    lib.optionalAttrs (system == "x86_64-linux") (misc // docs) // platforms // packages // mainGrouped;
 }


### PR DESCRIPTION
This was missed in #3665, let's see if it actually builds on all platforms currently...
