### PR TITLE
tests/modules/lsp: fix package-fallback assertion logic

### DIFF
--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -196,21 +196,21 @@
         let
           assertPrefix = name: pkg: [
             {
-              assertion = lib.all (x: x == pkg) config.extraPackages;
+              assertion = lib.elem pkg config.extraPackages;
               message = "Expected `${name}` to be in extraPackages";
             }
             {
-              assertion = lib.any (x: x != pkg) config.extraPackagesAfter;
+              assertion = !(lib.elem pkg config.extraPackagesAfter);
               message = "Expected `${name}` not to be in extraPackagesAfter";
             }
           ];
           assertSuffix = name: pkg: [
             {
-              assertion = lib.all (x: x != pkg) config.extraPackages;
+              assertion = !(lib.elem pkg config.extraPackages);
               message = "Expected `${name}` not to be in extraPackages";
             }
             {
-              assertion = lib.any (x: x == pkg) config.extraPackagesAfter;
+              assertion = lib.elem pkg config.extraPackagesAfter;
               message = "Expected `${name}` to be in extraPackagesAfter";
             }
           ];

--- a/tests/test-sources/plugins/lsp/_lsp.nix
+++ b/tests/test-sources/plugins/lsp/_lsp.nix
@@ -264,11 +264,11 @@
         let
           assertAfter = name: pkg: [
             {
-              assertion = lib.all (x: x != pkg) config.extraPackages;
+              assertion = !(lib.elem pkg config.extraPackages);
               message = "Expected `${name}` not to be in extraPackages";
             }
             {
-              assertion = lib.any (x: x == pkg) config.extraPackagesAfter;
+              assertion = lib.elem pkg config.extraPackagesAfter;
               message = "Expected `${name}` to be in extraPackagesAfter";
             }
           ];


### PR DESCRIPTION
The "is in" vs "isn't in" assertions added in ~~https://github.com/nix-community/nixvim/pull/3450 and~~ https://github.com/nix-community/nixvim/pull/3730 were accidentally inverted.

Raised by @wvffle after running into the issue in #4150.
