### PR TITLE
plugins/conform: refactor the autoInstall option implementation

### DIFF
--- a/plugins/by-name/conform-nvim/formatter-packages.nix
+++ b/plugins/by-name/conform-nvim/formatter-packages.nix
@@ -3,32 +3,34 @@
   ...
 }:
 with pkgs;
-rec {
-  sType = {
-    broken = "broken";
-    darwinOnly = "Darwin only";
+let
+  states = {
+    broken = _package: "broken";
+    darwinOnly = _package: "Darwin only";
     unpackaged = "unpackaged";
   };
-
+in
+{
+  inherit states;
   formatter-packages = {
     # 2025-11-15 dependency swift is broken
     # https://github.com/NixOS/nixpkgs/issues/461474
-    swift = sType.broken;
-    swift_format = sType.broken;
-    swiftformat = sType.broken;
-    swiftlint = sType.broken;
+    swift = states.broken swift;
+    swift_format = states.broken swift-format;
+    swiftformat = states.broken swiftformat;
+    swiftlint = states.broken swiftlint;
 
     # 2025-10-12 build failure on Darwin
-    smlfmt = if stdenv.isDarwin then sType.broken else smlfmt;
+    smlfmt = if stdenv.isDarwin then states.broken smlfmt else smlfmt;
 
     # 2025-11-25 build failure
-    roc = sType.broken;
+    roc = states.broken roc;
     # 2025-09-13 build failure
-    inko = sType.broken;
+    inko = states.broken inko;
     # 2025-09-17 build failure
-    gci = sType.broken;
+    gci = states.broken gci;
     # 2025-10-08 build failure (haskellPackages.hindent)
-    hindent = sType.broken;
+    hindent = states.broken haskellPackages.hindent;
 
     format-queries = null; # Uses neovim itself
     init = null; # Internal thingamajig
@@ -36,55 +38,55 @@ rec {
     trim_newlines = null; # Conform native formatter
     trim_whitespace = null; # Conform native formatter
 
-    auto_optional = sType.unpackaged;
-    bake = sType.unpackaged;
-    blue = sType.unpackaged;
-    bpfmt = sType.unpackaged;
-    bsfmt = sType.unpackaged;
-    caramel_fmt = sType.unpackaged;
-    crlfmt = sType.unpackaged;
-    darker = sType.unpackaged;
-    dcm_fix = sType.unpackaged;
-    dcm_format = sType.unpackaged;
-    easy-coding-standard = sType.unpackaged;
-    findent = sType.unpackaged;
-    ghokin = sType.unpackaged;
-    gluon_fmt = sType.unpackaged;
-    grain_format = sType.unpackaged;
-    hledger-fmt = sType.unpackaged;
-    imba_fmt = sType.unpackaged;
-    janet-format = sType.unpackaged;
-    json_repair = sType.unpackaged;
-    liquidsoap-prettier = sType.unpackaged;
-    llf = sType.unpackaged;
-    markdown-toc = sType.unpackaged;
-    markdownfmt = sType.unpackaged;
-    mdslw = sType.unpackaged;
-    mojo_format = sType.unpackaged;
-    nomad_fmt = sType.unpackaged;
-    npm-groovy-lint = sType.unpackaged;
-    packer_fmt = sType.unpackaged;
-    pangu = sType.unpackaged;
-    perlimports = sType.unpackaged;
-    pint = sType.unpackaged;
-    purs-tidy = sType.unpackaged;
-    pycln = sType.unpackaged;
-    pyink = sType.unpackaged;
-    pymarkdownlnt = sType.unpackaged;
-    reformat-gherkin = sType.unpackaged;
-    rescript-format = sType.unpackaged;
-    runic = sType.unpackaged;
-    spotless_gradle = sType.unpackaged;
-    spotless_maven = sType.unpackaged;
-    standard-clj = sType.unpackaged;
-    standardjs = sType.unpackaged;
-    tclfmt = sType.unpackaged;
-    tlint = sType.unpackaged;
-    twig-cs-fixer = sType.unpackaged;
-    typstfmt = sType.unpackaged;
-    vsg = sType.unpackaged;
-    ziggy = sType.unpackaged;
-    ziggy_schema = sType.unpackaged;
+    auto_optional = states.unpackaged;
+    bake = states.unpackaged;
+    blue = states.unpackaged;
+    bpfmt = states.unpackaged;
+    bsfmt = states.unpackaged;
+    caramel_fmt = states.unpackaged;
+    crlfmt = states.unpackaged;
+    darker = states.unpackaged;
+    dcm_fix = states.unpackaged;
+    dcm_format = states.unpackaged;
+    easy-coding-standard = states.unpackaged;
+    findent = states.unpackaged;
+    ghokin = states.unpackaged;
+    gluon_fmt = states.unpackaged;
+    grain_format = states.unpackaged;
+    hledger-fmt = states.unpackaged;
+    imba_fmt = states.unpackaged;
+    janet-format = states.unpackaged;
+    json_repair = states.unpackaged;
+    liquidsoap-prettier = states.unpackaged;
+    llf = states.unpackaged;
+    markdown-toc = states.unpackaged;
+    markdownfmt = states.unpackaged;
+    mdslw = states.unpackaged;
+    mojo_format = states.unpackaged;
+    nomad_fmt = states.unpackaged;
+    npm-groovy-lint = states.unpackaged;
+    packer_fmt = states.unpackaged;
+    pangu = states.unpackaged;
+    perlimports = states.unpackaged;
+    pint = states.unpackaged;
+    purs-tidy = states.unpackaged;
+    pycln = states.unpackaged;
+    pyink = states.unpackaged;
+    pymarkdownlnt = states.unpackaged;
+    reformat-gherkin = states.unpackaged;
+    rescript-format = states.unpackaged;
+    runic = states.unpackaged;
+    spotless_gradle = states.unpackaged;
+    spotless_maven = states.unpackaged;
+    standard-clj = states.unpackaged;
+    standardjs = states.unpackaged;
+    tclfmt = states.unpackaged;
+    tlint = states.unpackaged;
+    twig-cs-fixer = states.unpackaged;
+    typstfmt = states.unpackaged;
+    vsg = states.unpackaged;
+    ziggy = states.unpackaged;
+    ziggy_schema = states.unpackaged;
 
     inherit (python313Packages) autopep8;
     awk = gawk;


### PR DESCRIPTION
Now when setting a package as broken you need to provide the package name. This is for ease of maintaining. Currently setting a package as broken loses the name. When a package gets fixed, this forces the maintainers to either find the commit where it wasn't broken and get the name, or try looking it up again with `nix-locate` and such. With this change you just have to remove the `state.broken` part

some renames for clarity:
few `x` values get a proper name
`sType` -> `state`

I also removed an awful case where i had two functions checking if something was `sType`, but one was before being made into a list and the other after. Now there is only one check and i just create a partition attrset using a map and fold.

This is unrelated to the changes here, but should we set `autoInstall` to `true` by default now? I think this is the behaviour users expect and the initial bugs have been ironed out.