### PR TITLE
lib: reimplement `call`; drop `.override`

### DIFF
--- a/lib/top-level.nix
+++ b/lib/top-level.nix
@@ -22,13 +22,21 @@ lib.makeExtensible (
   self:
   let
     # Used when importing parts of our lib
-    call = lib.callPackageWith {
+    autoArgs = {
       inherit
         call
         self
         lib
         ;
     };
+
+    call =
+      fnOrFile:
+      let
+        fn = if builtins.isPath fnOrFile then import fnOrFile else fnOrFile;
+        fnAutoArgs = builtins.intersectAttrs (builtins.functionArgs fn) autoArgs;
+      in
+      args: fn (fnAutoArgs // args);
   in
   {
     autocmd = call ./autocmd-helpers.nix { };


### PR DESCRIPTION
Using `callPackageWith` adds `override` and `overrideDerivation` attributes to the result, which are not relevant to subsections of Nixvim's lib section.

Implement our own, simplified, `call` using `intersectAttrs` and `functionArgs`.

If users wish to modify parts of our lib section, they should extend the top-level fixpoint to ensure everything stays in sync. This can be done via the `lib.nixvim.extend` or `lib.extend` functions.
