### PR TITLE
plugins/neo-tree: Add defaultComponentConfigs.icon.useFilteredColors setting

### DIFF
--- a/plugins/by-name/neo-tree/default.nix
+++ b/plugins/by-name/neo-tree/default.nix
@@ -400,6 +400,8 @@ in
             Only a fallback, if you use nvim-web-devicons and configure default icons there
             then this will never be used.
           '';
+
+          useFilteredColors = helpers.defaultNullOpts.mkBool true "";
         };
 
         modified = {
@@ -1050,6 +1052,7 @@ in
               folder_empty = folderEmpty;
               folder_empty_open = folderEmptyOpen;
               inherit default highlight;
+              use_filtered_colors = useFilteredColors
             };
             inherit modified;
             name = with name; {


### PR DESCRIPTION
Add `plugins.neo-tree.defaultComponentConfigs.icon.useFilteredColors` for `default_component_configs.icon.use_filtered_colors`.

This is introduced in [3.37.0](https://github.com/nvim-neo-tree/neo-tree.nvim/releases/tag/3.37.0)

