### PR TITLE
modules/files: ensure derivation is recognized as vim plugin

### DIFF
--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -77,7 +77,7 @@ in
 
       # A directory with all the files in it
       # Implementation based on NixOS's /etc module
-      build.extraFiles = pkgs.runCommandLocal "nvim-config" { } ''
+      build.extraFiles = pkgs.runCommandLocal "nvim-config" { passthru.vimPlugin = true; } ''
         set -euo pipefail
 
         makeEntry() {


### PR DESCRIPTION
I am generating .luarc.json with [mrcjkb's gen-luarc](https://github.com/mrcjkb/nix-gen-luarc-json) for lua language server completion on my configuration, but it requires vimPlugin = true (defined by buildVimPlugin generally) for considering the plugin a vim plugin instead of a lua package