### PR TITLE
plugins/copilot-lua: add copilot-lsp

### DIFF
--- a/plugins/by-name/copilot-lua/default.nix
+++ b/plugins/by-name/copilot-lua/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (lib) types;
   inherit (lib.nixvim) defaultNullOpts;
@@ -170,6 +175,11 @@ lib.nixvim.plugins.mkNeovimPlugin {
         Please disable one of them.
       '';
     };
+
+    extraPlugins = [
+      # Next edit suggestion support
+      pkgs.vimPlugins.copilot-lsp
+    ];
   };
 
   # TODO: introduced 2025-01-07: remove after 25.05


### PR DESCRIPTION
Enables next edit suggestion support. Enabling configuration without plugin will throw an error. Also, will allow sidekick to use copilot-lsp for it's own support. Discovered in https://github.com/nix-community/nixvim/pull/3743#discussion_r2399203655