### PR TITLE
docs: discourage use of `follows`

### DIFF
--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -83,17 +83,13 @@ When using Nixvim, it is possible to encounter errors about something not being 
  error: <name> cannot be found in pkgs
 ```
 
-This usually means one of two things:
+This usually means one of few things:
+- You are using `follows` on `inputs.nixvim` causing Nixvim to have an unexpected version of Nixpkgs.
 - The nixpkgs version is not in line with Nixvim (for example nixpkgs nixos-25.11 is used with Nixvim master)
 - The nixpkgs unstable version used with Nixvim is not recent enough.
 
-When building Nixvim using flakes and our ["standalone mode"][standalone], we usually recommend _not_ declaring a "follows" for `inputs.nixvim`.
+When building Nixvim using flakes, we usually recommend _not_ declaring a `follows` for `inputs.nixvim`.
 This is so that Nixvim is built against the same nixpkgs revision we're using in our test suite.
-
-If you are building Nixvim using the NixOS, Home Manager, or nix-darwin modules then we advise that you keep your nixpkgs lock as close as possible to ours.
-
-> [!TIP]
-> Once [#1784](https://github.com/nix-community/nixvim/issues/1784) is implemented, there will be alternative ways to achieve this using the module system.
 
 [standalone]: ../platforms/standalone.md
 

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -35,13 +35,15 @@ When using flakes you can simply add `nixvim` to the inputs:
     inputs.nixvim = {
         url = "github:nix-community/nixvim";
         # If using a stable channel you can use `url = "github:nix-community/nixvim/nixos-<version>"`
-        inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # outputs...
 }
 
 ```
+We recommend against using `inputs.nixpkgs.follows = "nixpkgs";` on the `nixvim` input as we test Nixvim against our Nixpkgs revision.
+When you use `follows` you opt out of guarantees provided by these tests.
+If you choose to use it anyway, removing `follows` should be one of the first debugging steps when encountering issues.
 
 ## Usage
 
@@ -50,7 +52,6 @@ Nixvim can be used standalone or as a module for NixOS, Home Manager, or nix-dar
 When used standalone, a custom Nixvim derivation is produced that can be used like any other package.
 
 When used as a module, Nixvim can be enabled though `programs.nixvim.enable`.
-
 
 ### Usage as a module (NixOS, Home Manager, nix-darwin)
 


### PR DESCRIPTION
A lot of issues with Nixvim are caused by using `follows`. As I understand this made much more sense before Nixvim had it's own nixpkgs instance in non-standalone modes. Now follows should generally not be used even when Nixvim is a nixos/hm module.

This is also why i removed some text putting emphasis on having nixpkgs versions match, as to my understanding we aren't as sensitive to mismatches anymore even on module usage.

Also some minor changes.