### PR TITLE
plugins/efmls-configs: avoid reading HTML & JSON aliases

### DIFF
--- a/plugins/by-name/efmls-configs/default.nix
+++ b/plugins/by-name/efmls-configs/default.nix
@@ -182,7 +182,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
           (
             builtins.removeAttrs cfg.setup [
               "all"
+              # Rename aliases added 2025-06-25 in https://github.com/nix-community/nixvim/pull/3503
               "warnings"
+              "HTML"
+              "JSON"
             ]
           )
         )


### PR DESCRIPTION
https://github.com/nix-community/nixvim/pull/3503 added rename aliases for the HTML and JSON options, which print a trace when evaluated:

```
trace: Obsolete option `HTML' is used. It was renamed to `html'.
trace: Obsolete option `JSON' is used. It was renamed to `json'.
```

These were correctly removed when introspecting enabled tools, however they were not removed when constructing the "setup options" to serialise as a lua table.


To reproduce, run 
```
nix eval .#checks.x86_64-linux.tests.entries.plugins-by-name-efmls-configs
```