### PR TITLE
plugins/haskell-tools: init

### DIFF
--- a/plugins/by-name/haskell-tools/default.nix
+++ b/plugins/by-name/haskell-tools/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "haskell-tools";
+  package = "haskell-tools-nvim";
+  maintainers = [ lib.maintainers.saygo-png ];
+
+  # This is a filetype plugin that doesn't use a setup function.
+  # Configuration is passed to a global table.
+  callSetup = false;
+
+  extraOptions = {
+    enableTelescope = lib.mkEnableOption "telescope integration";
+    hlsPackage = lib.mkPackageOption pkgs "haskell-language-server" {
+      nullable = true;
+    };
+  };
+
+  settingsExample = {
+    hls = {
+      default_settings = {
+        haskell = {
+          formattingProvider = "ormolu";
+          plugin = {
+            hlint = {
+              codeActionsOn = false;
+              diagnosticsOn = false;
+            };
+            importLens = {
+              globalOn = false;
+              codeActionsOn = false;
+              codeLensOn = false;
+            };
+          };
+        };
+      };
+    };
+  };
+
+  extraConfig = cfg: {
+    globals.haskell_tools = cfg.settings;
+    extraPackages = [ cfg.hlsPackage ];
+
+    plugins.telescope.enabledExtensions = lib.mkIf cfg.enableTelescope [ "ht" ];
+    assertions = lib.nixvim.mkAssertions "plugins.haskell-tools" {
+      assertion = cfg.enableTelescope -> config.plugins.telescope.enable;
+      message = "The haskell-tools telescope integration needs telescope to function as intended.";
+    };
+
+    warnings = lib.nixvim.mkWarnings "plugins.haskell-tools" [
+      {
+        when = config.lsp.servers.hls.enable || config.plugins.lsp.servers.hls.enable;
+        message = ''
+          It is recommended to disable hls when using haskell-tools
+          as it can cause conflicts. The plugin sets up the server already.
+        '';
+      }
+    ];
+  };
+}

