### PR TITLE
ci: use prettier instead of (soon-removed) nodePackages.prettier

### DIFF
--- a/ci/generate.nix
+++ b/ci/generate.nix
@@ -5,14 +5,14 @@
   lspconfig-servers,
   conform-formatters,
   nixfmt,
-  nodePackages,
+  prettier,
 }:
 writeShellApplication {
   name = "generate";
 
   runtimeInputs = [
     nixfmt
-    nodePackages.prettier
+    prettier
   ];
 
   text = ''


### PR DESCRIPTION
Referencing `nodePackages.prettier` fails with newer `nixpkgs` revisions:
```
error: nodePackages has been removed. Many packages are now available at the top level (e.g. `pkgs.package-name`). Check on https://search.nixos.org to see if the package is still available.
```
This blocks our flake update GH action: https://github.com/nix-community/nixvim/actions/runs/24303099618/job/70959782885
