### PR TITLE
plugins: add new modules for various requests

### DIFF
--- a/plugins/by-name/claudecode/default.nix
+++ b/plugins/by-name/claudecode/default.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "claudecode";
+  package = "claudecode-nvim";
+  description = "A local AI coding helper inspired by copilot workflows.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  dependencies = [
+    "claude-code"
+  ];
+
+  settingsExample = {
+    port_range = {
+      min = 12000;
+      max = 12100;
+    };
+    log_level = "debug";
+    focus_after_send = true;
+    diff_opts = {
+      layout = "horizontal";
+      open_in_new_tab = true;
+    };
+    terminal = {
+      split_side = "left";
+      provider = "external";
+      provider_opts = {
+        external_terminal_cmd = "alacritty -e %s";
+      };
+      git_repo_cwd = true;
+    };
+  };
+}

--- a/plugins/by-name/codecompanion-history/default.nix
+++ b/plugins/by-name/codecompanion-history/default.nix
@@ -1,0 +1,38 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "codecompanion-history";
+  package = "codecompanion-history-nvim";
+  description = "Persists and reuses CodeCompanion chats from within Neovim.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsDescription = "Configuration merged into `plugins.codecompanion.settings.extensions.history.opts`.";
+
+  settingsExample = {
+    auto_save = false;
+    picker = "snacks";
+    continue_last_chat = true;
+    title_generation_opts = {
+      model = "gpt-4o-mini";
+      refresh_every_n_prompts = 3;
+    };
+    summary.generation_opts.model = "gpt-4o-mini";
+    memory = {
+      notify = false;
+      index_on_startup = true;
+    };
+  };
+
+  callSetup = false;
+  hasLuaConfig = false;
+
+  extraConfig = cfg: {
+    plugins.codecompanion = {
+      enable = lib.mkDefault true;
+      settings.extensions.history = {
+        enabled = true;
+        opts = cfg.settings;
+      };
+    };
+  };
+}

--- a/plugins/by-name/codex/default.nix
+++ b/plugins/by-name/codex/default.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "codex";
+  package = "codex-nvim";
+  description = "A Copilot-style coding assistant integration for Neovim.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    keymaps = {
+      toggle = "<leader>ac";
+    };
+    border = "rounded";
+    model = "gpt-5-codex";
+  };
+}

--- a/plugins/by-name/cspell/default.nix
+++ b/plugins/by-name/cspell/default.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "cspell";
+  package = "cspell-nvim";
+  description = "cspell diagnostics and code actions for none-ls.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  callSetup = false;
+  hasSettings = false;
+}

--- a/plugins/by-name/just/default.nix
+++ b/plugins/by-name/just/default.nix
@@ -1,0 +1,53 @@
+{ lib, pkgs, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "just";
+  package = "just-nvim";
+  description = "Lightweight task runner for `just` recipe files in Neovim.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    fidget_message_limit = 64;
+    play_sound = true;
+    open_qf_on_run = false;
+    telescope_borders = {
+      prompt = [
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+      ];
+      results = [
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+      ];
+      preview = [
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+        " "
+      ];
+    };
+  };
+
+  extraPlugins = [
+    pkgs.vimPlugins."plenary-nvim"
+    pkgs.vimPlugins."telescope-nvim"
+    pkgs.vimPlugins."fidget-nvim"
+    pkgs.vimPlugins."nvim-notify"
+  ];
+}

--- a/plugins/by-name/justice/default.nix
+++ b/plugins/by-name/justice/default.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "justice";
+  package = "nvim-justice";
+  description = "Alternative task runner for `just` files using Tree-sitter completion.";
+  callSetup = "optional";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    window = {
+      border = "single";
+      recipeCommentMaxLen = 0;
+    };
+    recipeModes.streaming.comment = [
+      "streaming"
+      "curl"
+      "watch"
+    ];
+    terminal.height = 15;
+  };
+}

--- a/plugins/by-name/live-share/default.nix
+++ b/plugins/by-name/live-share/default.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "live-share";
+  package = "live-share-nvim";
+  description = "Collaborative live coding in Neovim.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    port = 443;
+    username = "pairing-session";
+    workspace_root = "/srv/shared-project";
+    transport = "punch";
+    stun = "stun.cloudflare.com:3478";
+  };
+}

