### PR TITLE
plugins/tailwind-tools: throw warning when enabling

### DIFF
--- a/plugins/by-name/tailwind-tools/default.nix
+++ b/plugins/by-name/tailwind-tools/default.nix
@@ -101,6 +101,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
     };
   };
 
+  extraConfig = cfg: {
+    warnings = lib.nixvim.mkWarnings "plugins.tailwind-tools" {
+      message = ''The upstream GitHub project for tailwind-tools is archived, and enabling this plugin triggers an lspconfig deprecation warning. Consider disabling it or switching to an alternative.'';
+    };
+  };
+
   settingsExample = {
     document_color = {
       conceal = {

--- a/tests/test-sources/plugins/by-name/tailwind-tools/default.nix
+++ b/tests/test-sources/plugins/by-name/tailwind-tools/default.nix
@@ -1,6 +1,11 @@
 {
   empty = {
     plugins.tailwind-tools.enable = true;
+
+    test.warnings = expect: [
+      (expect "count" 1)
+      (expect "any" "Nixvim (plugins.tailwind-tools): The upstream GitHub project for tailwind-tools is archived,")
+    ];
   };
 
   defaults = {
@@ -41,6 +46,10 @@
         };
       };
     };
+
+    test.warnings = expect: [
+      (expect "count" 1)
+    ];
   };
 
   example = {
@@ -57,5 +66,9 @@
         };
       };
     };
+
+    test.warnings = expect: [
+      (expect "count" 1)
+    ];
   };
 }


### PR DESCRIPTION
This pull request adds a warning to the `tailwind-tools` plugin configuration to inform users about the plugin's upstream status and potential deprecation issues.

Configuration improvements:

* Added an `extraConfig` block to display a warning when the `tailwind-tools` plugin is enabled, notifying users that the upstream GitHub project is archived and that enabling the plugin triggers an `lspconfig` deprecation warning. Users are advised to consider disabling the plugin or switching to an alternative.