### PR TITLE
dependencies: ensure __depPackages.foo.* options are set only once

### DIFF
--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -28,7 +28,15 @@ let
       };
   };
 
-  attrPathType = with types; coercedTo str lib.toList (listOf str);
+  # Motivation:
+  # If one were to define `__depPackages.foo.default = "gzip";` in two places (by accident),
+  # the module system would merge the two definitions as `["gzip" "gzip"]`.
+  #
+  # Solution:
+  # -> Make attrPathType unique so the option can only be set once.
+  attrPathType =
+    with types;
+    unique { message = "attrPathType must be unique"; } (coercedTo str lib.toList (listOf str));
 
   literalExpressionType = lib.types.mkOptionType {
     name = "literal-expression";


### PR DESCRIPTION
## Motivation:
If one were to define `__depPackages.foo.default = "gzip";` in two places (by accident), the module system would merge the two definitions as `["gzip" "gzip"]`.
Naturally, `pkgs.gzip.gzip` does not exist and evaluation would fail.

## Solution:
-> Make `attrPathType` unique so the option can only be set once.

Result:
```
error: The option `__depPackages.imagemagick.default' is defined multiple times while it's expected to be unique.
attrPathType must be unique
Definition values:
- In `/nix/store/xr6yymx6n7qljsidrli67cc1i3vzq3aq-source/modules/dependencies.nix': "distant"
- In `/nix/store/xr6yymx6n7qljsidrli67cc1i3vzq3aq-source/plugins/by-name/telescope/extensions/media-files.nix': "imagemagick"
Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```
