### PR TITLE
plugins/direnv: fix `settingsOptions`

### DIFF
--- a/plugins/by-name/direnv/default.nix
+++ b/plugins/by-name/direnv/default.nix
@@ -16,11 +16,11 @@ lib.nixvim.plugins.mkVimPlugin {
   dependencies = [ "direnv" ];
 
   settingsOptions = {
-    direnv_auto = defaultNullOpts.mkFlagInt 1 ''
+    auto = defaultNullOpts.mkFlagInt 1 ''
       It will not execute `:DirenvExport` automatically if the value is `0`.
     '';
 
-    direnv_edit_mode =
+    edit_mode =
       defaultNullOpts.mkEnum
         [
           "edit"
@@ -33,7 +33,7 @@ lib.nixvim.plugins.mkVimPlugin {
           Select the command to open buffers to edit. Default: 'edit'.
         '';
 
-    direnv_silent_load = defaultNullOpts.mkFlagInt 1 ''
+    silent_load = defaultNullOpts.mkFlagInt 0 ''
       Stop echoing output from Direnv command.
     '';
   };

--- a/tests/test-sources/plugins/by-name/direnv/default.nix
+++ b/tests/test-sources/plugins/by-name/direnv/default.nix
@@ -8,9 +8,9 @@
       enable = true;
 
       settings = {
-        direnv_auto = 0;
-        direnv_edit_mode = "vsplit";
-        direnv_silent_load = 0;
+        auto = 0;
+        edit_mode = "vsplit";
+        silent_load = 1;
       };
     };
   };


### PR DESCRIPTION
This PR has done:

- Remove global prefixes in `settingsOptions`
- Correct the default value of `silent_load` [direnv/direnv.vim](https://github.com/direnv/direnv.vim/blob/ab2a7e08dd630060cd81d7946739ac7442a4f269/autoload/direnv.vim#L13-L15)