### PR TITLE
plugins/telescope/extensions/fzf-native: remove old renamed warnings

### DIFF
--- a/plugins/by-name/telescope/extensions/fzf-native.nix
+++ b/plugins/by-name/telescope/extensions/fzf-native.nix
@@ -8,14 +8,6 @@ mkExtension {
   extensionName = "fzf";
   package = "telescope-fzf-native-nvim";
 
-  # TODO: introduced 2024-03-24, remove on 2024-05-24
-  optionsRenamedToSettings = [
-    "fuzzy"
-    "overrideGenericSorter"
-    "overrideFileSorter"
-    "caseMode"
-  ];
-
   settingsOptions = {
     fuzzy = defaultNullOpts.mkBool true ''
       Whether to fuzzy search. False will do exact matching.


### PR DESCRIPTION
Fixes #3603 