### PR TITLE
lib/options/mkSettingsOption: use nestedLiteralLua

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -352,7 +352,7 @@ rec {
           {
             foo_bar = 42;
             hostname = "localhost:8080";
-            callback.__raw = ''
+            callback = lib.nixvim.nestedLiteralLua ''
               function()
                 print('nixvim')
               end


### PR DESCRIPTION
For colorscheme/plugin modules which don't have `settingsExample` set

| Before | After  |
| ------ | ------ |
| <img width="791" height="516" alt="Captura de tela de 2025-11-23 00-51-12" src="https://github.com/user-attachments/assets/07633d29-6c62-49e7-b1df-538abf4f83fb" /> | <img width="791" height="516" alt="Captura de tela de 2025-11-23 00-51-18" src="https://github.com/user-attachments/assets/469df524-da28-4fb9-8966-a42b823845f7" /> |
