### PR TITLE
flake/lib.nix: Use the pinned nixpkgs in from the flake for lib

### DIFF
--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -3,13 +3,16 @@
   config,
   lib,
   withSystem,
+  inputs,
   ...
 }:
 {
   # Public `lib` flake output
   flake.lib = {
     nixvim = lib.makeOverridable ({ lib }: (lib.extend self.lib.overlay).nixvim) {
-      inherit lib;
+      # NOTE: Use the lib from nixpkgs pin to prevent a dependency
+      # on pinning the flake-parts nixpkgs-lib to the nixpkgs pin
+      inherit (inputs.nixpkgs) lib;
     };
     overlay = import ../lib/overlay.nix {
       flake = self;


### PR DESCRIPTION
## Summary

Currently the lib that is propogated to nixvim modules comes from the `nixpkgs-lib` input from the `flake-parts` flake. This works fine locally because the `nixpkgs-lib` follows `nixpkgs` however downstream repos cannot cannot make `nixvim` follow their own version of `flake-parts` without also overriding `nixpkgs-lib`.

## Motivation

* Clearer path for where lib passed to modules is coming from
* Allow downstream repos more flexibility in follows

## Solution

Pull lib from the pinned `nixpkgs` input.