### PR TITLE
modules: allow `config.flake` to be undefined

### DIFF
--- a/docs/lib/index.md
+++ b/docs/lib/index.md
@@ -84,7 +84,8 @@ When Nixvim is built in standalone mode, it expects `lib` to have Nixvim's exten
 If you'd like to use a `lib` with your own extensions, you must supply it via `specialArgs`,
 however you must ensure Nixvim's extensions are also present.
 
-This can be achieved using the lib overlay, available via the `<nixvim>.lib.overlay` flake output.
+This can be achieved using the lib overlay, available via the `<nixvim>.lib.overlay` flake output
+or importing the `lib/overlay.nix` file.
 
 ```nix
 # Example flake

--- a/flake/dev/fmt.nix
+++ b/flake/dev/fmt.nix
@@ -25,6 +25,10 @@
             excludes = [
               # sema-unused-def-lambda-noarg-formal
               "ci/rust-analyzer/default.nix"
+
+              # sema-primop-overridden
+              # sema-primop-removed-prefix
+              "nixpkgs.nix"
             ];
           };
           nixfmt = {

--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -14,7 +14,7 @@
       # on pinning the flake-parts nixpkgs-lib to the nixpkgs pin
       inherit (inputs.nixpkgs) lib;
     };
-    overlay = import ../lib/overlay.nix {
+    overlay = import ../lib/overlay.internal.nix {
       flake = self;
     };
     # Top-top-level aliases

--- a/flake/wrappers.nix
+++ b/flake/wrappers.nix
@@ -34,7 +34,8 @@ in
     {
       legacyPackages = {
         makeNixvimWithModule = import ../wrappers/standalone.nix {
-          inherit lib self;
+          inherit lib;
+          inherit (self.lib) evalNixvim;
           defaultSystem = system;
         };
         makeNixvim = module: makeNixvimWithModule { inherit module; };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1,7 +1,7 @@
 {
   lib,
   self,
-  flake,
+  flake ? null,
 }:
 let
   removed = {
@@ -34,10 +34,10 @@ in
     lib.evalModules {
       modules = modules ++ [
         ../modules/top-level
-        {
+        (lib.optionalAttrs (lib.isAttrs flake) {
           _file = "<nixvim-flake>";
           flake = lib.mkOptionDefault flake;
-        }
+        })
         (lib.optionalAttrs (system != null) {
           _file = "evalNixvim";
           nixpkgs.hostPlatform = lib.mkOptionDefault { inherit system; };

--- a/lib/overlay.internal.nix
+++ b/lib/overlay.internal.nix
@@ -1,0 +1,42 @@
+/**
+  Internal function returning Nixvim's Nixpkgs `lib` overlay.
+
+  Publicly accessible at `./overlay.nix` and the `nixvim.lib.overlay` flake output.
+*/
+{ flake }:
+
+/**
+  Overlay function extending the Nixpkgs `lib` with Nixvim's additions.
+
+  This function is intended to be passed to `lib.extend`.
+
+  # Examples
+
+  Importing the file directly:
+  ```
+  lib.extend (import (nixvim + "/lib/overlay.nix"))
+  ```
+
+  Using the overlay from flake outputs:
+  ```
+  lib.extend nixvim.lib.overlay
+  ```
+
+  # Inputs
+
+  `lib`
+  : The final lib instance; the fixpoint of all extensions, including this one.
+
+  `prevLib`
+  : The lib instance prior to applying this overlay.
+*/
+lib: prevLib: {
+  # Add Nixvim's section to the lib
+  nixvim = import ./top-level.nix { inherit flake lib; };
+
+  # Extend the maintainers set with Nixvim-specific maintainers
+  maintainers = prevLib.maintainers // import ./maintainers.nix;
+
+  # Extend lib.types with Nixvim's custom types
+  types = prevLib.types // import ./types.nix { inherit lib; };
+}

--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -1,37 +1,4 @@
-{ flake }:
-
-/**
-  Overlay function extending the Nixpkgs `lib` with Nixvim's additions.
-
-  This function is intended to be passed to `lib.extend`.
-
-  # Examples
-
-  Importing the file directly:
-  ```
-  lib.extend (import ./overlay.nix { flake = nixvim; })
-  ```
-
-  Using the overlay from flake outputs:
-  ```
-  lib.extend nixvim.lib.overlay
-  ```
-
-  # Inputs
-
-  `lib`
-  : The final lib instance; the fixpoint of all extensions, including this one.
-
-  `prevLib`
-  : The lib instance prior to applying this overlay.
-*/
-lib: prevLib: {
-  # Add Nixvim's section to the lib
-  nixvim = import ./top-level.nix { inherit flake lib; };
-
-  # Extend the maintainers set with Nixvim-specific maintainers
-  maintainers = prevLib.maintainers // import ./maintainers.nix;
-
-  # Extend lib.types with Nixvim's custom types
-  types = prevLib.types // import ./types.nix { inherit lib; };
+# Public non-flake entrypoint for Nixvim's Nixpkgs-lib overlay
+import ./overlay.internal.nix {
+  flake = null;
 }

--- a/lib/top-level.nix
+++ b/lib/top-level.nix
@@ -16,7 +16,7 @@
 */
 {
   lib,
-  flake,
+  flake ? null,
 }:
 lib.makeExtensible (
   self:

--- a/modules/doc.nix
+++ b/modules/doc.nix
@@ -1,8 +1,10 @@
-{ lib, ... }:
+{ lib, options, ... }:
 {
   options.enableMan = lib.mkOption {
     type = lib.types.bool;
-    default = true;
+    # TODO: make `build.manDocsPackage` available in non-flake evals
+    default = options.flake.isDefined;
+    defaultText = lib.literalExpression "options.${options.flake}.isDefined";
     description = "Install the man pages for Nixvim options.";
   };
 }

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -9,6 +9,8 @@ let
   cfg = config.nixpkgs;
   opt = options.nixpkgs;
 
+  pinned = import ../../nixpkgs.nix;
+
   isConfig = x: builtins.isAttrs x || lib.isFunction x;
 
   mergeConfig =
@@ -188,7 +190,7 @@ in
     # NOTE: This is a nixvim-specific option; there's no equivalent in nixos
     source = lib.mkOption {
       type = lib.types.path;
-      default = config.flake.inputs.nixpkgs;
+      default = (lib.optionalAttrs options.flake.isDefined config.flake).inputs.nixpkgs or pinned;
       defaultText = lib.literalMD "Nixvim's flake `input.nixpkgs`";
       description = ''
         The path to import Nixpkgs from.

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -11,6 +11,8 @@ let
 
   pinned = import ../../nixpkgs.nix;
 
+  optionDefaultPrio = (lib.mkOptionDefault null).priority;
+
   isConfig = x: builtins.isAttrs x || lib.isFunction x;
 
   mergeConfig =
@@ -231,6 +233,16 @@ in
                 };
           in
           import cfg.source (args // systemArgs);
+
+      # Whether `pkgs` was constructed by this module.
+      # This is false when any of nixpkgs.pkgs or _module.args.pkgs is set.
+      constructedByMe =
+        # We set it with default priority and it can not be merged, so if the
+        # pkgs module argument has that priority, it's from us.
+        (lib.modules.mergeAttrDefinitionsWithPrio options._module.args).pkgs.highestPrio
+        == lib.modules.defaultOverridePriority
+        # Although, if nixpkgs.pkgs is set, we did forward it, but we did not construct it.
+        && !opt.pkgs.isDefined;
     in
     {
       # We explicitly set the default override priority, so that we do not need
@@ -256,5 +268,20 @@ in
           '';
         }
       ];
+
+      # TODO: consider `nixpkgs.source` always defaulting to `pinned`? That would bypass flake input following.
+      warnings =
+        lib.optional
+          (
+            constructedByMe
+            && opt.source.highestPrio == optionDefaultPrio
+            && pinned.narHash != cfg.source.narHash or null
+          )
+          ''
+            The `${opt.source}` default value has been affected by your flake input `follows`.
+            Nixvim's inputs pin Nixpkgs to `${pinned.rev}`.${
+              lib.optionalString (cfg.source ? rev) " Actual Nixpkgs is following `${cfg.source.rev}`."
+            }
+            Please remove your `inputs.nixvim.inputs.nixpkgs.follows` or explicitly define `${opt.source}` to suppress this warning.'';
     };
 }

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -351,7 +351,12 @@ in
           '';
         };
 
-        manDocsPackage = config.flake.packages.${system}.man-docs;
+        # TODO: make `build.manDocsPackage` available in non-flake evals.
+        # Also update `enableMan` default value.
+        manDocsPackage =
+          lib.throwIfNot options.flake.isDefined
+            "`${options.build.manDocsPackage}` currently requires `${options.flake}`, which is not defined."
+            config.flake.packages.${system}.man-docs;
       };
 
       # Set `wrapRc` and `impureRtp`s option defaults with even lower priority than `mkOptionDefault`

--- a/modules/wrappers.nix
+++ b/modules/wrappers.nix
@@ -1,9 +1,11 @@
 {
   lib,
   extendModules,
-  config,
   ...
 }:
+let
+  importWrapper = lib.flip lib.modules.importApply { inherit extendModules; };
+in
 {
   options.build = {
     nixosModule = lib.mkOption {
@@ -23,18 +25,9 @@
     };
   };
 
-  config.build = {
-    nixosModule = lib.modules.importApply ../wrappers/nixos.nix {
-      self = config.flake;
-      inherit extendModules;
-    };
-    homeModule = lib.modules.importApply ../wrappers/hm.nix {
-      self = config.flake;
-      inherit extendModules;
-    };
-    nixDarwinModule = lib.modules.importApply ../wrappers/darwin.nix {
-      self = config.flake;
-      inherit extendModules;
-    };
+  config.build = lib.mapAttrs (_: importWrapper) {
+    nixosModule = ../wrappers/nixos.nix;
+    homeModule = ../wrappers/hm.nix;
+    nixDarwinModule = ../wrappers/darwin.nix;
   };
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,91 @@
+/**
+  Fetches Nixvim's pinned revision of Nixpkgs without evaluating the flake.
+*/
+let
+  # fetchTree was added in Nix 2.4 as an experimental feature, so provide a fetchTarball-based polyfill
+  # Based on https://github.com/NixOS/flake-compat/blob/5edf11c4/default.nix#L20-L36
+  fetchTree =
+    builtins.fetchTree or (
+      info:
+      if info.type == "github" then
+        {
+          inherit (info) rev narHash lastModified;
+          shortRev = builtins.substring 0 7 info.rev;
+          lastModifiedDate = formatSecondsSinceEpoch info.lastModified;
+          outPath = fetchTarball {
+            url = "https://api.${info.host or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}";
+            sha256 = info.narHash;
+          };
+        }
+      else
+        throw "fetchTree: unsupported type '${info.type}'"
+    );
+
+  # Format number of seconds since the Unix epoch as %Y%m%d%H%M%S.
+  # Based on https://github.com/NixOS/flake-compat/blob/5edf11c4/default.nix#L172-L197
+  # Uses Howard Hinnant civil date algorithm.
+  formatSecondsSinceEpoch =
+    let
+      rem = x: y: x - x / y * y;
+      pad = s: if builtins.stringLength s < 2 then "0" + s else s;
+
+      second = 1;
+      minute = 60 * second;
+      hour = 60 * minute;
+      day = 24 * hour;
+
+      # Gregorian leap year rules:
+      # - leap year every 4 years
+      # - except every 100 years
+      # - except every 400 years
+      daysPerYear = 365;
+      daysPer4Years = daysPerYear * 4 + 1;
+      daysPer100Years = daysPerYear * 100 + 24;
+      daysPer400Years = daysPerYear * 400 + 97;
+
+      monthsToDaysDivisor = 153;
+      monthsToDaysOffset = 2;
+
+      # Days between civil date epoch 0000-03-01 and Unix epoch 1970-01-01.
+      civilDayOffset = 719468;
+    in
+    t:
+    let
+      z = (t / day) + civilDayOffset;
+      secondsInDay = rem t day;
+      hours = secondsInDay / hour;
+      minutes = (rem secondsInDay hour) / minute;
+      seconds = rem t minute;
+
+      # Gregorian calendars repeat every 400 years.
+      era = (if z >= 0 then z else z - (daysPer400Years - 1)) / daysPer400Years;
+
+      dayOfEra = z - era * daysPer400Years;
+
+      yearOfEra =
+        (
+          dayOfEra - dayOfEra / daysPer4Years + dayOfEra / daysPer100Years - dayOfEra / (daysPer400Years - 1)
+        )
+        / daysPerYear;
+
+      year' = yearOfEra + era * 400;
+      dayOfYear = dayOfEra - (daysPerYear * yearOfEra + yearOfEra / 4 - yearOfEra / 100);
+      month' = (5 * dayOfYear + monthsToDaysOffset) / monthsToDaysDivisor;
+      dayOfMonth = dayOfYear - (monthsToDaysDivisor * month' + monthsToDaysOffset) / 5 + 1;
+
+      # The algorithm uses March-indexed months, so offset back to January-index
+      month = month' + (if month' < 10 then 3 else -9);
+      year = year' + (if month <= 2 then 1 else 0);
+    in
+    toString year
+    + pad (toString month)
+    + pad (toString dayOfMonth)
+    + pad (toString hours)
+    + pad (toString minutes)
+    + pad (toString seconds);
+
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  node = lock.nodes.${lock.nodes.${lock.root}.inputs.nixpkgs};
+in
+assert !(node.locked ? dir);
+fetchTree node.locked

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -49,6 +49,7 @@ let
     no-flake = callTest ./no-flake.nix { };
     lib-tests = callTest ./lib-tests.nix { };
     maintainers = callTest ./maintainers.nix { };
+    nixpkgs-fetch = callTest ./nixpkgs-fetch.nix { };
     nixpkgs-module = callTest ./nixpkgs-module.nix { };
     plugins-by-name = callTest ./plugins-by-name.nix { };
     generated = callTest ./generated.nix { };

--- a/tests/nixpkgs-fetch.nix
+++ b/tests/nixpkgs-fetch.nix
@@ -1,0 +1,153 @@
+{
+  lib,
+  self,
+  jq,
+  nix,
+  linkFarmFromDrvs,
+  runCommandLocal,
+  writableTmpDirAsHomeHook,
+}:
+
+# nixpkgs.nix fetches our pinned nixpkgs using the `fetchTree` primop.
+#
+# In this file, we test that it is identical to our `inputs.nixpkgs` flake input.
+#
+# The primop is only available with `experimental-features = flakes` or `experimental-features = fetch-tree`,
+# so we have a `fetchTree` polyfill that delegates to `fetchTarball`.
+#
+# Permutations to test:
+# 1. fetchTree primop
+#   a. attrs
+#   b. outPath derivation
+# 2. fetchTree polyfill
+#   a. attrs
+#   b. outPath derivation
+#
+# As we run this test from a flake, we have `experimental-features = flakes` and `fetchTree` primop is available.
+# Therefore, we can test the `fetchTree` primop easily.
+#
+# By running `nix-instantiate` _within_ a build sandbox, we can configure `experimental-features =`
+# to test the polyfill's attrs. However, we cannot do an actual fetch in the sandbox.
+#
+# Since we can't do an actual fetch in the sandbox, the polyfill's outPath can be tested manually.
+# These should both evaluate to the same derivation:
+#     nix-instantiate --eval nixpkgs.nix --attr outPath --option experimental-features flakes
+#     nix-instantiate --eval nixpkgs.nix --attr outPath --option experimental-features ''
+
+let
+  flake-input = self.inputs.nixpkgs.sourceInfo;
+  pinned-input = import ../nixpkgs.nix;
+in
+linkFarmFromDrvs "nixpkgs-fetch-test" [
+
+  (runCommandLocal "nixpkgs-fetch-test-with-primop"
+    {
+      __structuredAttrs = true;
+      unsafeDiscardReferences.out = true;
+      strictDeps = true;
+
+      hasPrimop = builtins ? fetchTree;
+      expected = flake-input;
+      actual = pinned-input;
+
+      expectedAttrs = removeAttrs flake-input [ "outPath" ];
+      actualAttrs = removeAttrs pinned-input [ "outPath" ];
+
+      nativeBuildInputs = [
+        jq
+      ];
+    }
+    ''
+      echo 'Sanity check that `fetchTree` is enabled'
+      if [ -n "$hasPrimop" ]; then
+        echo "fetchTree is available" >&2
+      else
+        echo "fetchTree is not available" >&2
+        exit 1
+      fi
+
+      if [ "$expected" = "$actual" ]; then
+        echo "Expectation met: '$expected'" >&2
+      else
+        echo "Expected '$actual' to be '$expected'" >&2
+        exit 1
+      fi
+
+      mkdir "$out"
+      jq --sort-keys .expectedAttrs "$NIX_ATTRS_JSON_FILE" > "$out/expected.json"
+      jq --sort-keys .actualAttrs "$NIX_ATTRS_JSON_FILE" > "$out/actual.json"
+
+      # Compare actual.json and expected.json
+      if ! diff --unified "$out/expected.json" "$out/actual.json"; then
+        echo 'Unexpected difference between `expected.json` and `actual.json`' >&2
+        exit 1
+      fi
+    ''
+  )
+
+  (runCommandLocal "nixpkgs-fetch-test-with-polyfill"
+    {
+      __structuredAttrs = true;
+      unsafeDiscardReferences.out = true;
+      strictDeps = true;
+
+      src = lib.fileset.toSource {
+        root = ../.;
+        fileset = lib.fileset.unions [
+          ../flake.lock
+          ../nixpkgs.nix
+        ];
+      };
+
+      expectedAttrs = removeAttrs flake-input [ "outPath" ];
+
+      nativeBuildInputs = [
+        jq
+        nix
+        writableTmpDirAsHomeHook
+      ];
+    }
+    ''
+      # Setup nix environment
+      export TEST_ROOT="$PWD/test-tmp"
+      export NIX_CONF_DIR="$TEST_ROOT/etc"
+      export NIX_LOCALSTATE_DIR="$TEST_ROOT/var"
+      export NIX_LOG_DIR="$TEST_ROOT/var/log/nix"
+      export NIX_STATE_DIR="$TEST_ROOT/var/nix"
+      export PAGER=cat
+
+      mkdir -p "$NIX_CONF_DIR"
+      cat > "$NIX_CONF_DIR/nix.conf" <<EOF
+      store = dummy://
+      experimental-features =
+      EOF
+
+      echo 'Sanity check that `fetchTree` is disabled'
+      echo "NOTE: if this assertion fails, then 'fetch-tree' may no longer be an experimental feature"
+      nix-instantiate --eval --raw --expr '
+        if builtins ? fetchTree then
+          throw "fetchTree is available"
+        else
+          "fetchTree is not available\n"
+      '
+
+      mkdir "$out"
+
+      echo "Evaluating expected"
+      jq --sort-keys .expectedAttrs "$NIX_ATTRS_JSON_FILE" > "$out/expected.json"
+
+      echo "Evaluating actual"
+      nix-instantiate --eval --strict --json \
+        --argstr actual "$src/nixpkgs.nix" \
+        --expr '{ actual }: removeAttrs (import actual) [ "outPath" ]' \
+        | jq --sort-keys . > "$out/actual.json"
+
+      # Compare actual.json and expected.json
+      if ! diff --unified "$out/expected.json" "$out/actual.json"; then
+        echo 'Unexpected difference between `expected.json` and `actual.json`' >&2
+        exit 1
+      fi
+    ''
+  )
+
+]

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,6 +1,4 @@
 {
-  # The nixvim flake
-  self,
   # Function used to evaluate the `programs.nixvim` configuration
   extendModules,
   # Option path where extraFiles should go
@@ -15,6 +13,7 @@
   pkgs,
   lib,
   config,
+  options,
   ...
 }:
 let
@@ -24,7 +23,12 @@ let
     optionalAttrs
     setAttrByPath
     ;
+
   cfg = config.programs.nixvim;
+  opts = finalConfiguration.options;
+
+  flake = lib.optionalAttrs opts.flake.isDefined cfg.flake;
+  libOverlay = flake.lib.overlay or (import ../lib/overlay.nix);
 
   # FIXME: buildPlatform can't use mkOptionDefault because it already defaults to hostPlatform
   buildPlatformPrio = (lib.mkOptionDefault null).priority - 1;
@@ -43,12 +47,18 @@ let
       };
     };
 
-  nixvimConfiguration = extendModules {
+  baseConfiguration = extendModules {
     modules = [
       nixpkgsModule
       { disabledModules = [ "<internal:nixvim-nocheck-base-eval>" ]; }
     ];
   };
+
+  finalConfiguration =
+    options.programs.nixvim.valueMeta.configuration or (throw
+      # v2 check+merge was added 2025-08-28, halfway through the 25.11 cycle
+      "`${options.programs.nixvim}` was evaluated using Nixpkgs lib ${lib.trivial.release}, which does not support `valueMeta` added in Nixpkgs 25.11."
+    );
 
   extraFiles = lib.filter (file: file.enable) (lib.attrValues cfg.extraFiles);
 in
@@ -56,7 +66,7 @@ in
   _file = ./_shared.nix;
 
   options.programs.nixvim = lib.mkOption {
-    inherit (nixvimConfiguration) type;
+    inherit (baseConfiguration) type;
     default = { };
   };
 
@@ -76,8 +86,8 @@ in
       # NOTE: It is important that we use the flake-locked Nixpkgs lib,
       # so that we can safely use recently added lib features.
       # TODO: Consider deprecating `_module.args.nixvimLib`?
-      lib.nixvim = lib.mkDefault self.lib.nixvim;
-      _module.args.nixvimLib = lib.mkDefault (lib.extend self.lib.overlay);
+      lib.nixvim = lib.mkDefault finalConfiguration._module.specialArgs.lib.nixvim;
+      _module.args.nixvimLib = lib.mkDefault (lib.extend libOverlay);
     }
 
     # Propagate nixvim's assertions to the host modules

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -1,5 +1,4 @@
 {
-  self,
   extendModules,
 }:
 {
@@ -21,7 +20,6 @@ in
 
   imports = [
     (importApply ./_shared.nix {
-      inherit self;
       inherit
         (extendModules {
           specialArgs.darwinConfig = config;

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -1,5 +1,4 @@
 {
-  self,
   extendModules,
 }:
 {
@@ -18,7 +17,6 @@ in
 
   imports = [
     (import ./_shared.nix {
-      inherit self;
       inherit
         (extendModules {
           specialArgs.hmConfig = config;

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -1,5 +1,4 @@
 {
-  self,
   extendModules,
 }:
 {
@@ -18,7 +17,6 @@ in
 
   imports = [
     (import ./_shared.nix {
-      inherit self;
       inherit
         (extendModules {
           specialArgs.nixosConfig = config;

--- a/wrappers/standalone.nix
+++ b/wrappers/standalone.nix
@@ -1,7 +1,7 @@
 {
-  self,
   lib,
   defaultSystem,
+  evalNixvim,
 }:
 {
   # TODO: Deprecate this arg in favour of using module options
@@ -29,7 +29,7 @@ let
     mod:
     let
       modules = lib.toList mod;
-      nixvimConfig = self.lib.evalNixvim {
+      nixvimConfig = evalNixvim {
         modules = modules ++ [
           systemMod
         ];


### PR DESCRIPTION

Using a similar technique to flake-compat, we can read our `flake.lock` and fetch the locked Nixpkgs revision using `fetchTree`. This is done in a new `nixpkgs.nix` file, which when imported evaluates to the same thing as `inputs.nixpkgs`:
```nix
$ nix-instantiate --eval nixpkgs.nix
{ lastModified = 1778869304; lastModifiedDate = "20260515182144"; narHash = "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE="; outPath = "/nix/store/77dbgds155bbz3vd3qywq1sii07i5ljs-source"; rev = "d233902339c02a9c334e7e593de68855ad26c4cb"; shortRev = "d233902"; }
```

We use this to provide a fallback default for `nixpkgs.source`.

For `wrappers/`, we can access nixvim's lib and lib overlay internally from the `programs.nixvim` submodule configuration. There's no need to pass it in as an external argument.

For `build.manDocsPackage` things are a little more complicated; we currently encapsulate all docs-packages in `docs/default.nix` which itself needs an instance of the flake, so we always access docs packages via flake outputs. This is worth solving, but it too big a refactor for this PR. For now, I've changed `enableMan`'s default to check `options.flake.isDefined`.

`default.nix` could now be refactored to not rely on the flake at all, and drop flake-compat. But that's a bigger (potentially user-facing) change that I'd prefer to delay for a future PR. We also rely on flake-compat internally, e.g. in our update script we read `inputs.nixpkgs.rev` from `default.nix`.

This fixes #4288, and also allows us to warn users who have accidentally applied `follows` to our `nixpkgs.source` default.
We could also decide to drop the warning and circumvent `follows`, now or in the future.

To fully resolve #4288 we should address:

- [x] `nixpkgs.source` option.
- [x] `wrappers/_shared.nix` gets nixvim's `lib` from flake outputs.
- [x] manpage docs in `outputs.nix` are referenced via flake outputs.
      (Half-solved by having it be conditional; currently all docs packages are encapsulated in `docs/default.nix` and access to them isn't easy without flake-outputs)
- [x] `lib/top-level.nix` and `lib/overlay.nix` need a reference to `flake`. Remove this or make it optional.
- [ ] `default.nix` loads the flake via flake-compat, which is mostly unnecessary with this PR.
      (This is non-trivial to solve, as we use flake-compat for external access to flake input attributes)
      (I have ideas for deprecating this by applying `mapAttrs (_: warn "")` to the flake-compat result and shadowing it with `// {/* non-deprecated outputs */}`. For internal "what is `inputs.nixpkgs.rev`", we can actually use `(import ./nixpkgs.nix).rev`!)


cc @mightyiam