### PR TITLE
modules/keymaps: fix `lua` option deprecation warning

### DIFF
--- a/tests/test-sources/modules/keymaps.nix
+++ b/tests/test-sources/modules/keymaps.nix
@@ -92,4 +92,59 @@
           ];
     };
   };
+
+  luaWarning = {
+    imports = [
+      (lib.modules.setDefaultModuleLocation "test-module" {
+        keymaps = [
+          {
+            lua = true;
+            key = "a";
+            action = "function() print('keymaps') end";
+          }
+        ];
+        keymapsOnEvents.InsertEnter = [
+          {
+            lua = true;
+            key = "a";
+            action = "function() print('keymap on InsertEnter') end";
+          }
+        ];
+        plugins.lsp.keymaps.extra = [
+          {
+            lua = true;
+            key = "a";
+            action = "function() print('plugins.lsp.keymaps.extra') end";
+          }
+        ];
+        plugins.tmux-navigator.keymaps = [
+          {
+            lua = true;
+            key = "a";
+            action = "function() print('plugins.tmux-navigator.keymaps') end";
+          }
+        ];
+        plugins.barbar.keymaps.first = {
+          lua = true;
+          key = "a";
+          action = "function() print('plugins.barbar.keymaps') end";
+        };
+      })
+    ];
+
+    test.warnings = expect: [
+      (expect "count" 1)
+      (expect "any" "The `lua` keymap option is deprecated and will be removed")
+      (expect "any" "You should use a \"raw\" `action` instead;")
+      (expect "any" "e.g. `action.__raw = \"<lua code>\"` or `action = lib.nixvim.mkRaw \"<lua code>\"`.")
+      (expect "any" "- `keymaps.\"[definition 1-entry 1]\".lua' is defined in `test-module'")
+      (expect "any" "- `keymapsOnEvents.InsertEnter.\"[definition 1-entry 1]\".lua' is defined in `test-module'")
+      (expect "any" "- `plugins.lsp.keymaps.extra.\"[definition 1-entry 1]\".lua' is defined in `test-module'")
+      (expect "any" "- `plugins.tmux-navigator.keymaps.\"[definition 1-entry 1]\".lua' is defined in `test-module'")
+      # FIXME: nullOr breaks our warning
+      # (expect "any" "- `plugins.barbar.keymaps.first.lua' is defined in `test-module'")
+    ];
+
+    test.runNvim = false;
+  };
 }


### PR DESCRIPTION
The deprecation warning for the keymap-submocule `lua` option relied on `getSubOptions`, however this is fundamentally flawed because that function uses a different module eval from the one that merges submodule definitions.

Since definitions are not used by `getSubOptions`, `options.lua.isDefined` will never be true.

Instead, we have two choices:

1. Add a `luaIsDefined` option to the keymap submodule
2. Use the new v2 merge's `valueMeta` to access the actual module eval

In this PR I've implemented option 2, and added tests to ensure the warning actually works. Actually testing that warnings and deprecated options work as expected is important, as demonstrated by this one being broken so long without us noticing.

Since the warning will not have been shown to any users, I've pushed back the "will be removed after" epoch. (Sadly, I started working on this because I was hoping to _delete_ all the deprecated `lua` option code... Then I noticed it was fundamentally flawed).
