### PR TITLE
plugins/lazy: migrate to mkNeovimPlugin

### DIFF
--- a/plugins/pluginmanagers/lazy.nix
+++ b/plugins/pluginmanagers/lazy.nix
@@ -1,161 +1,134 @@
 {
   lib,
-  helpers,
-  config,
   pkgs,
   ...
 }:
-with lib;
-let
-  cfg = config.plugins.lazy;
-  lazyPlugins = cfg.plugins;
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "lazy";
+  package = "lazy-nvim";
+  maintainers = [ ];
 
-  processPlugin =
-    plugin:
+  hasSettings = false;
+  callSetup = false;
+
+  dependencies = [
+    "git"
+  ];
+
+  extraOptions =
     let
-      mkEntryFromDrv =
-        p:
-        if lib.isDerivation p then
-          {
-            name = "${lib.getName p}";
-            path = p;
-          }
-        else
-          {
-            name = "${lib.getName p.pkg}";
-            path = p.pkg;
-          };
-      processDependencies =
-        if plugin ? dependencies && plugin.dependencies != null then
-          builtins.concatMap processPlugin plugin.dependencies
-        else
-          [ ];
+      inherit (lib.nixvim) defaultNullOpts;
     in
-    [ (mkEntryFromDrv plugin) ] ++ processDependencies;
-
-  processedPlugins = builtins.concatLists (builtins.map processPlugin lazyPlugins);
-  lazyPath = pkgs.linkFarm "lazy-plugins" processedPlugins;
-in
-{
-  options = {
-    plugins.lazy = {
-      enable = mkEnableOption "lazy.nvim";
-
-      package = lib.mkPackageOption pkgs [
-        "vimPlugins"
-        "lazy-nvim"
-      ] { };
-
+    {
       performance.rtp = {
-        reset = helpers.defaultNullOpts.mkBool true ''
+        reset = defaultNullOpts.mkBool true ''
           reset the runtime path to $VIMRUNTIME and your config directory.
         '';
-        paths = helpers.defaultNullOpts.mkListOf lib.types.str [ ] ''
+        paths = defaultNullOpts.mkListOf lib.types.str [ ] ''
           add any custom paths here that you want to includes in the rtp
         '';
-        disabled_plugins = helpers.defaultNullOpts.mkListOf lib.types.str [ ] ''
+        disabled_plugins = defaultNullOpts.mkListOf lib.types.str [ ] ''
           list any plugins you want to disable here
         '';
       };
 
       plugins =
-        with types;
         let
-          pluginType = either package (submodule {
-            options = {
-              dir = helpers.mkNullOrOption str "A directory pointing to a local plugin";
+          inherit (lib) mkOption types;
+          inherit (lib.nixvim)
+            mkNullOrOption
+            mkNullOrLuaFn
+            mkNullOrStrLuaFnOr
+            ;
+          pluginType =
+            with types;
+            either package (submodule {
+              options = {
+                dir = mkNullOrOption str "A directory pointing to a local plugin";
 
-              pkg = mkOption {
-                type = package;
-                description = "Vim plugin to install";
-              };
+                pkg = mkOption {
+                  type = package;
+                  description = "Vim plugin to install";
+                };
 
-              name = helpers.mkNullOrOption str "Name of the plugin to install";
+                name = mkNullOrOption str "Name of the plugin to install";
 
-              dev = helpers.defaultNullOpts.mkBool false ''
-                When true, a local plugin directory will be used instead.
-                See config.dev
-              '';
+                dev = defaultNullOpts.mkBool false ''
+                  When true, a local plugin directory will be used instead.
+                  See config.dev
+                '';
 
-              lazy = helpers.defaultNullOpts.mkBool true ''
-                When true, the plugin will only be loaded when needed.
-                Lazy-loaded plugins are automatically loaded when their Lua modules are required,
-                or when one of the lazy-loading handlers triggers
-              '';
+                lazy = defaultNullOpts.mkBool true ''
+                  When true, the plugin will only be loaded when needed.
+                  Lazy-loaded plugins are automatically loaded when their Lua modules are required,
+                  or when one of the lazy-loading handlers triggers
+                '';
 
-              enabled = helpers.defaultNullOpts.mkStrLuaFnOr types.bool "`true`" ''
-                When false then this plugin will not be included in the spec. (accepts fun():boolean)
-              '';
+                enabled = defaultNullOpts.mkStrLuaFnOr bool "`true`" ''
+                  When false then this plugin will not be included in the spec. (accepts fun():boolean)
+                '';
 
-              cond = helpers.defaultNullOpts.mkStrLuaFnOr types.bool "`true`" ''
-                When false, or if the function returns false,
-                then this plugin will not be loaded. Useful to disable some plugins in vscode,
-                or firenvim for example. (accepts fun(LazyPlugin):boolean)
-              '';
+                cond = defaultNullOpts.mkStrLuaFnOr bool "`true`" ''
+                  When false, or if the function returns false,
+                  then this plugin will not be loaded. Useful to disable some plugins in vscode,
+                  or firenvim for example. (accepts fun(LazyPlugin):boolean)
+                '';
 
-              dependencies = helpers.mkNullOrOption (eitherRecursive str listOfPlugins) "Plugin dependencies";
+                dependencies = mkNullOrOption (eitherRecursive str listOfPlugins) "Plugin dependencies";
 
-              init = helpers.mkNullOrLuaFn "init functions are always executed during startup";
+                init = mkNullOrLuaFn "init functions are always executed during startup";
 
-              config = helpers.mkNullOrStrLuaFnOr (types.enum [ true ]) ''
-                config is executed when the plugin loads.
-                The default implementation will automatically run require(MAIN).setup(opts).
-                Lazy uses several heuristics to determine the plugin's MAIN module automatically based on the plugin's name.
-                See also opts. To use the default implementation without opts set config to true.
-              '';
+                config = mkNullOrStrLuaFnOr (enum [ true ]) ''
+                  config is executed when the plugin loads.
+                  The default implementation will automatically run require(MAIN).setup(opts).
+                  Lazy uses several heuristics to determine the plugin's MAIN module automatically based on the plugin's name.
+                  See also opts. To use the default implementation without opts set config to true.
+                '';
 
-              main = helpers.mkNullOrOption str ''
-                You can specify the main module to use for config() and opts(),
-                in case it can not be determined automatically. See config()
-              '';
+                main = mkNullOrOption str ''
+                  You can specify the main module to use for config() and opts(),
+                  in case it can not be determined automatically. See config()
+                '';
 
-              submodules = helpers.defaultNullOpts.mkBool true ''
-                When false, git submodules will not be fetched.
-                Defaults to true
-              '';
+                submodules = defaultNullOpts.mkBool true ''
+                  When false, git submodules will not be fetched.
+                  Defaults to true
+                '';
 
-              event =
-                with lib.types;
-                helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on event. Events can be specified as BufEnter or with a pattern like BufEnter *.lua";
+                event = mkNullOrOption (maybeRaw (either str (listOf str))) ''
+                  Lazy-load on event. Events can be specified as BufEnter or with a pattern like BufEnter *.lua"
+                '';
 
-              cmd =
-                with lib.types;
-                helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on command";
+                cmd = mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on command";
 
-              ft =
-                with lib.types;
-                helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on filetype";
+                ft = mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on filetype";
 
-              keys =
-                with lib.types;
-                helpers.mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on key mapping";
+                keys = mkNullOrOption (maybeRaw (either str (listOf str))) "Lazy-load on key mapping";
 
-              module = helpers.mkNullOrOption (enum [ false ]) ''
-                Do not automatically load this Lua module when it's required somewhere
-              '';
+                module = mkNullOrOption (enum [ false ]) ''
+                  Do not automatically load this Lua module when it's required somewhere
+                '';
 
-              priority = helpers.mkNullOrOption number ''
-                Only useful for start plugins (lazy=false) to force loading certain plugins first.
-                Default priority is 50. It's recommended to set this to a high number for colorschemes.
-              '';
+                priority = mkNullOrOption number ''
+                  Only useful for start plugins (lazy=false) to force loading certain plugins first.
+                  Default priority is 50. It's recommended to set this to a high number for colorschemes.
+                '';
 
-              optional = helpers.defaultNullOpts.mkBool false ''
-                When a spec is tagged optional, it will only be included in the final spec,
-                when the same plugin has been specified at least once somewhere else without optional.
-                This is mainly useful for Neovim distros, to allow setting options on plugins that may/may not be part
-                of the user's plugins
-              '';
+                optional = defaultNullOpts.mkBool false ''
+                  When a spec is tagged optional, it will only be included in the final spec,
+                  when the same plugin has been specified at least once somewhere else without optional.
+                  This is mainly useful for Neovim distros, to allow setting options on plugins that may/may not be part
+                  of the user's plugins
+                '';
 
-              opts =
-                with lib.types;
-                helpers.mkNullOrOption (maybeRaw (attrsOf anything)) ''
+                opts = mkNullOrOption (maybeRaw (attrsOf anything)) ''
                   opts should be a table (will be merged with parent specs),
                   return a table (replaces parent specs) or should change a table.
                   The table will be passed to the Plugin.config() function.
                   Setting this value will imply Plugin.config()
                 '';
-            };
-          });
+              };
+            });
 
           listOfPlugins = types.listOf pluginType;
         in
@@ -165,18 +138,39 @@ in
           description = "List of plugins";
         };
     };
-  };
 
-  config = mkIf cfg.enable {
-    extraPlugins = [ cfg.package ];
-
-    dependencies.git.enable = lib.mkDefault true;
-
-    extraConfigLua =
+  extraConfig = cfg: {
+    plugins.lazy.luaConfig.content =
       let
+        processPlugin =
+          plugin:
+          let
+            mkEntryFromDrv =
+              p:
+              if lib.isDerivation p then
+                {
+                  name = "${lib.getName p}";
+                  path = p;
+                }
+              else
+                {
+                  name = "${lib.getName p.pkg}";
+                  path = p.pkg;
+                };
+            processDependencies =
+              if plugin ? dependencies && plugin.dependencies != null then
+                builtins.concatMap processPlugin plugin.dependencies
+              else
+                [ ];
+          in
+          [ (mkEntryFromDrv plugin) ] ++ processDependencies;
+
+        processedPlugins = builtins.concatLists (builtins.map processPlugin cfg.plugins);
+        lazyPath = pkgs.linkFarm "lazy-plugins" processedPlugins;
+
         pluginToLua =
           plugin:
-          if isDerivation plugin then
+          if lib.isDerivation plugin then
             { dir = "${lazyPath}/${lib.getName plugin}"; }
           else
             {
@@ -202,8 +196,11 @@ in
                 submodules
                 ;
 
-              dependencies = helpers.ifNonNull' plugin.dependencies (
-                if isList plugin.dependencies then (pluginListToLua plugin.dependencies) else plugin.dependencies
+              dependencies = lib.nixvim.ifNonNull' plugin.dependencies (
+                if lib.isList plugin.dependencies then
+                  (pluginListToLua plugin.dependencies)
+                else
+                  plugin.dependencies
               );
 
               dir =
@@ -214,9 +211,9 @@ in
 
         plugins = pluginListToLua cfg.plugins;
 
-        packedPlugins = if length plugins == 1 then head plugins else plugins;
+        packedPlugins = if lib.length plugins == 1 then lib.head plugins else plugins;
       in
-      mkIf (cfg.plugins != [ ]) ''
+      lib.mkIf (cfg.plugins != [ ]) ''
         require('lazy').setup(
           {
             dev = {


### PR DESCRIPTION
In this PR, I make sure to keep the exact same API as the previous implementation.
This change does not affect users.

I plan to open a follow-up PR to investigate introducing a `settings` option.

- **plugins/lazy: remove old deprecation warning**
- **plugins/lazy: migrate to mkNeovimPlugin**

Tracking: #2638
