### PR TITLE
lspkind: cmp.enable default to plugins.cmp.enable

### DIFF
--- a/plugins/by-name/lspkind/default.nix
+++ b/plugins/by-name/lspkind/default.nix
@@ -23,7 +23,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
     cmp = {
       enable = lib.mkOption {
         type = types.bool;
-        default = true;
+        default = config.plugins.cmp.enable;
+        defaultText = lib.literalExpression "config.plugins.cmp.enable";
         description = "Integrate with nvim-cmp";
       };
 

--- a/tests/test-sources/plugins/by-name/lspkind/default.nix
+++ b/tests/test-sources/plugins/by-name/lspkind/default.nix
@@ -1,9 +1,6 @@
 {
   empty = {
-    plugins.lspkind = {
-      enable = true;
-      cmp.enable = false;
-    };
+    plugins.lspkind.enable = true;
   };
 
   example = {
@@ -24,10 +21,6 @@
         mode = "symbol_text";
         preset = "codicons";
         symbol_map = null;
-      };
-      cmp = {
-        enable = false;
-        after = null;
       };
     };
   };


### PR DESCRIPTION
Fixes hitting assert when `lspkind.enable = true` and no config for cmp set