### PR TITLE
plugins/telescope: add ast-grep extension

### DIFF
--- a/plugins/by-name/telescope/extensions/ast-grep.nix
+++ b/plugins/by-name/telescope/extensions/ast-grep.nix
@@ -1,0 +1,8 @@
+let
+  mkExtension = import ./_mk-extension.nix;
+in
+mkExtension {
+  name = "ast-grep";
+  extensionName = "ast_grep";
+  package = "telescope-ast-grep-nvim";
+}

--- a/plugins/by-name/telescope/extensions/default.nix
+++ b/plugins/by-name/telescope/extensions/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./advanced-git-search.nix
+    ./ast-grep.nix
     ./file-browser.nix
     ./frecency.nix
     ./fzf-native.nix

--- a/tests/test-sources/plugins/by-name/telescope/ast-grep.nix
+++ b/tests/test-sources/plugins/by-name/telescope/ast-grep.nix
@@ -1,0 +1,19 @@
+{
+  empty = {
+    plugins.telescope = {
+      enable = true;
+      extensions.ast-grep.enable = true;
+    };
+    plugins.web-devicons.enable = true;
+  };
+
+  combine-plugins = {
+    plugins.telescope = {
+      enable = true;
+      extensions.ast-grep.enable = true;
+    };
+
+    plugins.web-devicons.enable = true;
+    performance.combinePlugins.enable = true;
+  };
+}


### PR DESCRIPTION
Add [telescope-ast-grep.nvim](https://github.com/ray-x/telescope-ast-grep.nvim), an AST grep extension for telescope.nvim.

Closes #4174
