### PR TITLE
fix: adapt to upstream changes in provider generation

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -241,8 +241,17 @@ in
             dontFixup = true;
           };
 
+      nvimPackage = wrappedNeovim.override (prev: {
+        wrapperArgs =
+          (if lib.isString prev.wrapperArgs then prev.wrapperArgs else lib.escapeShellArgs prev.wrapperArgs)
+          + " "
+          + extraWrapperArgs;
+        wrapRc = false;
+      });
+
       customRC = lib.nixvim.concatNonEmptyLines [
         (lib.nixvim.wrapVimscriptForLua wrappedNeovim.initRc)
+        (nvimPackage.passthru.providerLuaRc or "")
         config.content
       ];
 
@@ -300,16 +309,8 @@ in
     in
     {
       build = {
-        inherit initFile initSource;
+        inherit initFile initSource nvimPackage;
         package = config.build.packageUnchecked;
-
-        nvimPackage = wrappedNeovim.override (prev: {
-          wrapperArgs =
-            (if lib.isString prev.wrapperArgs then prev.wrapperArgs else lib.escapeShellArgs prev.wrapperArgs)
-            + " "
-            + extraWrapperArgs;
-          wrapRc = false;
-        });
 
         packageUnchecked = pkgs.symlinkJoin {
           name = "nixvim";


### PR DESCRIPTION
This PR adapts to upstream https://github.com/NixOS/nixpkgs/pull/498687.

The biggest upstream change is that the host progs are no longer exposed. Hence, we have to include the upstream `providerLuaRc`.

Looking for feedback as I am unsure that a) `providerLuaRc` should be included unconditionally and that b) this is the correct place to do so.