### PR TITLE
modules/nixpkgs: sync with upstream

### DIFF
--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -19,8 +19,8 @@ let
     lhs_: rhs_:
     let
       optCall = maybeFn: x: if lib.isFunction maybeFn then maybeFn x else maybeFn;
-      lhs = optCall lhs_ { inherit pkgs; };
-      rhs = optCall rhs_ { inherit pkgs; };
+      lhs = optCall lhs_ { inherit lib pkgs; };
+      rhs = optCall rhs_ { inherit lib pkgs; };
     in
     lib.recursiveUpdate lhs rhs
     // lib.optionalAttrs (lhs ? allowUnfreePackages) {

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -150,9 +150,7 @@ in
       example = {
         system = "aarch64-linux";
       };
-      # FIXME: An elaborated platform is not supported,
-      # but an `apply` function is probably still needed.
-      # See https://github.com/NixOS/nixpkgs/pull/376988
+      apply = lib.systems.elaborate;
       defaultText = lib.literalMD ''
         - Inherited from the "host" configuration's `pkgs`
         - Or `evalNixvim`'s `system` argument
@@ -173,9 +171,14 @@ in
       example = {
         system = "x86_64-linux";
       };
-      # FIXME: An elaborated platform is not supported,
-      # but an `apply` function is probably still needed.
-      # See https://github.com/NixOS/nixpkgs/pull/376988
+      apply =
+        value:
+        let
+          elaborated = lib.systems.elaborate value;
+        in
+        # If equivalent to `hostPlatform`, make it actually identical so that `==` can be used
+        # See https://github.com/NixOS/nixpkgs/issues/278001
+        if lib.systems.equals elaborated cfg.hostPlatform then cfg.hostPlatform else elaborated;
       defaultText = lib.literalMD ''
         Inherited from the "host" configuration's `pkgs`.
         Or `config.nixpkgs.hostPlatform` when building a standalone nixvim.
@@ -216,13 +219,9 @@ in
               inherit (cfg) config overlays;
             };
 
-            elaborated = builtins.mapAttrs (_: lib.systems.elaborate) {
-              inherit (cfg) buildPlatform hostPlatform;
-            };
-
             # Configure `localSystem` and `crossSystem` as required
             systemArgs =
-              if lib.systems.equals elaborated.buildPlatform elaborated.hostPlatform then
+              if cfg.buildPlatform == cfg.hostPlatform then
                 {
                   localSystem = cfg.hostPlatform;
                 }

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -23,6 +23,9 @@ let
       rhs = optCall rhs_ { inherit pkgs; };
     in
     lib.recursiveUpdate lhs rhs
+    // lib.optionalAttrs (lhs ? allowUnfreePackages) {
+      allowUnfreePackages = lhs.allowUnfreePackages ++ (lib.attrByPath [ "allowUnfreePackages" ] [ ] rhs);
+    }
     // lib.optionalAttrs (lhs ? packageOverrides) {
       packageOverrides =
         pkgs:

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -250,7 +250,7 @@ in
       # which is somewhat costly for Nixpkgs. With an explicit priority, we only
       # evaluate the wrapper to find out that the priority is lower, and then we
       # don't need to evaluate `finalPkgs`.
-      _module.args.pkgs = lib.mkOverride lib.modules.defaultOverridePriority finalPkgs.__splicedPackages;
+      _module.args.pkgs = lib.mkOverride lib.modules.defaultOverridePriority finalPkgs;
 
       assertions = [
         {

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -41,9 +41,9 @@ let
         # Use global packages in nixvim's submodule
         pkgs = lib.mkIf config.nixpkgs.useGlobalPackages (lib.mkDefault pkgs);
 
-        # Inherit platforms
-        hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform.system;
-        buildPlatform = lib.mkOverride buildPlatformPrio pkgs.stdenv.buildPlatform.system;
+        # Inherit platform spec
+        hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform;
+        buildPlatform = lib.mkOverride buildPlatformPrio pkgs.stdenv.buildPlatform;
       };
     };
 


### PR DESCRIPTION
Cherry-picks relevant changes from https://github.com/NixOS/nixpkgs/commits/master/nixos/modules/misc/nixpkgs.nix

- **Revert "modules/nixpkgs: don't assign elaborated platforms"**
- **modules/nixpkgs: top-level `pkgs` now returns `__splicedPackages`**
- **modules/nixpkgs: add setting `nixpkgs.config.allowUnfreePackages = ["list" "of "packages"]`**
- **modules/nixpkgs: pass `lib` to config function**
