### PR TITLE
tests: `pkgs.system` → `stdenv.hostPlatform.system`

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,9 +4,9 @@
   lib,
   linkFarm,
   self, # The flake instance
-  system ? pkgs.stdenv.hostPlatform.system,
 }:
 let
+  inherit (pkgs.stdenv.hostPlatform) system;
 
   # Use a single common instance of nixpkgs, with allowUnfree
   # Having a single shared instance should speed up tests a little


### PR DESCRIPTION
`pkgs.system` is deprecated and prints an eval warning.
