### PR TITLE
plugins/atopile: fix package location

### DIFF
--- a/plugins/lsp/lsp-packages.nix
+++ b/plugins/lsp/lsp-packages.nix
@@ -190,7 +190,10 @@
     ast_grep = "ast-grep";
     astro = "astro-language-server";
     atlas = "atlas";
-    atopile = "atopile";
+    atopile = [
+      "python3Packages"
+      "atopile"
+    ];
     autotools_ls = "autotools-language-server";
     ballerina = "ballerina";
     basedpyright = "basedpyright";


### PR DESCRIPTION
This reverts cd63e6c9189bb0b26b354cb53022817571c34895