### PR TITLE
[backport 25.05] plugins/blink-cmp: add "exact" fuzzy sort

### DIFF
--- a/plugins/by-name/blink-cmp/settings-options.nix
+++ b/plugins/by-name/blink-cmp/settings-options.nix
@@ -443,6 +443,7 @@ in
     sorts =
       defaultNullOpts.mkListOf
         (types.enum [
+          "exact"
           "label"
           "sort_text"
           "kind"
@@ -450,7 +451,7 @@ in
         ])
         [ "score" "sort_text" ]
         ''
-          Controls which sorts to use and in which order, these three are currently the only allowed options
+          Controls which sorts to use and in which order, these five are currently the only allowed options
         '';
 
     prebuilt_binaries = {


### PR DESCRIPTION
Manual backport of #3622 

For some reason the `on: pull_request_target: labelled` event isn't triggering on the PR.