### PR TITLE
modules/lsp: rename server `settings` -> `cfg`

### DIFF
--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -98,7 +98,7 @@ in
       '';
       default = { };
       example = {
-        "*".settings = {
+        "*".cfg = {
           root_markers = [ ".git" ];
           capabilities.textDocument.semanticTokens = {
             multilineTokenSupport = true;
@@ -107,7 +107,7 @@ in
         lua_ls.enable = true;
         clangd = {
           enable = true;
-          settings = {
+          cfg = {
             cmd = [
               "clangd"
               "--background-index"
@@ -156,16 +156,16 @@ in
             server:
             let
               luaName = toLuaObject server.name;
-              luaSettings = toLuaObject server.settings;
-              wrap = server.__settingsWrapper or lib.id;
+              luaOptions = toLuaObject server.cfg;
+              wrap = server.__configWrapper or lib.id;
             in
             [
-              (lib.mkIf (server.settings != { }) "vim.lsp.config(${luaName}, ${wrap luaSettings})")
+              (lib.mkIf (server.cfg != { }) "vim.lsp.config(${luaName}, ${wrap luaOptions})")
               (lib.mkIf (server.activate or false) "vim.lsp.enable(${luaName})")
             ];
         in
         lib.mkMerge (
-          # Implement the legacy settings wrapping and capabilities mutation when `plugins.lsp` is enabled
+          # Implement the legacy config wrapping and capabilities mutation when `plugins.lsp` is enabled
           lib.optional oldCfg.enable ''
             local __lspCapabilities = function()
               local capabilities = vim.lsp.protocol.make_client_capabilities()
@@ -177,13 +177,13 @@ in
 
             local __setup = ${lib.foldr lib.id "{ capabilities = __lspCapabilities() }" oldCfg.setupWrappers}
 
-            local __wrapSettings = function(settings)
-              if settings == nil then
-                settings = __setup
+            local __wrapConfig = function(cfg)
+              if cfg == nil then
+                cfg = __setup
               else
-                settings = vim.tbl_extend("keep", settings, __setup)
+                cfg = vim.tbl_extend("keep", cfg, __setup)
               end
-              return settings
+              return cfg
             end
           ''
           ++ builtins.concatMap mkServerConfig enabledServers

--- a/modules/lsp/servers/global-server.nix
+++ b/modules/lsp/servers/global-server.nix
@@ -23,7 +23,7 @@ in
       readOnly = true;
     };
 
-    settings = lib.mkOption {
+    cfg = lib.mkOption {
       type = with types; attrsOf anything;
       description = ''
         Default configuration shared by all servers.

--- a/modules/lsp/servers/server-renames.nix
+++ b/modules/lsp/servers/server-renames.nix
@@ -11,11 +11,15 @@
   };
 
   imports = [
-    # TODO: rename added 2025-04-30 (during the 25.05 cycle)
-    # The previous name `config` was introduced 2025-04-28 (during the 25.05 cycle)
-    # Because the previous name `config` never made it into a stable release,
-    # we could consider dropping this alias sooner than normal.
-    (lib.mkRenamedOptionModule [ "config" ] [ "settings" ])
+    # NOTE:
+    # The freeform settings option was originally named `config` when it was
+    # introduced (2025-04-28), it was renamed to `settings` two days later
+    # (2025-04-30), then renamed again to `cfg` after a few months (2025-10-03).
+    #
+    # The original name `config` never made it into a stable release,
+    # so we could consider dropping that alias sooner than normal.
+    (lib.mkRenamedOptionModule [ "config" ] [ "cfg" ])
+    (lib.mkRenamedOptionModule [ "settings" ] [ "cfg" ])
   ];
 
 }

--- a/modules/lsp/servers/server.nix
+++ b/modules/lsp/servers/server.nix
@@ -2,7 +2,7 @@
 {
   name ? "the language server",
   package ? null,
-  settings ? null,
+  cfg ? null,
   pkgs ? { },
 }@args:
 {
@@ -64,14 +64,14 @@ in
       '';
     };
 
-    settings = lib.mkOption {
+    cfg = lib.mkOption {
       type = with types; attrsOf anything;
       description = ''
-        Configurations for ${displayName}. ${settings.extraDescription or ""}
+        Configurations for ${displayName}. ${cfg.extraDescription or ""}
       '';
       default = { };
       example =
-        settings.example or {
+        cfg.example or {
           cmd = [
             "clangd"
             "--background-index"

--- a/plugins/by-name/clangd-extensions/default.nix
+++ b/plugins/by-name/clangd-extensions/default.nix
@@ -85,7 +85,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
     lsp = {
       servers.clangd = {
-        settings = lib.mkIf cfg.enableOffsetEncodingWorkaround {
+        cfg = lib.mkIf cfg.enableOffsetEncodingWorkaround {
           capabilities = {
             offsetEncoding = [ "utf-16" ];
           };

--- a/plugins/by-name/schemastore/default.nix
+++ b/plugins/by-name/schemastore/default.nix
@@ -172,7 +172,7 @@ lib.nixvim.plugins.mkVimPlugin {
     };
 
     lsp.servers = {
-      jsonls.settings.settings = mkIf cfg.json.enable {
+      jsonls.cfg.settings = mkIf cfg.json.enable {
         schemas.__raw = ''
           require('schemastore').json.schemas(${lib.nixvim.toLuaObject cfg.json.settings})
         '';
@@ -182,7 +182,7 @@ lib.nixvim.plugins.mkVimPlugin {
         validate.enable = mkDefault true;
       };
 
-      yamlls.settings.settings = mkIf cfg.yaml.enable {
+      yamlls.cfg.settings = mkIf cfg.yaml.enable {
         schemaStore = {
           # From the README: "You must disable built-in schemaStore support if you want to use
           # this plugin and its advanced options like `ignore`."

--- a/plugins/lsp/language-servers/_mk-lsp.nix
+++ b/plugins/lsp/language-servers/_mk-lsp.nix
@@ -195,8 +195,8 @@ in
     # so define a "longhand" function module.
     lsp.servers.${serverName} = _: {
       # Top-secret internal option that only exists when the server is enabled via the old API.
-      # The new API checks if this attr exists and uses it to wrap the server's settings string.
-      options.__settingsWrapper = lib.mkOption {
+      # The new API checks if this attr exists and uses it to wrap the server's lua cfg string.
+      options.__configWrapper = lib.mkOption {
         type = lib.types.functionTo lib.types.str;
         description = ''
           This internal option exists to preserve the old `plugins.lsp` behaviour.
@@ -217,9 +217,9 @@ in
           lib.modules.mkAliasAndWrapDefsWithPriority lib.id opts.package
         );
         packageFallback = lib.modules.mkAliasAndWrapDefsWithPriority lib.id opts.packageFallback;
-        __settingsWrapper =
-          settings: "__wrapSettings(${lib.foldr lib.id settings config.plugins.lsp.setupWrappers})";
-        settings = {
+        __configWrapper =
+          luaConfig: "__wrapConfig(${lib.foldr lib.id luaConfig config.plugins.lsp.setupWrappers})";
+        cfg = {
           autostart = lib.mkIf (cfg.autostart != null) cfg.autostart;
           cmd = lib.mkIf (cfg.cmd != null) cfg.cmd;
           filetypes = lib.mkIf (cfg.filetypes != null) cfg.filetypes;

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -1,7 +1,7 @@
 {
   example = {
     lsp.servers = {
-      "*".settings = {
+      "*".cfg = {
         enable = true;
         root_markers = [ ".git" ];
         capabilities.textDocument.semanticTokens = {
@@ -11,7 +11,7 @@
       luals.enable = true;
       clangd = {
         enable = true;
-        settings = {
+        cfg = {
           cmd = [
             "clangd"
             "--background-index"


### PR DESCRIPTION
This is one possible solution to [the RFC](https://github.com/nix-community/nixvim/issues/3745), other solutions include [renaming back to `config`](https://github.com/nix-community/nixvim/pull/3762), doing nothing, or removing the freeform structured config option and having top-level explicit options instead.

**Please keep discussion on this PR limited to code review, discussion about which solution to choose should happen on the RFC issue.**

The commit message is written as-if we've chosen this solution; once it's merged we have. Until this or an alternative is merged, the RFC is still up for debate.

> While `settings` is the idiomatic name for an RFC42-style freeform structured config option, it is very confusing when `settings` itself has a `settings` sub-option.
>
> `config` is also a poor choice, as it conflicts with module system terminology and requires using `shorthandOnlyDefinesConfig`.
>
> Neovim's `:h vim.lsp.config()` documentation names the parameter `{cfg}`, so we've chosen that at the least-bad option.

Closes #3762
