### PR TITLE
modules/performance: add uncompiledPlugins option to plugin byte compilation

### DIFF
--- a/modules/performance.nix
+++ b/modules/performance.nix
@@ -60,6 +60,17 @@ in
       luaLib = lib.mkEnableOption "luaLib" // {
         description = "Whether to byte compile lua library.";
       };
+      excludedPlugins = lib.mkOption {
+        type = with types; listOf (either str package);
+        default = [ ];
+        example = lib.literalExpression ''
+          [
+            "faster.nvim"
+             pkgs.vimPlugins.conform-nvim
+          ];
+        '';
+        description = "List of plugins (names or packages) to exclude from byte compilation.";
+      };
     };
 
     combinePlugins = {

--- a/modules/top-level/plugins/default.nix
+++ b/modules/top-level/plugins/default.nix
@@ -32,7 +32,10 @@ in
     build.plugins =
       let
         shouldCompilePlugins = byteCompileCfg.enable && byteCompileCfg.plugins;
-        byteCompilePlugins = pkgs.callPackage ./byte-compile-plugins.nix { inherit lib; };
+        byteCompilePlugins = pkgs.callPackage ./byte-compile-plugins.nix {
+          inherit lib;
+          inherit (config.performance.byteCompileLua) excludedPlugins;
+        };
 
         shouldCompileLuaLib = byteCompileCfg.enable && byteCompileCfg.luaLib;
         inherit (pkgs.callPackage ./byte-compile-lua-lib.nix { inherit lib; }) byteCompilePluginDeps;


### PR DESCRIPTION
This option is a sister option to `standalonePlugins`in `combinePlugins`. It allows the user to skip some plugins from byte compilation.

This is a needed change because some plugins (I know of at least faster and conform) break when byte compiled. With this option users don't have to choose between having byte compilation, having broken functionality or not using certain plugins. It allows for a compromise where only the problematic plugins are skipped, meanwhile the rest is still compiled.

I've tested that adding`faster.nvim` to the exception list (either as a package or name) fixes https://github.com/nix-community/nixvim/issues/3659

Things of note:
1. This breaks all existing configurations that set `performance.byteCompileLua.plugins` to a boolean.

     I could not figure out a way to deprecate this without an error, because this PR changes the old option to a set.
     The [error thrown by nixpkgs](https://github.com/NixOS/nixpkgs/blob/e8381f9fd66682d6618e6827207745e31100426c/lib/modules.nix#L775) is fairly good.
   * `mkRenamedOptionModule` throws infinite recursion
   * `mkRemovedOptionModule` throws because `.plugins` is not removed
   * `mkChangedOptionModule` throws because `.plugins` is not removed
   * an assertion in `assertions` is overridden by the nixpkgs assertion of the module system. It detects that the attrset is set to a boolean and throws a "type" error.

2. This PR does not include a test.

     The lua tests are broken due to a build failure for luajit. I couldn't feasibly write a new and correct test without the ability to run it and check its behavior.
