### PR TITLE
plugins/colorschemes: add warning to gruvbox-material

### DIFF
--- a/plugins/colorschemes/gruvbox-material.nix
+++ b/plugins/colorschemes/gruvbox-material.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, config, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "gruvbox-material";
   isColorscheme = true;
@@ -18,5 +18,16 @@ lib.nixvim.plugins.mkVimPlugin {
       ];
     };
     show_eob = 0;
+  };
+
+  extraConfig = cfg: {
+    warnings = lib.nixvim.mkWarnings "colorschemes.gruvbox-material" {
+      when = (cfg.settings.better_performance or 0 == 1) && !config.impureRtp;
+      message = ''
+        You have enabled 'better_performance', but the top-level option 'impureRtp' is false.
+        The performance option generates syntax files at runtime that cannot be accessed with impureRtp disabled.
+        This breaks the plugin. Either disable 'better_performance' or enable 'impureRtp'.
+      '';
+    };
   };
 }


### PR DESCRIPTION
The plugin creates files in `~/.config/nvim/after/syntax` when `better_performance` is enabled that need to be loaded.
Due to the way we isolate standalone Nixvim this will silently(!) fail. The warning clarifies this preventing confusion.

https://github.com/sainnhe/gruvbox-material/blob/9bcf7c90e546119c841fecc9807efbd498a3f513/doc/gruvbox-material.txt#L582-L605