### PR TITLE
modules/top-level/files: set pname on nvim-config wrapper plugin

### DIFF
--- a/modules/top-level/files/default.nix
+++ b/modules/top-level/files/default.nix
@@ -101,6 +101,7 @@ in
       build.extraFiles =
         pkgs.runCommandLocal "nvim-config"
           {
+            pname = "nvim-config";
             __structuredAttrs = true;
             nativeBuildInputs = [ pkgs.jq ];
             inherit targets;


### PR DESCRIPTION
## Description

The `build.extraFiles` wrapper plugin is constructed with `pkgs.runCommandLocal "nvim-config"`, which sets only the derivation `name`, not `pname`.

Recent nixpkgs (as of 2026-04) extended `pkgs.vim-pack-dir` to map `plugin.pname` over the `start` / `opt` plugin list when checking for an `nvim-treesitter` / `nvim-treesitter-legacy` conflict ([vim-utils.nix#L221](https://github.com/NixOS/nixpkgs/blob/0726a0ecb6d4e08f6adced58726b95db924cef57/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix#L221)). As a result, building any standalone nixvim package against current `nixos-unstable` fails:

```
… while evaluating derivation 'vim-pack-dir'
… while evaluating attribute 'chosenOutputs' of derivation 'vim-pack-dir'
…
error: attribute 'pname' missing
       at .../vim-utils.nix:221:47:
          221|           allAndOptPluginNames = map (plugin: plugin.pname) (allPlugins ++ opt);
       Did you mean name?
```

This is reproducible with an empty config (`makeNixvim { }`) — `nvim-config` is added to `extraPlugins` whenever `wrapRc` is true, and it's the only plugin in `allPlugins` without a `pname`.

## Fix

Set `pname = "nvim-config"` on the `runCommandLocal` invocation. One line, no behavior change beyond what `vim-pack-dir` now expects.

## Reproducer

```sh
nix build --impure --expr '
  let
    nixpkgs = builtins.getFlake "github:NixOS/nixpkgs/nixos-unstable";
    nixvim = builtins.getFlake "github:nix-community/nixvim";
    system = "x86_64-linux";
  in
    nixvim.legacyPackages.${system}.makeNixvim { }
'
```

Without this patch: `error: attribute 'pname' missing`. With it: builds successfully.

Closes https://github.com/nix-community/nixvim/issues/4271