### PR TITLE
colorschemes/github-theme: set colorscheme

### DIFF
--- a/colorschemes/github-theme/default.nix
+++ b/colorschemes/github-theme/default.nix
@@ -6,6 +6,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   name = "github-theme";
   package = "github-nvim-theme";
   isColorscheme = true;
+  colorscheme = "github_dark";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
 


### PR DESCRIPTION
The default value of `colorscheme` is `github-theme` which [isn't supported](https://github.com/projekt0n/github-nvim-theme/#supported-colorschemes--comparisons) and breaks default configurations.

Errors look like:
```
Error in ~/.config/nvim/init.lua:                                                                                                            
E5113: Lua chunk: vim/_editor.lua:0: ~/.config/nvim/init.lua..nvim_exec2() called at ~/.config/nvim/init.lua:0, line 1: Vim(col
orscheme):E185: Cannot find color scheme 'github-theme'                                                                                                    
stack traceback:                                                                                                                                           
        [C]: in function 'nvim_exec2'                                                                                                                      
        vim/_editor.lua: in function 'cmd'                                                                                                                 
        ~/.config/nvim/init.lua:7: in main chunk
```
