### PR TITLE
plugins/schemastore: use the correct LSP configuration keys for the new lsp module

### DIFF
--- a/plugins/by-name/schemastore/default.nix
+++ b/plugins/by-name/schemastore/default.nix
@@ -172,7 +172,7 @@ lib.nixvim.plugins.mkVimPlugin {
     };
 
     lsp.servers = {
-      jsonls.config.settings = mkIf cfg.json.enable {
+      jsonls.config.settings.json = mkIf cfg.json.enable {
         schemas.__raw = ''
           require('schemastore').json.schemas(${lib.nixvim.toLuaObject cfg.json.settings})
         '';
@@ -182,7 +182,7 @@ lib.nixvim.plugins.mkVimPlugin {
         validate.enable = mkDefault true;
       };
 
-      yamlls.config.settings = mkIf cfg.yaml.enable {
+      yamlls.config.settings.yaml = mkIf cfg.yaml.enable {
         schemaStore = {
           # From the README: "You must disable built-in schemaStore support if you want to use
           # this plugin and its advanced options like `ignore`."


### PR DESCRIPTION
The old lsp module wrapped (in plugins/lsp/language-servers/default.nix) all configuration of the jsonls and yamlls servers in `json` and `yaml` keys respectively, so the schemastore module never needed to add those keys.

However, the new lsp module passes the configuration as-is instead. This means that the schemastore module must be the one to wrap the configuration in the `json` and `yaml` keys. Without this, jsonls does not get its support enabled at all, and yamlls falls back to the built-in support.