### PR TITLE
lib/options: fix typo

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -436,7 +436,7 @@ rec {
       default = throw ''
         Nixvim (${optionName}): No package is known for ${packageName}, to resolve this either:
           - install externally and set this option to `null`
-          - or provide a derviation to install this package
+          - or provide a derivation to install this package
       '';
       defaultText = lib.literalMD "No package, throws when undefined";
     };


### PR DESCRIPTION
Big first contribution, I guess! Just stumbled across this typo while evaluating a config and could not unsee it :innocent: 