### PR TITLE
Add missing `lib` on `gitignore` plugin

### DIFF
--- a/plugins/by-name/gitignore/default.nix
+++ b/plugins/by-name/gitignore/default.nix
@@ -15,7 +15,7 @@ lib.nixvim.plugins.mkVimPlugin {
         nullOr (
           either str (submodule {
             options = {
-              key = mkOption {
+              key = lib.mkOption {
                 type = str;
                 description = "The key to map.";
                 example = "<leader>gi";


### PR DESCRIPTION
Commit https://github.com/nix-community/nixvim/commit/629f9d75f81fc1dd3ce703110688afeff73e60dc removed the with lib, but forgot to add a lib to a line.