### PR TITLE
modules: drop `helpers` alias

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -48,12 +48,6 @@ in
         # however see https://github.com/nix-community/nixvim/issues/2879
         inherit lib;
         modulesPath = ../modules;
-        # TODO: deprecated 2025-11-19
-        helpers = lib.warn ''
-          nixvim: the `helpers` module arg has been renamed to `lib.nixvim`.
-          Nixvim modules can access this via the `lib` module arg.
-          For wrapper modules (e.g. NixOS or Home Manager modules), see:
-          https://nix-community.github.io/nixvim/lib/nixvim/index.html#accessing-nixvims-functions'' self;
       }
       // extraSpecialArgs;
     };

--- a/tests/enable-except-in-tests.nix
+++ b/tests/enable-except-in-tests.nix
@@ -11,17 +11,12 @@ let
     name = "enable-except-in-tests-test";
     inherit pkgs;
     module =
-      { lib, helpers, ... }:
+      { lib, ... }:
       {
         assertions = [
           {
             assertion = !lib.nixvim.enableExceptInTests;
             message = "Expected lib.nixvim.enableExceptInTests to be false";
-          }
-          {
-            # NOTE: evaluating `helpers` here prints an eval warning
-            assertion = !helpers.enableExceptInTests;
-            message = "Expected helpers.enableExceptInTests to be false";
           }
         ];
       };
@@ -32,17 +27,12 @@ let
       nvim = makeNixvimWithModule {
         inherit pkgs;
         module =
-          { lib, helpers, ... }:
+          { lib, ... }:
           {
             assertions = [
               {
                 assertion = lib.nixvim.enableExceptInTests;
                 message = "Expected lib.nixvim.enableExceptInTests to be true";
-              }
-              {
-                # NOTE: evaluating `helpers` here prints an eval warning
-                assertion = helpers.enableExceptInTests;
-                message = "Expected helpers.enableExceptInTests to be true";
               }
             ];
           };

--- a/tests/main.nix
+++ b/tests/main.nix
@@ -37,9 +37,6 @@ let
             imports = lib.toList module;
           }
         ];
-        extraSpecialArgs = {
-          helpers = throw "nixvim: `helpers` used internally.";
-        };
       };
     in
     configuration.config.build.test.overrideAttrs (old: {

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -72,11 +72,6 @@ in
     default = { };
   };
 
-  # TODO: Added 2024-07-24; remove after 24.11
-  imports = [
-    (lib.mkRenamedOptionModule [ "nixvim" "helpers" ] [ "lib" "nixvim" ])
-  ];
-
   config = mkMerge [
     {
       # Make Nixvim's extended lib available to the host modules


### PR DESCRIPTION
It has been soft-deprecated for years now, but the warning was introduced just before 25.11 was branched off. We've therefore had the warning for two stable releases and ~1 unstable cycle.

Normally I'd advocate for having another release cycle with a `helpers = throw` stub, but I think in this case it's very unlikely anyone is still using nixvim's `helpers` module argument, so it's better to remove `specialArgs.helpers` entirely, in case an end-user wants to define their own unrelated `_module.args.helpers`.\*

_\*The original motivation for deprecating `helpers` was that the name was too generic for a shared namespace._
