### PR TITLE
copilot-chat: update the config to the latest way mentioned in the do…

### DIFF
--- a/plugins/by-name/copilot-chat/default.nix
+++ b/plugins/by-name/copilot-chat/default.nix
@@ -39,16 +39,16 @@ lib.nixvim.plugins.mkNeovimPlugin {
     '';
 
     headers = {
-      user_header = defaultNullOpts.mkStr "## User " ''
+      user = defaultNullOpts.mkStr "## User " ''
         Header to use for user questions.
       '';
 
-      assistant_header = defaultNullOpts.mkStr "## Copilot " ''
+      assistant = defaultNullOpts.mkStr "## Copilot " ''
         Header to use for AI answers.
       '';
 
-      error_header = defaultNullOpts.mkStr "## Error " ''
-        Header to use for errors.
+      tool = defaultNullOpts.mkStr "## Error " ''
+        Header to use for tool
       '';
     };
 
@@ -304,9 +304,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   settingsExample = {
     headers = {
-      user_header = "## User ";
-      assistant_header = "## Copilot ";
-      error_header = "## Error ";
+      user = "## User ";
+      assistant = "## Copilot ";
+      tool = "## Tool ";
     };
     prompts = {
       Explain = "Please explain how the following code works.";


### PR DESCRIPTION
…cs of copilot-chat to generate the required lua config


the previous config that it was generating is like this 
```lua
require("CopilotChat").setup({
    answer_header = "## Ai ",
    auto_follow_cursor = true,
    highlight_selection = false,
    model = "gpt-4o",
    question_header = "## santosh ",
    show_help = false,
    window = { border = "none", height = 1, layout = "float", title = "─", width = 1 },
})
``` 
but the latest settings that we need to put there to make things like header work are mentioned there in the docs in the copilot chat so 
```lua

  headers = {
    user = '👤 You',
    assistant = '🤖 Copilot',
    tool = '🔧 Tool',
  },
``` 
so changed the following line which might fix it 