### PR TITLE
flake: add nixf-diagnose to treefmt config

### DIFF
--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -8,7 +8,6 @@
     {
       pkgs,
       config,
-      self',
       system,
       ...
     }:

--- a/flake/dev/fmt.nix
+++ b/flake/dev/fmt.nix
@@ -5,7 +5,7 @@
   ];
 
   perSystem =
-    { config, pkgs, ... }:
+    { pkgs, ... }:
     {
       treefmt.config = {
         projectRootFile = "flake.nix";
@@ -15,6 +15,10 @@
           # keep-sorted start block=yes newline_separated=no
           isort.enable = true;
           keep-sorted.enable = true;
+          nixf-diagnose = {
+            enable = true;
+            priority = -1;
+          };
           nixfmt = {
             enable = true;
             package = pkgs.nixfmt-rfc-style;
@@ -30,6 +34,7 @@
           shfmt.enable = true;
           statix = {
             enable = true;
+            priority = -2;
             disabled-lints = [
               # We often use `nullable == true`
               "bool_comparison"
@@ -58,6 +63,14 @@
             "docs/gfm-alerts-to-admonitions/tests/**/*.yml"
           ];
           formatter.ruff-format.options = [ "--isolated" ];
+          formatter.nixf-diagnose.options = [
+            "--auto-fix"
+            "--ignore=sema-unused-def-lambda-witharg-formal"
+          ];
+          formatter.nixf-diagnose.excludes = [
+            # sema-unused-def-lambda-noarg-formal
+            "ci/rust-analyzer/default.nix"
+          ];
         };
       };
 

--- a/flake/overlays.nix
+++ b/flake/overlays.nix
@@ -2,12 +2,7 @@
 {
   imports = [ inputs.flake-parts.flakeModules.easyOverlay ];
   perSystem =
-    {
-      config,
-      pkgs,
-      final,
-      ...
-    }:
+    { config, ... }:
     {
       overlayAttrs = {
         nixvim = {

--- a/flake/wrappers.nix
+++ b/flake/wrappers.nix
@@ -5,7 +5,7 @@
 }:
 {
   perSystem =
-    { system, pkgs, ... }:
+    { system, ... }:
     {
       _module.args = {
         makeNixvimWithModule = import ../wrappers/standalone.nix {

--- a/modules/highlights.nix
+++ b/modules/highlights.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  helpers,
-  config,
-  ...
-}:
+{ lib, config, ... }:
 {
   options = {
     highlight = lib.mkOption {

--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -1,9 +1,4 @@
-{
-  config,
-  lib,
-  options,
-  ...
-}:
+{ config, lib, ... }:
 with lib;
 let
   inherit (lib.nixvim)

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  options,
-  config,
-  ...
-}:
+{ lib, config, ... }:
 let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts mkSettingsRenamedOptionModules;

--- a/plugins/by-name/commentary/default.nix
+++ b/plugins/by-name/commentary/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "commentary";
   package = "vim-commentary";

--- a/plugins/by-name/copilot-lua/default.nix
+++ b/plugins/by-name/copilot-lua/default.nix
@@ -1,9 +1,4 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ config, lib, ... }:
 let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;

--- a/plugins/by-name/coq-thirdparty/default.nix
+++ b/plugins/by-name/coq-thirdparty/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  helpers,
   config,
   pkgs,
   ...

--- a/plugins/by-name/diffview/default.nix
+++ b/plugins/by-name/diffview/default.nix
@@ -3,7 +3,6 @@
   helpers,
   config,
   pkgs,
-  options,
   ...
 }:
 with lib;

--- a/plugins/by-name/endwise/default.nix
+++ b/plugins/by-name/endwise/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "endwise";
   package = "vim-endwise";

--- a/plugins/by-name/firenvim/default.nix
+++ b/plugins/by-name/firenvim/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  config,
-  options,
-  ...
-}:
+{ lib, config, ... }:
 let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;

--- a/plugins/by-name/headlines/default.nix
+++ b/plugins/by-name/headlines/default.nix
@@ -1,16 +1,10 @@
-{
-  lib,
-  helpers,
-  config,
-  ...
-}:
-with lib;
+{ lib, config, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "headlines";
   package = "headlines-nvim";
   description = "A plugin that adds horizontal highlights for text filetypes, like markdown, orgmode, and neorg.";
 
-  maintainers = [ maintainers.GaetanLepage ];
+  maintainers = [ lib.maintainers.GaetanLepage ];
 
   settingsExample = {
     org.headline_highlights = false;

--- a/plugins/by-name/helm/default.nix
+++ b/plugins/by-name/helm/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "helm";
   package = "vim-helm";

--- a/plugins/by-name/hunk/default.nix
+++ b/plugins/by-name/hunk/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  helpers,
-  config,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "hunk";
   package = "hunk-nvim";

--- a/plugins/by-name/idris2/default.nix
+++ b/plugins/by-name/idris2/default.nix
@@ -1,8 +1,4 @@
-{
-  helpers,
-  lib,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "idris2";
   package = "idris2-nvim";

--- a/plugins/by-name/lsp-lines/default.nix
+++ b/plugins/by-name/lsp-lines/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 with lib;
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "lsp-lines";

--- a/plugins/by-name/lualine/default.nix
+++ b/plugins/by-name/lualine/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts mkSettingsRenamedOptionModules;
   inherit (lib) types;

--- a/plugins/by-name/nix/default.nix
+++ b/plugins/by-name/nix/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "nix";
   package = "vim-nix";

--- a/plugins/by-name/preview/default.nix
+++ b/plugins/by-name/preview/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "preview";
   package = "Preview-nvim";
@@ -11,5 +6,5 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   hasSettings = false;
 
-  maintainers = [ maintainers.GaetanLepage ];
+  maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/rest/default.nix
+++ b/plugins/by-name/rest/default.nix
@@ -1,9 +1,4 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ config, lib, ... }:
 let
   inherit (lib) mkRemovedOptionModule types;
   inherit (lib.nixvim) defaultNullOpts;

--- a/plugins/by-name/rustaceanvim/default.nix
+++ b/plugins/by-name/rustaceanvim/default.nix
@@ -2,7 +2,6 @@
   lib,
   helpers,
   config,
-  pkgs,
   ...
 }:
 with lib;
@@ -26,7 +25,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     })
   ];
 
-  settingsOptions = import ./settings-options.nix { inherit lib helpers pkgs; };
+  settingsOptions = import ./settings-options.nix { inherit lib helpers; };
 
   settingsExample = {
     server = {

--- a/plugins/by-name/rustaceanvim/settings-options.nix
+++ b/plugins/by-name/rustaceanvim/settings-options.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  pkgs,
-}:
+{ lib, helpers }:
 with lib;
 {
   tools =

--- a/plugins/by-name/smart-splits/default.nix
+++ b/plugins/by-name/smart-splits/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "smart-splits";
   package = "smart-splits-nvim";

--- a/plugins/by-name/timerly/default.nix
+++ b/plugins/by-name/timerly/default.nix
@@ -1,9 +1,4 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "timerly";
   package = "timerly";

--- a/plugins/by-name/treesitter-refactor/default.nix
+++ b/plugins/by-name/treesitter-refactor/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  helpers,
   config,
   pkgs,
   ...

--- a/plugins/by-name/undotree/default.nix
+++ b/plugins/by-name/undotree/default.nix
@@ -1,11 +1,6 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 with lib;
-with lib.nixvim.plugins;
-mkVimPlugin {
+lib.nixvim.plugins.mkVimPlugin {
   name = "undotree";
   globalPrefix = "undotree_";
   description = "The undo history visualizer for Vim.";

--- a/plugins/by-name/vim-be-good/default.nix
+++ b/plugins/by-name/vim-be-good/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "vim-be-good";
   package = "vim-be-good";

--- a/plugins/by-name/vim-surround/default.nix
+++ b/plugins/by-name/vim-surround/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  helpers,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "vim-surround";
   package = "vim-surround";

--- a/plugins/by-name/vimtex/default.nix
+++ b/plugins/by-name/vimtex/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  helpers,
-  pkgs,
-  ...
-}:
+{ lib, pkgs, ... }:
 with lib;
 lib.nixvim.plugins.mkVimPlugin {
   name = "vimtex";

--- a/plugins/by-name/wakatime/default.nix
+++ b/plugins/by-name/wakatime/default.nix
@@ -1,13 +1,8 @@
-{
-  lib,
-  helpers,
-  ...
-}:
-with lib;
+{ lib, ... }:
 lib.nixvim.plugins.mkVimPlugin {
   name = "wakatime";
   package = "vim-wakatime";
   description = "Vim plugin for WakaTime, a time tracking service for developers.";
 
-  maintainers = [ maintainers.GaetanLepage ];
+  maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/plugins/by-name/yaml-schema-detect/default.nix
+++ b/plugins/by-name/yaml-schema-detect/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  config,
-  options,
-  ...
-}:
+{ lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "yaml-schema-detect";
   package = "yaml-schema-detect-nvim";

--- a/plugins/cmp/sources/default.nix
+++ b/plugins/cmp/sources/default.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  helpers,
-  pkgs,
-  ...
-}@args:
+{ lib, pkgs, ... }:
 let
 
   # A list of most cmp source plugins, passed to mkCmpSourcePlugin.
@@ -183,7 +178,9 @@ let
     }
   ];
 
-  mkCmpSourcePlugin = import ./_mk-cmp-plugin.nix args;
+  mkCmpSourcePlugin = import ./_mk-cmp-plugin.nix {
+    inherit lib pkgs;
+  };
   pluginModules = builtins.map mkCmpSourcePlugin sources;
 in
 {

--- a/tests/extra-args.nix
+++ b/tests/extra-args.nix
@@ -12,7 +12,7 @@ let
     };
   generated = makeNixvimWithModule {
     module =
-      { regularArg, extraModule, ... }:
+      { extraModule, ... }:
       {
         _module.args = {
           regularArg = "regularValue";

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -4,8 +4,6 @@
   lib ? pkgs.lib,
   linkFarm,
   pkgs,
-  self,
-  system,
   pkgsForTest,
 }:
 let

--- a/tests/test-sources/modules/dependencies.nix
+++ b/tests/test-sources/modules/dependencies.nix
@@ -27,12 +27,7 @@ in
     };
 
   all =
-    {
-      lib,
-      pkgs,
-      options,
-      ...
-    }:
+    { lib, options, ... }:
     let
       enableDep = depName: depOption: {
         enable = isDepEnabled depName depOption.package.default;

--- a/tests/test-sources/plugins/pluginmanagers/lz-n.nix
+++ b/tests/test-sources/plugins/pluginmanagers/lz-n.nix
@@ -64,7 +64,7 @@ in
     };
 
   example-multiple-plugin =
-    { pkgs, lib, ... }:
+    { pkgs, ... }:
     {
       extraPlugins =
         with pkgs.vimPlugins;


### PR DESCRIPTION
Checks nixd's diagnostic lints using libnixf.

We already have statix, but nixd (libnixf) has some additional linting rules that are worth checking too.

Inspired by https://github.com/NixOS/nixpkgs/pull/438559
