### PR TITLE
plugins/otter: fix highlighting warning

### DIFF
--- a/plugins/by-name/otter/default.nix
+++ b/plugins/by-name/otter/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   config,
+  options,
   ...
 }:
 lib.nixvim.plugins.mkNeovimPlugin {
@@ -89,10 +90,14 @@ lib.nixvim.plugins.mkNeovimPlugin {
         in
         !(treesitter.enable && highlightEnabled);
 
-      message = ''
-        You have enabled otter, but treesitter syntax highlighting is not enabled.
-        Otter functionality might not work as expected without it. Make sure `plugins.treesitter.highlight.enable` and `plugins.treesitter.enable` are enabled.
-      '';
+      message =
+        let
+          inherit (options.plugins) treesitter;
+        in
+        ''
+          You have enabled otter, but treesitter syntax highlighting is not enabled.
+          Otter functionality might not work as expected without it. Make sure `${treesitter.highlight.enable}` and `${treesitter.enable}` are enabled.
+        '';
     };
 
     lsp.onAttach = lib.mkIf cfg.autoActivate ''

--- a/tests/test-sources/plugins/by-name/otter/default.nix
+++ b/tests/test-sources/plugins/by-name/otter/default.nix
@@ -67,6 +67,7 @@
     test.warnings = expect: [
       (expect "count" 1)
       (expect "any" "You have enabled otter, but treesitter syntax highlighting is not enabled.")
+      (expect "any" "Make sure `plugins.treesitter.highlight.enable` and `plugins.treesitter.enable` are enabled.")
     ];
     plugins = {
       otter.enable = true;
@@ -79,6 +80,7 @@
     test.warnings = expect: [
       (expect "count" 1)
       (expect "any" "You have enabled otter, but treesitter syntax highlighting is not enabled.")
+      (expect "any" "Make sure `plugins.treesitter.highlight.enable` and `plugins.treesitter.enable` are enabled.")
     ];
     plugins = {
       otter.enable = true;


### PR DESCRIPTION
Folllowup to #4115, which adapted the warning to the new `plugins.treesitter.highlight.enable` option, but failed to remove the leftover `null` check.
`highlight == null` would _never_ be true.
