### PR TITLE
plugins/lsp/packages: make ansiblels unpackaged

### DIFF
--- a/plugins/lsp/lsp-packages.nix
+++ b/plugins/lsp/lsp-packages.nix
@@ -5,6 +5,7 @@
     "alloy_ls"
     "anakin_language_server"
     "antlersls"
+    "ansiblels"
     "apex_ls"
     "autohotkey_lsp"
     "awk_ls"
@@ -186,7 +187,6 @@
     aiken = "aiken";
     air = "air-formatter";
     angularls = "angular-language-server";
-    ansiblels = "ansible-language-server";
     arduino_language_server = "arduino-language-server";
     asm_lsp = "asm-lsp";
     ast_grep = "ast-grep";


### PR DESCRIPTION
[ansible-language-server](https://github.com/NixOS/nixpkgs/pull/445884) was removed upstream.
Despite not using this language server, the absence of the package upstream was preventing my configuration from building.
I imagine most configurations would be broken by this once it hits nixpkgs-unstable.
I have moved this into the class of unpackaged LSPs. This allows users to package this server themselves if they wish.
For those wanting to keep their configurations with ansiblels working for the time being, I was able to build but not test (I don't use ansible) using the following:

```
          lsp.servers.ansiblels = {
            enable = true;
            package = pkgs.buildNpmPackage rec {

              pname = "ansible-language-server";
              version = "1.2.1";

              src = pkgs.fetchFromGitHub {
                owner = "ansible";
                repo = "ansible-language-server";
                tag = "v${version}";
                hash = "sha256-e6cOWoryOxWnl8q62rlGmSgwLVnoxLMwNFoGlUZw2bQ=";
              };

              npmDepsHash = "sha256-Lzwj0/2fxa44DJBsgDPa43AbRxggqh881X/DFnlNLig=";
              npmBuildScript = "compile";

              postPatch = ''
                sed -i '/"prepare"/d' package.json
                sed -i '/"prepack"/d' package.json
              '';

              npmPackFlags = [ "--ignore-scripts" ];
            };
          };
```