### PR TITLE
flake: remove lib.<system>.helpers

### DIFF
--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -32,9 +32,6 @@
         check = pkgs.callPackage ../lib/tests.nix {
           inherit lib self system;
         };
-
-        # NOTE: no longer needs to be per-system
-        helpers = lib.warn "nixvim: `<nixvim>.lib.${system}.helpers` has been moved to `<nixvim>.lib.nixvim` and no longer depends on a specific system" self.lib.nixvim;
       }
     )
   );


### PR DESCRIPTION
Remove the deprecated `<flake>.lib.<system>.helpers` output, deprecated in https://github.com/nix-community/nixvim/pull/2727 during the 25.05 cycle (shortly _after_ 24.11 branch off).

Maybe we should hold off on this until after 25.11 is released and merge this during the 26.05 cycle?
