### PR TITLE
modules/lsp: test lsp keymaps & cleanup lua table

### DIFF
--- a/modules/lsp/keymaps.nix
+++ b/modules/lsp/keymaps.nix
@@ -104,7 +104,12 @@ in
         group = "nixvim_lsp_binds";
         callback = lib.nixvim.mkRaw ''
           function(args)
-            local __keymaps = ${lib.nixvim.toLuaObject cfg.keymaps}
+            local __keymaps = ${
+              lib.nixvim.lua.toLua' {
+                multiline = true;
+                indent = "  ";
+              } cfg.keymaps
+            }
 
             for _, keymap in ipairs(__keymaps) do
               local options = vim.tbl_extend(

--- a/modules/lsp/keymaps.nix
+++ b/modules/lsp/keymaps.nix
@@ -105,10 +105,20 @@ in
         callback = lib.nixvim.mkRaw ''
           function(args)
             local __keymaps = ${
-              lib.nixvim.lua.toLua' {
-                multiline = true;
-                indent = "  ";
-              } cfg.keymaps
+              lib.pipe cfg.keymaps [
+                (map (keymap: {
+                  inherit (keymap)
+                    mode
+                    key
+                    action
+                    options
+                    ;
+                }))
+                (lib.nixvim.lua.toLua' {
+                  multiline = true;
+                  indent = "  ";
+                })
+              ]
             }
 
             for _, keymap in ipairs(__keymaps) do

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -29,6 +29,123 @@
     };
   };
 
