### PR TITLE
tests/lsp-servers: disable building unfree default packages

### DIFF
--- a/tests/lsp-servers.nix
+++ b/tests/lsp-servers.nix
@@ -58,11 +58,17 @@ let
       plugins.lsp.servers = lib.pipe options.plugins.lsp.servers [
         (lib.mapAttrs (
           server: opts:
+          let
+            # Some servers are defined using mkUnpackagedOption whose default will throw
+            pkg = builtins.tryEval opts.package.default;
+            hasPkg = opts ? package.default && pkg.success;
+            isUnfree = pkg.value.meta.unfree or false;
+            isDisabled = lib.elem server disabled;
+          in
           {
-            enable = !(lib.elem server disabled);
+            enable = !isDisabled;
           }
-          # Some servers are defined using mkUnpackagedOption whose default will throw
-          // lib.optionalAttrs (opts ? package && !(builtins.tryEval opts.package.default).success) {
+          // lib.optionalAttrs (hasPkg -> isUnfree) {
             package = null;
           }
         ))


### PR DESCRIPTION

This is extracted from (unpushed) work on #3748

Currently none of the server packages we build are unfree, however if any unfree defaults are added then this test will fail.

When adding some defaults for the new servers added in #3748, at least one of them is unfree.

The two solutions are:
1. Filter out unfree packages
   - Either set `enable = false` or `package = null`
2. Allow building unfree packages
   - By setting `nixpkgs.config.allowUnfree = true`

For now, I've gone with option 1.
