### PR TITLE
ci: only build packages on x86_64-linux

### DIFF
--- a/flake/dev/package-tests.nix
+++ b/flake/dev/package-tests.nix
@@ -1,12 +1,16 @@
+{ lib, ... }:
 {
   perSystem =
-    { config, ... }:
+    { config, system, ... }:
     {
       # Test that all packages build fine when running `nix flake check`.
       checks = config.packages;
 
       # Test that all packages build when running buildbot
-      # TODO: only test the docs on x86_64-linux
-      ci.buildbot = config.packages;
+      # FIXME: we want to build most platforms on all systems,
+      # but building the docs is often too expensive.
+      # For now, we restrict the whole packages output to one platform.
+      # TODO: move building the docs to GHA
+      ci.buildbot = lib.mkIf (system == "x86_64-linux") config.packages;
     };
 }


### PR DESCRIPTION
As a temporary solution, we only include the `packages` output in the `ci.buildbot` output on x86_64-linux.

At some point, we should consider explicitly copying each package to `ci.buildbot`, and maybe omitting some.

Some packages may be better off being built on GHA, such as the docs.

cc @MattSturgeon (I cherry-picked your commit from #3647)
