### PR TITLE
plugins/treesitter-textobjects: keymaps update

### DIFF
--- a/plugins/by-name/treesitter-textobjects/default.nix
+++ b/plugins/by-name/treesitter-textobjects/default.nix
@@ -4,18 +4,22 @@ lib.nixvim.plugins.mkNeovimPlugin {
   package = "nvim-treesitter-textobjects";
   maintainers = [ lib.maintainers.GaetanLepage ];
 
+  description = ''
+    Syntax-aware textobjects using tree-sitter.
+
+    > [!WARNING]
+    > Upstream refactored this plugin so textobject keymaps are no longer configured through
+    > `require("nvim-treesitter.configs").setup({ textobjects = ... })`.
+    > Define keymaps through Neovim's keymap API instead, for example with nixvim's top-level
+    > `keymaps` option and calls to `require("nvim-treesitter-textobjects.<module>")`.
+  '';
+
   # TODO: introduced 2025-10-17: remove after 26.05
   inherit (import ./deprecations.nix lib) deprecateExtraOptions optionsRenamedToSettings imports;
 
   settingsExample = {
     enable = true;
     lookahead = true;
-    keymaps = {
-      ab = "@block.outer";
-      ib = "@block.inner";
-      ac = "@call.outer";
-      ic = "@call.inner";
-    };
   };
 
   callSetup = false;

--- a/tests/test-sources/plugins/by-name/treesitter-textobjects/default.nix
+++ b/tests/test-sources/plugins/by-name/treesitter-textobjects/default.nix
@@ -17,15 +17,6 @@
             enable = true;
             disable.__empty = { };
             lookahead = true;
-            keymaps = {
-              af = "@function.outer";
-              "if" = "@function.inner";
-              ac = "@class.outer";
-              ic = {
-                query = "@class.inner";
-                desc = "Select inner part of a class region";
-              };
-            };
             selection_modes = {
               "@parameter.outer" = "v";
               "@function.outer" = "V";
@@ -36,47 +27,15 @@
           swap = {
             enable = true;
             disable.__empty = { };
-            swap_next = {
-              "<leader>a" = "@parameter.inner";
-            };
-            swap_previous = {
-              "<leader>A" = "@parameter.inner";
-            };
           };
           move = {
             enable = true;
             disable.__empty = { };
             set_jumps = true;
-            goto_next_start = {
-              "]m" = "@function.outer";
-              "]]" = "@class.outer";
-            };
-            goto_next_end = {
-              "]M" = "@function.outer";
-              "][" = "@class.outer";
-            };
-            goto_previous_start = {
-              "[m" = "@function.outer";
-              "[[" = "@class.outer";
-            };
-            goto_previous_end = {
-              "[M" = "@function.outer";
-              "[]" = "@class.outer";
-            };
-            goto_next = {
-              "]d" = "@conditional.outer";
-            };
-            goto_previous = {
-              "[d" = "@conditional.outer";
-            };
           };
           lsp_interop = {
             enable = true;
             border = "none";
-            peek_definition_code = {
-              "<leader>df" = "@function.outer";
-              "<leader>dF" = "@class.outer";
-            };
             floating_preview_opts.__empty = { };
           };
         };


### PR DESCRIPTION
Breaking changes recently introduced in all the nvim-treesitter rewrite. Just make it more known that the `settings` keymaps will have no effect in newer versions.

closes https://github.com/nix-community/nixvim/issues/4216