### PR TITLE
plugins/blink-cmp: add blink_cmp_fuzzy lib to combinePlugins.pathsToLink

### DIFF
--- a/plugins/by-name/blink-cmp/default.nix
+++ b/plugins/by-name/blink-cmp/default.nix
@@ -56,5 +56,8 @@ lib.nixvim.plugins.mkNeovimPlugin {
           -- Capabilities configuration for blink-cmp
           capabilities = require("blink-cmp").get_lsp_capabilities(capabilities)
         '';
+
+    # blink_cmp_fuzzy lib
+    performance.combinePlugins.pathsToLink = [ "/target/release" ];
   };
 }


### PR DESCRIPTION
This PR adds blink.cmp native lib to `pathsToLink`, because it's easy to forget. It falls back to lua implementation without it.
