### PR TITLE
ci: only build "grouped" tests on x86_64-linux

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -93,5 +93,5 @@ in
 
   # TODO: consider whether all these tests are needed to be built by buildbot
   buildbot =
-    lib.optionalAttrs (system == "x86_64-linux") (misc // docs) // platforms // packages // mainGrouped;
+    lib.optionalAttrs (system == "x86_64-linux") (misc // docs // mainGrouped) // platforms // packages;
 }

--- a/tests/lsp-servers.nix
+++ b/tests/lsp-servers.nix
@@ -1,8 +1,5 @@
 {
-  lib,
   nixvimConfiguration,
-  stdenv,
-  runCommandLocal,
   name ? "lsp-all-servers",
 }:
 let
@@ -32,11 +29,9 @@ let
     {
       lib,
       options,
-      pkgs,
       ...
     }:
     let
-      inherit (pkgs.stdenv) hostPlatform;
 
       disabled = [
         # TODO: 2025-07-25 python313Packages.lsp-tree-sitter marked as broken
@@ -52,19 +47,6 @@ let
         "ruff_lsp"
         "bufls"
         "typst_lsp"
-      ]
-      ++ lib.optionals (hostPlatform.isLinux && hostPlatform.isAarch64) [
-        # TODO: 2025-04-20 build failure (swift-corelibs-xctest)
-        "sourcekit"
-
-        # pkgs.vectorcode cannot run in the build sandbox on this platform, due to issues with onnxruntime
-        "vectorcode_server"
-
-        # TODO: 2024-10-05 build failure
-        "fstar"
-
-        # TODO: 2025-03-04 marked as broken
-        "nickel_ls"
       ];
     in
     {
@@ -93,11 +75,4 @@ let
     ];
   };
 in
-# This fails on darwin
-# See https://github.com/NixOS/nix/issues/4119
-if stdenv.isDarwin then
-  runCommandLocal name { } ''
-    touch $out
-  ''
-else
-  result.config.build.test
+result.config.build.test

--- a/tests/test-sources/modules/dependencies.nix
+++ b/tests/test-sources/modules/dependencies.nix
@@ -6,13 +6,7 @@
 let
   inherit (pkgs.stdenv) hostPlatform;
 
-  disabledDeps = lib.optionals hostPlatform.isDarwin [
-    # One of its dependencies is not available on darwin
-    "fontpreview"
-
-    # TODO: Failing to compile on darwin CI atm
-    "claude-code"
-  ];
+  disabledDeps = [ ];
 
   isDepEnabled =
     name: package:

