### PR TITLE
plugins/friendly-snippets: fix warning

### DIFF
--- a/plugins/by-name/friendly-snippets/default.nix
+++ b/plugins/by-name/friendly-snippets/default.nix
@@ -27,7 +27,9 @@ lib.nixvim.plugins.mkVimPlugin {
       {
         when =
           config.performance.combinePlugins.enable
-          && !(builtins.elem "friendly-snippets" config.performance.combinePlugins.standalonePlugins)
+          && !(builtins.elem "friendly-snippets" (
+            map lib.getName config.performance.combinePlugins.standalonePlugins
+          ))
           && (enabledConsumers != [ ]);
         message = ''
           When using ${options.performance.combinePlugins.enable}, ${options.plugins.friendly-snippets.enable} and ${enabledConsumersPretty}:


### PR DESCRIPTION
This makes the warning work properly when a package is used instead of a string in `standalonePlugins`. `lib.getName` on a string returns the string, so its safe to map here.