### PR TITLE
flake: defer `homeManagerModules` warning

### DIFF
--- a/flake/wrappers.nix
+++ b/flake/wrappers.nix
@@ -5,6 +5,9 @@
 }:
 let
   inherit (lib.modules) importApply;
+  # Added 2025-05-25; warning shown since 2025-08-01 (25.11)
+  # NOTE: top-level binding of a fully resolved value, to avoid printing multiple times
+  homeManagerModulesWarning = lib.warn "nixvim: flake output `homeManagerModules` has been renamed to `homeModules`." null;
 in
 {
   perSystem =
@@ -28,13 +31,7 @@ in
       default = self.nixosModules.nixvim;
     };
     # Alias for backward compatibility
-    # Added 2025-05-25 in https://github.com/nix-community/nixvim/pull/3387
-    homeManagerModules =
-      let
-        cond = lib.trivial.oldestSupportedReleaseIsAtLeast 2505;
-        msg = "nixvim: flake output `homeManagerModules` has been renamed to `homeModules`.";
-      in
-      lib.warnIf cond msg self.homeModules;
+    homeManagerModules = lib.mapAttrs (_: lib.seq homeManagerModulesWarning) self.homeModules;
     homeModules = {
       nixvim = importApply ../wrappers/hm.nix self;
       default = self.homeModules.nixvim;


### PR DESCRIPTION
Since August when 25.05 became the "oldest supported release", I noticed the `homeManagerModules` rename warning is triggering a bit too eagerly.

I'm not sure if this is happening because of flake-parts' module eval, or because of the `nix` command reading flake outputs. Regardless, we should delay the warning so that it only shows up when the module is actually used.

There are two ways we can solve this. Either we warn when the module is imported, or we warn when home-manager checks its `warnings` option.

Each approach has pros and cons. The former is simpler and more reliable; the warning should always show up. The latter is delayed until later and groups the warning with other home-manager warnings. One major downside of using the `warnings` option in this case, is that we won't warn about the flake-output rename if any `assertions` are false.

Printing the warning earlier (when importing) is probably best in this case. Implemented that approach in this PR.

`oldestSupportedReleaseIsAtLeast 2505` will always be true on `main`, and will always be false on `nixos-25.05`. Since I don't anticipate needing to backport this or deal with merge conflicts backporting other changes, I've factored out that condition.
