### PR TITLE
wrappers: pass in existing `lib.nixvim`

### DIFF
--- a/modules/wrappers.nix
+++ b/modules/wrappers.nix
@@ -4,7 +4,10 @@
   ...
 }:
 let
-  importWrapper = lib.flip lib.modules.importApply { inherit extendModules; };
+  importWrapper = lib.flip lib.modules.importApply {
+    inherit extendModules;
+    nixvimLib = lib.nixvim;
+  };
 in
 {
   options.build = {

--- a/tests/platforms/darwin.nix
+++ b/tests/platforms/darwin.nix
@@ -14,5 +14,6 @@ self.inputs.nix-darwin.lib.darwinSystem {
       system.stateVersion = 5;
     }
     self.nixDarwinModules.nixvim
+    ./inf-rec-lib.nix
   ];
 }

--- a/tests/platforms/hm.nix
+++ b/tests/platforms/hm.nix
@@ -19,5 +19,6 @@ self.inputs.home-manager.lib.homeManagerConfiguration {
       programs.home-manager.enable = true;
     }
     self.homeModules.nixvim
+    ./inf-rec-lib.nix
   ];
 }

--- a/tests/platforms/inf-rec-lib.nix
+++ b/tests/platforms/inf-rec-lib.nix
@@ -1,0 +1,7 @@
+# Regression test to ensure `config.lib` can be used to define nixvim modules.
+# This causes infinite recursion if any of `config.lib`'s own definitions depend on `program.nixvim`'s result.
+{ config, ... }:
+{
+  lib.test.nixvimModule = { };
+  programs.nixvim = config.lib.test.nixvimModule;
+}

--- a/tests/platforms/nixos.nix
+++ b/tests/platforms/nixos.nix
@@ -19,5 +19,6 @@ self.inputs.nixpkgs.lib.nixosSystem {
       };
     }
     self.nixosModules.nixvim
+    ./inf-rec-lib.nix
   ];
 }

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -1,4 +1,6 @@
 {
+  # A `lib.nixvim` instance
+  nixvimLib,
   # Function used to evaluate the `programs.nixvim` configuration
   extendModules,
   # Option path where extraFiles should go
@@ -86,7 +88,7 @@ in
       # NOTE: It is important that we use the flake-locked Nixpkgs lib,
       # so that we can safely use recently added lib features.
       # TODO: Consider deprecating `_module.args.nixvimLib`?
-      lib.nixvim = lib.mkDefault finalConfiguration._module.specialArgs.lib.nixvim;
+      lib.nixvim = lib.mkDefault nixvimLib;
       _module.args.nixvimLib = lib.mkDefault (lib.extend libOverlay);
     }
 

--- a/wrappers/darwin.nix
+++ b/wrappers/darwin.nix
@@ -1,4 +1,5 @@
 {
+  nixvimLib,
   extendModules,
 }:
 {
@@ -20,6 +21,7 @@ in
 
   imports = [
     (importApply ./_shared.nix {
+      inherit nixvimLib;
       inherit
         (extendModules {
           specialArgs.darwinConfig = config;

--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -1,4 +1,5 @@
 {
+  nixvimLib,
   extendModules,
 }:
 {
@@ -17,6 +18,7 @@ in
 
   imports = [
     (import ./_shared.nix {
+      inherit nixvimLib;
       inherit
         (extendModules {
           specialArgs.hmConfig = config;

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -1,4 +1,5 @@
 {
+  nixvimLib,
   extendModules,
 }:
 {
@@ -17,6 +18,7 @@ in
 
   imports = [
     (import ./_shared.nix {
+      inherit nixvimLib;
       inherit
         (extendModules {
           specialArgs.nixosConfig = config;


### PR DESCRIPTION
e1ad5c4e92ab4506d102123720d0b45fec8403f4 made it so the `lib` nixos config option\* definition that defines `config.lib.nixvim` depends on `program.nixvim`'s result.

If any of `programs.nixvim`'s modules are constructed by anything in `config.lib`, that means we cannot use `programs.nixvim`'s value to define anything in `config.lib` without running into infinite recursion.

Usually laziness would make this recursion ok, but unfortunately the `lib` nixos option has type `attrsOf`, as opposed to `lazyAttrsOf`, which means it suffers from this strictness: https://github.com/NixOS/nixpkgs/blob/d30e720ca6f9c9c748a56ca27031a65b105d05ca/lib/types.nix#L881-L885

This PR fixes that by reverting to passing in the "original" configuration's `lib.nixvim`. This is the lazy configuration with `_module.check = false` responsible for passing in its `extendModules`.

Fixes https://github.com/nix-community/nixvim/issues/4341
Fixes https://github.com/nix-community/stylix/issues/2323

Adds a regression test to ensure `config.lib` can be used to define `programs.nixvim` modules.

_\* different to the nixpkgs `lib` passed as a module argument._
