### PR TITLE
plugins/hunk: remove nui auto-enable

### DIFF
--- a/plugins/by-name/hunk/default.nix
+++ b/plugins/by-name/hunk/default.nix
@@ -15,8 +15,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.jalil-salame ];
 
-  extraConfig.plugins.nui.enable = lib.mkDefault true; # required dependency
-
   settingsExample = {
     keys.global.quit = [ "x" ];
 


### PR DESCRIPTION
The nui-nvim dependency is bundled with the hunk-nvim derivation, so there's no need to auto-enable `plugins.nui`.

Was there since inception with https://github.com/nix-community/nixvim/pull/3293 but doesn't appear to be required, since it's included in the upstream [derivation](https://github.com/NixOS/nixpkgs/blob/45af851ce7b0c1a95d7d901bb7a9816c3cb2378f/pkgs/applications/editors/vim/plugins/overrides.nix#L1469-L1471).