### PR TITLE
lib/options (mkSettingsOption): allow more types for settingsOption when no sub-options are explicitly declared

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -329,14 +329,22 @@ rec {
       options ? { },
       description,
       example ? null,
+      # If no sub-options are explicitly declared, settings do not need to be a submodule.
+      submoduleType ? options != { },
     }:
     lib.mkOption {
       type =
-        with types;
-        submodule {
-          freeformType = attrsOf lib.nixvim.lua-types.anything;
-          inherit options;
-        };
+        let
+          anyLuaType = lib.nixvim.lua-types.anything;
+        in
+        if submoduleType then
+          types.submodule {
+            freeformType = types.attrsOf anyLuaType;
+            inherit options;
+          }
+        else
+          assert options == { };
+          anyLuaType;
       default = { };
       inherit description;
       example =

--- a/plugins/lsp/language-servers/_mk-lsp.nix
+++ b/plugins/lsp/language-servers/_mk-lsp.nix
@@ -179,6 +179,12 @@ in
       settings = lib.nixvim.mkSettingsOption {
         description = "The settings for this LSP.";
         options = settingsOptions;
+
+        # Some servers declare settings sub-options without using `settingsOptions`.
+        # This leads the `settings` option to not be typed as a submodule.
+        # Hence, we force all `plugins.lsp.<name>.settings` options to be types as submodules.
+        # FIXME This is not ideal, but `plugins.lsp` will be dropped entirely in a few months.
+        submoduleType = true;
       };
 
       extraOptions = mkOption {


### PR DESCRIPTION
Currently, all `settings` options are typed as `types.submodule`.
This allows to explicitly define sub-options, as explained in [RFC 42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md).

However, we recently moved towards declaring as few sub-options as possible.
Besides, certain plugins' `setup` function allow for a non-attrs-like argument (e.g. list, string).

This PR types the `settings` option returned by `mkSettingsOption` as `lib.nixvim.lua-types.anything` if no sub-option was passed to the function. Further, it switches the submodule freeformType from `attrsOf anything` to `attrsOf lua-types.anything`.

This is the first time we're actually using `lua-types`, added back in #3213 
