### PR TITLE
modules/output: load wrapped config via VIMINIT

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -420,6 +420,13 @@ in
       wrapRc = lib.mkOverride 1501 true;
       impureRtp = lib.mkOverride 1501 false;
 
+      assertions = lib.nixvim.mkAssertions "output" [
+        {
+          assertion = config.impureRtp || config.wrapRc;
+          message = "`impureRtp = false` requires `wrapRc = true` so Nixvim can suppress system/XDG startup config.";
+        }
+      ];
+
       extraConfigLuaPre = lib.mkOrder 100 (
         lib.concatStringsSep "\n" (
           lib.optional (!config.impureRtp) ''

--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -77,7 +77,7 @@ in
       description = ''
         Whether the config will be included in the wrapper script.
 
-        When enabled, the Nixvim config will be passed to `nvim` using the `-u` option.
+        When enabled, the Nixvim config will be passed to `nvim` using the `VIMINIT` environment variable.
       '';
       defaultText = lib.literalMD ''
         Configured by your installation method: `false` when using the Home Manager module, `true` otherwise.
@@ -90,6 +90,7 @@ in
         Whether to keep the (impure) nvim config directory in the runtimepath.
 
         If disabled, the XDG config dirs `nvim` and `nvim/after` will be removed from the runtimepath.
+        When `wrapRc` is enabled, the wrapper will also ignore system/XDG config dirs during startup.
       '';
       defaultText = lib.literalMD ''
         Configured by your installation method: `true` when using the Home Manager module, `false` otherwise.
@@ -276,6 +277,48 @@ in
         else
           initSource;
 
+      # `:help initialization` says sysinit is sourced before `VIMINIT` from
+      # `$XDG_CONFIG_DIRS/nvim/sysinit.vim` or, as fallback, `$VIM/sysinit.vim`.
+      impureStartupEnvVars = [
+        "XDG_CONFIG_DIRS"
+        "VIM"
+      ];
+
+      # Runs via `--cmd` before sysinit, so system/XDG config dirs are hidden
+      # before Nvim checks them without relying on makeWrapper-only `--run`.
+      saveAndClearImpureStartupEnvVars = ''
+        _G.__nixvim_impure_startup_env = {}
+        for _, name in ipairs(${lib.nixvim.toLuaObject impureStartupEnvVars}) do
+          local value = vim.env[name]
+          if value ~= nil then
+            _G.__nixvim_impure_startup_env[name] = {
+              set = true,
+              value = value,
+            }
+          else
+            _G.__nixvim_impure_startup_env[name] = {
+              set = false,
+            }
+          end
+          vim.env[name] = nil
+        end
+      '';
+
+      # Restore before loading the generated config so user code sees the original
+      # environment while sysinit remains skipped.
+      restoreImpureStartupEnvVars = ''
+        local saved_impure_startup_env = _G.__nixvim_impure_startup_env or {}
+        for _, name in ipairs(${lib.nixvim.toLuaObject impureStartupEnvVars}) do
+          local saved = saved_impure_startup_env[name]
+          if saved ~= nil and saved.set then
+            vim.env[name] = saved.value
+          else
+            vim.env[name] = nil
+          end
+        end
+        _G.__nixvim_impure_startup_env = nil
+      '';
+
       extraWrapperArgs = builtins.concatStringsSep " " (
         # Setting environment variables in the wrapper
         (lib.mapAttrsToList (
@@ -292,7 +335,21 @@ in
         ++ (optional (
           config.extraPackagesAfter != [ ]
         ) ''--suffix PATH : "${lib.makeBinPath config.extraPackagesAfter}"'')
-        ++ (optional config.wrapRc ''--add-flags -u --add-flags "${initFile}"'')
+        ++ (optional (config.wrapRc && !config.impureRtp) (
+          lib.escapeShellArgs [
+            "--add-flag"
+            "--cmd"
+            "--add-flag"
+            "lua ${saveAndClearImpureStartupEnvVars}"
+          ]
+        ))
+        ++ (optional config.wrapRc (
+          lib.escapeShellArgs [
+            "--set"
+            "VIMINIT"
+            "lua ${lib.optionalString (!config.impureRtp) restoreImpureStartupEnvVars} dofile('${initFile}')"
+          ]
+        ))
       );
 
       package =

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -150,6 +150,127 @@
     '';
   };
 
+  wrapRc-uses-viminit-for-exrc =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      wrapperArgs = config.build.nvimPackage.wrapperArgs;
+      exrcTest =
+        pkgs.runCommandLocal "wraprc-viminit-exrc-test"
+          {
+            nativeBuildInputs = [ config.build.nvimPackage ];
+          }
+          ''
+            mkdir -p project home xdg/nvim vim
+
+            cat > project/.nvim.lua <<'EOF'
+            vim.g.nixvim_exrc_loaded = true
+            EOF
+
+            cat > project/check.lua <<'EOF'
+            assert(vim.g.nixvim_exrc_loaded == true, ".nvim.lua was not sourced")
+            assert(vim.g.nixvim_xdg_sysinit_loaded == nil, "XDG sysinit.vim was sourced")
+            assert(vim.g.nixvim_vim_sysinit_loaded == nil, "VIM sysinit.vim was sourced")
+            assert(_G.__nixvim_impure_startup_env == nil, "saved startup env was not cleared")
+
+            if vim.env.NIXVIM_TEST_XDG_CONFIG_DIRS == "" then
+              assert(vim.env.XDG_CONFIG_DIRS == nil, "XDG_CONFIG_DIRS was not restored to unset")
+            else
+              assert(
+                vim.env.XDG_CONFIG_DIRS == vim.env.NIXVIM_TEST_XDG_CONFIG_DIRS,
+                "XDG_CONFIG_DIRS was not restored"
+              )
+            end
+
+            if vim.env.NIXVIM_TEST_VIM == "" then
+              assert(vim.env.VIM == nil, "VIM was not restored to unset")
+            else
+              assert(vim.env.VIM == vim.env.NIXVIM_TEST_VIM, "VIM was not restored")
+            end
+            EOF
+
+            cat > xdg/nvim/sysinit.vim <<'EOF'
+            let g:nixvim_xdg_sysinit_loaded = v:true
+            EOF
+
+            cat > vim/sysinit.vim <<'EOF'
+            let g:nixvim_vim_sysinit_loaded = v:true
+            EOF
+
+            cd project
+            run_nvim_with_impure_startup_env() {
+              env \
+                XDG_CONFIG_DIRS="$1" \
+                VIM="$2" \
+                NIXVIM_TEST_XDG_CONFIG_DIRS="$1" \
+                NIXVIM_TEST_VIM="$2" \
+                HOME="$(realpath ../home)" \
+                nvim --headless -S check.lua +qa
+            }
+
+            run_nvim_without_impure_startup_env() {
+              env \
+                -u XDG_CONFIG_DIRS \
+                -u VIM \
+                NIXVIM_TEST_XDG_CONFIG_DIRS= \
+                NIXVIM_TEST_VIM= \
+                HOME="$(realpath ../home)" \
+                nvim --headless -S check.lua +qa
+            }
+
+            xdg_config_dirs="$(realpath ../xdg)"
+            vim_dir="$(realpath ../vim)"
+            run_nvim_with_impure_startup_env "$xdg_config_dirs" "$vim_dir"
+            run_nvim_without_impure_startup_env
+
+            touch $out
+          '';
+    in
+    {
+      wrapRc = true;
+
+      opts = {
+        exrc = true;
+        secure = true;
+      };
+
+      extraConfigLuaPre = ''
+        vim.secure.trust({
+          action = "allow",
+          path = vim.fn.getcwd() .. "/.nvim.lua",
+        })
+      '';
+
+      test.extraInputs = [ exrcTest ];
+
+      assertions = [
+        {
+          assertion = lib.hasInfix "--set VIMINIT" wrapperArgs;
+          message = "`wrapRc` should pass the generated config through VIMINIT.";
+        }
+        {
+          assertion = !(lib.hasInfix "--add-flags -u" wrapperArgs);
+          message = "`wrapRc` should not pass the generated config through `-u`.";
+        }
+        {
+          assertion = lib.hasInfix "--add-flag --cmd" wrapperArgs;
+          message = "`wrapRc` should ignore system config dirs during startup when `impureRtp` is disabled.";
+        }
+        {
+          assertion = lib.hasInfix "__nixvim_impure_startup_env" wrapperArgs;
+          message = "`wrapRc` should restore `XDG_CONFIG_DIRS` after startup.";
+        }
+        {
+          assertion = lib.hasInfix "__nixvim_impure_startup_env" wrapperArgs;
+          message = "`wrapRc` should restore `VIM` after startup.";
+        }
+      ];
+    };
+
   extraPackagesAfter =
     { pkgs, ... }:
     {

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -271,6 +271,18 @@
       ];
     };
 
+  impureRtp-disabled-requires-wrapRc = {
+    wrapRc = false;
+    impureRtp = false;
+
+    test.assertions = expect: [
+      (expect "count" 1)
+      (expect "anyExact" "Nixvim (output): `impureRtp = false` requires `wrapRc = true` so Nixvim can suppress system/XDG startup config.")
+    ];
+
+    test.buildNixvim = false;
+  };
+
   extraPackagesAfter =
     { pkgs, ... }:
     {


### PR DESCRIPTION
Wrapped Nixvim configs previously passed the generated init.lua with -u. Neovim treats that startup path as an explicit user config and skips exrc processing, so project-local .nvim.lua files were not sourced even when users enabled the exrc option.

Load the generated config through a forced VIMINIT instead. This preserves the current wrapped-config precedence while allowing Neovim's normal exrc startup path to run for trusted project config files.

When impureRtp is disabled, clear XDG_CONFIG_DIRS and VIM from an early --cmd before sysinit is checked, then restore them before loading the generated config so runtime code and child processes see the original environment.

Keep the saved startup environment in a short-lived global Lua table shared between the --cmd and VIMINIT chunks, then clear it after restore.

Add a modules-output regression test that checks the wrapper args no longer include -u, verifies VIMINIT is set, confirms trusted .nvim.lua is sourced, blocks sysinit.vim, verifies XDG_CONFIG_DIRS and VIM are restored, and ensures the saved startup state is cleared.

Closes #3506