### PR TITLE
plugins/blink-pairs: init

### DIFF
--- a/plugins/by-name/blink-pairs/default.nix
+++ b/plugins/by-name/blink-pairs/default.nix
@@ -1,0 +1,31 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "blink-pairs";
+  moduleName = "blink.pairs";
+
+  maintainers = [ lib.maintainers.GaetanLepage ];
+
+  settingsExample = {
+    mappings.enabled = false;
+    highlights = {
+      enabled = true;
+      cmdline = true;
+      groups = [
+        "rainbow1"
+        "rainbow2"
+        "rainbow3"
+        "rainbow4"
+        "rainbow5"
+        "rainbow6"
+      ];
+      unmatched_group = "";
+      matchparen = {
+        enabled = true;
+        cmdline = false;
+        include_surrounding = false;
+        group = "BlinkPairsMatchParen";
+        priority = 250;
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/blink-pairs/default.nix
+++ b/tests/test-sources/plugins/by-name/blink-pairs/default.nix
@@ -1,0 +1,67 @@
+{
+  empty = {
+    plugins.blink-pairs.enable = true;
+  };
+
+  defaults = {
+    plugins.blink-pairs = {
+      enable = true;
+      settings = {
+        mappings = {
+          enabled = true;
+          cmdline = true;
+          disabled_filetypes = [ ];
+          pairs = [ ];
+        };
+        highlights = {
+          enabled = true;
+          cmdline = true;
+          groups = [
+            "BlinkPairsOrange"
+            "BlinkPairsPurple"
+            "BlinkPairsBlue"
+          ];
+          unmatched_group = "BlinkPairsUnmatched";
+          matchparen = {
+            enabled = true;
+            cmdline = false;
+            include_surrounding = false;
+            group = "BlinkPairsMatchParen";
+            priority = 250;
+          };
+        };
+        debug = false;
+      };
+    };
+  };
+
+  example = {
+    plugins.blink-pairs = {
+      enable = true;
+
+      settings = {
+        mappings.enabled = false;
+        highlights = {
+          enabled = true;
+          cmdline = true;
+          groups = [
+            "rainbow1"
+            "rainbow2"
+            "rainbow3"
+            "rainbow4"
+            "rainbow5"
+            "rainbow6"
+          ];
+          unmatched_group = "";
+          matchparen = {
+            enabled = true;
+            cmdline = false;
+            include_surrounding = false;
+            group = "BlinkPairsMatchParen";
+            priority = 250;
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [blink.pairs](https://github.com/saghen/blink.pairs), a plugin providing rainbow highlighting and intelligent auto-pairs.

Closes #4166
