### PR TITLE
plugins/lsp/lsp-packages: drop customCmd feature

### DIFF
--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -60,19 +60,16 @@ let
       default = { };
     };
 
-  # Combine `packages` and `customCmd` sets from `packages.nix`
+  # Import `packages` from `packages.nix`
   # We use this set to generate the package-option defaults
   serverPackages =
     let
-      inherit (import ./packages.nix)
-        packages
-        customCmd
-        ;
+      inherit (import ./packages.nix) packages;
     in
     builtins.mapAttrs (name: v: {
       inherit name;
       package = v.package or v;
-    }) (packages // customCmd);
+    }) packages;
 in
 {
   options.lsp = {

--- a/modules/lsp/servers/packages.nix
+++ b/modules/lsp/servers/packages.nix
@@ -448,9 +448,4 @@
     zls = "zls";
     zuban = "zuban";
   };
-
-  # Servers that can't/don't use the provided upstream command in Nix, or packages with no upstream commands
-  customCmd = {
-  };
-
 }

--- a/plugins/lsp/language-servers/default.nix
+++ b/plugins/lsp/language-servers/default.nix
@@ -224,9 +224,6 @@ let
       // lib.optionalAttrs (lspPackages.packages ? ${name}) {
         package = lspPackages.packages.${name};
       }
-      // lib.optionalAttrs (lspPackages.customCmd ? ${name}) {
-        inherit (lspPackages.customCmd.${name}) package cmd;
-      }
       // lspExtraArgs.${name} or { }
     ))
   ];

--- a/tests/generated.nix
+++ b/tests/generated.nix
@@ -45,7 +45,7 @@ let
   errors = lib.concatStringsSep "\n" (
     checkDeclarations (
       let
-        inherit (import ../modules/lsp/servers/packages.nix) unpackaged packages customCmd;
+        inherit (import ../modules/lsp/servers/packages.nix) unpackaged packages;
       in
       {
         name = "lsp";
@@ -53,7 +53,7 @@ let
 
         packages = builtins.attrValues packages;
 
-        declared = unpackaged ++ lib.attrsets.attrNames (packages // customCmd);
+        declared = unpackaged ++ lib.attrsets.attrNames packages;
 
         generated = builtins.attrNames (lib.importJSON ../generated/lspconfig-servers.json);
         unsupported = lib.importJSON ../generated/unsupported-lspconfig-servers.json;


### PR DESCRIPTION
- **plugins/lsp/lsp-packages: remove unnecessary customCmd defs**
- **plugins/lsp/lsp-packages: drop customCmd feature**

NOTE: holding this until https://github.com/NixOS/nixpkgs/pull/470237 lands in `nixos-unstable` (https://nixpkgs-tracker.ocfox.me/?pr=470237).