### PR TITLE
Revert "tests/plugins/codecompanion: disable runNvim as the plugin emits a warning"

### DIFF
--- a/tests/test-sources/plugins/by-name/codecompanion/default.nix
+++ b/tests/test-sources/plugins/by-name/codecompanion/default.nix
@@ -1,14 +1,9 @@
-# 2025-12-02: set runNvim to false as the following warning is shown unconditionally:
-# ERROR: [WARN] CodeCompanion.nvim will experience breaking changes soon. Pin to version v17.33.0 or earlier to avoid this.
-# See: https://github.com/olimorris/codecompanion.nvim/pull/2439
 {
   empty = {
-    test.runNvim = false;
     plugins.codecompanion.enable = true;
   };
 
   defaults = {
-    test.runNvim = false;
     plugins.codecompanion = {
       enable = true;
 
@@ -949,7 +944,6 @@
   };
 
   example = {
-    test.runNvim = false;
     plugins.codecompanion = {
       enable = true;
 


### PR DESCRIPTION
This reverts commit f775c1e0b46f82297c6579a25fac2a5a3050982f.
