### PR TITLE
modules/lsp: add `inotify-tools` package when any lsp server is enabled

### DIFF
--- a/modules/dependencies.nix
+++ b/modules/dependencies.nix
@@ -135,6 +135,7 @@ in
       grep.default = "gnugrep";
       gzip.default = "gzip";
       imagemagick.default = "imagemagick";
+      inotify-tools.default = "inotify-tools";
       jupytext.default = [
         "python313Packages"
         "jupytext"

--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -151,6 +151,10 @@ in
       extraPackages = lib.mkIf (packages.prefix or [ ] != [ ]) packages.prefix;
       extraPackagesAfter = lib.mkIf (packages.suffix or [ ] != [ ]) packages.suffix;
 
+      dependencies.inotify-tools = lib.mkIf (enabledServers != [ ] && pkgs.stdenv.hostPlatform.isLinux) {
+        enable = true;
+      };
+
       lsp.luaConfig.content =
         let
           mkServerConfig =


### PR DESCRIPTION
Before this change `:LspInfo` complains about `vim.lsp` using `libuv-watchdirs` for file watcher:
```
vim.lsp: File Watcher ~
- File watch backend: libuv-watchdirs
- ⚠️ WARNING libuv-watchdirs has known performance issues. Consider installing inotify-tools.
```

This PR adds `inotify-tools` as extra package when any of the lsp servers is enabled via `lsp.servers.*.enable` option, so the warning goes away.