### PR TITLE
plugins/conform: fix eval when formatters are not defined

### DIFF
--- a/plugins/by-name/conform-nvim/default.nix
+++ b/plugins/by-name/conform-nvim/default.nix
@@ -254,7 +254,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
         configuredFormatters = cfg.settings.formatters;
         inherit (cfg.autoInstall) overrides;
       };
-      names = collectFormatters (attrValues cfg.settings.formatters_by_ft);
+      names = collectFormatters (attrValues cfg.settings.formatters_by_ft or { });
       packageList = map getPackageByNameWith names;
       warns = (mkWarnsFromMaybePackageList opts) packageList;
     in


### PR DESCRIPTION
when enabling autoInstall, but not defining any formatters it currently fails to eval