### PR TITLE
plugins/conform-nvim: mark oxfmt as packaged

### DIFF
--- a/plugins/by-name/conform-nvim/formatter-packages.nix
+++ b/plugins/by-name/conform-nvim/formatter-packages.nix
@@ -73,7 +73,6 @@ in
     mojo_format = states.unpackaged;
     nomad_fmt = states.unpackaged;
     npm-groovy-lint = states.unpackaged;
-    oxfmt = states.unpackaged;
     packer_fmt = states.unpackaged;
     pangu = states.unpackaged;
     perlimports = states.unpackaged;


### PR DESCRIPTION
`oxfmt` has been packaged in nixpkgs.
