### PR TITLE
ci: enable stricter Bash error checking

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,10 @@ on:
       - closed
       - labeled
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   backport:
     name: Backport Pull Request

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - "main"
+defaults:
+  run:
+    shell: bash
 jobs:
   flakehub-publish:
     if: github.repository == 'nix-community/nixvim'

--- a/.github/workflows/flakestry-publish-rolling.yml
+++ b/.github/workflows/flakestry-publish-rolling.yml
@@ -9,6 +9,9 @@ on:
         description: "The existing reference to publish"
         type: "string"
         required: true
+defaults:
+  run:
+    shell: bash
 jobs:
   publish-flake:
     if: github.event_name != 'push' || github.repository == 'nix-community/nixvim'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
       - "LICENSE"
       - "flake.lock"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   treefmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   merged:
     name: Show info

--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -14,6 +14,10 @@ permissions:
   contents: read # To checkout code
   pull-requests: write # To add/remove reviewers and comment
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   tag-maintainers:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -17,6 +17,10 @@ on:
         default: false
         type: boolean
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   update-maintainers:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-other.yml
+++ b/.github/workflows/update-other.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   actions: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   prepare:
     name: Compute list of branches

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,10 @@ permissions:
   contents: write
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   update:
     name: Update the flake inputs and generate options

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,6 +12,10 @@ concurrency:
   group: docs-website
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   prepare:
     name: Version info


### PR DESCRIPTION
```
Co-authored-by: Matt Sturgeon <matt@sturgeon.me.uk>
```

This PR is entirely inspired by https://github.com/nix-community/stylix/pull/2001.

I suppose the following does not work because it is not a top-level `/.github/workflows/<WORKFLOW>.yml` file and because my LSP reports a `Property defaults is not allowed. [513]` error:

```diff
diff --git a/.github/actions/build-docs/action.yml b/.github/actions/build-docs/action.yml
index c745974c..b7907c5b 100644
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -26,6 +26,10 @@ outputs:
     description: The ID of the artifact that was uploaded.
     value: ${{ steps.upload.outputs.artifact-id }}

+defaults:
+  run:
+    shell: bash
+
 runs:
   using: "composite"
   steps:
```

Hopefully, `/.github/actions/build-docs/action.yml` is already covered by the following declarations:

- https://github.com/nix-community/nixvim/blob/695b0b80f8452bc584adf23eb58bdc9f599e35eb/.github/actions/build-docs/action.yml#L34
- https://github.com/nix-community/nixvim/blob/695b0b80f8452bc584adf23eb58bdc9f599e35eb/.github/actions/build-docs/action.yml#L43

If this breaks certain workflows upon merging, feel free to revert the affected workflows.

CC: @MattSturgeon