### PR TITLE
lib: move `enableExceptInTests` impl to `build.test` option

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,7 +2,6 @@
   lib,
   flake,
   _isExtended ? false,
-  _nixvimTests ? false,
 }:
 lib.makeExtensible (
   self:
@@ -25,7 +24,7 @@ lib.makeExtensible (
     modules = call ./modules.nix { inherit flake; };
     options = call ./options.nix { };
     plugins = call ./plugins { };
-    utils = call ./utils.nix { inherit _nixvimTests; } // call ./utils.internal.nix { };
+    utils = call ./utils.nix { } // call ./utils.internal.nix { };
 
     # Top-level helper aliases:
     # TODO: deprecate some aliases

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -15,7 +15,6 @@ let
       ...
     }:
     let
-      # FIXME: this doesn't support helpers.enableExceptInTests, a context option would be better
       result = nvim.extend {
         config.test = {
           inherit name;
@@ -35,20 +34,13 @@ let
       extraSpecialArgs ? { },
     }:
     let
-      # NOTE: we are importing this just for evalNixvim
-      helpers = self.lib.nixvim.override {
-        # TODO: deprecate helpers.enableExceptInTests,
-        # add a context option e.g. `config.isTest`?
-        _nixvimTests = true;
-      };
-
       systemMod =
         if pkgs == null then
           { nixpkgs.hostPlatform = lib.mkDefault { inherit system; }; }
         else
           { nixpkgs.pkgs = lib.mkDefault pkgs; };
 
-      result = helpers.modules.evalNixvim {
+      result = self.lib.evalNixvim {
         modules = [
           module
           (lib.optionalAttrs (name != null) { test.name = name; })

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -1,7 +1,4 @@
-{
-  lib,
-  _nixvimTests,
-}:
+{ lib }:
 rec {
   /**
     Transforms a list to an _"unkeyed"_ attribute set.
@@ -23,15 +20,14 @@ rec {
     builtins.listToAttrs (lib.lists.imap0 (idx: lib.nameValuePair "__unkeyed-${toString idx}") list);
 
   /**
-    Usually `true`, except when nixvim is being evaluated by
-    `mkTestDerivationFromNixvimModule`, where it is `false`.
+    Usually `true`, except within the `build.test` option, where it is `false`.
 
     This can be used to dynamically enable plugins that can't be run in the
     test environment.
   */
   # TODO: replace and deprecate
   # We shouldn't need to use another instance of `lib` when building a test drv
-  enableExceptInTests = !_nixvimTests;
+  enableExceptInTests = true;
 
   /**
     An empty lua table `{ }` that will be included in the final lua configuration.

--- a/tests/enable-except-in-tests.nix
+++ b/tests/enable-except-in-tests.nix
@@ -15,9 +15,8 @@ let
       {
         assertions = [
           {
-            # FIXME: should be false
-            assertion = lib.nixvim.enableExceptInTests;
-            message = "Expected lib.nixvim.enableExceptInTests to be true";
+            assertion = !lib.nixvim.enableExceptInTests;
+            message = "Expected lib.nixvim.enableExceptInTests to be false";
           }
           {
             # NOTE: evaluating `helpers` here prints an eval warning

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -9,10 +9,24 @@
 let
   fetchTests = callTest ./fetch-tests.nix { };
 
+  # Avoid `build.test` re-evaluating its nixvim configuration by providing a
+  # "test mode" lib from the start
+  testLib = lib.extend (
+    final: prev: {
+      nixvim = prev.nixvim.extend (
+        final: prev: {
+          utils = prev.utils // {
+            enableExceptInTests = false;
+          };
+        }
+      );
+    }
+  );
+
   moduleToTest =
     file: name: module:
     let
-      configuration = lib.nixvim.modules.evalNixvim {
+      configuration = testLib.nixvim.modules.evalNixvim {
         modules = [
           {
             test.name = lib.mkDefault name;

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -9,14 +9,10 @@
   # NOTE: `defaultSystem` is the only reason this function can't go in `<nixvim>.lib`
   system ? defaultSystem,
   extraSpecialArgs ? { },
-  _nixvimTests ? false,
   module,
 }:
 let
   # NOTE: we are importing this just for evalNixvim
-  helpers = self.lib.nixvim.override { inherit _nixvimTests; };
-  inherit (helpers.modules) evalNixvim;
-
   systemMod =
     if pkgs == null then
       {
@@ -33,7 +29,7 @@ let
     mod:
     let
       modules = lib.toList mod;
-      nixvimConfig = evalNixvim {
+      nixvimConfig = self.lib.evalNixvim {
         modules = modules ++ [
           systemMod
         ];


### PR DESCRIPTION
- **modules/test: fix passthru example**
- **lib: move `enableExceptInTests` impl to `build.test` option**

Motivated by https://github.com/nix-community/nixvim/issues/3951 and similar instances of `enableExceptInTests` not working well with our less-abstracted APIs.

Simplify the `enableExceptInTests` attribute, removing the `_nixvimTests` argument.

We now do a full re-eval of the nixvim configuration before building the test, giving us a central place to implement `enableExceptInTests` and its eventual replacement(s).

This extends support for `enableExceptInTests` to all methods of getting a nixvim test derivation. Previously, it only worked when using `mkTestDerivationFromNixvimModule` and it only worked for `helpers`, not `lib.nixvim`.

I'm a bit concerned about the re-eval increasing out buildbot load. But I can't see an alternative way to achieve a "we are in test mode now" without things getting messy.

Maybe we could have it so that the `build.test` option only uses `extendModules` when not already in "test mode"? That way our test suite could explicitly set test mode on the initial eval, with no re-eval needed...
