### PR TITLE
plugins.lsp: automatically remove unsupported servers

### DIFF
--- a/ci/generate.nix
+++ b/ci/generate.nix
@@ -51,6 +51,7 @@ writeShellApplication {
 
     generate_json "${conform-formatters}" "conform-formatters"
     generate_json "${lspconfig-servers}" "lspconfig-servers"
+    generate_json "${lspconfig-servers.unsupported}" "unsupported-lspconfig-servers"
 
     if [ -n "$commit" ]; then
       cd "$generated_dir"

--- a/ci/nvim-lspconfig/default.nix
+++ b/ci/nvim-lspconfig/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  callPackage,
   vimPlugins,
   neovimUtils,
   wrapNeovimUnstable,
@@ -31,6 +32,7 @@ runCommand "lspconfig-servers"
       pandoc
       python3
     ];
+    passthru.unsupported = callPackage ./unsupported.nix { };
   }
   ''
     export HOME=$(realpath .)

--- a/ci/nvim-lspconfig/unsupported.nix
+++ b/ci/nvim-lspconfig/unsupported.nix
@@ -1,0 +1,24 @@
+{
+  runCommand,
+  jq,
+  vimPlugins,
+}:
+/**
+  Produces a JSON array of all nvim-lspconfig server configs that don't yet
+  support the new system.
+
+  I.e., files in the old `lua/lspconfig/configs/` directory, that aren't
+  present in the new `lsp/` directory.
+*/
+runCommand "unsupported-lspconfig-servers"
+  {
+    nativeBuildInputs = [ jq ];
+    lspconfig = vimPlugins.nvim-lspconfig;
+  }
+  ''
+    for file in "$lspconfig"/lua/lspconfig/configs/*.lua
+    do
+      name=$(basename --suffix=.lua "$file")
+      [ -f "$lspconfig"/lsp/"$name".lua ] || echo "$name"
+    done | jq --raw-input . | jq --slurp [.] > "$out"
+  ''

--- a/generated/unsupported-lspconfig-servers.json
+++ b/generated/unsupported-lspconfig-servers.json
@@ -1,0 +1,16 @@
+[
+  "bitbake_ls",
+  "bqnlsp",
+  "cadence",
+  "clarity_lsp",
+  "codeqlls",
+  "delphi_ls",
+  "drools_lsp",
+  "haxe_language_server",
+  "openedge_ls",
+  "pkgbuild_language_server",
+  "relay_lsp",
+  "sourcery",
+  "vdmj",
+  "vuels"
+]

--- a/tests/lsp-servers.nix
+++ b/tests/lsp-servers.nix
@@ -1,11 +1,14 @@
 {
+  lib,
   nixvimConfiguration,
   name ? "lsp-all-servers",
 }:
 let
   _file = ./lsp-servers.nix;
 
-  renamed = builtins.attrNames (import ../plugins/lsp/language-servers/_renamed.nix);
+  unsupported =
+    builtins.attrNames (import ../plugins/lsp/language-servers/_renamed.nix)
+    ++ lib.importJSON ../generated/unsupported-lspconfig-servers.json;
 
   enable-lsp-module = {
     inherit _file;
@@ -63,7 +66,7 @@ let
             package = null;
           }
         ))
-        (lib.filterAttrs (server: _: !(lib.elem server renamed)))
+        (lib.filterAttrs (server: _: !(lib.elem server unsupported)))
       ];
 
       # TODO 2025-10-01


### PR DESCRIPTION
In #3733 we refactored `plugins.lsp` to use the new `lsp` module under the hood. This means `plugins.lsp` switched from using nvim-lspconfig's deprecated `require('lspconfig')` API to neovim's new API.

Unfortunately, not _all_ server configs have been migrated to the new API. We can detect this by reading files in the respective _new_ and _old_ directories. If a server config module exists in the old directory but not the new directory, then it only supports the old API. The reverse is also true for servers only in the new directory, but that's a separate issue we will solve in #3748.

A new update script will check which "old" files do not have an equivalent "new" file, then the plugins.lsp module will create a removal assertion for any servers that are listed in the generated file.
