### PR TITLE
modules/top-level/output: add autowrapRuntimeDeps

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -13,6 +13,14 @@ let
 in
 {
   options = {
+    autowrapRuntimeDeps = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to automatically add plugin runtime dependencies to the Neovim wrapper's `PATH`.
+      '';
+    };
+
     viAlias = mkOption {
       type = types.bool;
       default = false;
@@ -212,6 +220,7 @@ in
         (pkgs.wrapNeovimUnstable package {
           extraLuaPackages = luaPackagesForWrapper;
           inherit (config)
+            autowrapRuntimeDeps
             extraPython3Packages
             viAlias
             vimAlias

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -161,4 +161,57 @@
         end
       '';
     };
+
+  autowrapRuntimeDeps =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      plugin = pkgs.vimUtils.buildVimPlugin {
+        pname = "nixvim-runtime-deps-test";
+        version = "1";
+        src = pkgs.runCommandLocal "nixvim-runtime-deps-test-src" { } "mkdir -p $out";
+        runtimeDeps = [ pkgs.hello ];
+      };
+    in
+    {
+      extraPlugins = [ plugin ];
+
+      assertions = [
+        {
+          assertion = lib.elem pkgs.hello config.build.nvimPackage.runtimeDeps;
+          message = "`autowrapRuntimeDeps` should add plugin runtime dependencies by default.";
+        }
+      ];
+    };
+
+  autowrapRuntimeDeps-disabled =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      plugin = pkgs.vimUtils.buildVimPlugin {
+        pname = "nixvim-runtime-deps-disabled-test";
+        version = "1";
+        src = pkgs.runCommandLocal "nixvim-runtime-deps-disabled-test-src" { } "mkdir -p $out";
+        runtimeDeps = [ pkgs.hello ];
+      };
+    in
+    {
+      autowrapRuntimeDeps = false;
+      extraPlugins = [ plugin ];
+
+      assertions = [
+        {
+          assertion = !lib.elem pkgs.hello config.build.nvimPackage.runtimeDeps;
+          message = "`autowrapRuntimeDeps = false` should not add plugin runtime dependencies.";
+        }
+      ];
+    };
 }


### PR DESCRIPTION
Support user's overriding the wrapper behavior for wrapping runtime deps from nixpkgs. Default to enabled, matching the wrapper.