### PR TITLE
modules/lsp: handle missing package in server option desc

### DIFF
--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -31,8 +31,13 @@ let
         (opt: opt.type.getSubOptions opt.loc)
         # Get suboptions of `lsp.servers.<name>`
         (opts: opts.${name}.type.getSubOptions opts.${name}.loc)
-        # Get package option's homepage
-        (opts: opts.package.default.meta.homepage or null)
+        # Get the default package
+        (opts: opts.package.default or null)
+        # The default throws if mkPackageOption can't find the package
+        # E.g. mismatched nixpkgs revision
+        (package: (builtins.tryEval package).value)
+        # Get package's homepage
+        (package: package.meta.homepage or null)
       ];
 
       # If there's a known homepage for this language server,


### PR DESCRIPTION
The `lsp.servers.<name>` option description links to the server's homepage if it can evaluate the default package's `meta.homepage`.

However, users may evaluate this description, e.g. when building NixOS docs with `documentation.nixos.includeAllModules`. Further, users may have a different nixpkgs revisions to ours. Therefore, we need to allow for the package not being in nixpkgs.

Since `mkPackageOption` will throw in the default, we can catch it with `tryEval`.

This fixes #3780. While it fixes the underlying reason behind #3788, it doesn't implement the proposed "enforcement" of keeping `pkgs` access lazy.
