### PR TITLE
plugins/lint: allow configuring linters with special names

### DIFF
--- a/plugins/by-name/lint/default.nix
+++ b/plugins/by-name/lint/default.nix
@@ -228,7 +228,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
             linterConfig' =
               if builtins.isString linterConfig then lib.nixvim.mkRaw linterConfig else linterConfig;
           in
-          "__lint.linters.${customLinter} = ${toLuaObject linterConfig'}"
+          ''__lint.linters["${customLinter}"] = ${toLuaObject linterConfig'}''
         ) cfg.customLinters
       )
     ))
@@ -241,7 +241,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
               propName: propValue:
               lib.optionalString (
                 propValue != null
-              ) "__lint.linters.${linter}.${propName} = ${toLuaObject propValue}"
+              ) ''__lint.linters["${linter}"].${propName} = ${toLuaObject propValue}''
             ) linterConfig
           ) cfg.linters
         )


### PR DESCRIPTION
This PR makes configuring linters with special characters in their names possible.

The following code would currently result in a compilation error because `markdownlint-cli2` contains a dash character.
```nix
plugins.lint.linters.markdownlint-cli2 = {
  cmd = lib.getExe pkgs.markdownlint-cli2;
  stdin = true;
  args = [
    "--config"
    "${mdConfig}"
    "-"
  ];
};
```