### PR TITLE
dev/list-plugins: remove treesitter-refactor exceptions

### DIFF
--- a/flake/dev/list-plugins/list-plugins.py
+++ b/flake/dev/list-plugins/list-plugins.py
@@ -71,7 +71,6 @@ KNOWN_PATHS: dict[
     ],
 ] = {
     "plugins/by-name/coq-thirdparty/default.nix": (State.OLD, Kind.NEOVIM, False),
-    "plugins/by-name/treesitter-refactor/default.nix": (State.OLD, Kind.MISC, True),
     "plugins/by-name/treesitter-textobjects/default.nix": (
         State.OLD,
         Kind.NEOVIM,


### PR DESCRIPTION
`treesitter-refactor` was migrated to `mkNeovimPlugin` in https://github.com/nix-community/nixvim/pull/3826
