### PR TITLE
github/workflows/lint: run on all PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,6 @@ name: lint
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.svg"
-      - ".gitignore"
-      - "LICENSE"
 
 defaults:
   run:


### PR DESCRIPTION
Avoid edge-cases where ignored files can indirectly break formatting.

Some of these exclusions are also outdated, as for example spellcheck applies to markdown files.

Running this CI unconditionally also allows us to specify it as a "required status check".
