### PR TITLE
plugins/opencode: add lsof to extraPackages

### DIFF
--- a/plugins/by-name/opencode/default.nix
+++ b/plugins/by-name/opencode/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "opencode";
   package = "opencode-nvim";
@@ -23,6 +23,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   hasLuaConfig = false;
   extraConfig = cfg: {
     globals.opencode_opts = cfg.settings;
+    extraPackages = [ pkgs.lsof ];
   };
 
   settingsExample = {


### PR DESCRIPTION
## Summary
- Add lsof to extraPackages for opencode.nvim plugin

opencode.nvim uses lsof to detect running opencode instances in the current working directory. Without lsof available, the plugin spawns new terminal instances instead of reusing existing ones.