### PR TITLE
allow raw lua in blink-cmp keymap via lib.nixvim.mkRaw

### DIFF
--- a/plugins/by-name/blink-cmp/settings-options.nix
+++ b/plugins/by-name/blink-cmp/settings-options.nix
@@ -75,7 +75,8 @@ in
         "snippet_backward"
         "fallback"
       ];
-
+      # Example using raw Lua:
+      "<C-a>" = lib.nixvim.mkRaw "require('some-module').custom_function()";
     };
     description = ''
       The keymap can be:
@@ -83,6 +84,9 @@ in
       - A table of `keys => command[]` (optionally with a "preset" key to merge with a preset)
       When specifying 'preset' in the keymap table, the custom key mappings are merged with the preset,
       and any conflicting keys will overwrite the preset mappings.
+
+      For advanced use cases, you can use raw Lua with `lib.nixvim.mkRaw` to define custom
+      keymap logic.
     '';
   };
 


### PR DESCRIPTION
Allows to define raw lua commands to the keymap section of blink-cmp.

as im quite new to coding in nix, im not sure I've used the best approach, please do fell free to come with constructive suggestions.

Note: personally needed this to add code completion through minuet