### PR TITLE
envrc: nix-direnv 2.3.0 → 3.1.0; update watch_file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
-if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
 
 watch_file flake/**/*


### PR DESCRIPTION
- **envrc: update watch_file**

The `flake-modules` directory was renamed to `flake` in https://github.com/nix-community/nixvim/pull/2860 (2025-01-19)

- **envrc: nix-direnv 2.3.0 → 3.1.0**

Update to the latest version. Not all tags have release notes, but some are available at <https://github.com/nix-community/nix-direnv/releases>

The full diff is <https://github.com/nix-community/nix-direnv/compare/2.3.0...3.1.0>
