### PR TITLE
plugins/rainbow-delimiters: migrate to mkNeovimPlugin

### DIFF
--- a/plugins/by-name/rainbow-delimiters/deprecations.nix
+++ b/plugins/by-name/rainbow-delimiters/deprecations.nix
@@ -1,0 +1,40 @@
+lib:
+let
+  inherit (lib) mapAttrs' nameValuePair;
+  inherit (lib.nixvim) ifNonNull';
+  basePathAnd = lib.concat [
+    "plugins"
+    "rainbow-delimiters"
+  ];
+in
+{
+  deprecateExtraOptions = true;
+
+  optionsRenamedToSettings = map (lib.splitString ".") [
+    "highlight"
+    "whitelist"
+    "blacklist"
+    "log.file"
+    "log.level"
+  ];
+
+  imports = [
+    (
+      let
+        oldOptPath = basePathAnd [ "query" ];
+      in
+      lib.mkChangedOptionModule oldOptPath
+        (basePathAnd [
+          "settings"
+          "query"
+        ])
+        (
+          config:
+          let
+            old = lib.getAttrFromPath oldOptPath config;
+          in
+          ifNonNull' old (mapAttrs' (n: nameValuePair (if n == "default" then "" else n)) old)
+        )
+    )
+  ];
+}

--- a/tests/test-sources/plugins/by-name/rainbow-delimiters/default.nix
+++ b/tests/test-sources/plugins/by-name/rainbow-delimiters/default.nix
@@ -11,58 +11,56 @@
       treesitter.enable = true;
       rainbow-delimiters = {
         enable = true;
-
-        strategy = {
-          default = "global";
-          html = "local";
-          latex.__raw = ''
-            function()
-              -- Disabled for very large files, global strategy for large files,
-              -- local strategy otherwise
-              if vim.fn.line('$') > 10000 then
-                  return nil
-              elseif vim.fn.line('$') > 1000 then
-                  return rainbow.strategy['global']
-              end
-              return rainbow.strategy['local']
-            end
-          '';
-        };
-        query = {
-          default = "rainbow-delimiters";
-          lua = "rainbow-blocks";
-        };
-        highlight = [
-          "RainbowDelimiterRed"
-          "RainbowDelimiterYellow"
-          "RainbowDelimiterBlue"
-          "RainbowDelimiterOrange"
-          "RainbowDelimiterGreen"
-          "RainbowDelimiterViolet"
-          "RainbowDelimiterCyan"
-        ];
-        blacklist = [
-          "c"
-          "cpp"
-        ];
-        log = {
-          file.__raw = "vim.fn.stdpath('log') .. '/rainbow-delimiters.log'";
-          level = "warn";
+        settings = {
+          settingsExample = {
+            blacklist = [ "json" ];
+            strategy = {
+              "".__raw = "require 'rainbow-delimiters'.strategy['global']";
+              "nix".__raw = "require 'rainbow-delimiters'.strategy['local']";
+            };
+            highlight = [
+              "RainbowDelimiterViolet"
+              "RainbowDelimiterBlue"
+              "RainbowDelimiterGreen"
+            ];
+          };
         };
       };
     };
   };
 
-  example-whitelist = {
+  defaults = {
     plugins = {
       treesitter.enable = true;
       rainbow-delimiters = {
         enable = true;
+        settings = {
+          query = {
+            "" = "rainbow-delimiters";
+            javascript = "rainbow-delimiters-react";
+          };
+          strategy = {
+            "".__raw = "require 'rainbow-delimiters'.strategy['global']";
+          };
+          priority = {
+            "".__raw =
+              "math.floor(((vim.hl or vim.highlight).priorities.semantic_tokens + (vim.hl or vim.highlight).priorities.treesitter) / 2)";
+          };
+          log = {
+            level.__raw = "vim.log.levels.WARN";
+            file.__raw = "vim.fn.stdpath('log') .. '/rainbow-delimiters.log'";
+          };
+          highlight = [
+            "RainbowDelimiterRed"
+            "RainbowDelimiterYellow"
+            "RainbowDelimiterBlue"
+            "RainbowDelimiterOrange"
+            "RainbowDelimiterGreen"
+            "RainbowDelimiterViolet"
+            "RainbowDelimiterCyan"
+          ];
 
-        whitelist = [
-          "c"
-          "cpp"
-        ];
+        };
       };
     };
   };


### PR DESCRIPTION
tracking: https://github.com/nix-community/nixvim/issues/2638

Things of note:

I'm deprecating "default" for `""` as i think that was a hack for us not converting "" to proper lua.
Sadly i'm not sure how I can shove this deprecation into `deprecations.nix`

Keeping the old strategies option overall because I think it's nice to make users not write Lua for that.

Users can define both `strategies` and `settings.strategies` which leads to mkMerge errors. I think that's okay and is clear enough to the user.