### PR TITLE
plugins/dap: allow lua for adapters

### DIFF
--- a/plugins/by-name/dap/dapHelpers.nix
+++ b/plugins/by-name/dap/dapHelpers.nix
@@ -98,7 +98,11 @@ rec {
 
   mkAdapterOption =
     name: type:
-    mkNullOrOption (with types; attrsOf (either str type)) ''
+    let
+      # TODO: Added 2025-12-11 (26.05)
+      strToRawLua = lib.nixvim.deprecation.transitionType types.str lib.nixvim.mkRaw types.rawLua;
+    in
+    mkNullOrOption (with types; attrsOf (either strToRawLua type)) ''
       Debug adapters of `${name}` type.
       The adapters can also be set to a function which takes three arguments:
 
@@ -150,8 +154,8 @@ rec {
     type: adapters:
     lib.mapAttrs (
       _: adapter:
-      if builtins.isString adapter then
-        lib.nixvim.mkRaw adapter
+      if lib.types.isRawType adapter then
+        adapter
       else
         lib.filterAttrs (n: _: n != "enrichConfig") (
           adapter

--- a/tests/test-sources/plugins/by-name/dap/default.nix
+++ b/tests/test-sources/plugins/by-name/dap/default.nix
@@ -8,14 +8,50 @@
       enable = true;
 
       adapters = {
+        python.__raw = ''
+          function(cb, config)
+            if config.request == 'attach' then
+              local port = (config.connect or config).port
+              local host = (config.connect or config).host or '127.0.0.1'
+              cb({
+                type = 'server',
+                port = assert(port, '`connect.port` is required for a python `attach` configuration'),
+                host = host,
+                options = {
+                  source_filetype = 'python',
+                },
+              })
+            else
+              cb({
+                type = 'executable',
+                command = 'path/to/virtualenvs/debugpy/bin/python',
+                args = { '-m', 'debugpy.adapter' },
+                options = {
+                  source_filetype = 'python',
+                },
+              })
+            end
+          end
+        '';
+
         executables = {
-          python = {
+          pythonStructured = {
             command = ".virtualenvs/tools/bin/python";
             args = [
               "-m"
               "debugpy.adapter"
             ];
           };
+          lldb.__raw = ''
+            function(on_config, config)
+              local command = config.lldbCommand or "lldb-vscode"
+              on_config({
+                type = "executable",
+                command = command,
+                name = "lldb",
+              })
+            end
+          '';
         };
         servers = {
           java = ''


### PR DESCRIPTION
Support `mkRaw` for adapter definitions to support more flexible configuration.

https://codeberg.org/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation

