### PR TITLE
jdtls: update repository URL

### DIFF
--- a/plugins/by-name/jdtls/settings-options.nix
+++ b/plugins/by-name/jdtls/settings-options.nix
@@ -37,7 +37,7 @@ in
     You need to extend the `bundles` with paths to jar files if you want to use additional
     `eclipse.jdt.ls` plugins.
 
-    See https://github.com/mfussenegger/nvim-jdtls#java-debug-installation
+    See https://codeberg.org/mfussenegger/nvim-jdtls#java-debug-installation
 
     If you don't plan on using the debugger or other `eclipse.jdt.ls` plugins, ignore this option
   '';


### PR DESCRIPTION
The repository has been moved from GitHub to Codeberg.