### PR TITLE
most dev flake inputs flake=false

### DIFF
--- a/flake/dev/devshell.nix
+++ b/flake/dev/devshell.nix
@@ -1,7 +1,7 @@
 { lib, inputs, ... }:
 {
   imports = [
-    inputs.devshell.flakeModule
+    "${inputs.devshell}/flake-module.nix"
   ];
 
   perSystem =

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -133,12 +133,7 @@
       }
     },
     "nix-darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1781761792,
         "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -91,12 +91,7 @@
       }
     },
     "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1782220169,
         "narHash": "sha256-NxykfEdGQjop9m49Bk61pXpAduH8ICHgXC1N3Ph3Jp0=",

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -254,12 +254,7 @@
       }
     },
     "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1780220602,
         "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -1,12 +1,7 @@
 {
   "nodes": {
     "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1768818222,
         "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -75,16 +75,7 @@
       }
     },
     "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1781733627,
         "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
@@ -96,27 +87,6 @@
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -16,7 +16,7 @@
     # keep-sorted start block=yes newline_separated=yes
     devshell = {
       url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "nixvim/nixpkgs";
+      flake = false;
     };
 
     git-hooks = {

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -21,8 +21,7 @@
 
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixvim/nixpkgs";
-      inputs.flake-compat.follows = "flake-compat";
+      flake = false;
     };
 
     home-manager = {

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -31,7 +31,7 @@
 
     nix-darwin = {
       url = "github:nix-darwin/nix-darwin";
-      inputs.nixpkgs.follows = "nixvim/nixpkgs";
+      flake = false;
     };
 
     nuschtosSearch = {

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -1,6 +1,8 @@
 {
   description = "Private inputs for development purposes. These are used by the top level flake in the `dev` partition, but do not appear in consumers' lock files.";
 
+  # Avoid `flake = true` when we do not need to evaluate flake outputs or fetch flake inputs.
+  # e.g. when we only import loose files.
   inputs = {
     # Nix 2.26 improved support for relative path flake inputs.
     # This dev-flake is only evaluated by flake-parts' flake-compat,

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -26,7 +26,7 @@
 
     home-manager = {
       url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixvim/nixpkgs";
+      flake = false;
     };
 
     nix-darwin = {

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -42,7 +42,7 @@
 
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixvim/nixpkgs";
+      flake = false;
     };
 
     # keep-sorted end

--- a/flake/dev/fmt.nix
+++ b/flake/dev/fmt.nix
@@ -1,7 +1,7 @@
 { inputs, ... }:
 {
   imports = [
-    inputs.treefmt-nix.flakeModule
+    "${inputs.treefmt-nix}/flake-module.nix"
   ];
 
   perSystem =

--- a/flake/dev/git-hooks.nix
+++ b/flake/dev/git-hooks.nix
@@ -1,7 +1,7 @@
 { inputs, ... }:
 {
   imports = [
-    inputs.git-hooks.flakeModule
+    "${inputs.git-hooks}/flake-module.nix"
   ];
 
   perSystem =

--- a/tests/platforms/hm-extra-files-byte-compiling.nix
+++ b/tests/platforms/hm-extra-files-byte-compiling.nix
@@ -1,11 +1,11 @@
 {
   self,
   pkgs,
+  lib,
 }:
 let
-  inherit (self.inputs.home-manager.lib)
-    homeManagerConfiguration
-    ;
+  hmLib = import "${self.inputs.home-manager}/lib" { inherit lib; };
+  inherit (hmLib) homeManagerConfiguration;
 
   config = {
     home = {

--- a/tests/platforms/hm-submodule-merge.nix
+++ b/tests/platforms/hm-submodule-merge.nix
@@ -1,6 +1,7 @@
 {
   self,
   pkgs,
+  lib,
 }:
 # This test covers a user-reported regression where nixvim's submodule-option (programs.nixvim)
 # cannot correctly merge options declared from the parent scope.
@@ -9,9 +10,8 @@
 #
 # To be clear, this is an upstream module system bug, this test validates our workaround.
 let
-  inherit (self.inputs.home-manager.lib)
-    homeManagerConfiguration
-    ;
+  hmLib = import "${self.inputs.home-manager}/lib" { inherit lib; };
+  inherit (hmLib) homeManagerConfiguration;
 
   # This test module declares a nixvim option from a Home Manager module
   # The module system will attempt an option-type merge on the `programs.nixvim` option,

--- a/tests/platforms/hm.nix
+++ b/tests/platforms/hm.nix
@@ -1,8 +1,12 @@
 {
   self,
   pkgs,
+  lib,
 }:
-self.inputs.home-manager.lib.homeManagerConfiguration {
+let
+  hmLib = import "${self.inputs.home-manager}/lib" { inherit lib; };
+in
+hmLib.homeManagerConfiguration {
   inherit pkgs;
 
   modules = [


### PR DESCRIPTION
This sets `flake=false` for 5 out of the 8 dev flake inputs.

These 5 inputs seem to support being used as vanilla nix.

This eliminates the `inputs.<name>.inputs.<name>.follows.<name>` shenanigans.
It also eliminates the risk of failing to notice that an input has a new input.

Yes, we benefit from some flake features, such as purity, eval cache and input pinning.
But we don't have to use inputs as flakes if that incurs a cost and no benefit.

This is how I personally would like to consume flake inputs whenever they support it, including NixVim.
That is discussed in https://github.com/nix-community/nixvim/discussions/4288
and is mostly decoupled from this change.

By the way, I tried `nix flake check` in this repo and ran out of memory.
What's the trick to succeed?
