### PR TITLE
plugins/vim-hypr-nav: init

### DIFF
--- a/plugins/by-name/vim-hypr-nav/default.nix
+++ b/plugins/by-name/vim-hypr-nav/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "vim-hypr-nav";
+  description = "Seamless navigation between hyprland windows and (Neo)Vim splits with the same key bindings.";
+  url = "https://github.com/nuchs/vim-hypr-nav";
+  maintainers = [ ];
+
+  hasSettings = false;
+  callSetup = false;
+}

--- a/plugins/by-name/vim-hypr-nav/default.nix
+++ b/plugins/by-name/vim-hypr-nav/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "vim-hypr-nav";
+  description = "Seamless navigation between hyprland windows and (Neo)Vim splits with the same key bindings.";
+  url = "https://github.com/nuchs/vim-hypr-nav/";
+  maintainers = [ ];
+
+  hasSettings = false;
+  callSetup = false;
+}

--- a/tests/test-sources/plugins/by-name/vim-hypr-nav/default.nix
+++ b/tests/test-sources/plugins/by-name/vim-hypr-nav/default.nix
@@ -1,0 +1,5 @@
+{
+  empty = {
+    plugins.vim-hypr-nav.enable = true;
+  };
+}


### PR DESCRIPTION
Adds [vim-hypr-nav](https://github.com/nuchs/vim-hypr-nav).

Works locally, but requires some setup outside of nvim. 
Not sure where to document that, might just package it in addition to the plugin.