### PR TITLE
treewide(docs): use literalLua instead of __raw in option examples

### DIFF
--- a/plugins/by-name/auto-session/default.nix
+++ b/plugins/by-name/auto-session/default.nix
@@ -18,7 +18,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       Enables/disables auto creating, saving and restoring.
     '';
 
-    root_dir = defaultNullOpts.mkStr { __raw = "vim.fn.stdpath 'data' .. '/sessions/'"; } ''
+    root_dir = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath 'data' .. '/sessions/'") ''
       Root directory for session files.
       Can be either a string or lua code (using `{__raw = 'foo';}`).
     '';
@@ -89,7 +89,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       '';
 
       session_control = {
-        control_dir = defaultNullOpts.mkStr { __raw = "vim.fn.stdpath 'data' .. '/auto_session/'"; } ''
+        control_dir = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath 'data' .. '/auto_session/'") ''
           Auto session control dir, for control files, like alternating between two sessions
           with session-lens.
         '';

--- a/plugins/by-name/aw-watcher/default.nix
+++ b/plugins/by-name/aw-watcher/default.nix
@@ -12,12 +12,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   settingsOptions = {
     bucket = {
-      hostname = defaultNullOpts.mkStr { __raw = "vim.uv.os_gethostname()"; } ''
+      hostname = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.uv.os_gethostname()") ''
         The hostname to be presented to the ActivityWatch server.
         Defaults to the hostname of the computer.
       '';
 
-      name = defaultNullOpts.mkStr { __raw = "'aw-watcher-neovim_' .. bucket.hostname'"; } ''
+      name = defaultNullOpts.mkStr (lib.nixvim.literalLua "'aw-watcher-neovim_' .. bucket.hostname'") ''
         The name of the bucket in the ActivityWatch server.
       '';
     };

--- a/plugins/by-name/clipboard-image/default.nix
+++ b/plugins/by-name/clipboard-image/default.nix
@@ -55,9 +55,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
         types.rawLua
       ]) "img" "Directory that will be inserted into text/buffer.";
 
-      img_name = defaultNullOpts.mkStr {
-        __raw = "function() return os.date('%Y-%m-%d-%H-%M-%S') end";
-      } "Image's name.";
+      img_name = defaultNullOpts.mkStr (lib.nixvim.literalLua "function() return os.date('%Y-%m-%d-%H-%M-%S') end") "Image's name.";
 
       img_handler = defaultNullOpts.mkLuaFn "function(img) end" ''
         Function that will handle image after pasted.

--- a/plugins/by-name/copilot-chat/default.nix
+++ b/plugins/by-name/copilot-chat/default.nix
@@ -89,7 +89,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
           Default context to use, `"buffers"`, `"buffer"` or `null` (can be specified manually in prompt via @).
         '';
 
-    history_path = defaultNullOpts.mkStr (lib.nixvim.mkRaw "vim.fn.stdpath('data') .. '/copilotchat_history'") ''
+    history_path = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath('data') .. '/copilotchat_history'") ''
       Default path to stored history.
     '';
 

--- a/plugins/by-name/glow/default.nix
+++ b/plugins/by-name/glow/default.nix
@@ -23,7 +23,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   ];
 
   settingsOptions = {
-    glow_path = defaultNullOpts.mkStr (lib.nixvim.mkRaw "vim.fn.exepath('glow')") ''
+    glow_path = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.exepath('glow')") ''
       Path to `glow` binary.
 
       If null or `""`, `glow` in your `$PATH` with be used if available.

--- a/plugins/by-name/jdtls/settings-options.nix
+++ b/plugins/by-name/jdtls/settings-options.nix
@@ -20,11 +20,9 @@ in
     '';
   };
 
-  root_dir =
-    defaultNullOpts.mkStr { __raw = "require('jdtls.setup').find_root({'.git', 'mvnw', 'gradlew'})"; }
-      ''
-        Function to identify the root directory from which to run the language server.
-      '';
+  root_dir = defaultNullOpts.mkStr (lib.nixvim.literalLua "require('jdtls.setup').find_root({'.git', 'mvnw', 'gradlew'})") ''
+    Function to identify the root directory from which to run the language server.
+  '';
 
   settings = mkNullOrOption (with types; attrsOf anything) ''
     Here you can configure `eclipse.jdt.ls` specific settings.

