### PR TITLE
wrappers: use flake-locked `lib` instead of host's

### DIFF
--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -70,10 +70,16 @@ in
 
   config = mkMerge [
     {
-      # Make our lib available to the host modules
-      # - the `config.lib.nixvim` option is the nixvim-lib
-      # - the `nixvimLib` arg is `lib` extended with our overlay
-      lib.nixvim = lib.mkDefault config._module.args.nixvimLib.nixvim;
+      # Make Nixvim's extended lib available to the host modules
+      # - The `config.lib.nixvim` option is Nixvim's section of the lib
+      #   (based on our flake's locked Nixpkgs lib)
+      # - The `nixvimLib` arg is `lib` extended with our overlay
+      #   (based on the host configuration's `lib`)
+      #
+      # NOTE: It is important that we use the flake-locked Nixpkgs lib,
+      # so that we can safely use recently added lib features.
+      # TODO: Consider deprecating `_module.args.nixvimLib`?
+      lib.nixvim = lib.mkDefault self.lib.nixvim;
       _module.args.nixvimLib = lib.mkDefault (lib.extend self.lib.overlay);
     }
 


### PR DESCRIPTION
Previously, we constructed Nixvim's extended lib from the host configuration's lib.

Naïvely, this potentially allowed fetching fewer Nixpkgs revisions and instantiating fewer lib instances. However, it also means our `lib` interface is unstable, especially when the host configuration is using a different Nixpkgs release to Nixvim.

This should fix #3966 (needs testing), a regression caused by https://github.com/nix-community/nixvim/pull/3960.

See also: [matrix discussion](https://matrix.to/#/!wfudwzqQUiJYJnqfSY:nixos.org/$7p-ahKCwFWf5HMEHmuYERs43L4NKOzmUVZWUzYgixGg).
