### PR TITLE
plugins/conform: fix eval error

### DIFF
--- a/plugins/by-name/conform-nvim/default.nix
+++ b/plugins/by-name/conform-nvim/default.nix
@@ -259,7 +259,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
       );
     in
     {
-      warnings = lib.mkIf (enable && enableWarnings) (mkWarnsFromStates opts packagesAndStates.wrong);
-      extraPackages = lib.mkIf enable packagesAndStates.right;
+      warnings = lib.mkIf (enable && enableWarnings) (
+        mkWarnsFromStates opts (packagesAndStates.wrong or [ ])
+      );
+      extraPackages = lib.mkIf enable (packagesAndStates.right or [ ]);
     };
 }


### PR DESCRIPTION
Fixes a serious bug introduced by https://github.com/nix-community/nixvim/pull/3988 preventing eval.
The fold result doesn't always have a `wrong` or `right` attribute, as the first only exists when there are warnings and the latter when packages are defined.

So sorry for introducing this, I don't know how i missed this while testing it locally on my config.