### PR TITLE
modules/clipboard: add pbcopy clipboard provider

### DIFF
--- a/modules/clipboard.nix
+++ b/modules/clipboard.nix
@@ -24,14 +24,20 @@ in
         type = lib.types.submodule {
           options =
             lib.mapAttrs
-              (name: packageName: {
-                enable = lib.mkEnableOption name;
-                package = lib.mkPackageOption pkgs packageName { };
-              })
+              (
+                name: packageName:
+                {
+                  enable = lib.mkEnableOption name;
+                }
+                // lib.optionalAttrs (packageName != null) {
+                  package = lib.mkPackageOption pkgs packageName { };
+                }
+              )
               {
                 wl-copy = "wl-clipboard";
                 xclip = "xclip";
                 xsel = "xsel";
+                pbcopy = null;
               };
         };
         default = { };
@@ -47,7 +53,7 @@ in
     opts.clipboard = lib.mkIf (cfg.register != null) cfg.register;
 
     extraPackages = lib.mapAttrsToList (n: v: v.package) (
-      lib.filterAttrs (n: v: v.enable) cfg.providers
+      lib.filterAttrs (n: v: v.enable && v ? package) cfg.providers
     );
   };
 }

--- a/tests/test-sources/modules/clipboard.nix
+++ b/tests/test-sources/modules/clipboard.nix
@@ -27,4 +27,11 @@
       providers.wl-copy.enable = pkgs.stdenv.hostPlatform.isLinux;
     };
   };
+
+  example-with-builtin = {
+    clipboard = {
+      # pbcopy is only available on darwin, and is built-in
+      providers.pbcopy.enable = pkgs.stdenv.hostPlatform.isDarwin;
+    };
+  };
 }


### PR DESCRIPTION
Extend the clipboard detection to work on macOS with the builtin `pbcopy`/`pbpaste` commands