### PR TITLE
feat(output): add vimdiffAlias option to provide nvim -d as vimdiff alias

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -29,6 +29,14 @@ in
       '';
     };
 
+    vimdiffAlias = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Create a `vimdiff` alias that runs `nvim -d`.
+      '';
+    };
+
     waylandSupport = mkOption {
       type = types.bool;
       default = lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.wayland;
@@ -170,6 +178,15 @@ in
         description = ''
           A tool to show the content of the generated `init.lua` file.
           Run using `${config.build.printInitPackage.meta.mainProgram}`.
+        '';
+        readOnly = true;
+        visible = false;
+      };
+
+      vimdiffPackage = mkOption {
+        type = types.package;
+        description = ''
+          A wrapper script that runs `nvim -d` as `vimdiff`.
         '';
         readOnly = true;
         visible = false;
@@ -318,6 +335,9 @@ in
             ]
             ++ lib.optionals config.enablePrintInit [
               printInitPackage
+            ]
+            ++ lib.optionals config.vimdiffAlias [
+              vimdiffPackage
             ];
           meta.mainProgram = "nvim";
           passthru = {
@@ -335,6 +355,10 @@ in
             bat --language=lua "$init"
           '';
         };
+
+        vimdiffPackage = pkgs.writeShellScriptBin "vimdiff" ''
+          exec "${config.build.nvimPackage}/bin/nvim" -d "$@"
+        '';
 
         manDocsPackage = config.flake.packages.${system}.man-docs;
       };

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -161,4 +161,50 @@
         end
       '';
     };
+
+  vimdiffAlias-enabled =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    {
+      vimdiffAlias = true;
+
+      test.extraInputs = [
+        (pkgs.runCommandLocal "vimdiff-enabled-integration-test" { } ''
+          # Verify vimdiff exists and is executable in final package
+          if [ ! -x "${config.build.package}/bin/vimdiff" ]; then
+            echo "vimdiff binary should exist and be executable in final package" >&2
+            exit 1
+          fi
+
+          # Verify proper invocation pattern (nvim followed by -d)
+          if ! grep -qE 'nvim.*-d' "${config.build.package}/bin/vimdiff"; then
+            echo "vimdiff should invoke nvim with -d flag" >&2
+            exit 1
+          fi
+
+          touch $out
+        '')
+      ];
+    };
+
+  vimdiffAlias-disabled =
+    { config, pkgs, ... }:
+    {
+      vimdiffAlias = false;
+
+      test.extraInputs = [
+        (pkgs.runCommandLocal "vimdiff-disabled-integration-test" { } ''
+          # Verify vimdiff does NOT exist in final package
+          if [ -e "${config.build.package}/bin/vimdiff" ]; then
+            echo "vimdiff binary should NOT exist when vimdiffAlias is disabled" >&2
+            exit 1
+          fi
+
+          touch $out
+        '')
+      ];
+    };
 }

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -42,11 +42,5 @@ in
       EDITOR = "nvim";
       VISUAL = "nvim";
     };
-
-    programs = mkIf cfg.vimdiffAlias {
-      bash.shellAliases.vimdiff = "nvim -d";
-      fish.shellAliases.vimdiff = "nvim -d";
-      zsh.shellAliases.vimdiff = "nvim -d";
-    };
   };
 }

--- a/wrappers/modules/hm.nix
+++ b/wrappers/modules/hm.nix
@@ -2,14 +2,6 @@
 {
   options = {
     defaultEditor = lib.mkEnableOption "nixvim as the default editor";
-
-    vimdiffAlias = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Alias `vimdiff` to `nvim -d`.
-      '';
-    };
   };
 
   imports = [ ./shared.nix ];


### PR DESCRIPTION
## Summary

relative issue: #1621

Add a `vimdiffAlias` option that creates a `vimdiff` wrapper script invoking `nvim -d`, similar to the existing `viAlias` and `vimAlias` options.

## Changes

- Add `vimdiffAlias` option (`bool`, default `false`) to `modules/top-level/output.nix`
- Add `build.vimdiffPackage` output that creates a shell script wrapper for `nvim -d`
- Include `vimdiffPackage` in the final package when `vimdiffAlias = true`
- Remove the Home Manager-specific shell alias implementation (bash/fish/zsh) in favor of a universal wrapper script approach
- Add tests for both enabled and disabled states

## Motivation

Previously, the `vimdiffAlias` option only worked via Home Manager shell aliases, which was:
1. Limited to Home Manager users
2. Shell-specific (required separate aliases for bash, fish, zsh)
3. Inconsistent with how `viAlias` and `vimAlias` work (which use symlinks in the package)

This change makes `vimdiffAlias` work universally by creating an executable wrapper script included in the package itself, making it available regardless of shell or installation method.

## Test Plan

- [x] `vimdiffAlias-enabled` test verifies wrapper script contains `nvim` and `-d`
- [x] `vimdiffAlias-enabled` test verifies `vimdiff` exists and is executable in final package
- [x] `vimdiffAlias-disabled` test verifies `vimdiff` does NOT exist in final package
