### PR TITLE
modules/dependencies: add `packageFallback` option

### DIFF
--- a/tests/test-sources/modules/dependencies.nix
+++ b/tests/test-sources/modules/dependencies.nix
@@ -65,6 +65,56 @@ in
       ];
     };
 
+  package-fallback-false =
+    {
+      lib,
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      dependencies.git = {
+        enable = true;
+        packageFallback = false;
+      };
+
+      assertions = [
+        {
+          assertion = lib.elem pkgs.git config.extraPackages;
+          message = "Expected git to be in extraPackages.";
+        }
+        {
+          assertion = !lib.elem pkgs.git config.extraPackagesAfter;
+          message = "Expected git not to be in extraPackagesAfter.";
+        }
+      ];
+    };
+
+  package-fallback-true =
+    {
+      lib,
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      dependencies.git = {
+        enable = true;
+        packageFallback = true;
+      };
+
+      assertions = [
+        {
+          assertion = !lib.elem pkgs.git config.extraPackages;
+          message = "Expected git not to be in extraPackages.";
+        }
+        {
+          assertion = lib.elem pkgs.git config.extraPackagesAfter;
+          message = "Expected git to be in extraPackagesAfter.";
+        }
+      ];
+    };
+
   # Integration test for `lib.nixvim.deprecation.mkRemovedPackageOptionModule`
   removed-package-options =
     {


### PR DESCRIPTION
This PR:
- introduces `packageFallback` option to `dependencies` module
  - When set to true, the package is added to `extraPackagesAfter` instead of `extraPackages`
  - This is aligned with the existing [`lsp.servers.*.packageFallback` definition](https://github.com/nix-community/nixvim/blob/3c27e1b35ca0fee6a89bfc20840654361ffe888d/modules/lsp/servers/server.nix#L56-L64)
- adds tests for the option

This allows users to fall back to local dependencies (e.g. via `direnv`) and prevents version mismatches when LSPs use dependencies from this module instead of project-local ones.