### PR TITLE
lazyload: ignore ethersync rename

### DIFF
--- a/modules/lazyload.nix
+++ b/modules/lazyload.nix
@@ -39,6 +39,7 @@ in
           "null-ls"
           "wilder-nvim"
           "presence-nvim"
+          "ethersync"
         ];
 
         pluginsWithLazyLoad = builtins.filter (


### PR DESCRIPTION
Generates a trace because of being read. Missed in 4728aae7cfdcc6b0b3172ee04f04f006019c4a7e