### PR TITLE
plugins/lsp/vue_ls: add vtslsIntegration option

### DIFF
--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -9,6 +9,15 @@ let
 
   inherit (lib) mkOption types;
 
+  typescriptFiletypes = [
+    "javascript"
+    "javascriptreact"
+    "javascript.jsx"
+    "typescript"
+    "typescriptreact"
+    "typescript.tsx"
+  ];
+
   lspExtraArgs = {
     dartls = {
       settings = cfg: { dart = cfg; };
@@ -57,14 +66,7 @@ let
       # `plugins.lsp.servers.volar.tslsIntegration` and `plugins.lsp.servers.vue_ls.tslsIntegration` don't wipe out the default filetypes
       extraConfig = {
         plugins.lsp.servers.ts_ls = {
-          filetypes = [
-            "javascript"
-            "javascriptreact"
-            "javascript.jsx"
-            "typescript"
-            "typescriptreact"
-            "typescript.tsx"
-          ];
+          filetypes = typescriptFiletypes;
         };
       };
     };
@@ -78,27 +80,52 @@ let
           default = true;
           example = false;
         };
-      };
-      extraConfig = cfg: opts: {
-        assertions = lib.nixvim.mkAssertions "plugins.lsp.servers.vue_ls" {
-          assertion = cfg.tslsIntegration -> (cfg.package != null);
-          message = "When `${opts.tslsIntegration}` is enabled, `${opts.package}` must not be null.";
+        vtslsIntegration = mkOption {
+          type = types.bool;
+          description = ''
+            Enable integration with vtsls.
+          '';
+          default = true;
+          example = false;
         };
-        plugins.lsp.servers.ts_ls = lib.mkIf (cfg.enable && cfg.tslsIntegration) {
-          filetypes = [ "vue" ];
-          extraOptions = {
-            init_options = {
-              plugins = lib.mkIf (cfg.package != null) [
-                {
-                  name = "@vue/typescript-plugin";
-                  location = "${lib.getBin cfg.package}/lib/language-tools/packages/language-server";
-                  languages = [ "vue" ];
-                }
+      };
+      extraConfig =
+        cfg: opts:
+        let
+          plugin = {
+            name = "@vue/typescript-plugin";
+            location = "${lib.getBin cfg.package}/lib/language-tools/packages/language-server";
+            languages = [ "vue" ];
+          };
+        in
+        {
+          assertions = lib.nixvim.mkAssertions "plugins.lsp.servers.vue_ls" {
+            assertion = (cfg.tslsIntegration or cfg.vtslsIntegration) -> (cfg.package != null);
+            message = "When `${opts.tslsIntegration}` or `${opts.vtslsIntegration}` is enabled, `${opts.package}` must not be null.";
+          };
+          plugins.lsp.servers.ts_ls = lib.mkIf (cfg.enable && cfg.tslsIntegration) {
+            filetypes = [ "vue" ];
+            extraOptions = {
+              init_options = {
+                plugins = lib.mkIf (cfg.package != null) [ plugin ];
+              };
+            };
+          };
+          plugins.lsp.servers.vtsls = lib.mkIf (cfg.enable && cfg.vtslsIntegration) {
+            filetypes = typescriptFiletypes ++ [ "vue" ];
+            settings.vtsls.tsserver = {
+              globalPlugins = lib.mkIf (cfg.package != null) [
+                (
+                  plugin
+                  // {
+                    configNamespace = "typescript";
+                    enableForWorkspaceTypeScriptVersions = true;
+                  }
+                )
               ];
             };
           };
         };
-      };
     };
     vls = {
       extraOptions = {

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -100,10 +100,10 @@ let
         in
         {
           assertions = lib.nixvim.mkAssertions "plugins.lsp.servers.vue_ls" {
-            assertion = (cfg.tslsIntegration or cfg.vtslsIntegration) -> (cfg.package != null);
+            assertion = (cfg.tslsIntegration || cfg.vtslsIntegration) -> (cfg.package != null);
             message = "When `${opts.tslsIntegration}` or `${opts.vtslsIntegration}` is enabled, `${opts.package}` must not be null.";
           };
-          plugins.lsp.servers.ts_ls = lib.mkIf (cfg.enable && cfg.tslsIntegration) {
+          plugins.lsp.servers.ts_ls = lib.mkIf cfg.tslsIntegration {
             filetypes = [ "vue" ];
             extraOptions = {
               init_options = {
@@ -111,7 +111,7 @@ let
               };
             };
           };
-          plugins.lsp.servers.vtsls = lib.mkIf (cfg.enable && cfg.vtslsIntegration) {
+          plugins.lsp.servers.vtsls = lib.mkIf cfg.vtslsIntegration {
             filetypes = typescriptFiletypes ++ [ "vue" ];
             settings.vtsls.tsserver = {
               globalPlugins = lib.mkIf (cfg.package != null) [
@@ -140,7 +140,7 @@ let
         };
       };
       extraConfig = cfg: {
-        filetype.extension = lib.mkIf (cfg.enable && cfg.autoSetFiletype) { v = "vlang"; };
+        filetype.extension = lib.mkIf cfg.autoSetFiletype { v = "vlang"; };
       };
     };
     volar = {
@@ -159,7 +159,7 @@ let
           assertion = cfg.tslsIntegration -> (cfg.package != null);
           message = "When `${opts.tslsIntegration}` is enabled, `${opts.package}` must not be null.";
         };
-        plugins.lsp.servers.ts_ls = lib.mkIf (cfg.enable && cfg.tslsIntegration) {
+        plugins.lsp.servers.ts_ls = lib.mkIf cfg.tslsIntegration {
           filetypes = [ "vue" ];
           extraOptions = {
             init_options = {


### PR DESCRIPTION
Add a vue_ls integration by default for vtsls in addition to tsls which is already implemented (see #3771).

Haven't added it to Volar since it is deprecated anyway (#3600)