### PR TITLE
plugins/blink-cmp-avante: init

### DIFF
--- a/plugins/by-name/blink-cmp-avante/default.nix
+++ b/plugins/by-name/blink-cmp-avante/default.nix
@@ -1,0 +1,51 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "blink-cmp-avante";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  description = ''
+    Avante source for blink-cmp.
+
+    ---
+
+    This plugin should be configured through blink-cmp's `sources.providers` settings.
+
+    For example:
+
+    ```nix
+    plugins.blink-cmp = {
+      enable = true;
+      settings.sources.providers = {
+        avante = {
+          module = "blink-cmp-avante";
+          name = "Avante";
+          opts = {
+            # options for blink-cmp-avante
+          };
+        };
+      };
+    };
+    ```
+
+    And then you can add it to blink-cmp's `sources.default` option:
+
+    ```nix
+    plugins.blink-cmp = {
+      enable = true;
+      settings.sources.default = [
+        "lsp"
+        "path"
+        "luasnip"
+        "buffer"
+        "avante"
+      ];
+    };
+    ```
+  '';
+
+  # Configured through blink-cmp
+  callSetup = false;
+  hasLuaConfig = false;
+  hasSettings = false;
+}

--- a/tests/test-sources/plugins/by-name/blink-cmp-avante/default.nix
+++ b/tests/test-sources/plugins/by-name/blink-cmp-avante/default.nix
@@ -1,0 +1,35 @@
+{
+  empty = {
+    plugins = {
+      blink-cmp.enable = true;
+      blink-cmp-avante.enable = true;
+    };
+  };
+
+  example = {
+    plugins = {
+      blink-cmp-avante.enable = true;
+      blink-cmp = {
+        enable = true;
+
+        settings = {
+          sources = {
+            default = [
+              "avante"
+              "lsp"
+              "path"
+              "buffer"
+            ];
+            providers = {
+              avante = {
+                module = "blink-cmp-avante";
+                name = "Avante";
+                opts = { };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [blink-cmp-avante](https://github.com/Kaiser-Yang/blink-cmp-avante), the Avante source for blink-cmp.

Closes #4088
