### PR TITLE
plugins/blink-cmp: relax type of settings.sources.per_filetype.<ft>

### DIFF
--- a/plugins/by-name/blink-cmp/settings-options.nix
+++ b/plugins/by-name/blink-cmp/settings-options.nix
@@ -497,7 +497,7 @@ in
       Default sources.
     '';
 
-    per_filetype = defaultNullOpts.mkAttrsOf (with types; listOf str) { } ''
+    per_filetype = defaultNullOpts.mkAttrsOf (with types; listOf anything) { } ''
       Sources per filetype.
     '';
 


### PR DESCRIPTION
The current type prevents users from writing:
```nix
plugins.blink-cmp = {
  enabled = true;
  sources.per_filetype.markdown = [
    {
      inherit_defaults = true;
      __unkeyed = "<MODULE_NAME>";
    }
  ];
};
```
