### PR TITLE
flake/dev/flake.lock: update nix-dawrin url

### DIFF
--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -181,13 +181,13 @@
       "locked": {
         "lastModified": 1779036909,
         "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
-        "owner": "lnl7",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
         "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
-        "owner": "lnl7",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
         "type": "github"
       }

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -31,7 +31,7 @@
     };
 
     nix-darwin = {
-      url = "github:lnl7/nix-darwin";
+      url = "github:nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixvim/nixpkgs";
     };
 


### PR DESCRIPTION
I noticed when looking at the 26.05 pins that nix-darwin has moved from `lnl7/nix-darwin` to `nix-darwin/nix-darwin`.