+  keymaps =
+    {
+      lib,
+      pkgs,
+      config,
+      ...
+    }:
+    let
+      autoCmds = config.autoCmd;
+      autoCmd = builtins.head autoCmds;
+
+      print = lib.generators.toPretty { };
+      expect = name: expected: actual: {
+        assertion = expected == actual;
+        message = "Expected ${name} to be ${print expected}, but found ${print actual}";
+      };
+    in
+    {
+      lsp.keymaps = [
+        {
+          key = "gd";
+          lspBufAction = "definition";
+        }
+        {
+          key = "K";
+          lspBufAction = "hover";
+        }
+        {
+          key = "<leader>k";
+          action = lib.nixvim.mkRaw "function() vim.diagnostic.jump({ count=-1, float=true }) end";
+        }
+        {
+          key = "<leader>j";
+          action = lib.nixvim.mkRaw "function() vim.diagnostic.jump({ count=1, float=true }) end";
+        }
+        {
+          key = "<leader>lx";
+          action = "<CMD>LspStop<Enter>";
+        }
+      ];
+
+      assertions = [
+        (expect "number of autocmds" 1 (builtins.length autoCmds))
+        (expect "event" "LspAttach" autoCmd.event)
+        (expect "group" "nixvim_lsp_binds" autoCmd.group)
+      ];
+
+      test.extraInputs = [
+        (pkgs.testers.testEqualContents {
+          assertion = "lsp keymaps autocmd callback";
+          actual = pkgs.writeText "actual.lua" (autoCmd.callback.__raw or "");
+          expected = pkgs.writeText "expected.lua" ''
+            function(args)
+              local __keymaps = { { action = vim.lsp.buf["definition"], key = "gd", lspBufAction = "definition", mode = "" }, { action = vim.lsp.buf["hover"], key = "K", lspBufAction = "hover", mode = "" }, { action = function() vim.diagnostic.jump({ count=-1, float=true }) end, key = "<leader>k", mode = "" }, { action = function() vim.diagnostic.jump({ count=1, float=true }) end, key = "<leader>j", mode = "" }, { action = "<CMD>LspStop<Enter>", key = "<leader>lx", mode = "" } }
+
+              for _, keymap in ipairs(__keymaps) do
+                local options = vim.tbl_extend(
+                  "keep",
+                  keymap.options or {},
+                  { buffer = args.buf }
+                )
+                vim.keymap.set(keymap.mode, keymap.key, keymap.action, options)
+              end
+            end
+          '';
+        })
+      ];
+
+      # Test that keymaps are registered after LspAttach
+      extraConfigLuaPost = ''
+        -- Assert keymaps not registered
+        local keymaps_pre_attach = vim.api.nvim_buf_get_keymap(0, "")
+        if not vim.tbl_isempty(keymaps_pre_attach) then
+          print("Unexpected keymaps registered before LspAttach:")
+          vim.print(keymaps_pre_attach)
+        end
+
+        -- Trigger the LspAttach autocmd
+        vim.api.nvim_exec_autocmds("LspAttach", {
+          group = "nixvim_lsp_binds",
+          buffer = 0,
+          modeline = false,
+          data = {
+            client_id = "stub_id",
+          },
+        })
+
+        -- Assert keymaps are registered
+        local keymaps_post_attach = vim.api.nvim_buf_get_keymap(0, "")
+
+        local keymaps_post_attach_len = vim.tbl_count(keymaps_post_attach)
+        if keymaps_post_attach_len ~= 5 then
+          print("Expected 5 keymaps to be registered after LspAttach, but found", keymaps_post_attach_len)
+          vim.print(keymaps_post_attach)
+        end
+
+        for _, expected in
+          ipairs({
+            "gd",
+            "K",
+            "\\k",
+            "\\j",
+            "\\lx",
+          })
+        do
+          local has_keymap = vim.tbl_contains(
+            keymaps_post_attach,
+            function(keymap) return keymap.lhsraw == expected end,
+            { predicate = true }
+          )
+          if not has_keymap then
+            print("keymap", expected, "was not registered")
+          end
+        end
+      '';
+    };
+
   package-fallback =
     { lib, config, ... }:
     {

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -86,13 +86,11 @@
                 {
                   action = vim.lsp.buf["definition"],
                   key = "gd",
-                  lspBufAction = "definition",
                   mode = ""
                 },
                 {
                   action = vim.lsp.buf["hover"],
                   key = "K",
-                  lspBufAction = "hover",
                   mode = ""
                 },
                 {

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -82,7 +82,35 @@
           actual = pkgs.writeText "actual.lua" (autoCmd.callback.__raw or "");
           expected = pkgs.writeText "expected.lua" ''
             function(args)
-              local __keymaps = { { action = vim.lsp.buf["definition"], key = "gd", lspBufAction = "definition", mode = "" }, { action = vim.lsp.buf["hover"], key = "K", lspBufAction = "hover", mode = "" }, { action = function() vim.diagnostic.jump({ count=-1, float=true }) end, key = "<leader>k", mode = "" }, { action = function() vim.diagnostic.jump({ count=1, float=true }) end, key = "<leader>j", mode = "" }, { action = "<CMD>LspStop<Enter>", key = "<leader>lx", mode = "" } }
+              local __keymaps = {
+                {
+                  action = vim.lsp.buf["definition"],
+                  key = "gd",
+                  lspBufAction = "definition",
+                  mode = ""
+                },
+                {
+                  action = vim.lsp.buf["hover"],
+                  key = "K",
+                  lspBufAction = "hover",
+                  mode = ""
+                },
+                {
+                  action = function() vim.diagnostic.jump({ count=-1, float=true }) end,
+                  key = "<leader>k",
+                  mode = ""
+                },
+                {
+                  action = function() vim.diagnostic.jump({ count=1, float=true }) end,
+                  key = "<leader>j",
+                  mode = ""
+                },
+                {
+                  action = "<CMD>LspStop<Enter>",
+                  key = "<leader>lx",
+                  mode = ""
+                }
+              }
 
               for _, keymap in ipairs(__keymaps) do
                 local options = vim.tbl_extend(


### PR DESCRIPTION
- **modules/test: add `extraInputs` option**
- **tests/modules/lsp: test lsp keymaps**
- **modules/lsp: print keymaps table multiline**
- **modules/lsp: select relevant fields in keymaps table**

Follow up to #3737, this PR adds a test to assert the expected autoCmd is created for LSP keymaps. Follow-up commits then tweak the output to be more readable by printing a multiline table and omitting irrelevant fields.

My nvim knowledge is too weak to come up with a way to verify the lua code at runtime, which would be nice for catching syntax errors. The issue is the lua code only runs when the `LspAttach` autocmd event is triggered, and I don't know how to do that in our headless test environment. For now, I just set `test.runNvim = false`, but any ideas for a better solution would be great. EDIT: [done](https://github.com/nix-community/nixvim/compare/e2e2b3f1825600bc4acf41200ebbbcd7a8d8cc78..68b63ac2694d2fd91cc763d5062abea473c0613a).
