### PR TITLE
plugins/dap: fix adapters generation

### DIFF
--- a/plugins/by-name/dap/default.nix
+++ b/plugins/by-name/dap/default.nix
@@ -118,7 +118,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       options = {
         inherit (cfg) configurations;
 
-        adapters = lib.mkMerge [
+        adapters = lib.lists.foldr (x: y: x // y) { } [
           (lib.removeAttrs (cfg.adapters or { }) [
             "executables"
             "servers"


### PR DESCRIPTION
this fixes a regresssion in [d5b2ba8](https://github.com/nix-community/nixvim/commit/d5b2ba8f2ae56b692d185bf3ac80a83c67dd4813) as outlined by #4111. I hope this won't cause any new regressions, but at least the `dap` plugin should work now as it does for me