--- a/tests/test-sources/plugins/by-name/cmp-tabnine/default.nix
+++ b/tests/test-sources/plugins/by-name/cmp-tabnine/default.nix
@@ -1,11 +1,4 @@
-{ lib, pkgs, ... }:
-let
-  platform = pkgs.stdenv.hostPlatform;
-
-  # tabnine is not available on aarch64-linux.
-  doRun = !(platform.isLinux && platform.isAarch64);
-in
-lib.optionalAttrs doRun {
+{
   empty = {
     plugins = {
       cmp.enable = true;

--- a/tests/test-sources/plugins/by-name/dbee/default.nix
+++ b/tests/test-sources/plugins/by-name/dbee/default.nix
@@ -1,9 +1,5 @@
-{ lib, pkgs, ... }:
-let
-  inherit (pkgs.stdenv) hostPlatform;
-in
-# TODO: 2025-07-25 duckdb is broken on aarch64-linux
-lib.optionalAttrs (!(hostPlatform.isLinux && hostPlatform.isAarch64)) {
+{ lib, ... }:
+{
   empty = {
     plugins.dbee.enable = true;
   };

--- a/tests/test-sources/plugins/by-name/efmls-configs/default.nix
+++ b/tests/test-sources/plugins/by-name/efmls-configs/default.nix
@@ -4,14 +4,8 @@
   };
 
   all =
-    {
-      lib,
-      options,
-      pkgs,
-      ...
-    }:
+    { options, ... }:
     let
-      inherit (pkgs.stdenv) hostPlatform;
       inherit (options.plugins.efmls-configs) setup;
 
       # toolOptions is an attrsets of the form:
@@ -38,33 +32,6 @@
         "phpcs"
         "phpstan"
         "psalm"
-      ]
-      ++ lib.optionals (hostPlatform.isLinux && hostPlatform.isAarch64) [
-        # TODO: 2025-04-20 build failure (swift-corelibs-xctest)
-        "swiftformat"
-      ]
-      ++ lib.optionals hostPlatform.isDarwin [
-        # As of 2024-01-04, texliveMedium is broken on darwin
-        # TODO: re-enable those tests when fixed
-        "chktex"
-        "latexindent"
-
-        # TODO 2025-04-20 build failure
-        "ansible_lint"
-      ]
-      ++ lib.optionals (hostPlatform.isDarwin && hostPlatform.isAarch64) [
-        # As of 2025-07-25, zig-zlint is failing on aarch64-darwin
-        "ZLint"
-
-        # As of 2025-03-18, several python311Packages.* dependencies of bashate fail on aarch64-darwin
-        # TODO: re-enable this test when fixed
-        "bashate"
-      ]
-      ++ lib.optionals (hostPlatform.isDarwin && hostPlatform.isx86_64) [
-        # As of 2024-07-31, dmd is broken on x86_64-darwin
-        # https://github.com/NixOS/nixpkgs/pull/331373
-        # TODO: re-enable this test when fixed
-        "dmd"
       ];
 
       # TODO: respect unpackaged from generated
@@ -97,11 +64,6 @@
         "swiftformat"
         "swiftlint"
         "xo"
-      ]
-      ++ lib.optionals pkgs.stdenv.isDarwin [ "clazy" ]
-      ++ lib.optionals pkgs.stdenv.isAarch64 [
-        "dmd"
-        "smlfmt"
       ];
 
       # Fetch the valid enum members from the tool options

--- a/tests/test-sources/plugins/by-name/godot/default.nix
+++ b/tests/test-sources/plugins/by-name/godot/default.nix
@@ -1,13 +1,4 @@
 {
-  lib,
-  pkgs,
-  ...
-}:
-let
-  # Godot is only available on Linux
-  enable = lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.godot_4;
-in
-lib.optionalAttrs enable {
   empty = {
     plugins.godot.enable = true;
   };

--- a/tests/test-sources/plugins/by-name/none-ls/default.nix
+++ b/tests/test-sources/plugins/by-name/none-ls/default.nix
@@ -89,15 +89,7 @@
   };
 
   with-sources =
-    {
-      options,
-      lib,
-      pkgs,
-      ...
-    }:
-    let
-      inherit (pkgs.stdenv) hostPlatform;
-    in
+    { options, lib, ... }:
     {
       plugins.none-ls = {
         enable = true;
@@ -108,43 +100,6 @@
               # TODO Added 2025-04-01
               # php-cs-fixer is marked as broken
               "phpcsfixer"
-            ]
-            ++ lib.optionals (hostPlatform.isLinux && hostPlatform.isAarch64) [
-              # Not available on aarch64-linux
-              "smlfmt"
-
-              # TODO: 2025-04-20 build failure (swift-corelibs-xctest)
-              "swift_format"
-
-              # TODO: 2025-04-20 build failure (open-policy-agent)
-              "opacheck"
-              "rego"
-            ]
-            ++ lib.optionals hostPlatform.isDarwin [
-              # TODO 2025-07-25 prisma build failure
-              "prisma_format"
-              "puppet_lint"
-              # TODO 2025-04-20 build failure
-              "ansiblelint"
-              # TODO 2025-06-24 build failure
-              "elm_format"
-              # TODO 2025-06-24 marked broken / unsupported platform
-              "clazy"
-              "haml_lint"
-              "racket_fixw"
-              "raco_fmt"
-              "rubyfmt"
-
-              # TODO 2025-07-07 open-policy-agent is broken on darwin
-              "opacheck"
-              "rego"
-            ]
-            ++ lib.optionals (hostPlatform.isDarwin && hostPlatform.isx86_64) [
-              # TODO: 2025-06-24 build failure
-              "gleam_format"
-              "ptop"
-              # NOTE: No hash for x86 darwin
-              "verible_verilog_format"
             ];
           in
           # Enable every none-ls source that has an option

--- a/tests/test-sources/plugins/by-name/openscad/default.nix
+++ b/tests/test-sources/plugins/by-name/openscad/default.nix
@@ -1,8 +1,4 @@
-{ lib, pkgs, ... }:
-# TODO: Added 2025-05-28
-# `opencsg` fails to build on darwin
-# https://github.com/NixOS/nixpkgs/issues/411700
-lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
+{
   empty = {
     plugins.openscad.enable = true;
   };

--- a/tests/test-sources/plugins/by-name/papis/default.nix
+++ b/tests/test-sources/plugins/by-name/papis/default.nix
@@ -1,7 +1,4 @@
-{ lib, pkgs, ... }:
-# TODO: as of 2025-05-18, luajitPackages.luv is broken on darwin
-# https://github.com/NixOS/nixpkgs/issues/408528
-lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
+{
   empty = {
     plugins.papis.enable = true;
   };

--- a/tests/test-sources/plugins/by-name/telescope/media-files.nix
+++ b/tests/test-sources/plugins/by-name/telescope/media-files.nix
@@ -1,4 +1,3 @@
-{ pkgs, ... }:
 {
   empty = {
     plugins.telescope = {
@@ -46,7 +45,7 @@
       chafa.enable = true;
       epub-thumbnailer.enable = true;
       ffmpegthumbnailer.enable = true;
-      fontpreview.enable = !pkgs.stdenv.hostPlatform.isDarwin;
+      fontpreview.enable = true;
       imagemagick.enable = true;
       poppler-utils.enable = true;
     };

--- a/tests/test-sources/plugins/cmp/all-sources.nix
+++ b/tests/test-sources/plugins/cmp/all-sources.nix
@@ -1,7 +1,6 @@
-{ lib, pkgs, ... }:
 {
   all-sources =
-    { config, ... }:
+    { lib, config, ... }:
     {
       plugins = {
         copilot-lua = {
@@ -16,10 +15,7 @@
         cmp = {
           enable = true;
           settings.sources =
-            with pkgs.lib;
             let
-              inherit (pkgs.stdenv) hostPlatform;
-
               disabledSources = [
                 # We do not provide the required HF_API_KEY environment variable.
                 "cmp_ai"
@@ -31,16 +27,9 @@
                 "supermaven"
                 # Sometimes get auth error
                 "codeium"
-              ]
-              ++ lib.optionals (hostPlatform.isLinux && hostPlatform.isAarch64) [
-                "cmp_tabnine"
-              ]
-              ++ lib.optionals hostPlatform.isDarwin [
-                # TODO: as of 2025-05-18, luajitPackages.luv is broken on darwin
-                # https://github.com/NixOS/nixpkgs/issues/408528
-                "papis"
               ];
             in
+            with lib;
             pipe config.cmpSourcePlugins [
               # All known source names
               attrNames


### PR DESCRIPTION
Similar to 939a4428334e880eec7608c452a01b8c8b499aae by @zowoq, but with #3666 we will be more confident only running these tests on a single platform; as outlined by #3238.

As part of reducing these test cases to a single platform, I've also gone through and removed the now-redundant disablements.
