### PR TITLE
docs/mdbook: general cleanup and renames

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -84,7 +84,7 @@ let
       ) opt.declarations;
     };
 
-  evaledModules = helpers.modules.evalNixvim {
+  configuration = helpers.modules.evalNixvim {
     modules = [
       {
         isDocs = true;
@@ -95,7 +95,7 @@ let
 
   options-json =
     (pkgs.nixosOptionsDoc {
-      inherit (evaledModules) options;
+      inherit (configuration) options;
       inherit transformOptions;
     }).optionsJSON;
 
@@ -123,7 +123,7 @@ lib.fix (self: {
   };
 
   docs = pkgs.callPackage ./mdbook {
-    inherit evaledModules transformOptions;
+    inherit configuration transformOptions;
     inherit (self) search lib-docs;
   };
 


### PR DESCRIPTION
Clean up the `docs/mdbook/default.nix` expression in an attempt to make it easier to understand.

I'm trying to understand how this expression works, in particular how it decides which options should go on a page vs a new sub-page. As part of my effort to understand the code, I've made a few renames and cleanup.

This PR should be close to zero rebuilds, with the exception of some of the "page summary" derivations now having a more descriptive drv name. These "summary" derivations encapsulate the "plugin description", maintainer list, URL, etc.

Eventually, I'd love to completely delete this file and replace it with something based on `optionAttrSetToDocList` (and using `groupBy` to group options into pages). But if we want to have redirects to prevent breaking existing links,[^1] then I'll need to understand the existing code well enough to produce an index of where specific options _used to be_.


[^1]: If we are happy to break the old URLs, then a rewrite would suddenly get **much** simpler...