### PR TITLE
plugins/sidekick/assertion: no copilot dependency when nes disabled

### DIFF
--- a/plugins/by-name/sidekick/default.nix
+++ b/plugins/by-name/sidekick/default.nix
@@ -17,10 +17,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
     "opencode"
   ];
 
-  extraConfig = {
+  extraConfig = cfg: {
     assertions = lib.nixvim.mkAssertions "plugins.sidekick" {
-      assertion = config.plugins.copilot-lua.enable || config.lsp.servers.copilot.enable;
-      message = "sidekick requires either copilot-lua (${options.plugins.copilot-lua.enable}) or copilot LSP (${options.lsp.servers}.copilot.enable) to be enabled";
+      assertion =
+        (cfg.settings.opts.nes.enabled or true)
+        -> (config.plugins.copilot-lua.enable || config.lsp.servers.copilot.enable);
+      message = "sidekick requires either copilot-lua (${options.plugins.copilot-lua.enable}) or copilot LSP (${options.lsp.servers}.copilot.enable) to be enabled when NES is enabled";
     };
   };
 


### PR DESCRIPTION
When the Sidekick plugin has Next Edit Suggestions disabled we should not enforce the dependency on Copilot.

See:

https://github.com/folke/sidekick.nvim?tab=readme-ov-file#can-i-use-this-without-nes-just-for-cli-tools