### PR TITLE
plugins/copilot-vim: update nodejs

### DIFF
--- a/plugins/by-name/copilot-vim/default.nix
+++ b/plugins/by-name/copilot-vim/default.nix
@@ -24,8 +24,8 @@ lib.nixvim.plugins.mkVimPlugin {
   settingsOptions = {
     node_command = mkOption {
       type = with types; nullOr str;
-      default = lib.getExe pkgs.nodejs_20;
-      defaultText = lib.literalExpression "lib.getExe pkgs.nodejs_20";
+      default = lib.getExe pkgs.nodejs_22;
+      defaultText = lib.literalExpression "lib.getExe pkgs.nodejs_22";
       description = "Tell Copilot what `node` binary to use.";
     };
 


### PR DESCRIPTION
Copilot-vim started to complain about nodejs being too old
and it recommends to update to 22

<img width="682" height="50" alt="image" src="https://github.com/user-attachments/assets/192d3f1d-572c-45d8-b183-905648bf58b6" />