--- a/tests/test-sources/plugins/by-name/haskell-tools/default.nix
+++ b/tests/test-sources/plugins/by-name/haskell-tools/default.nix
@@ -1,0 +1,277 @@
+{
+  empty = {
+    plugins.haskell-tools.enable = true;
+  };
+
+  example = {
+    plugins = {
+      haskell-tools = {
+        enable = true;
+        settings = {
+          hls.default_settings.haskell = {
+            formattingProvider = "ormolu";
+            plugin = {
+              hlint = {
+                codeActionsOn = false;
+                diagnosticsOn = false;
+              };
+              importLens = {
+                globalOn = false;
+                codeActionsOn = false;
+                codeLensOn = false;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  defaults = {
+    plugins.haskell-tools = {
+      enable = true;
+      settings = {
+        tools = {
+          codeLens = {
+            autoRefresh = true;
+          };
+          hoogle = {
+            mode = "auto";
+          };
+          hover = {
+            enable = true;
+            border = [
+              [
+                "╭"
+                "FloatBorder"
+              ]
+              [
+                "─"
+                "FloatBorder"
+              ]
+              [
+                "╮"
+                "FloatBorder"
+              ]
+              [
+                "│"
+                "FloatBorder"
+              ]
+              [
+                "╯"
+                "FloatBorder"
+              ]
+              [
+                "─"
+                "FloatBorder"
+              ]
+              [
+                "╰"
+                "FloatBorder"
+              ]
+              [
+                "│"
+                "FloatBorder"
+              ]
+            ];
+            stylize_markdown = false;
+            auto_focus = false;
+          };
+          definition = {
+            hoogle_signature_fallback = false;
+          };
+          repl = {
+            handler = "builtin";
+            prefer.__raw = ''
+              function()
+                return vim.fn.executable("stack") == 1 and "stack" or "cabal"
+              end
+            '';
+            builtin = {
+              create_repl_window.__raw = ''
+                function(view)
+                  return view.create_repl_split { size = vim.o.lines / 3 }
+                end
+              '';
+            };
+            auto_focus.__raw = "nil";
+          };
+          tags = {
+            enable.__raw = ''
+              function()
+                return vim.fn.executable('fast-tags') == 1
+              end
+            '';
+            package_events = [ "BufWritePost" ];
+          };
+          log = {
+            logfile.__raw = "vim.fs.joinpath(vim.fn.stdpath('log'), 'haskell-tools.log')";
+            level.__raw = "vim.log.levels.WARN";
+          };
+          open_url.__raw = ''
+            function(url)
+              require("haskell-tools.os").open_browser(url)
+            end
+          '';
+        };
+
+        hls = {
+          auto_attach.__raw = ''
+            function()
+              local Types = require("haskell-tools.types.internal")
+              local cmd = Types.evaluate(HTConfig.hls.cmd)
+              local hls_bin = cmd[1]
+              return vim.fn.executable(hls_bin) == 1
+            end
+          '';
+          debug = false;
+          on_attach.__raw = "function(_, _, _) end";
+          cmd.__raw = ''
+            function()
+              local hls_bin = "haskell-language-server"
+              local hls_wrapper_bin = hls_bin .. "-wrapper"
+              local bin = vim.fn.executable(hls_wrapper_bin) == 1 and hls_wrapper_bin or hls_bin
+              local cmd = { bin, "--lsp", "--logfile", HTConfig.hls.logfile }
+              if HTConfig.hls.debug then
+                table.insert(cmd, "--debug")
+              end
+              return cmd
+            end
+          '';
+          capabilities.__raw = "vim.lsp.protocol.make_client_capabilities()";
+          settings.__raw = ''
+            function(project_root)
+              local ht = require("haskell-tools")
+              return ht.lsp.load_hls_settings(project_root)
+            end
+          '';
+          default_settings = {
+            haskell = {
+              formattingProvider = "fourmolu";
+              maxCompletions = 40;
+              checkProject = true;
+              checkParents = "CheckOnSave";
+              plugin = {
+                alternateNumberFormat = {
+                  globalOn = true;
+                };
+                callHierarchy = {
+                  globalOn = true;
+                };
+                changeTypeSignature = {
+                  globalOn = true;
+                };
+                class = {
+                  codeActionsOn = true;
+                  codeLensOn = true;
+                };
+                eval = {
+                  globalOn = true;
+                  config = {
+                    diff = true;
+                    exception = true;
+                  };
+                };
+                explicitFixity = {
+                  globalOn = true;
+                };
+                gadt = {
+                  globalOn = true;
+                };
+                "ghcide-code-actions-bindings" = {
+                  globalOn = true;
+                };
+                "ghcide-code-actions-fill-holes" = {
+                  globalOn = true;
+                };
+                "ghcide-code-actions-imports-exports" = {
+                  globalOn = true;
+                };
+                "ghcide-code-actions-type-signatures" = {
+                  globalOn = true;
+                };
+                "ghcide-completions" = {
+                  globalOn = true;
+                  config = {
+                    autoExtendOn = true;
+                    snippetsOn = true;
+                  };
+                };
+                "ghcide-hover-and-symbols" = {
+                  hoverOn = true;
+                  symbolsOn = true;
+                };
+                "ghcide-type-lenses" = {
+                  globalOn = true;
+                  config = {
+                    mode = "always";
+                  };
+                };
+                haddockComments = {
+                  globalOn = true;
+                };
+                hlint = {
+                  codeActionsOn = true;
+                  diagnosticsOn = true;
+                };
+                importLens = {
+                  globalOn = true;
+                  codeActionsOn = true;
+                  codeLensOn = true;
+                };
+                moduleName = {
+                  globalOn = true;
+                };
+                pragmas = {
+                  codeActionsOn = true;
+                  completionOn = true;
+                };
+                qualifyImportedNames = {
+                  globalOn = true;
+                };
+                refineImports = {
+                  codeActionsOn = true;
+                  codeLensOn = true;
+                };
+                rename = {
+                  globalOn = true;
+                  config = {
+                    crossModule = true;
+                  };
+                };
+                retrie = {
+                  globalOn = true;
+                };
+                splice = {
+                  globalOn = true;
+                };
+                tactics = {
+                  codeActionsOn = true;
+                  codeLensOn = true;
+                  config = {
+                    auto_gas = 4;
+                    hole_severity.__raw = "nil";
+                    max_use_ctor_actions = 5;
+                    proofstate_styling = true;
+                    timeout_duration = 2;
+                  };
+                  hoverOn = true;
+                };
+              };
+            };
+          };
+          logfile.__raw = ''vim.fn.tempname() .. "-haskell-language-server.log"'';
+        };
+        dap = {
+          cmd = [ "haskell-debug-adapter" ];
+          logFile.__raw = ''vim.fn.stdpath("data") .. "/haskell-dap.log"'';
+          logLevel = "Warning";
+          auto_discover = true;
+        };
+        debug_info = {
+          was_g_haskell_tools_sourced.__raw = "vim.g.haskell_tools ~= nil";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
https://github.com/MrcJkb/haskell-tools.nvim

closes https://github.com/nix-community/nixvim/issues/2813

This plugin is complicated — it hooks up to a lot of different tools. This PR does not add integrations for them beyond Telescope. I'd certainly want to add one for `iron-nvim` too. I think it will be easier to do that incrementally though. Later i'll play around with local Hoogle installations and see if there is anything we can add on the Nixvim side to make the setup easier.

Lazyloading with Telescope integration is broken, but that's a problem with our telescope module not accounting for lazyloading and loading every extension at one point. This plugin is lazy by design so there is no real need to lazyload it manually.