### PR TITLE
modules/lsp/onAttach: preserve event scope

### DIFF
--- a/modules/lsp/on-attach.nix
+++ b/modules/lsp/on-attach.nix
@@ -51,7 +51,7 @@ in
                 return
               end
 
-              __nixvim_lsp_on_attach(client, event.buf)
+              __nixvim_lsp_on_attach(client, event.buf, event)
             end
           end
         '';
@@ -60,7 +60,7 @@ in
     ];
 
     extraConfigLua = ''
-      local function __nixvim_lsp_on_attach(client, bufnr)
+      local function __nixvim_lsp_on_attach(client, bufnr, event)
         ${cfg.onAttach}
       end
 
@@ -73,7 +73,12 @@ in
           end
 
           for bufnr, _ in pairs(client.attached_buffers) do
-            __nixvim_lsp_on_attach(client, bufnr)
+            __nixvim_lsp_on_attach(client, bufnr, {
+              buf = bufnr,
+              data = {
+                client_id = client.id,
+              },
+            })
           end
 
           return result

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -178,6 +178,8 @@
       table.insert(_G.__nixvim_lsp_on_attach_calls, {
         client = client.id,
         bufnr = bufnr,
+        event_buf = event.buf,
+        event_client = event.data.client_id,
       })
     '';
 
@@ -219,15 +221,19 @@
       end
 
       local expected_calls = {
-        { client = "stub_id", bufnr = attach_buf },
-        { client = "stub_id", bufnr = 1 },
+        { client = "stub_id", bufnr = attach_buf, event_buf = attach_buf, event_client = "stub_id" },
+        { client = "stub_id", bufnr = 1, event_buf = 1, event_client = "stub_id" },
       }
 
       for index, expected in ipairs(expected_calls) do
         local actual = _G.__nixvim_lsp_on_attach_calls[index]
         if actual == nil then
           print("Missing lsp.onAttach call", index)
-        elseif actual.client ~= expected.client or actual.bufnr ~= expected.bufnr then
+        elseif actual.client ~= expected.client
+          or actual.bufnr ~= expected.bufnr
+          or actual.event_buf ~= expected.event_buf
+          or actual.event_client ~= expected.event_client
+        then
           print(
             "Unexpected lsp.onAttach call",
             index,


### PR DESCRIPTION
Pass the LspAttach autocmd event into the shared onAttach helper so existing configs can still read event.buf and event.data.client_id after dynamic registration support moved the user body out of the autocmd callback.

For registerCapability reruns, provide a synthetic event with the fields Neovim documents for LspAttach that nixvim can still know: buf and data.client_id.

Fixes #4335