### PR TITLE
fix: manpage NAME to use lowercase nixvim

### DIFF
--- a/docs/man/nixvim-header-start.5
+++ b/docs/man/nixvim-header-start.5
@@ -1,4 +1,4 @@
-.TH "NIXVIM" "5" "01/01/1980" "Nixvim" "Nixvim Reference Pages"
+.TH "NIXVIM" "5" "01/01/1980" "Nixvim"
 .\" disable hyphenation
 .nh
 .\" disable justification (adjust text to left margin only)
@@ -6,7 +6,7 @@
 .\" enable line breaks after slashes
 .cflags 4 /
 .SH "NAME"
-Nixvim options specification
+\fInixvim\fP \- Nixvim options specification
 .SH "DESCRIPTION"
 .PP
 This page lists all the options that can be used in Nixvim. It can either be used as a Home Manager module, an NixOS module or a standalone package. Please refer to the installation instructions for more details.


### PR DESCRIPTION
## Summary
  - Fix the manpage header to use the standard `name \- description` format in the NAME section
  - Previously, the NAME section used freeform text (`Nixvim options specification`), causing tools like fish's autocomplete to register the command as `Nixvim` instead of `nixvim`
  - Also dropped the redundant 5th `.TH` argument to match home-manager's manpage convention
  
  Fixes #4233 
