### PR TITLE
mailmap: map NAHO developer identity to Noah Biewesch

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Noah Biewesch <dev@noahbiewesch.com> <90870942+trueNAHO@users.noreply.github.com>


### PR DESCRIPTION
Map my NAHO developer identity to Noah Biewesch to correct existing contributions, which would also be valuable to align with future contributions.

This PR is part of a coordinated effort to canonicalize my developer identity:

- https://github.com/NixOS/nixpkgs/pull/519557
- https://github.com/nix-community/home-manager/pull/9308
- https://github.com/nix-community/nixvim/pull/4287
- https://github.com/nix-community/stylix/pull/2309