### PR TITLE
modules/lazyload: fix provider warning detection

### DIFF
--- a/modules/lazyload.nix
+++ b/modules/lazyload.nix
@@ -38,8 +38,8 @@ in
 
         pluginsWithLazyLoad = builtins.filter (
           x:
-          lib.isOption (options.plugins.${x}.lazyload or null)
-          && isVisible options.plugins.${x}.lazyload
+          lib.isOption (options.plugins.${x}.lazyLoad or null)
+          && isVisible options.plugins.${x}.lazyLoad
           && config.plugins.${x}.lazyLoad.enable
         ) (builtins.attrNames config.plugins);
         count = builtins.length pluginsWithLazyLoad;

--- a/tests/test-sources/plugins/lazyloading/lz-n.nix
+++ b/tests/test-sources/plugins/lazyloading/lz-n.nix
@@ -180,6 +180,32 @@ in
       ];
     };
 
+  warn-when-lazy-loading-without-provider = {
+    test = {
+      runNvim = false;
+      warnings = expect: [
+        (expect "count" 1)
+        (expect "any" "You have enabled lazy loading support")
+      ];
+    };
+
+    plugins.neotest = {
+      enable = true;
+      lazyLoad = {
+        enable = true;
+        settings = {
+          keys = [
+            {
+              __unkeyed-1 = "<leader>nt";
+              __unkeyed-3 = "<CMD>Neotest summary<CR>";
+              desc = "Summary toggle";
+            }
+          ];
+        };
+      };
+    };
+  };
+
   lazy-load-colorscheme-properly =
     { config, lib, ... }:
     {


### PR DESCRIPTION
Check the existing lazyLoad option when collecting plugins that request lazy loading without an enabled provider. The previous lowercase lookup skipped the warning entirely.

Add a regression test that expects the missing-provider warning.