### PR TITLE
plugins/sidekick: don't bundle providers default

### DIFF
--- a/plugins/by-name/sidekick/default.nix
+++ b/plugins/by-name/sidekick/default.nix
@@ -10,12 +10,19 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   maintainers = [ lib.maintainers.khaneliman ];
 
-  dependencies = [
-    "claude-code"
-    "copilot"
-    "gemini"
-    "opencode"
-  ];
+  description = ''
+    A Neovim plugin for using AI coding CLIs from the editor.
+
+    Sidekick's NES feature requires the Copilot language server. Enable either
+    `plugins.copilot-lua.enable` or `lsp.servers.copilot.enable`, or disable
+    NES in `plugins.sidekick.settings.opts.nes.enabled`.
+
+    Sidekick supports several external CLI tools, but nixvim does not enable
+    them automatically. Enable the tools you use explicitly, for example with
+    `dependencies.claude-code.enable`, `dependencies.copilot.enable`,
+    `dependencies.gemini.enable`, or `dependencies.opencode.enable`, or add
+    the desired packages to your environment yourself.
+  '';
 
   extraConfig = cfg: {
     assertions = lib.nixvim.mkAssertions "plugins.sidekick" {


### PR DESCRIPTION
Default to no providers installed, opt-in vs opt-out to reduce closure size by default. Most of these require subscriptions or familiarity with anyways and doesn't make sense to default enable everything.

Closes https://github.com/nix-community/nixvim/issues/4218

Technically a breaking change, don't want to force explicit acknowledgement though for a list of providers to be explicitly disabled/enabled... 