### PR TITLE
modules/lsp: feat add ansiblels back and add defaults for ansiblels cmd

### DIFF
--- a/modules/lsp/servers/custom/ansiblels.nix
+++ b/modules/lsp/servers/custom/ansiblels.nix
@@ -1,0 +1,8 @@
+{ lib, config, ... }:
+{
+  # cmd depends on evaluated config.package, so set via module config
+  config.config.cmd = lib.mkIf (config.package != null) [
+    (lib.getExe config.package)
+    "--stdio"
+  ];
+}

--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -70,7 +70,18 @@ in
         {
           # Declare explicit options for each `packages.nix` entry with a known package
           options = builtins.mapAttrs (
-            name: package: mkServerOption { inherit name package; }
+            name: value:
+            let
+              args =
+                if builtins.isAttrs value then
+                  { inherit name; } // value
+                else
+                  {
+                    inherit name;
+                    package = value;
+                  };
+            in
+            mkServerOption args
           ) (import ./packages.nix).packages;
         }
         {

--- a/modules/lsp/servers/packages.nix
+++ b/modules/lsp/servers/packages.nix
@@ -5,7 +5,6 @@
     "alloy_ls"
     "anakin_language_server"
     "antlersls"
-    "ansiblels"
     "apex_ls"
     "autohotkey_lsp"
     "awk_ls"
@@ -191,6 +190,15 @@
     aiken = "aiken";
     air = "air-formatter";
     angularls = "angular-language-server";
+    ansiblels = {
+      package = "ansible-language-server";
+      config.default = {
+        cmd = [
+          "ansible-language-server"
+          "--stdio"
+        ];
+      };
+    };
     arduino_language_server = "arduino-language-server";
     asm_lsp = "asm-lsp";
     ast_grep = "ast-grep";

--- a/modules/lsp/servers/server.nix
+++ b/modules/lsp/servers/server.nix
@@ -84,7 +84,7 @@ in
       description = ''
         Configurations for ${displayName}. ${args.config.extraDescription or ""}
       '';
-      default = { };
+      default = args.config.default or { };
       example =
         args.config.example or {
           cmd = [


### PR DESCRIPTION
This might not be the best way to do this, but I figured out a way to add back in ansiblels and set the cmd.

did this because I added ansible-language-server to upstream nixpkgs so that I could use it in nixvim, so I figured I'd open a PR here.