### PR TITLE
tests/platforms: init `nixos-hm` test

### DIFF
--- a/tests/platforms/default.nix
+++ b/tests/platforms/default.nix
@@ -16,6 +16,7 @@ in
 }
 // lib.optionalAttrs isLinux {
   nixos-module = (callTest ./nixos.nix { }).config.system.build.toplevel;
+  nixos-hm-module = (callTest ./nixos-hm.nix { }).config.system.build.toplevel;
 }
 // lib.optionalAttrs isDarwin {
   darwin-module = (callTest ./darwin.nix { }).system;

--- a/tests/platforms/nixos-hm.nix
+++ b/tests/platforms/nixos-hm.nix
@@ -1,0 +1,39 @@
+{
+  self,
+  system,
+}:
+self.inputs.nixpkgs.lib.nixosSystem {
+  inherit system;
+
+  modules = [
+    {
+      system.stateVersion = "25.05";
+      boot.loader.systemd-boot.enable = true;
+      fileSystems."/" = {
+        device = "/non/existent/device";
+      };
+
+      users.users.nixvim = {
+        description = "Nixvim User";
+        initialPassword = "password";
+        home = "/invalid/dir";
+        isNormalUser = true;
+      };
+
+      home-manager = {
+        useGlobalPkgs = true;
+        useUserPackages = true;
+        users.nixvim = {
+          home.stateVersion = "25.05";
+
+          programs.nixvim = {
+            enable = true;
+          };
+
+          imports = [ self.homeModules.nixvim ];
+        };
+      };
+    }
+    self.inputs.home-manager.nixosModules.home-manager
+  ];
+}


### PR DESCRIPTION
Test using home-manager module via a NixOS-managed home-manager configuration.

I was hoping this might reproduce #3966, but it does not. Maybe this is a useful test permutation regardless?