--- a/plugins/by-name/mcphub/default.nix
+++ b/plugins/by-name/mcphub/default.nix
@@ -1,0 +1,31 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "mcphub";
+  package = "mcphub-nvim";
+  description = "Integrates MCP tools into CodeCompanion chats.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  dependencies = [
+    # mcphub.nvim can install/run its mcp-hub backend through npm.
+    # Replace this with a direct mcp-hub dependency if it gets packaged.
+    "nodejs"
+  ];
+
+  settingsExample = {
+    port = 4040;
+    auto_toggle_mcp_servers = false;
+    use_bundled_binary = true;
+    workspace = {
+      look_for = [
+        ".mcphub/servers.json"
+        ".cursor/mcp.json"
+      ];
+      port_range = {
+        min = 41001;
+        max = 41100;
+      };
+    };
+    extensions.copilotchat.add_mcp_prefix = true;
+  };
+}

--- a/plugins/by-name/neotab/default.nix
+++ b/plugins/by-name/neotab/default.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "neotab";
+  package = "neotab-nvim";
+  description = "Handles smarter tab completion and indentation behaviors.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    tabkey = "";
+    behavior = "closing";
+    exclude = [ "markdown" ];
+    smart_punctuators.escape = {
+      enabled = true;
+      triggers."+" = {
+        pairs = [
+          {
+            open = "\"";
+            close = "\"";
+          }
+        ];
+        format = " %s ";
+        ft = [ "java" ];
+      };
+    };
+  };
+}

--- a/plugins/by-name/nvchad-ui/default.nix
+++ b/plugins/by-name/nvchad-ui/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "nvchad-ui";
+  description = "UI component modules from NvChad for standalone Neovim setups.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  callSetup = false;
+  hasSettings = false;
+}

--- a/plugins/by-name/sioyek-highlights/default.nix
+++ b/plugins/by-name/sioyek-highlights/default.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "sioyek-highlights";
+  package = "nvim-sioyek-highlights";
+  description = "Integrates Sioyek-like highlighting for docs and notes.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    db_path = "/srv/notes/sioyek.db";
+    format_function = lib.nixvim.nestedLiteralLua ''
+      function(text)
+        return vim.tbl_map(function(line)
+          return "> " .. line
+        end, vim.split(text, "\n", { plain = true }))
+      end
+    '';
+  };
+}

--- a/plugins/by-name/trailblazer/default.nix
+++ b/plugins/by-name/trailblazer/default.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "trailblazer";
+  package = "trailblazer-nvim";
+  description = "Creates and navigates persistent trail marks with optional session state.";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    auto_save_trailblazer_state_on_exit = true;
+    trail_options = {
+      current_trail_mark_mode = "buffer_local_line_sorted";
+      mark_symbol = "●";
+      newest_mark_symbol = "◆";
+    };
+    mappings.nv.motions.new_trail_mark = "<leader>m";
+  };
+}

--- a/plugins/by-name/vectorcode/default.nix
+++ b/plugins/by-name/vectorcode/default.nix
@@ -1,0 +1,17 @@
+{ lib, pkgs, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "vectorcode";
+  package = "vectorcode-nvim";
+  description = "Code-aware local retrieval and completion integration for Neovim.";
+  callSetup = "optional";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  settingsExample = {
+    async_backend = "lsp";
+    n_query = 5;
+    sync_log_env_var = true;
+  };
+
+  extraPackages = [ pkgs.vectorcode ];
+}

--- a/tests/all-package-defaults.nix
+++ b/tests/all-package-defaults.nix
@@ -41,6 +41,9 @@ let
     # "tabnine"
     "cmp-tabnine"
 
+    # 2026-05-20: vectorcode is marked badPlatforms on aarch64-linux
+    "vectorcode.nvim"
+
     # luajitPackages.neotest is flaky: (temporarily?) disable tests that depend on it
     "compiler.nvim"
     "hardhat.nvim"
@@ -102,6 +105,7 @@ let
 
     # 2025-11-16 dependency pyarrow is broken
     "vectorcode"
+    "vectorcode.nvim"
 
     # 2026-04-28: bundled tree-sitter grammar build failure on Darwin
     "kulala.nvim"