--- a/plugins/by-name/magma-nvim/default.nix
+++ b/plugins/by-name/magma-nvim/default.nix
@@ -53,7 +53,7 @@ mkVimPlugin {
       The highlight group to be used for highlighting cells.
     '';
 
-    save_path = helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath('data') .. '/magma'"; } ''
+    save_path = helpers.defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath('data') .. '/magma'") ''
       Where to save/load with `:MagmaSave` and `:MagmaLoad` (with no parameters).
       The generated file is placed in this directory, with the filename itself being the
       buffer's name, with `%` replaced by `%%` and `/` replaced by `%`, and postfixed with the

--- a/plugins/by-name/neoclip/default.nix
+++ b/plugins/by-name/neoclip/default.nix
@@ -42,12 +42,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
       [README](https://github.com/AckslD/nvim-neoclip.lua#custom-actions).
     '';
 
-    db_path =
-      helpers.defaultNullOpts.mkStr { __raw = "vim.fn.stdpath('data') .. '/databases/neoclip.sqlite3'"; }
-        ''
-          The path to the sqlite database to store history if `enable_persistent_history=true`.
-          Defaults to `$XDG_DATA_HOME/nvim/databases/neoclip.sqlite3`.
-        '';
+    db_path = helpers.defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath('data') .. '/databases/neoclip.sqlite3'") ''
+      The path to the sqlite database to store history if `enable_persistent_history=true`.
+      Defaults to `$XDG_DATA_HOME/nvim/databases/neoclip.sqlite3`.
+    '';
 
     filter = helpers.defaultNullOpts.mkLuaFn null ''
       A function to filter what entries to store (default all are stored).

--- a/plugins/by-name/none-ls/settings.nix
+++ b/plugins/by-name/none-ls/settings.nix
@@ -103,7 +103,7 @@ in
       method, described in [BUILTIN_CONFIG](https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTIN_CONFIG.md).
   '';
 
-  fallback_severity = defaultNullOpts.mkUnsignedInt { __raw = "vim.diagnostic.severity.ERROR"; } ''
+  fallback_severity = defaultNullOpts.mkUnsignedInt (lib.nixvim.literalLua "vim.diagnostic.severity.ERROR") ''
     Defines the severity used when a diagnostic source does not explicitly define a severity.
     See `:help diagnostic-severity` for available values.
   '';

--- a/plugins/by-name/nvim-snippets/default.nix
+++ b/plugins/by-name/nvim-snippets/default.nix
@@ -41,7 +41,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
     '';
 
     search_paths =
-      defaultNullOpts.mkListOf types.str [ { __raw = "vim.fn.stdpath('config') .. '/snippets'"; } ]
+      defaultNullOpts.mkListOf types.str
+        (lib.nixvim.literalLua "{ vim.fn.stdpath('config') .. '/snippets' }")
         ''
           Paths to search for snippets.
         '';

--- a/plugins/by-name/project-nvim/default.nix
+++ b/plugins/by-name/project-nvim/default.nix
@@ -70,9 +70,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
           What scope to change the directory.
         '';
 
-    data_path = defaultNullOpts.mkStr {
-      __raw = "vim.fn.stdpath('data')";
-    } "Path where project.nvim will store the project history for use in telescope.";
+    data_path = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath('data')") "Path where project.nvim will store the project history for use in telescope.";
   };
 
   settingsExample = {

--- a/plugins/by-name/rest/default.nix
+++ b/plugins/by-name/rest/default.nix
@@ -87,7 +87,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
           Encode URL before making request.
         '';
 
-        user_agent = defaultNullOpts.mkStr (lib.nixvim.mkRaw ''"rest.nvim v" .. require("rest-nvim.api").VERSION'') ''
+        user_agent = defaultNullOpts.mkStr (lib.nixvim.literalLua ''"rest.nvim v" .. require("rest-nvim.api").VERSION'') ''
           Set `User-Agent` header when it is empty.
         '';
 
@@ -135,7 +135,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
         Whether to enable cookies support or not.
       '';
 
-      path = defaultNullOpts.mkStr (lib.nixvim.mkRaw ''vim.fs.joinpath(vim.fn.stdpath("data") --[[@as string]], "rest-nvim.cookies")'') ''
+      path = defaultNullOpts.mkStr (lib.nixvim.literalLua ''vim.fs.joinpath(vim.fn.stdpath("data") --[[@as string]], "rest-nvim.cookies")'') ''
         Environment variables file pattern for `telescope.nvim`.
       '';
     };

--- a/plugins/by-name/rustaceanvim/settings-options.nix
+++ b/plugins/by-name/rustaceanvim/settings-options.nix
@@ -273,7 +273,7 @@ with lib;
       Disabling it may improve rust-analyzer's startup time.
     '';
 
-    logfile = helpers.defaultNullOpts.mkStr { __raw = "vim.fn.tempname() .. '-rust-analyzer.log'"; } ''
+    logfile = helpers.defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.tempname() .. '-rust-analyzer.log'") ''
       The path to the rust-analyzer log file.
     '';
 

--- a/plugins/by-name/snacks/default.nix
+++ b/plugins/by-name/snacks/default.nix
@@ -20,7 +20,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
         Whether to show notification when big file detected.
       '';
 
-      size = defaultNullOpts.mkNum { __raw = "1.5 * 1024 * 1024"; } ''
+      size = defaultNullOpts.mkNum (lib.nixvim.literalLua "1.5 * 1024 * 1024") ''
         The size at which a file is considered big.
       '';
 

--- a/plugins/by-name/sniprun/default.nix
+++ b/plugins/by-name/sniprun/default.nix
@@ -82,7 +82,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     ] "Display modes used in `live_mode`.";
 
     display_options = {
-      terminal_scrollback = helpers.defaultNullOpts.mkUnsignedInt { __raw = "vim.o.scrollback"; } ''
+      terminal_scrollback = helpers.defaultNullOpts.mkUnsignedInt (lib.nixvim.literalLua "vim.o.scrollback") ''
         Change terminal display scrollback lines.
       '';
 

--- a/plugins/by-name/telescope/extensions/file-browser.nix
+++ b/plugins/by-name/telescope/extensions/file-browser.nix
@@ -15,12 +15,12 @@ mkExtension {
       Custom theme, will use your global theme by default.
     '';
 
-    path = defaultNullOpts.mkStr { __raw = "vim.loop.cwd()"; } ''
+    path = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.loop.cwd()") ''
       Directory to browse files from.
       `vim.fn.expanded` automatically.
     '';
 
-    cwd = defaultNullOpts.mkStr { __raw = "vim.loop.cwd()"; } ''
+    cwd = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.loop.cwd()") ''
       Directory to browse folders from.
       `vim.fn.expanded` automatically.
     '';

--- a/plugins/by-name/telescope/extensions/frecency.nix
+++ b/plugins/by-name/telescope/extensions/frecency.nix
@@ -13,7 +13,7 @@ mkExtension {
       If true, it removes stale entries count over than `db_validate_threshold`.
     '';
 
-    db_root = defaultNullOpts.mkStr { __raw = "vim.fn.stdpath 'data'"; } ''
+    db_root = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath 'data'") ''
       Path to parent directory of custom database location.
       Defaults to `$XDG_DATA_HOME/nvim` if unset.
     '';

--- a/plugins/by-name/toggleterm/default.nix
+++ b/plugins/by-name/toggleterm/default.nix
@@ -141,7 +141,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       Close the terminal window when the process exits.
     '';
 
-    shell = helpers.defaultNullOpts.mkStr { __raw = "vim.o.shell"; } ''
+    shell = helpers.defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.o.shell") ''
       Change the default shell.
     '';
 

--- a/plugins/by-name/which-key/default.nix
+++ b/plugins/by-name/which-key/default.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   inherit (lib) types;
-  inherit (lib.nixvim) defaultNullOpts mkRaw;
+  inherit (lib.nixvim) defaultNullOpts;
 
   specExamples = [
     # Basic group with custom icon
@@ -85,7 +85,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     ] "Preset style for WhichKey. Set to false to disable.";
 
     delay = defaultNullOpts.mkInt' {
-      pluginDefault.__raw = ''
+      pluginDefault = lib.nixvim.literalLua ''
         function(ctx)
           return ctx.plugin and 0 or 200
         end
@@ -94,7 +94,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     };
 
     filter = defaultNullOpts.mkLuaFn' {
-      pluginDefault.__raw = ''
+      pluginDefault = lib.nixvim.literalLua ''
         function(mapping)
           return true
         end
@@ -126,7 +126,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     ] "Manually setup triggers";
 
     defer = defaultNullOpts.mkLuaFn' {
-      pluginDefault.__raw = ''
+      pluginDefault = lib.nixvim.literalLua ''
         function(ctx)
           return ctx.mode == "V" or ctx.mode == "<C-V>
          end'';
@@ -230,11 +230,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
     expand = defaultNullOpts.mkInt 0 "Expand groups when <= n mappings.";
 
     replace = {
-      key = defaultNullOpts.mkListOf (types.either types.strLuaFn (with types; listOf str)) (mkRaw ''
-        function(key)
-          return require("which-key.view").format(key)
-        end
-      '') "Lua functions or list of strings to replace key left side key name with.";
+      key =
+        defaultNullOpts.mkListOf (types.either types.strLuaFn (with types; listOf str))
+          (lib.nixvim.literalLua ''
+            function(key)
+              return require("which-key.view").format(key)
+            end
+          '')
+          "Lua functions or list of strings to replace key left side key name with.";
       desc = defaultNullOpts.mkListOf (with types; listOf str) [
         [
           "<Plug>%(?(.*)%)?"

--- a/plugins/by-name/yazi/default.nix
+++ b/plugins/by-name/yazi/default.nix
@@ -53,7 +53,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
     enable_mouse_support = defaultNullOpts.mkBool false "Enables mouse support.";
 
     open_file_function = defaultNullOpts.mkLuaFn' {
-      pluginDefault.__raw = ''
+      pluginDefault = lib.nixvim.literalLua ''
         function(chosen_file)
           vim.cmd(string.format("edit %s", vim.fn.fnameescape(chosen_file)))
         end
@@ -99,7 +99,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
     hooks = {
       yazi_opened = defaultNullOpts.mkLuaFn' {
-        pluginDefault.__raw = ''
+        pluginDefault = lib.nixvim.literalLua ''
           function(preselected_path, yazi_buffer_id, config)
           end
         '';
@@ -110,7 +110,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       };
 
       yazi_closed_successfully = defaultNullOpts.mkLuaFn' {
-        pluginDefault.__raw = ''
+        pluginDefault = lib.nixvim.literalLua ''
           function(chosen_file, config, state)
           end
         '';
@@ -118,7 +118,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       };
 
       yazi_opened_multiple_files = defaultNullOpts.mkLuaFn' {
-        pluginDefault.__raw = ''
+        pluginDefault = lib.nixvim.literalLua ''
           function(chosen_files)
             vim.cmd("args" .. table.concat(chosen_files, " "))
           end

--- a/plugins/colorschemes/catppuccin.nix
+++ b/plugins/colorschemes/catppuccin.nix
@@ -3,7 +3,12 @@
   ...
 }:
 let
-  inherit (lib.nixvim) defaultNullOpts mkNullOrOption mkNullOrStrLuaFnOr;
+  inherit (lib.nixvim)
+    defaultNullOpts
+    mkNullOrOption
+    mkNullOrStrLuaFnOr
+    literalLua
+    ;
   inherit (lib) types;
 in
 lib.nixvim.plugins.mkNeovimPlugin {
@@ -23,9 +28,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       ];
     in
     {
-      compile_path = defaultNullOpts.mkStr {
-        __raw = "vim.fn.stdpath 'cache' .. '/catppuccin'";
-      } "Set the compile cache directory.";
+      compile_path = defaultNullOpts.mkStr (literalLua "vim.fn.stdpath 'cache' .. '/catppuccin'") "Set the compile cache directory.";
 
       flavour = mkNullOrOption (types.enum (flavours ++ [ "auto" ])) ''
         Theme flavour.

--- a/plugins/colorschemes/nightfox.nix
+++ b/plugins/colorschemes/nightfox.nix
@@ -3,7 +3,7 @@
   ...
 }:
 let
-  inherit (lib.nixvim) defaultNullOpts mkNullOrOption;
+  inherit (lib.nixvim) defaultNullOpts mkNullOrOption literalLua;
   inherit (lib) types;
 in
 lib.nixvim.plugins.mkNeovimPlugin {
@@ -34,7 +34,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   settingsOptions = {
     options = {
-      compile_path = defaultNullOpts.mkStr { __raw = "vim.fn.stdpath('cache') .. '/nightfox'"; } ''
+      compile_path = defaultNullOpts.mkStr (literalLua "vim.fn.stdpath('cache') .. '/nightfox'") ''
         The output directory path where the compiled results will be written to.
       '';
 

--- a/plugins/colorschemes/palette.nix
+++ b/plugins/colorschemes/palette.nix
@@ -98,9 +98,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       Whether to enable caching.
     '';
 
-    cache_dir = defaultNullOpts.mkStr {
-      __raw = "vim.fn.stdpath('cache') .. '/palette'";
-    } "Cache directory.";
+    cache_dir = defaultNullOpts.mkStr (lib.nixvim.literalLua "vim.fn.stdpath('cache') .. '/palette'") "Cache directory.";
   };
 
   settingsExample = { };


### PR DESCRIPTION
See https://github.com/nix-community/nixvim/pull/3076#discussion_r2404140875