### PR TITLE
plugins/treesitter: fix folding option

### DIFF
--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -472,7 +472,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
     opts = mkIf cfg.folding {
       foldmethod = mkDefault "expr";
-      foldexpr = mkDefault "nvim_treesitter#foldexpr()";
+      foldexpr = mkDefault "v:lua.vim.treesitter.foldexpr()";
     };
   };
 }


### PR DESCRIPTION
This snippet in main is out of date and does not work.
https://neovim.io/doc/user/treesitter.html#vim.treesitter.foldexpr()