### PR TITLE
plugins/jj-nvim: rename -> jj

### DIFF
--- a/plugins/by-name/jj/default.nix
+++ b/plugins/by-name/jj/default.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 lib.nixvim.plugins.mkNeovimPlugin {
-  name = "jj-nvim";
+  name = "jj";
   moduleName = "jj";
   package = "jj-nvim";
   description = "Drive Jujutsu (jj) VCS from Neovim like a pro";

--- a/tests/test-sources/plugins/by-name/jj/default.nix
+++ b/tests/test-sources/plugins/by-name/jj/default.nix
@@ -1,13 +1,13 @@
 {
   empty = {
-    plugins.jj-nvim.enable = true;
+    plugins.jj.enable = true;
   };
 
   example = {
     plugins.snacks.enable = true;
     plugins.codediff.enable = true;
 
-    plugins.jj-nvim = {
+    plugins.jj = {
       enable = true;
 
       settings = {
@@ -20,7 +20,7 @@
   };
 
   no-packages = {
-    plugins.jj-nvim.enable = true;
+    plugins.jj.enable = true;
     dependencies.jujutsu.enable = false;
   };
 }


### PR DESCRIPTION
> I was expecting an options eval error when this merged and realized it was `jj-nvim` instead of `jj`. I thought we were stripping `-nvim` from plugin names in our modules. Thoughts on a quick rename? 

See https://github.com/nix-community/nixvim/pull/4290#issuecomment-4455883922