### PR TITLE
modules/lsp: fix `mkServerOption` homepage tryEval evaluation

### DIFF
--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -40,10 +40,10 @@ let
         # Get suboptions of `lsp.servers.<name>`
         (opts: opts.${name}.type.getSubOptions opts.${name}.loc)
         # Get the default package
-        (opts: opts.package.default or null)
-        # The default throws if mkPackageOption can't find the package
-        # E.g. mismatched nixpkgs revision
-        (package: (builtins.tryEval package).value)
+        #
+        # Use tryEval to catch throws when mkPackageOption can't find the package,
+        # e.g., due to a mismatched nixpkgs revision
+        (opts: (builtins.tryEval (opts.package.default or null)).value)
         # Get package's homepage
         (package: package.meta.homepage or null)
       ];


### PR DESCRIPTION
https://github.com/nix-community/nixvim/pull/3794 attempted to fix errors that occur when evaluating LSP server option descriptions if an option's package is missing from nixpkgs. That approach was ineffective because `lib.pipe` strictly evaluates intermediate steps using `foldl'`. As a result, piping:

```nix
[
  (opts: opts.package.default or null)
  (package: (tryEval package).value)
]
```

does not work, since `opts.package.default` is evaluated **before** `tryEval` can catch errors.

This PR inlines `opts.package.default` directly into the `tryEval` expression, ensuring missing-package errors are caught correctly.

Added a regression test to assert this is working as expected.

---

- Resolves errors when building NixOS or nix-darwin docs that include Nixvim options.
- Fixes https://github.com/nix-community/nixvim/issues/4033
- and https://github.com/nix-community/nixvim/issues/3780 (for real this time).

**Related issues:**
- https://github.com/nix-community/nixvim/issues/3788

