### PR TITLE
plugins/codecompanion: add history extension

### DIFF
--- a/plugins/by-name/codecompanion/default.nix
+++ b/plugins/by-name/codecompanion/default.nix
@@ -5,7 +5,7 @@ let
     mkNullOrStr'
     mkNullOrStr
     ;
-  inherit (lib) types;
+  inherit (lib) types mkOption;
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "codecompanion";
@@ -13,6 +13,10 @@ lib.nixvim.plugins.mkNeovimPlugin {
   description = "AI-powered coding, seamlessly in Neovim.";
 
   maintainers = [ lib.maintainers.GaetanLepage ];
+
+  imports = [
+    ./extensions
+  ];
 
   settingsOptions = {
     adapters = defaultNullOpts.mkAttrsOf' {
@@ -225,6 +229,12 @@ lib.nixvim.plugins.mkNeovimPlugin {
         use_default_prompts = true;
       };
       pluginDefault = lib.literalExpression "See upstream documentation";
+    };
+
+    extensions = mkOption {
+      type = with types; attrsOf anything;
+      description = "Attribute set for extensions";
+      default = { };
     };
   };
 

--- a/plugins/by-name/codecompanion/extensions/_mk-extension.nix
+++ b/plugins/by-name/codecompanion/extensions/_mk-extension.nix
@@ -1,0 +1,96 @@
+# snatched from telescope's _mk-extension.nix
+{
+  name,
+  package,
+  extensionName ? name,
+  dependencies ? [ ],
+  settingsOptions ? { },
+  settingsExample ? null,
+  extraOptions ? { },
+  imports ? [ ],
+  optionsRenamedToSettings ? [ ],
+  extraConfig ? cfg: { },
+}:
+let
+  getPluginAttr = attrs: attrs.plugins.codecompanion.extensions.${name};
+
+  renameModule =
+    { lib, ... }:
+    {
+      # TODO remove this once all deprecation warnings will have been removed.
+      imports =
+        let
+          basePluginPath = [
+            "plugins"
+            "codecompanion"
+            "extensions"
+            name
+          ];
+          settingsPath = basePluginPath ++ [ "settings" ];
+        in
+        lib.nixvim.mkSettingsRenamedOptionModules basePluginPath settingsPath optionsRenamedToSettings;
+    };
+
+  module =
+    {
+      lib,
+      config,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = getPluginAttr config;
+    in
+    {
+      options.plugins.codecompanion.extensions.${name} = {
+        enable = lib.mkEnableOption "the `${name}` codecompanion extension";
+
+        package = lib.mkPackageOption pkgs name {
+          default = [
+            "vimPlugins"
+            package
+          ];
+        };
+
+        settings = lib.nixvim.mkSettingsOption {
+          description = "settings for the `${name}` codecompanion extension.";
+          options = settingsOptions;
+          example = settingsExample;
+        };
+      }
+      // extraOptions;
+
+      config = lib.mkIf cfg.enable (
+        lib.mkMerge [
+          {
+            extraPlugins = [ cfg.package ];
+
+            plugins.codecompanion = {
+              settings.extensions.${extensionName} = cfg.settings;
+            };
+          }
+          (lib.nixvim.plugins.utils.enableDependencies dependencies)
+        ]
+      );
+    };
+
+  extraConfigModule =
+    {
+      lib,
+      config,
+      options,
+      ...
+    }:
+    lib.nixvim.plugins.utils.applyExtraConfig {
+      inherit extraConfig;
+      cfg = getPluginAttr config;
+      opts = getPluginAttr options;
+    };
+in
+{
+  imports = imports ++ [
+    module
+    extraConfigModule
+    renameModule
+  ];
+}

--- a/plugins/by-name/codecompanion/extensions/default.nix
+++ b/plugins/by-name/codecompanion/extensions/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./history.nix
+  ];
+}

--- a/plugins/by-name/codecompanion/extensions/history.nix
+++ b/plugins/by-name/codecompanion/extensions/history.nix
@@ -1,0 +1,18 @@
+let
+  mkExtension = import ./_mk-extension.nix;
+in
+mkExtension {
+  name = "history";
+  extensionName = "history";
+  package = "codecompanion-history-nvim";
+
+  settingsExample = {
+    keymap = "gh";
+    auto_generate_title = true;
+    continue_last_chat = false;
+    delete_on_clearing_chat = false;
+    picker = "telescope";
+    enable_logging = false;
+    dir_to_save.__raw = "vim.fn.stdpath('data') .. '/codecompanion-history'";
+  };
+}

--- a/tests/test-sources/plugins/by-name/codecompanion/history.nix
+++ b/tests/test-sources/plugins/by-name/codecompanion/history.nix
@@ -1,0 +1,46 @@
+{
+  empty = {
+    plugins = {
+      codecompanion = {
+        enable = true;
+        extensions.history.enable = true;
+      };
+      snacks.enable = true;
+    };
+  };
+
+  defaults = {
+    plugins = {
+      snacks.enable = true;
+      codecompanion = {
+        enable = true;
+
+        extensions.history = {
+          enable = true;
+
+          settings = {
+            keymap = "gh";
+            auto_generate_title = true;
+            continue_last_chat = false;
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins = {
+      snacks.enable = true;
+      codecompanion = {
+        enable = true;
+
+        extensions.history = {
+          enable = true;
+
+          settings = {
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
# Things done
* add the basic structure for extensions in codecompanion
* related to: #3325
* shamefully steals `_mk-extension` from telescope and adapts it to codecompanion
* add tests for history
* add history codecompanion plugin