### PR TITLE
plugins/blame-nvim: rename to blame

### DIFF
--- a/plugins/by-name/blame/default.nix
+++ b/plugins/by-name/blame/default.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
-  name = "blame-nvim";
-  moduleName = "blame";
+  name = "blame";
+  package = "blame-nvim";
   description = "fugitive.vim-style `git blame` visualizer for Neovim";
 
   maintainers = [ lib.maintainers.axka ];

--- a/tests/test-sources/plugins/by-name/blame/default.nix
+++ b/tests/test-sources/plugins/by-name/blame/default.nix
@@ -1,10 +1,10 @@
 {
   empty = {
-    plugins.blame-nvim.enable = true;
+    plugins.blame.enable = true;
   };
 
   defaults = {
-    plugins.blame-nvim = {
+    plugins.blame = {
       enable = true;
       settings = {
         date_format = "%d.%m.%Y";
@@ -37,7 +37,7 @@
   };
 
   example = {
-    plugins.blame-nvim = {
+    plugins.blame = {
       enable = true;
       settings = {
         date_format = "%Y-%m-%d";


### PR DESCRIPTION
The plugin has been introduced a few hours ago, no need to bother adding a rename warning.
