### PR TITLE
github/workflows/lint: run on Merge Queue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: lint
 
 on:
   pull_request:
+  merge_group:
 
 defaults:
   run:


### PR DESCRIPTION
If we're gonna require `treefmt` status check, we also need to run it on Merge Queue groups. Otherwise, nothing can _leave_ the queue!
