### PR TITLE
plugins/language-servers: fix warning about `propagatedBuildInputs`

### DIFF
--- a/plugins/lsp/language-servers/pylsp.nix
+++ b/plugins/lsp/language-servers/pylsp.nix
@@ -508,7 +508,7 @@ in
         inherit (cfg.settings) plugins;
 
         nativePlugins =
-          (map
+          (lib.concatMap
             (
               pluginName:
               (lib.optionals (isEnabled plugins.${pluginName}) cfg.package.optional-dependencies.${pluginName})


### PR DESCRIPTION
```
warning: Dependency of package 'python3.13-python-lsp-server-1.14.0' uses a nested list in attribute 'propagatedBuildInputs'.
This is deprecated as of Nixpkgs release 26.05, and support will be removed in a future nixpkgs release.
```

in my case `propagatedBuildInputs` contained empty lists which this also fixes.