### PR TITLE
modules/lsp/hls: port `ghcPackage` option from `plugins.lsp`

### DIFF
--- a/modules/lsp/servers/custom/hls.nix
+++ b/modules/lsp/servers/custom/hls.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  pkgs,
+  config,
+  options,
+  ...
+}:
+{
+  options = {
+    installGhc = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = "Whether to install `ghc`.";
+    };
+
+    ghcPackage = lib.mkPackageOption pkgs "ghc" { };
+  };
+
+  config = lib.mkIf config.enable {
+    warnings = lib.nixvim.mkWarnings "lsp.servers.hls" {
+      when = options.installGhc.highestPrio == 1500;
+      message = ''
+        `hls` relies on `ghc` (the Glasgow Haskell Compiler).
+        - Set `${options.installGhc} = true` to install it automatically with Nixvim.
+          You can customize which package to install by changing `${options.ghcPackage}`.
+        - Set `${options.installGhc} = false` to not have it install through Nixvim.
+          By doing so, you will dismiss this warning.
+      '';
+    };
+
+    packages = lib.mkIf config.installGhc {
+      ${if config.packageFallback then "suffix" else "prefix"} = [
+        config.ghcPackage
+      ];
+    };
+  };
+}

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -187,6 +187,7 @@
           hls = {
             enable = true;
             packageFallback = true;
+            installGhc = true;
           };
         };
       };
@@ -219,6 +220,7 @@
           assertPrefix "nil" nil_ls.package
           ++ assertSuffix "rust-analyzer" rust_analyzer.package
           ++ assertSuffix "haskell-language-server" hls.package
+          ++ assertSuffix "ghc" hls.ghcPackage
         );
     };
 }


### PR DESCRIPTION
WIP PR to begin porting `plugins.lsp` server-specific options to the new `lsp` module. Depends on #3783.

Open questions:
- Do we still want `installXyz` and `xyzPackage` options, or just nullable package options?
- Which options should be ported to `lsp` and which to `plugins.lspconfig`?
