### PR TITLE
plugins/vscode-diff: rename to codediff

### DIFF
--- a/plugins/by-name/codediff/default.nix
+++ b/plugins/by-name/codediff/default.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
-  name = "vscode-diff";
+  name = "codediff";
   package = "codediff-nvim";
 
   maintainers = [ lib.maintainers.GaetanLepage ];

--- a/plugins/deprecation.nix
+++ b/plugins/deprecation.nix
@@ -43,6 +43,8 @@ let
     presence-nvim = "presence";
     # Added 2025-11-07
     ethersync = "teamtype";
+    # Added 2026-01-24
+    vscode-diff = "codediff";
   };
   # Added 2024-09-21; remove after 24.11
   # `iconsPackage` options were briefly available in the following plugins for ~3 weeks

--- a/tests/test-sources/plugins/by-name/codediff/default.nix
+++ b/tests/test-sources/plugins/by-name/codediff/default.nix
@@ -3,14 +3,14 @@
     # TODO: re-enable after next flake lock update (nixpkgs PR #482779)
     # Plugin tries to download libgomp from GitHub during setup
     test.runNvim = false;
-    plugins.vscode-diff.enable = true;
+    plugins.codediff.enable = true;
   };
 
   defaults = {
     # TODO: re-enable after next flake lock update (nixpkgs PR #482779)
     # Plugin tries to download libgomp from GitHub during setup
     test.runNvim = false;
-    plugins.vscode-diff = {
+    plugins.codediff = {
       enable = true;
 
       settings = {
@@ -41,7 +41,7 @@
     # TODO: re-enable after next flake lock update (nixpkgs PR #482779)
     # Plugin tries to download libgomp from GitHub during setup
     test.runNvim = false;
-    plugins.vscode-diff = {
+    plugins.codediff = {
       enable = true;
 
       settings = {


### PR DESCRIPTION
`vscode-diff.nvim` is now [codediff.nvim](https://github.com/esmuellert/codediff.nvim).
