### PR TITLE
plugins/blink-cmp-nixpkgs-maintainers: init

### DIFF
--- a/plugins/by-name/blink-cmp-nixpkgs-maintainers/default.nix
+++ b/plugins/by-name/blink-cmp-nixpkgs-maintainers/default.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "blink-cmp-nixpkgs-maintainers";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  description = ''
+    nixpkgs-maintainers source for blink-cmp.
+
+    ---
+
+    This plugin should be configured through blink-cmp's `sources.providers` settings.
+
+    For example:
+
+    ```nix
+    plugins.blink-cmp = {
+      enable = true;
+      settings.sources = {
+        per_filetype = {
+          markdown = [ "nixpkgs_maintainers" ];
+        };
+        providers = {
+          nixpkgs_maintainers = {
+            module = "blink_cmp_nixpkgs_maintainers";
+            name = "nixpkgs maintainers";
+            opts = {
+              # Number of days after which the list of maintainers is refreshed
+              cache_lifetime = 14;
+              # Do not print status messages
+              silent = false;
+              # Customize the `nixpkgs` source flake for fetching the maintainers list
+              # Example: "github:NixOS/nixpkgs/master"
+              nixpkgs_flake_uri = "nixpkgs";
+            };
+          };
+        };
+      };
+    };
+    ```
+  '';
+
+  # Configured through blink-cmp
+  callSetup = false;
+  hasLuaConfig = false;
+  hasSettings = false;
+}

--- a/tests/test-sources/plugins/by-name/blink-cmp-nixpkgs-maintainers/default.nix
+++ b/tests/test-sources/plugins/by-name/blink-cmp-nixpkgs-maintainers/default.nix
@@ -1,0 +1,34 @@
+{
+  empty = {
+    plugins = {
+      blink-cmp.enable = true;
+      blink-cmp-nixpkgs-maintainers.enable = true;
+    };
+  };
+
+  example = {
+    plugins = {
+      blink-cmp-nixpkgs-maintainers.enable = true;
+      blink-cmp = {
+        enable = true;
+
+        settings.sources = {
+          per_filetype = {
+            markdown = [ "nixpkgs_maintainers" ];
+          };
+          providers = {
+            nixpkgs_maintainers = {
+              module = "blink_cmp_nixpkgs_maintainers";
+              name = "nixpkgs maintainers";
+              opts = {
+                cache_lifetime = 14;
+                silent = false;
+                nixpkgs_flake_uri = "nixpkgs";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [blink-cmp-nixpkgs-maintainers](https://github.com/GaetanLepage/blink-cmp-nixpkgs-maintainers), a blink-cmp source for completing [nixpkgs](https://github.com/NixOS/nixpkgs/) [maintainers](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix) when editing PR messages.