### PR TITLE
plugins/ethersync: init

### DIFF
--- a/plugins/by-name/ethersync/default.nix
+++ b/plugins/by-name/ethersync/default.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "ethersync";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  callSetup = false;
+  hasSettings = false;
+}

--- a/tests/test-sources/plugins/by-name/ethersync/default.nix
+++ b/tests/test-sources/plugins/by-name/ethersync/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.ethersync.enable = true;
+  };
+}


### PR DESCRIPTION
Add [ethersync-nvim](https://github.com/ethersync/ethersync/tree/main/nvim-plugin), a neovim plugin for  [Ethersync](https://github.com/ethersync/ethersync)-compatible collaborative software.

Closes #3625 