### PR TITLE
plugins/harpoon: fix pack path name

### DIFF
--- a/plugins/by-name/harpoon/default.nix
+++ b/plugins/by-name/harpoon/default.nix
@@ -9,6 +9,7 @@ in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "harpoon";
   package = "harpoon2";
+  packPathName = "harpoon2";
   description = "Quickly access files and marks in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];


### PR DESCRIPTION
Lazy loading needs the correct name for finding the plugin in `opt`. With change to `harpoon2` as the default, we need to fix the `packPathName` to match.