### PR TITLE
plugins/barbar: add nullOr workaround for keymaps lua warning

### DIFF
--- a/modules/keymaps.nix
+++ b/modules/keymaps.nix
@@ -69,7 +69,6 @@ in
               options.plugins.tmux-navigator.keymaps.valueMeta.list
 
               # NOTE: barbar added `mapOptionSubmodule` support shortly _before_ branching off 24.05
-              # FIXME: types.nullOr doesn't propagate valueMeta as it doesn't implement v2 check+merge
               (lib.mapAttrsToList (name: opt: opt.valueMeta) (
                 builtins.removeAttrs options.plugins.barbar.keymaps [ "silent" ]
               ))

--- a/tests/test-sources/modules/keymaps.nix
+++ b/tests/test-sources/modules/keymaps.nix
@@ -141,8 +141,7 @@
       (expect "any" "- `keymapsOnEvents.InsertEnter.\"[definition 1-entry 1]\".lua' is defined in `test-module'")
       (expect "any" "- `plugins.lsp.keymaps.extra.\"[definition 1-entry 1]\".lua' is defined in `test-module'")
       (expect "any" "- `plugins.tmux-navigator.keymaps.\"[definition 1-entry 1]\".lua' is defined in `test-module'")
-      # FIXME: nullOr breaks our warning
-      # (expect "any" "- `plugins.barbar.keymaps.first.lua' is defined in `test-module'")
+      (expect "any" "- `plugins.barbar.keymaps.first.lua' is defined in `test-module'")
     ];
 
     test.runNvim = false;


### PR DESCRIPTION
Follow-up to https://github.com/nix-community/nixvim/pull/3960.

Fixes the keymap `lua` deprecation warning for `plugins.barbar.keymaps.*`.

These options are the only ones that both support the deprecated `lua` field and use a `nullOr submodule` type, making them the only ones affected.

Currently, `types.nullOr` does not propagate the new `valueMeta` attribute added by [v2 check and merge](https://github.com/NixOS/nixpkgs/pull/391544), but `types.either` does.

Since the warning logic in `modules/keymaps.nix` depends on `valueMeta`, this PR re-implements `nullOr` using `types.either` as a local workaround.

