### PR TITLE
wrappers: use `importApply` to preserve module location

### DIFF
--- a/flake/wrappers.nix
+++ b/flake/wrappers.nix
@@ -3,6 +3,9 @@
   lib,
   ...
 }:
+let
+  inherit (lib.modules) importApply;
+in
 {
   perSystem =
     { system, ... }:
@@ -17,7 +20,7 @@
 
   flake = {
     nixosModules = {
-      nixvim = import ../wrappers/nixos.nix self;
+      nixvim = importApply ../wrappers/nixos.nix self;
       default = self.nixosModules.nixvim;
     };
     # Alias for backward compatibility
@@ -29,11 +32,11 @@
       in
       lib.warnIf cond msg self.homeModules;
     homeModules = {
-      nixvim = import ../wrappers/hm.nix self;
+      nixvim = importApply ../wrappers/hm.nix self;
       default = self.homeModules.nixvim;
     };
     nixDarwinModules = {
-      nixvim = import ../wrappers/darwin.nix self;
+      nixvim = importApply ../wrappers/darwin.nix self;
       default = self.nixDarwinModules.nixvim;
     };
   };

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -8,6 +8,9 @@ let
   inherit (lib)
     mkIf
     ;
+  inherit (lib.modules)
+    importApply
+    ;
   cfg = config.programs.nixvim;
   evalArgs = {
     extraSpecialArgs = {
@@ -21,7 +24,7 @@ in
 {
   _file = ./darwin.nix;
 
-  imports = [ (import ./_shared.nix { inherit self evalArgs; }) ];
+  imports = [ (importApply ./_shared.nix { inherit self evalArgs; }) ];
 
   config = mkIf cfg.enable {
     environment.systemPackages = [


### PR DESCRIPTION
The `import module args` pattern is useful for applying inputs from outside of the module system, however it discards module location metadata that is usually associated with file-path modules.

`lib.modules.importApply` solves that problem by wrapping the applied module using `lib.modules.setDefaultModuleLocation`.

This means documentation, warnings, and errors will show the correct location.
