### PR TITLE
flake/dev: replace `dev-nixpkgs` hack with local-path flake input

### DIFF
--- a/ci/update.nix
+++ b/ci/update.nix
@@ -108,12 +108,8 @@ writeShellApplication {
     fi
 
     # Update the dev lockfile
-    root_nixpkgs=$(nix eval --raw --file . 'inputs.nixpkgs.rev')
     echo "Updating dev lockfile"
-    nix flake update \
-        --override-input 'dev-nixpkgs' "github:NixOS/nixpkgs/$root_nixpkgs" \
-        --flake './flake/dev' \
-        2> >(tee "$dev_update" >&2)
+    nix flake update --flake './flake/dev' 2> >(tee "$dev_update" >&2)
     cleanUpdateOutput "$dev_update" > "$dev_msg"
     if [ -s "$dev_msg" ]; then
       {

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -59,7 +59,10 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": [
+          "nixvim",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -258,21 +261,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -1,25 +1,10 @@
 {
   "nodes": {
-    "dev-nixpkgs": {
-      "locked": {
-        "lastModified": 1779259093,
-        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "devshell": {
       "inputs": {
         "nixpkgs": [
-          "dev-nixpkgs"
+          "nixvim",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -51,9 +36,30 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -76,7 +82,8 @@
         ],
         "gitignore": "gitignore",
         "nixpkgs": [
-          "dev-nixpkgs"
+          "nixvim",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -117,7 +124,8 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "dev-nixpkgs"
+          "nixvim",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -163,7 +171,8 @@
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
-          "dev-nixpkgs"
+          "nixvim",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -180,12 +189,45 @@
         "type": "github"
       }
     },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779259093,
+        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixvim": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      },
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      },
+      "parent": []
+    },
     "nuschtosSearch": {
       "inputs": {
         "flake-utils": "flake-utils",
         "ixx": "ixx",
         "nixpkgs": [
-          "dev-nixpkgs"
+          "nixvim",
+          "nixpkgs"
         ]
       },
       "locked": {
@@ -205,12 +247,12 @@
     },
     "root": {
       "inputs": {
-        "dev-nixpkgs": "dev-nixpkgs",
         "devshell": "devshell",
         "flake-compat": "flake-compat",
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
+        "nixvim": "nixvim",
         "nuschtosSearch": "nuschtosSearch",
         "treefmt-nix": "treefmt-nix"
       }
@@ -230,10 +272,26 @@
         "type": "github"
       }
     },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "dev-nixpkgs"
+          "nixvim",
+          "nixpkgs"
         ]
       },
       "locked": {

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -36,6 +36,7 @@
       # TODO: newer versions fail with: TimeoutError: The operation was aborted due to timeout
       url = "github:NuschtOS/search/b6f77b88e9009bfde28e2130e218e5123dc66796";
       inputs.nixpkgs.follows = "nixvim/nixpkgs";
+      inputs.flake-utils.inputs.systems.follows = "nixvim/systems";
     };
 
     treefmt-nix = {

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -2,10 +2,10 @@
   description = "Private inputs for development purposes. These are used by the top level flake in the `dev` partition, but do not appear in consumers' lock files.";
 
   inputs = {
-    # NOTE: Use a different name to the root flake's inputs.nixpkgs to avoid shadowing it.
-    # NOTE: The only reason we specify a nixpkgs input at all here, is so the other inputs can follow it.
-    # TODO: Once nix 2.26 is more prevalent, follow the root flake's inputs using a "path:../.." input.
-    dev-nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Nix 2.26 improved support for relative path flake inputs.
+    # This dev-flake is only evaluated by flake-parts' flake-compat,
+    # and is only managed by our update CI, so we can safely rely on it.
+    nixvim.url = ../..;
 
     # flake-compat is used by the root `default.nix` to allow non-flake users to import nixvim
     flake-compat.url = "github:NixOS/flake-compat";
@@ -13,34 +13,34 @@
     # keep-sorted start block=yes newline_separated=yes
     devshell = {
       url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "dev-nixpkgs";
+      inputs.nixpkgs.follows = "nixvim/nixpkgs";
     };
 
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "dev-nixpkgs";
+      inputs.nixpkgs.follows = "nixvim/nixpkgs";
       inputs.flake-compat.follows = "flake-compat";
     };
 
     home-manager = {
       url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "dev-nixpkgs";
+      inputs.nixpkgs.follows = "nixvim/nixpkgs";
     };
 
     nix-darwin = {
       url = "github:lnl7/nix-darwin";
-      inputs.nixpkgs.follows = "dev-nixpkgs";
+      inputs.nixpkgs.follows = "nixvim/nixpkgs";
     };
 
     nuschtosSearch = {
       # TODO: newer versions fail with: TimeoutError: The operation was aborted due to timeout
       url = "github:NuschtOS/search/b6f77b88e9009bfde28e2130e218e5123dc66796";
-      inputs.nixpkgs.follows = "dev-nixpkgs";
+      inputs.nixpkgs.follows = "nixvim/nixpkgs";
     };
 
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "dev-nixpkgs";
+      inputs.nixpkgs.follows = "nixvim/nixpkgs";
     };
 
     # keep-sorted end

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -8,7 +8,10 @@
     nixvim.url = ../..;
 
     # flake-compat is used by the root `default.nix` to allow non-flake users to import nixvim
-    flake-compat.url = "github:NixOS/flake-compat";
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
 
     # keep-sorted start block=yes newline_separated=yes
     devshell = {


### PR DESCRIPTION
- **flake/dev: drop dev-nixpkgs for nixvim path ref**
- **flake/dev: have nuschtosSearch systems input follow nixivm's**
- **flake/dev: mark flake-compat as `flake = false`**

Simplifies the update script and our mental model of how dev-inputs are managed.

Instead of "manually" syncing two `nixpkgs` inputs (root `nixpkgs` and dev `dev-nixpkgs`), we have the dev flake inherit all of the root flake's inputs via a `../..` path reference.

Internally, a relative-path flake reference within the same root flake is seen as a path-offset within the same fixed-output-derivation. If one was to compare the root `nixvim`, `nixvim/flake/dev`, and `nixvim/flake/dev`'s `nixvim` input, they would find:
- All have identical `sourceInfo` derivations
- The root flake's `outPath` matches `sourceInfo`
- `nixvim/flake/dev`'s `outPath` is `"${sourceInfo}/flake/dev`
- `nixvim/flake/dev`'s `nixvim` input's `outPath` is `"${sourceInfo}/flake/dev/../..`
- All three therefore refer to the same store object

When running `nix flake lock ./flake/dev`, the root nixvim flake's inputs are synced into `flake/dev/flake.lock` (just like any other flake input's inputs). It is therefore still important to run `nix flake lock ./flake/dev` after running `nix flake lock`, to keep both in sync; our CI update script is still responsible for this.

As a side-effect, we now have easier access to other root-nixvim inputs, like our `systems` input. This allows `nuschtosSearch.inputs.flake-utils.inputs.systems` to follow it.

We held off on doing this sooner as nix and flake-compat have historically had flaky support for relative-path flake inputs. These days, support is good enough for our needs.

cc @mightyiam: this will conflict with #4294, sorry.