--- a/tests/test-sources/plugins/by-name/claudecode/default.nix
+++ b/tests/test-sources/plugins/by-name/claudecode/default.nix
@@ -1,0 +1,97 @@
+{ lib }:
+{
+  empty = {
+    plugins.claudecode = {
+      enable = true;
+      # The default starts a WebSocket server, then logs an INFO shutdown message on VimLeavePre.
+      # Nixvim's headless test runner treats any stderr output as a failure.
+      settings.auto_start = false;
+    };
+  };
+
+  defaults = {
+    plugins.claudecode = {
+      enable = true;
+      settings = {
+        # See `empty` above.
+        auto_start = false;
+        port_range = {
+          min = 10000;
+          max = 65535;
+        };
+        terminal_cmd = lib.nixvim.mkRaw "nil";
+        env.__empty = { };
+        log_level = "info";
+        track_selection = true;
+        focus_after_send = false;
+        visual_demotion_delay_ms = 50;
+        connection_wait_delay = 600;
+        connection_timeout = 10000;
+        queue_timeout = 5000;
+        diff_opts = {
+          layout = "vertical";
+          open_in_new_tab = false;
+          keep_terminal_focus = false;
+          hide_terminal_in_new_tab = false;
+          on_new_file_reject = "keep_empty";
+        };
+        models = [
+          {
+            name = "Claude Opus 4.1 (Latest)";
+            value = "opus";
+          }
+          {
+            name = "Claude Sonnet 4.5 (Latest)";
+            value = "sonnet";
+          }
+          {
+            name = "Opusplan: Claude Opus 4.1 (Latest) + Sonnet 4.5 (Latest)";
+            value = "opusplan";
+          }
+          {
+            name = "Claude Haiku 4.5 (Latest)";
+            value = "haiku";
+          }
+        ];
+        terminal = {
+          split_side = "right";
+          split_width_percentage = 0.3;
+          provider = "auto";
+          show_native_term_exit_tip = true;
+          provider_opts.external_terminal_cmd = lib.nixvim.mkRaw "nil";
+          auto_close = true;
+          snacks_win_opts.__empty = { };
+          cwd = lib.nixvim.mkRaw "nil";
+          git_repo_cwd = false;
+          cwd_provider = lib.nixvim.mkRaw "nil";
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.claudecode = {
+      enable = true;
+      settings = {
+        # See `defaults` above.
+        auto_start = false;
+        port_range = {
+          min = 12000;
+          max = 12100;
+        };
+        log_level = "debug";
+        focus_after_send = true;
+        diff_opts = {
+          layout = "horizontal";
+          open_in_new_tab = true;
+        };
+        terminal = {
+          split_side = "left";
+          provider = "external";
+          provider_opts.external_terminal_cmd = "alacritty -e %s";
+          git_repo_cwd = true;
+        };
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/codecompanion-history/default.nix
+++ b/tests/test-sources/plugins/by-name/codecompanion-history/default.nix
@@ -1,0 +1,101 @@
+{ lib }:
+{
+  empty = {
+    plugins.codecompanion-history.enable = true;
+  };
+
+  defaults = {
+    plugins = {
+      codecompanion-history.enable = true;
+      codecompanion = {
+        enable = true;
+        settings.extensions.history = {
+          enabled = true;
+          opts = {
+            default_buf_title = "[CodeCompanion]  ";
+            keymap = "gh";
+            keymap_description = "Browse saved chats";
+            save_chat_keymap = "sc";
+            save_chat_keymap_description = "Save current chat";
+            auto_save = true;
+            expiration_days = 0;
+            picker = lib.nixvim.mkRaw ''require("codecompanion._extensions.history.pickers").history'';
+            picker_keymaps = {
+              rename = {
+                n = "r";
+                i = "<M-r>";
+              };
+              delete = {
+                n = "d";
+                i = "<M-d>";
+              };
+              duplicate = {
+                n = "<C-y>";
+                i = "<C-y>";
+              };
+            };
+            auto_generate_title = true;
+            title_generation_opts = {
+              adapter = lib.nixvim.mkRaw "nil";
+              model = lib.nixvim.mkRaw "nil";
+              refresh_every_n_prompts = 0;
+              max_refreshes = 3;
+              format_title = lib.nixvim.mkRaw "nil";
+            };
+            summary = {
+              create_summary_keymap = "gcs";
+              browse_summaries_keymap = "gbs";
+              generation_opts = {
+                adapter = lib.nixvim.mkRaw "nil";
+                model = lib.nixvim.mkRaw "nil";
+                context_size = 90000;
+                include_references = true;
+                include_tool_outputs = true;
+                system_prompt = lib.nixvim.mkRaw "nil";
+                format_summary = lib.nixvim.mkRaw "nil";
+              };
+            };
+            continue_last_chat = false;
+            delete_on_clearing_chat = false;
+            dir_to_save = lib.nixvim.mkRaw ''vim.fn.stdpath("data") .. "/codecompanion-history"'';
+            enable_logging = false;
+            memory = {
+              auto_create_memories_on_summary_generation = true;
+              vectorcode_exe = "vectorcode";
+              tool_opts.default_num = 10;
+              notify = true;
+              index_on_startup = false;
+            };
+            chat_filter = lib.nixvim.mkRaw "nil";
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins = {
+      codecompanion-history.enable = true;
+      codecompanion = {
+        enable = true;
+        settings.extensions.history = {
+          enabled = true;
+          opts = {
+            auto_save = false;
+            picker = "snacks";
+            continue_last_chat = true;
+            title_generation_opts = {
+              model = "gpt-4o-mini";
+              refresh_every_n_prompts = 3;
+            };
+            summary.generation_opts.model = "gpt-4o-mini";
+            memory = {
+              notify = false;
+              index_on_startup = true;
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/codex/default.nix
+++ b/tests/test-sources/plugins/by-name/codex/default.nix
@@ -1,0 +1,35 @@
+{ lib }:
+{
+  empty = {
+    plugins.codex.enable = true;
+  };
+
+  defaults = {
+    plugins.codex = {
+      enable = true;
+      settings = {
+        keymaps = {
+          toggle = lib.nixvim.mkRaw "nil";
+          quit = "<C-q>";
+        };
+        border = "single";
+        width = 0.8;
+        height = 0.8;
+        cmd = "codex";
+        model = lib.nixvim.mkRaw "nil";
+        autoinstall = true;
+      };
+    };
+  };
+
+  example = {
+    plugins.codex = {
+      enable = true;
+      settings = {
+        keymaps.toggle = "<leader>ac";
+        border = "rounded";
+        model = "gpt-5-codex";
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/cspell/default.nix
+++ b/tests/test-sources/plugins/by-name/cspell/default.nix
@@ -1,0 +1,9 @@
+{
+  empty = {
+    plugins.cspell.enable = true;
+  };
+
+  defaults = {
+    plugins.cspell.enable = true;
+  };
+}

--- a/tests/test-sources/plugins/by-name/just/default.nix
+++ b/tests/test-sources/plugins/by-name/just/default.nix
@@ -1,0 +1,92 @@
+{
+  empty = {
+    plugins.just.enable = true;
+  };
+
+  defaults = {
+    plugins.just = {
+      enable = true;
+      settings = {
+        fidget_message_limit = 32;
+        play_sound = false;
+        open_qf_on_error = true;
+        open_qf_on_run = true;
+        telescope_borders = {
+          prompt = [
+            "─"
+            "│"
+            " "
+            "│"
+            "┌"
+            "┐"
+            "│"
+            "│"
+          ];
+          results = [
+            "─"
+            "│"
+            "─"
+            "│"
+            "├"
+            "┤"
+            "┘"
+            "└"
+          ];
+          preview = [
+            "─"
+            "│"
+            "─"
+            "│"
+            "┌"
+            "┐"
+            "┘"
+            "└"
+          ];
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.just = {
+      enable = true;
+      settings = {
+        fidget_message_limit = 64;
+        play_sound = true;
+        open_qf_on_run = false;
+        telescope_borders = {
+          prompt = [
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+          ];
+          results = [
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+          ];
+          preview = [
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+            " "
+          ];
+        };
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/justice/default.nix
+++ b/tests/test-sources/plugins/by-name/justice/default.nix
@@ -1,0 +1,129 @@
+{ lib }:
+{
+  empty =
+    { config, ... }:
+    {
+      plugins.justice.enable = true;
+
+      assertions = [
+        {
+          assertion = !(lib.hasInfix "require('justice').setup(" config.content);
+          message = "Empty justice config should not emit a setup call.";
+        }
+      ];
+    };
+
+  defaults =
+    { config, ... }:
+    {
+      plugins.justice = {
+        enable = true;
+        settings = {
+          recipeModes = {
+            streaming = {
+              name = [ "download" ];
+              comment = [
+                "streaming"
+                "curl"
+              ];
+            };
+            terminal = {
+              name = [ ];
+              comment = [
+                "input"
+                "terminal"
+                "fzf"
+              ];
+            };
+            quickfix = {
+              name = [ "%-qf$" ];
+              comment = [ "quickfix" ];
+            };
+            ignore = {
+              name = [ ];
+              comment = [ ];
+            };
+          };
+          window = {
+            border = lib.nixvim.mkRaw ''
+              (function()
+                local ok, winborder = pcall(function()
+                  return vim.o.winborder
+                end)
+                if not ok or winborder == "" or winborder == "none" then
+                  return "rounded"
+                end
+                return winborder
+              end)()
+            '';
+            recipeCommentMaxLen = 30;
+            keymaps = {
+              next = "<Tab>";
+              prev = "<S-Tab>";
+              runRecipeUnderCursor = "<CR>";
+              runFirstRecipe = "1";
+              closeWin = [
+                "q"
+                "<Esc>"
+              ];
+              showRecipe = "<Space>";
+              showVariables = "?";
+              dontUseForQuickKey = [
+                "j"
+                "k"
+                "-"
+                "_"
+              ];
+            };
+            highlightGroups = {
+              quickKey = "Keyword";
+              icons = "Function";
+            };
+            icons = {
+              just = "󰖷";
+              streaming = "ﲋ";
+              quickfix = "";
+              terminal = "";
+              ignore = "󰈉";
+              recipeParameters = "󰘎";
+            };
+          };
+          terminal.height = 10;
+        };
+      };
+
+      assertions = [
+        {
+          assertion = lib.hasInfix "require('justice').setup(" config.content;
+          message = "Justice defaults should emit a setup call.";
+        }
+      ];
+    };
+
+  example =
+    { config, ... }:
+    {
+      plugins.justice = {
+        enable = true;
+        settings = {
+          window = {
+            border = "single";
+            recipeCommentMaxLen = 0;
+          };
+          recipeModes.streaming.comment = [
+            "streaming"
+            "curl"
+            "watch"
+          ];
+          terminal.height = 15;
+        };
+      };
+
+      assertions = [
+        {
+          assertion = lib.hasInfix "require('justice').setup(" config.content;
+          message = "Configured justice should emit a setup call.";
+        }
+      ];
+    };
+}

--- a/tests/test-sources/plugins/by-name/live-share/default.nix
+++ b/tests/test-sources/plugins/by-name/live-share/default.nix
@@ -1,0 +1,39 @@
+{ lib }:
+{
+  empty = {
+    plugins.live-share.enable = true;
+  };
+
+  defaults = {
+    plugins.live-share = {
+      enable = true;
+      settings = {
+        port_internal = 9876;
+        port = 80;
+        max_attempts = 40;
+        service = "nokey@localhost.run";
+        service_url = lib.nixvim.mkRaw "nil";
+        ip_local = "127.0.0.1";
+        username = lib.nixvim.mkRaw "nil";
+        workspace_root = lib.nixvim.mkRaw "nil";
+        debug = false;
+        openssl_lib = lib.nixvim.mkRaw "nil";
+        transport = "ws";
+        stun = "stun.l.google.com:19302";
+      };
+    };
+  };
+
+  example = {
+    plugins.live-share = {
+      enable = true;
+      settings = {
+        port = 443;
+        username = "pairing-session";
+        workspace_root = "/srv/shared-project";
+        transport = "punch";
+        stun = "stun.cloudflare.com:3478";
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/mcphub/default.nix
+++ b/tests/test-sources/plugins/by-name/mcphub/default.nix
@@ -1,0 +1,127 @@
+{ lib }:
+{
+  empty = {
+    # mcphub.nvim setup immediately runs `mcp-hub --version`.
+    # The backend is installed through npm/upstream bundling and is not packaged in nixpkgs yet.
+    test.runNvim = false;
+    plugins.mcphub.enable = true;
+  };
+
+  defaults = {
+    # See `empty` above.
+    test.runNvim = false;
+    plugins.mcphub = {
+      enable = true;
+      settings = {
+        port = 37373;
+        server_url = lib.nixvim.mkRaw "nil";
+        config = lib.nixvim.mkRaw ''vim.fn.expand("~/.config/mcphub/servers.json")'';
+        shutdown_delay = 300000;
+        mcp_request_timeout = 60000;
+        native_servers.__empty = { };
+        builtin_tools.edit_file = {
+          parser = {
+            track_issues = true;
+            extract_inline_content = true;
+          };
+          locator = {
+            fuzzy_threshold = 0.8;
+            enable_fuzzy_matching = true;
+          };
+          ui = {
+            go_to_origin_on_complete = true;
+            keybindings = {
+              accept = ".";
+              reject = ",";
+              next = "n";
+              prev = "p";
+              accept_all = "ga";
+              reject_all = "gr";
+            };
+          };
+          feedback = {
+            include_parser_feedback = true;
+            include_locator_feedback = true;
+            include_ui_summary = true;
+            ui = {
+              include_session_summary = true;
+              include_final_diff = true;
+              send_diagnostics = true;
+              wait_for_diagnostics = 500;
+              diagnostic_severity = lib.nixvim.mkRaw "vim.diagnostic.severity.WARN";
+            };
+          };
+        };
+        json_decode = lib.nixvim.mkRaw "nil";
+        auto_approve = false;
+        auto_toggle_mcp_servers = true;
+        use_bundled_binary = false;
+        global_env.__empty = { };
+        cmd = lib.nixvim.mkRaw "nil";
+        cmdArgs = lib.nixvim.mkRaw "nil";
+        log = {
+          level = lib.nixvim.mkRaw "vim.log.levels.ERROR";
+          to_file = false;
+          file_path = lib.nixvim.mkRaw "nil";
+          prefix = "MCPHub";
+        };
+        ui = {
+          window.__empty = { };
+          wo.__empty = { };
+        };
+        extensions = {
+          avante = {
+            enabled = true;
+            make_slash_commands = true;
+          };
+          copilotchat = {
+            enabled = true;
+            convert_tools_to_functions = true;
+            convert_resources_to_functions = true;
+            add_mcp_prefix = false;
+          };
+        };
+        workspace = {
+          enabled = true;
+          look_for = [
+            ".mcphub/servers.json"
+            ".vscode/mcp.json"
+            ".cursor/mcp.json"
+          ];
+          reload_on_dir_changed = true;
+          port_range = {
+            min = 40000;
+            max = 41000;
+          };
+          get_port = lib.nixvim.mkRaw "nil";
+        };
+        on_ready = lib.nixvim.mkRaw "function() end";
+        on_error = lib.nixvim.mkRaw "function(msg) end";
+      };
+    };
+  };
+
+  example = {
+    # See `empty` above.
+    test.runNvim = false;
+    plugins.mcphub = {
+      enable = true;
+      settings = {
+        port = 4040;
+        auto_toggle_mcp_servers = false;
+        use_bundled_binary = true;
+        workspace = {
+          look_for = [
+            ".mcphub/servers.json"
+            ".cursor/mcp.json"
+          ];
+          port_range = {
+            min = 41001;
+            max = 41100;
+          };
+        };
+        extensions.copilotchat.add_mcp_prefix = true;
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/neotab/default.nix
+++ b/tests/test-sources/plugins/by-name/neotab/default.nix
@@ -1,0 +1,88 @@
+{
+  empty = {
+    plugins.neotab.enable = true;
+  };
+
+  defaults = {
+    plugins.neotab = {
+      enable = true;
+      settings = {
+        tabkey = "<Tab>";
+        reverse_key = "<S-Tab>";
+        act_as_tab = true;
+        behavior = "nested";
+        pairs = [
+          {
+            open = "(";
+            close = ")";
+          }
+          {
+            open = "[";
+            close = "]";
+          }
+          {
+            open = "{";
+            close = "}";
+          }
+          {
+            open = "<";
+            close = ">";
+          }
+          {
+            open = "'";
+            close = "'";
+          }
+          {
+            open = "\"";
+            close = "\"";
+          }
+          {
+            open = "`";
+            close = "`";
+          }
+        ];
+        exclude = [ ];
+        smart_punctuators = {
+          enabled = false;
+          semicolon = {
+            enabled = false;
+            ft = [
+              "cs"
+              "c"
+              "cpp"
+              "java"
+            ];
+          };
+          escape = {
+            enabled = false;
+            triggers.__empty = { };
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.neotab = {
+      enable = true;
+      settings = {
+        tabkey = "";
+        behavior = "closing";
+        exclude = [ "markdown" ];
+        smart_punctuators.escape = {
+          enabled = true;
+          triggers."+" = {
+            pairs = [
+              {
+                open = "\"";
+                close = "\"";
+              }
+            ];
+            format = " %s ";
+            ft = [ "java" ];
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/nvchad-ui/default.nix
+++ b/tests/test-sources/plugins/by-name/nvchad-ui/default.nix
@@ -1,0 +1,9 @@
+{
+  empty = {
+    plugins.nvchad-ui.enable = true;
+  };
+
+  defaults = {
+    plugins.nvchad-ui.enable = true;
+  };
+}

--- a/tests/test-sources/plugins/by-name/sioyek-highlights/default.nix
+++ b/tests/test-sources/plugins/by-name/sioyek-highlights/default.nix
@@ -1,0 +1,49 @@
+{ lib }:
+{
+  empty = {
+    plugins.sioyek-highlights.enable = true;
+  };
+
+  defaults = {
+    plugins.sioyek-highlights = {
+      enable = true;
+      settings = {
+        db_path = lib.nixvim.mkRaw ''vim.fn.expand("~/.local/share/sioyek/shared.db")'';
+        format_function = lib.nixvim.mkRaw ''
+          function(text)
+            local lines = vim.split(text, '\n', { plain = true })
+            local formatted_lines = {}
+            if #lines > 0 then
+              lines[1] = '> *"' .. lines[1]
+              lines[#lines] = lines[#lines] .. '"*'
+              for i, line in ipairs(lines) do
+                if i > 1 then
+                  table.insert(formatted_lines, '> ' .. line)
+                else
+                  table.insert(formatted_lines, line)
+                end
+              end
+            end
+            return formatted_lines
+          end
+        '';
+      };
+    };
+  };
+
+  example = {
+    plugins.sioyek-highlights = {
+      enable = true;
+      settings = {
+        db_path = "/srv/notes/sioyek.db";
+        format_function = lib.nixvim.mkRaw ''
+          function(text)
+            return vim.tbl_map(function(line)
+              return "> " .. line
+            end, vim.split(text, "\n", { plain = true }))
+          end
+        '';
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/trailblazer/default.nix
+++ b/tests/test-sources/plugins/by-name/trailblazer/default.nix
@@ -1,0 +1,182 @@
+{
+  empty = {
+    plugins.trailblazer.enable = true;
+  };
+
+  defaults = {
+    plugins.trailblazer = {
+      enable = true;
+      settings = {
+        lang = "en";
+        auto_save_trailblazer_state_on_exit = false;
+        auto_load_trailblazer_state_on_enter = false;
+        custom_session_storage_dir = "";
+        trail_options = {
+          trail_mark_priority = 10001;
+          available_trail_mark_modes = [
+            "global_chron"
+            "global_buf_line_sorted"
+            "global_fpath_line_sorted"
+            "global_chron_buf_line_sorted"
+            "global_chron_fpath_line_sorted"
+            "global_chron_buf_switch_group_chron"
+            "global_chron_buf_switch_group_line_sorted"
+            "buffer_local_chron"
+            "buffer_local_line_sorted"
+          ];
+          current_trail_mark_mode = "global_chron";
+          current_trail_mark_list_type = "quickfix";
+          trail_mark_list_rows = 10;
+          verbose_trail_mark_select = true;
+          mark_symbol = "•";
+          newest_mark_symbol = "⬤";
+          cursor_mark_symbol = "⬤";
+          next_mark_symbol = "⬤";
+          previous_mark_symbol = "⬤";
+          multiple_mark_symbol_counters_enabled = true;
+          number_line_color_enabled = true;
+          trail_mark_in_text_highlights_enabled = true;
+          trail_mark_symbol_line_indicators_enabled = false;
+          symbol_line_enabled = true;
+          default_trail_mark_stacks = [ "default" ];
+          available_trail_mark_stack_sort_modes = [
+            "alpha_asc"
+            "alpha_dsc"
+            "chron_asc"
+            "chron_dsc"
+          ];
+          current_trail_mark_stack_sort_mode = "alpha_asc";
+          move_to_nearest_before_peek = false;
+          move_to_nearest_before_peek_motion_directive_up = "fpath_up";
+          move_to_nearest_before_peek_motion_directive_down = "fpath_down";
+          move_to_nearest_before_peek_dist_type = "lin_char_dist";
+        };
+        mappings.nv = {
+          motions = {
+            new_trail_mark = "<A-l>";
+            track_back = "<A-b>";
+            peek_move_next_down = "<A-J>";
+            peek_move_previous_up = "<A-K>";
+            move_to_nearest = "<A-n>";
+            toggle_trail_mark_list = "<A-m>";
+          };
+          actions = {
+            delete_all_trail_marks = "<A-L>";
+            paste_at_last_trail_mark = "<A-p>";
+            paste_at_all_trail_marks = "<A-P>";
+            set_trail_mark_select_mode = "<A-t>";
+            switch_to_next_trail_mark_stack = "<A-.>";
+            switch_to_previous_trail_mark_stack = "<A-,>";
+            set_trail_mark_stack_sort_mode = "<A-s>";
+          };
+        };
+        quickfix_mappings = {
+          nv = {
+            motions.qf_motion_move_trail_mark_stack_cursor = "<CR>";
+            actions = {
+              qf_action_delete_trail_mark_selection = "d";
+              qf_action_save_visual_selection_start_line = "v";
+            };
+            alt_actions.qf_action_save_visual_selection_start_line = "V";
+          };
+          v.actions = {
+            qf_action_move_selected_trail_marks_down = "<C-j>";
+            qf_action_move_selected_trail_marks_up = "<C-k>";
+          };
+        };
+        hl_groups = {
+          TrailBlazerTrailMark = {
+            guifg = "White";
+            guibg = "none";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkNext = {
+            guifg = "Green";
+            guibg = "none";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkPrevious = {
+            guifg = "Red";
+            guibg = "none";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkCursor = {
+            guifg = "Black";
+            guibg = "Orange";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkNewest = {
+            guifg = "Black";
+            guibg = "LightBlue";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkCustomOrd = {
+            guifg = "Black";
+            guibg = "LightSlateBlue";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkGlobalChron = {
+            guifg = "Black";
+            guibg = "Red";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkGlobalBufLineSorted = {
+            guifg = "Black";
+            guibg = "LightRed";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkGlobalFpathLineSorted = {
+            guifg = "Black";
+            guibg = "LightRed";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkGlobalChronBufLineSorted = {
+            guifg = "Black";
+            guibg = "Olive";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkGlobalChronFpathLineSorted = {
+            guifg = "Black";
+            guibg = "Olive";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkGlobalChronBufSwitchGroupChron = {
+            guifg = "Black";
+            guibg = "VioletRed";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkGlobalChronBufSwitchGroupLineSorted = {
+            guifg = "Black";
+            guibg = "MediumSpringGreen";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkBufferLocalChron = {
+            guifg = "Black";
+            guibg = "Green";
+            gui = "bold";
+          };
+          TrailBlazerTrailMarkBufferLocalLineSorted = {
+            guifg = "Black";
+            guibg = "LightGreen";
+            gui = "bold";
+          };
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.trailblazer = {
+      enable = true;
+      settings = {
+        auto_save_trailblazer_state_on_exit = true;
+        trail_options = {
+          current_trail_mark_mode = "buffer_local_line_sorted";
+          mark_symbol = "●";
+          newest_mark_symbol = "◆";
+        };
+        mappings.nv.motions.new_trail_mark = "<leader>m";
+      };
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/vectorcode/default.nix
+++ b/tests/test-sources/plugins/by-name/vectorcode/default.nix
@@ -1,0 +1,60 @@
+{ lib }:
+{
+  empty =
+    { config, ... }:
+    {
+      plugins.vectorcode.enable = true;
+
+      assertions = [
+        {
+          assertion = !(lib.hasInfix "require('vectorcode').setup(" config.content);
+          message = "Empty vectorcode config should not emit a setup call.";
+        }
+      ];
+    };
+
+  defaults = {
+    plugins.vectorcode = {
+      enable = true;
+      settings = {
+        cli_cmds.vectorcode = "vectorcode";
+        async_opts = {
+          debounce = 10;
+          events = [
+            "BufWritePost"
+            "InsertEnter"
+            "BufReadPost"
+          ];
+          exclude_this = true;
+          n_query = 1;
+          notify = false;
+          query_cb = lib.nixvim.mkRaw ''require("vectorcode.utils").make_surrounding_lines_cb(-1)'';
+          run_on_register = false;
+          single_job = false;
+          timeout_ms = 5000;
+        };
+        async_backend = "default";
+        exclude_this = true;
+        n_query = 1;
+        notify = true;
+        timeout_ms = 5000;
+        on_setup = {
+          update = false;
+          lsp = false;
+        };
+        sync_log_env_var = false;
+      };
+    };
+  };
+
+  example = {
+    plugins.vectorcode = {
+      enable = true;
+      settings = {
+        async_backend = "lsp";
+        n_query = 5;
+        sync_log_env_var = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
  Add plugin modules for:

  - claudecode.nvim
  - codecompanion-history.nvim
  - codex.nvim
  - cspell.nvim
  - just.nvim
  - nvim-justice
  - live-share.nvim
  - mcphub.nvim
  - neotab.nvim
  - nvchad/ui
  - nvim-sioyek-highlights
  - trailblazer.nvim
  - vectorcode.nvim

  Closes #3500
  Closes #3325
  Closes #4220
  Closes #2812
  Closes #4204
  Closes #4205
  Closes #3650
  Closes #3077
  Closes #4186
  Closes #2352
  Closes #4259
  Closes #3453
  Closes #3326
