### PR TITLE
plugins/chadtree: enable xdg setting to fix deps installation

### DIFF
--- a/plugins/by-name/chadtree/default.nix
+++ b/plugins/by-name/chadtree/default.nix
@@ -17,6 +17,11 @@ lib.nixvim.plugins.mkNeovimPlugin {
     plugins.chadtree.luaConfig.content = ''
       vim.api.nvim_set_var("chadtree_settings", ${lib.nixvim.toLuaObject cfg.settings})
     '';
+
+    # Use XDG specifications for storing the CHADTree runtime and session files.
+    # If set to false, will store everything under repo location.
+    # Fixes https://github.com/nix-community/nixvim/issues/4154
+    plugins.chadtree.settings.xdg = lib.mkDefault true;
   };
 
   settingsExample = {


### PR DESCRIPTION
Makes the [xdg](https://github.com/ms-jpq/chadtree/blob/chad/docs/CONFIGURATION.md#chadtree_settingsxdg) setting default to `true`.
This makes chadtree install its deps under the XDG directories instead of the plugin's repo (which is in the nix store and thus not writable).

Fixes #4154
