### PR TITLE
treewide: support `mini-icons.mockdevIcons`

### DIFF
--- a/plugins/by-name/alpha/default.nix
+++ b/plugins/by-name/alpha/default.nix
@@ -166,9 +166,12 @@ in
             opt.iconsEnabled.isDefined
             && cfg.iconsEnabled
             && !(
-              config.plugins.mini.enable
-              && config.plugins.mini.modules ? icons
-              && config.plugins.mini.mockDevIcons
+              (
+                config.plugins.mini.enable
+                && config.plugins.mini.modules ? icons
+                && config.plugins.mini.mockDevIcons
+              )
+              || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
             )
           )
           {

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -212,9 +212,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
     # TODO: added 2024-09-20 remove after 24.11
     plugins.web-devicons = mkIf (
       !(
-        config.plugins.mini.enable
-        && config.plugins.mini.modules ? icons
-        && config.plugins.mini.mockDevIcons
+        (
+          config.plugins.mini.enable
+          && config.plugins.mini.modules ? icons
+          && config.plugins.mini.mockDevIcons
+        )
+        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
       )
     ) { enable = mkOverride 1490 true; };
 

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -663,9 +663,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
     # TODO: added 2024-09-20 remove after 24.11
     plugins.web-devicons = lib.mkIf (
       !(
-        config.plugins.mini.enable
-        && config.plugins.mini.modules ? icons
-        && config.plugins.mini.mockDevIcons
+        (
+          config.plugins.mini.enable
+          && config.plugins.mini.modules ? icons
+          && config.plugins.mini.mockDevIcons
+        )
+        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
       )
     ) { enable = lib.mkOverride 1490 true; };
 

--- a/plugins/by-name/diffview/default.nix
+++ b/plugins/by-name/diffview/default.nix
@@ -826,9 +826,12 @@ in
       # TODO: added 2024-09-20 remove after 24.11
       plugins.web-devicons = mkIf (
         !(
-          config.plugins.mini.enable
-          && config.plugins.mini.modules ? icons
-          && config.plugins.mini.mockDevIcons
+          (
+            config.plugins.mini.enable
+            && config.plugins.mini.modules ? icons
+            && config.plugins.mini.mockDevIcons
+          )
+          || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
         )
       ) { enable = mkOverride 1490 true; };
 

--- a/plugins/by-name/fzf-lua/default.nix
+++ b/plugins/by-name/fzf-lua/default.nix
@@ -124,9 +124,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
           opts.iconsEnabled.isDefined
           && cfg.iconsEnabled
           && !(
-            config.plugins.mini.enable
-            && config.plugins.mini.modules ? icons
-            && config.plugins.mini.mockDevIcons
+            (
+              config.plugins.mini.enable
+              && config.plugins.mini.modules ? icons
+              && config.plugins.mini.mockDevIcons
+            )
+            || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
           )
         )
         {

--- a/plugins/by-name/lspsaga/deprecations.nix
+++ b/plugins/by-name/lspsaga/deprecations.nix
@@ -40,9 +40,12 @@ lib: {
               cfg.enable
               && (cfg.settings.ui.devicon or true)
               && !(
-                config.plugins.mini.enable
-                && config.plugins.mini.modules ? icons
-                && config.plugins.mini.mockDevIcons
+                (
+                  config.plugins.mini.enable
+                  && config.plugins.mini.modules ? icons
+                  && config.plugins.mini.mockDevIcons
+                )
+                || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
               )
             )
             {

--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -924,7 +924,7 @@ in
 
   config =
     let
-      inherit (helpers) ifNonNull' mkRaw;
+      inherit (helpers) ifNonNull';
 
       processRendererComponent =
         component:
@@ -1126,9 +1126,12 @@ in
       # TODO: added 2024-09-20 remove after 24.11
       plugins.web-devicons = mkIf (
         !(
-          config.plugins.mini.enable
-          && config.plugins.mini.modules ? icons
-          && config.plugins.mini.mockDevIcons
+          (
+            config.plugins.mini.enable
+            && config.plugins.mini.modules ? icons
+            && config.plugins.mini.mockDevIcons
+          )
+          || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
         )
       ) { enable = mkOverride 1490 true; };
 

--- a/plugins/by-name/nvim-tree/default.nix
+++ b/plugins/by-name/nvim-tree/default.nix
@@ -134,9 +134,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
       # TODO: added 2024-09-20 remove after 24.11
       plugins.web-devicons = lib.mkIf (
         !(
-          config.plugins.mini.enable
-          && config.plugins.mini.modules ? icons
-          && config.plugins.mini.mockDevIcons
+          (
+            config.plugins.mini.enable
+            && config.plugins.mini.modules ? icons
+            && config.plugins.mini.mockDevIcons
+          )
+          || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
         )
       ) { enable = lib.mkOverride 1490 true; };
 

--- a/plugins/by-name/telescope/default.nix
+++ b/plugins/by-name/telescope/default.nix
@@ -103,9 +103,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
     # TODO: added 2024-09-20 remove after 24.11
     plugins.web-devicons = mkIf (
       !(
-        config.plugins.mini.enable
-        && config.plugins.mini.modules ? icons
-        && config.plugins.mini.mockDevIcons
+        (
+          config.plugins.mini.enable
+          && config.plugins.mini.modules ? icons
+          && config.plugins.mini.mockDevIcons
+        )
+        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
       )
     ) { enable = mkOverride 1490 true; };
 

--- a/plugins/by-name/trouble/default.nix
+++ b/plugins/by-name/trouble/default.nix
@@ -383,9 +383,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
     # TODO: added 2024-09-20 remove after 24.11
     plugins.web-devicons = lib.mkIf (
       !(
-        config.plugins.mini.enable
-        && config.plugins.mini.modules ? icons
-        && config.plugins.mini.mockDevIcons
+        (
+          config.plugins.mini.enable
+          && config.plugins.mini.modules ? icons
+          && config.plugins.mini.mockDevIcons
+        )
+        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
       )
     ) { enable = lib.mkOverride 1490 true; };
   };


### PR DESCRIPTION
Prevent the `web-devicons` enablement when using the `mini-icons` module.