### PR TITLE
modules/dependencies: fix enable option description

### DIFF
--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -10,7 +10,11 @@ let
   cfg = config.dependencies;
 
   mkDependencyOption = name: properties: {
-    enable = lib.mkEnableOption "Add ${name} to dependencies.";
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to add ${name} to dependencies.";
+    };
 
     package =
       lib.mkPackageOption pkgs name properties


### PR DESCRIPTION
Small documentation fix. Removing example since i think its pointless for a boolean

<img width="300" height="326" alt="image" src="https://github.com/user-attachments/assets/ce9bacd1-7899-484f-b64d-731627875f76" />
<img width="300" height="319" alt="image" src="https://github.com/user-attachments/assets/ce8f7073-9699-4e3a-887a-fc22e283f2d7" />
