### PR TITLE
modules/lazyload: replace `ignoredPackages` with `isVisible`

### DIFF
--- a/modules/lazyload.nix
+++ b/modules/lazyload.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   ...
 }:
@@ -28,24 +29,17 @@ in
       ];
     warnings =
       let
-        ignoredPackages = [
-          # removed
-          "packer"
-          "rust-tools"
-          "nvim-osc52"
-          "treesitter-playground"
-          # renamed
-          "surround"
-          "null-ls"
-          "wilder-nvim"
-          "presence-nvim"
-          "ethersync"
-        ];
+        isVisible =
+          opt:
+          let
+            visible = opt.visible or true;
+          in
+          if lib.isBool visible then visible else visible == "shallow";
 
         pluginsWithLazyLoad = builtins.filter (
           x:
-          !(lib.elem x ignoredPackages)
-          && lib.hasAttr "lazyLoad" config.plugins.${x}
+          lib.isOption (options.plugins.${x}.lazyload or null)
+          && isVisible options.plugins.${x}.lazyload
           && config.plugins.${x}.lazyLoad.enable
         ) (builtins.attrNames config.plugins);
         count = builtins.length pluginsWithLazyLoad;


### PR DESCRIPTION
Instead of explicitly listing all renames and removals, we can check if the plugin's lazyload option is visible and in the top-level option set.

This rules out cases where `plugins.foo` is itself a rename/removal option, and cases where `plugins.foo.lazyload` is not visible.

This should prevent #3919 from reoccurring.
