### PR TITLE
plugins/blink-indent: init

### DIFF
--- a/plugins/by-name/blink-indent/default.nix
+++ b/plugins/by-name/blink-indent/default.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "blink-indent";
+  moduleName = "blink.indent";
+
+  maintainers = [ lib.maintainers.HeitorAugustoLN ];
+
+  settingsExample = {
+    static.highlights = [
+      "BlinkIndentRed"
+      "BlinkIndentOrange"
+      "BlinkIndentYellow"
+      "BlinkIndentGreen"
+      "BlinkIndentViolet"
+      "BlinkIndentCyan"
+    ];
+
+    scope.underline.enable = true;
+  };
+}

--- a/tests/test-sources/plugins/by-name/blink-indent/default.nix
+++ b/tests/test-sources/plugins/by-name/blink-indent/default.nix
@@ -1,0 +1,76 @@
+{ lib, ... }:
+{
+  empty = {
+    plugins.blink-indent.enable = true;
+  };
+
+  defaults = {
+    plugins.blink-indent = {
+      enable = true;
+
+      settings = {
+        blocked = {
+          buftypes.include_defaults = true;
+          filetypes.include_defaults = true;
+        };
+
+        mappings = {
+          border = "both";
+          object_scope = "ii";
+          object_scope_with_border = "ai";
+          goto_top = "[i";
+          goto_bottom = "]i";
+        };
+
+        static = {
+          enabled = true;
+          char = "▎";
+          whitespace_char = lib.nixvim.mkRaw "nil";
+          priority = 1;
+          highlights = [ "BlinkIndent" ];
+        };
+
+        scope = {
+          enabled = true;
+          char = "▎";
+          priority = 1000;
+
+          highlights = [
+            "BlinkIndentOrange"
+            "BlinkIndentViolet"
+            "BlinkIndentBlue"
+          ];
+
+          underline = {
+            enabled = false;
+
+            highlights = [
+              "BlinkIndentOrangeUnderline"
+              "BlinkIndentVioletUnderline"
+              "BlinkIndentBlueUnderline"
+            ];
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.blink-indent = {
+      enable = true;
+
+      settings = {
+        static.highlights = [
+          "BlinkIndentRed"
+          "BlinkIndentOrange"
+          "BlinkIndentYellow"
+          "BlinkIndentGreen"
+          "BlinkIndentViolet"
+          "BlinkIndentCyan"
+        ];
+
+        scope.underline.enable = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds support for [blink.indent](https://github.com/saghen/blink.indent), a performant indent guides plugin for neovim