### PR TITLE
flake: remove `helpers` module arg

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,5 +1,4 @@
 {
-  helpers,
   system,
   nixvim,
   nixpkgs,
@@ -84,7 +83,7 @@ let
       ) opt.declarations;
     };
 
-  configuration = helpers.modules.evalNixvim {
+  configuration = nixvim.lib.evalNixvim {
     modules = [
       {
         isDocs = true;

--- a/flake/dev/tests.nix
+++ b/flake/dev/tests.nix
@@ -1,14 +1,10 @@
-{
-  self,
-  helpers,
-  ...
-}:
+{ self, ... }:
 {
   perSystem =
     { pkgs, ... }:
     let
       tests = pkgs.callPackage ../../tests {
-        inherit helpers self;
+        inherit self;
       };
     in
     {

--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -6,11 +6,6 @@
   ...
 }:
 {
-  # Expose lib as a flake-parts module arg
-  _module.args = {
-    helpers = self.lib.nixvim;
-  };
-
   # Public `lib` flake output
   flake.lib = {
     nixvim = lib.makeOverridable ({ lib }: (lib.extend self.lib.overlay).nixvim) {

--- a/flake/nixvim-configurations.nix
+++ b/flake/nixvim-configurations.nix
@@ -1,9 +1,9 @@
-{ helpers, ... }:
+{ self, ... }:
 {
   perSystem =
     { system, ... }:
     {
-      nixvimConfigurations.default = helpers.modules.evalNixvim {
+      nixvimConfigurations.default = self.lib.evalNixvim {
         inherit system;
       };
     };

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -1,9 +1,4 @@
-{
-  self,
-  inputs,
-  helpers,
-  ...
-}:
+{ self, inputs, ... }:
 {
   perSystem =
     {
@@ -18,7 +13,6 @@
 
       packages = import ../docs {
         nixvim = self;
-        inherit helpers;
         inherit system;
         inherit (inputs) nixpkgs;
         inherit (inputs') nuschtosSearch;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,12 +1,12 @@
 {
   pkgs,
-  helpers,
   lib,
   linkFarm,
   self, # The flake instance
 }:
 let
   inherit (pkgs.stdenv.hostPlatform) system;
+  helpers = self.lib.nixvim;
 
   # Use a single common instance of nixpkgs, with allowUnfree
   # Having a single shared instance should speed up tests a little


### PR DESCRIPTION
Not to be confused with the Nixvim-configuration `helpers` module arg, remove the flake-parts `helpers` module arg.

Flake-parts modules are internal, so we don't need any deprecation for this.
