### PR TITLE
plugins/chadtree: fix misplaced ignore settings

### DIFF
--- a/plugins/by-name/chadtree/default.nix
+++ b/plugins/by-name/chadtree/default.nix
@@ -70,31 +70,29 @@ in
       versionControl = helpers.defaultNullOpts.mkBool true ''
         Enable version control. This can also be toggled. But unlike `show_hidden`, does not have a default keybind.
       '';
-
-      ignore = {
-        nameExact =
-          mkListStr
-            [
-              ".DS_Store"
-              ".directory"
-              "thumbs.db"
-              ".git"
-            ]
-            ''
-              Files whose name match these exactly will be ignored.
-            '';
-
-        nameGlob = mkListStr [ ] ''
-          Files whose name match these glob patterns will be ignored.
-          ie. `*.py` will match all python files
-        '';
-
-        pathGlob = mkListStr [ ] ''
-          Files whose full path match these glob patterns will be ignored.
-        '';
-      };
     };
+    ignore = {
+      nameExact =
+        mkListStr
+          [
+            ".DS_Store"
+            ".directory"
+            "thumbs.db"
+            ".git"
+          ]
+          ''
+            Files whose name match these exactly will be ignored.
+          '';
 
+      nameGlob = mkListStr [ ] ''
+        Files whose name match these glob patterns will be ignored.
+        ie. `*.py` will match all python files
+      '';
+
+      pathGlob = mkListStr [ ] ''
+        Files whose full path match these glob patterns will be ignored.
+      '';
+    };
     view = {
       openDirection =
         helpers.defaultNullOpts.mkEnum
@@ -423,11 +421,11 @@ in
           inherit session;
           show_hidden = showHidden;
           version_control = versionControl;
-          ignore = with ignore; {
-            name_exact = nameExact;
-            name_glob = nameGlob;
-            path_glob = pathGlob;
-          };
+        };
+        ignore = with cfg.ignore; {
+          name_exact = nameExact;
+          name_glob = nameGlob;
+          path_glob = pathGlob;
         };
         view = with view; {
           open_direction = openDirection;

--- a/tests/test-sources/plugins/by-name/chadtree/default.nix
+++ b/tests/test-sources/plugins/by-name/chadtree/default.nix
@@ -25,16 +25,16 @@
           session = true;
           showHidden = false;
           versionControl = true;
-          ignore = {
-            nameExact = [
-              ".DS_Store"
-              ".directory"
-              "thumbs.db"
-              ".git"
-            ];
-            nameGlob = [ ];
-            pathGlob = [ ];
-          };
+        };
+        ignore = {
+          nameExact = [
+            ".DS_Store"
+            ".directory"
+            "thumbs.db"
+            ".git"
+          ];
+          nameGlob = [ ];
+          pathGlob = [ ];
         };
         view = {
           openDirection = "left";


### PR DESCRIPTION
I tried to modify the ignore settings for chadtree but it has been misplaced in `options.ignore`. The proper place is outside of `options` (https://github.com/ms-jpq/chadtree/blob/chad/docs/CONFIGURATION.md#chadtree_settingsignore)

To check that it is actually broken, you can add the following to your `nixvim` configuration. That should build, but chadtree throws an error when we start neovim.

```nix
  plugins.chadtree = {
    enable = true;
    ignore = {
      nameExact = [ "__pycache__" ".git" ];
    };
  };
```