### PR TITLE
plugins/codesettings: init

### DIFF
--- a/plugins/by-name/codesettings/default.nix
+++ b/plugins/by-name/codesettings/default.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "codesettings";
+  package = "codesettings-nvim";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    config_file_paths = [
+      ".vscode/settings.json"
+      "codesettings.json"
+      "lspsettings.json"
+      ".codesettings.json"
+      ".lspsettings.json"
+      ".nvim/codesettings.json"
+      ".nvim/lspsettings.json"
+    ];
+    jsonls_integration = true;
+    default_merge_opts = {
+      list_behavior = "prepend";
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/codesettings/default.nix
+++ b/tests/test-sources/plugins/by-name/codesettings/default.nix
@@ -1,0 +1,48 @@
+{
+  empty = {
+    plugins.codesettings.enable = true;
+  };
+
+  defaults = {
+    plugins.codesettings = {
+      enable = true;
+
+      settings = {
+        config_file_paths = [
+          ".vscode/settings.json"
+          "codesettings.json"
+          "lspsettings.json"
+        ];
+        jsonc_filetype = true;
+        jsonls_integration = true;
+        live_reload = false;
+        loader_extensions = [ ];
+        lua_ls_integration = true;
+        merge_lists = "append";
+        root_dir.__raw = "nil";
+      };
+    };
+  };
+
+  example = {
+    plugins.codesettings = {
+      enable = true;
+
+      settings = {
+        config_file_paths = [
+          ".vscode/settings.json"
+          "codesettings.json"
+          "lspsettings.json"
+          ".codesettings.json"
+          ".lspsettings.json"
+          ".nvim/codesettings.json"
+          ".nvim/lspsettings.json"
+        ];
+        jsonls_integration = true;
+        default_merge_opts = {
+          list_behavior = "prepend";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [codesettings.nvim](https://github.com/mrjones2014/codesettings.nvim), a plugin that allows to load project-local settings (like `.vscode/settings.json`) into Neovim 0.11+ native LSP settings easily.

Closes #4100
