### PR TITLE
plugins/fileline: init

### DIFF
--- a/plugins/by-name/fileline/default.nix
+++ b/plugins/by-name/fileline/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "fileline";
+  package = "fileline-nvim";
+
+  callSetup = false;
+  hasSettings = false;
+
+  maintainers = [ lib.maintainers.nim65s ];
+}

--- a/tests/test-sources/plugins/by-name/fileline/default.nix
+++ b/tests/test-sources/plugins/by-name/fileline/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.fileline.enable = true;
+  };
+}


### PR DESCRIPTION
Hi,

This add support for https://github.com/lewis6991/fileline.nvim to allow opening files directly on the right line / column.

I find this useful for example when `ruff` says :
```
RUF059 Unpacked variable `c` is never used
   --> happypose/toolbox/datasets/augmentations.py:432:15
    |
430 |         assert obs.segmentation is not None
431 |         rgb = obs.rgb.copy()
432 |         h, w, c = rgb.shape
    |               ^
```

then I can start nvim with a copy-paste of `happypose/toolbox/datasets/augmentations.py:432:15`

(https://github.com/astral-sh/ruff/issues/14341 would be even better, of course, but it is not there yet)