### PR TITLE
docs: switch to `evalNixvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,26 +175,36 @@ For more detail, see the [Usage](https://nix-community.github.io/nixvim/user-gui
 
 ### Standalone Usage
 
-If you want to use it standalone, you can use the `makeNixvim` function:
+Nixvim can also be used separately from NixOS, Home Manager, etc.
+To use Nixvim standalone, evaluate a Nixvim configuration and use its package output:
 
 ```nix
-{ pkgs, nixvim, ... }: {
-  environment.systemPackages = [
-    (nixvim.legacyPackages."${pkgs.stdenv.hostPlatform.system}".makeNixvim {
-      colorschemes.gruvbox.enable = true;
-    })
-  ];
-}
+let
+  nixvim = import (builtins.fetchTarball {
+    # ...
+  });
+  configuration = nixvim.lib.evalNixvim {
+    system = builtins.currentSystem;
+
+    modules = [
+      {
+        colorschemes.gruvbox.enable = true;
+      }
+    ];
+  };
+in
+configuration.config.build.package
 ```
+
+The configuration also exposes a test derivation through `configuration.config.build.test`, which can be used from `checks`.
 
 To get started with a standalone configuration, you can use the template by running the following command in an empty directory (recommended):
 
-```
+```console
 nix flake init --template github:nix-community/nixvim
 ```
 
-Alternatively, if you want a minimal flake to allow building a custom Neovim you
-can use the following:
+Alternatively, you can create a minimal flake:
 
 <details>
   <summary>Minimal flake configuration</summary>
@@ -211,10 +221,6 @@ can use the following:
   outputs =
     { nixpkgs, nixvim, ... }:
     let
-      config = {
-        colorschemes.gruvbox.enable = true;
-      };
-
       systems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -227,59 +233,29 @@ can use the following:
       packages = forAllSystems (
         system:
         let
-          nixvim' = nixvim.legacyPackages.${system};
-          nvim = nixvim'.makeNixvim config;
+          configuration = nixvim.lib.evalNixvim {
+            inherit system;
+
+            modules = [
+              {
+                colorschemes.gruvbox.enable = true;
+              }
+            ];
+          };
         in
         {
-          inherit nvim;
-          default = nvim;
+          default = configuration.config.build.package;
         }
       );
     };
 }
 ```
-</details>
-
-You can then run Neovim using `nix run .# -- <file>`. This can be useful to test
-config changes easily.
-
-### Advanced Usage
-
-You may want more control over the Nixvim modules, like:
-
-- Splitting your configuration in multiple files
-- Adding custom nix modules to enhance Nixvim
-- Change the nixpkgs used by Nixvim
-
-In this case, you can use the `makeNixvimWithModule` function.
-
-It takes a set with the following keys:
-- `pkgs`: The nixpkgs to use (defaults to the nixpkgs pointed at by the Nixvim flake)
-- `module`: The nix module definition used to extend Nixvim.
-  This is useful to pass additional module machinery like `options` or `imports`.
-- `extraSpecialArgs`: Extra arguments to pass to the modules when using functions.
-  Can be `self` in a flake, for example.
-
-For more detail, see the [Standalone Usage](https://nix-community.github.io/nixvim/platforms/standalone.html) section of our documentation.
-
-### With a `devShell`
-
-You can also use Nixvim to define an instance which will only be available inside a Nix `devShell`:
-
-<details>
-  <summary>devShell configuration</summary>
-
-```nix
-let
-  nvim = nixvim.legacyPackages.x86_64-linux.makeNixvim {
-    plugins.lsp.enable = true;
-  };
-in pkgs.mkShell {
-  buildInputs = [nvim];
-};
-```
 
 </details>
+
+You can then run Neovim using `nix run .# -- <file>`. This can be useful for testing configuration changes.
+
+For more information, see the [Standalone Usage](https://nix-community.github.io/nixvim/platforms/standalone.html) docs.
 
 # Documentation
 Documentation is available on this project's GitHub Pages page:

--- a/docs/lib/pages.nix
+++ b/docs/lib/pages.nix
@@ -13,10 +13,16 @@
         source = ./index.md;
       };
 
+      modules._page = {
+        title = "lib.nixvim.modules: module functions";
+        functions.file = ../../lib/modules.nix;
+      };
+
       utils._page = {
         title = "lib.nixvim.utils: utility functions";
         functions.file = ../../lib/utils.nix;
       };
+
       lua._page = {
         title = "lib.nixvim.lua: lua functions";
         functions.file = ../../lib/to-lua.nix;

--- a/docs/mdbook/SUMMARY.md
+++ b/docs/mdbook/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Nixvim Platforms](./platforms/index.md)
 @PLATFORM_OPTIONS@
 	- [Standalone](./platforms/standalone.md)
+	- [Standalone (legacy)](./platforms/standalone-legacy.md)
 
 # Options
 

--- a/docs/platforms/standalone-legacy.md
+++ b/docs/platforms/standalone-legacy.md
@@ -1,0 +1,140 @@
+# Legacy Standalone Functions
+
+> [!WARNING]
+> The functions documented on this page are deprecated.
+> New configurations should prefer `nixvim.lib.evalNixvim`.
+>
+> See [Standalone Usage](./standalone.md) for the recommended approach.
+
+## makeNixvim
+
+`makeNixvim` is available at:
+
+```nix
+nixvim.legacyPackages.${system}.makeNixvim
+```
+
+It accepts a single Nixvim module and returns a Nixvim package.
+
+```nix
+nixvim.legacyPackages.${system}.makeNixvim {
+  colorschemes.gruvbox.enable = true;
+}
+```
+
+This is equivalent to evaluating a configuration and using its package output.
+
+> [!TIP]
+> `makeNixvim module` is equivalent to `makeNixvimWithModule { inherit module; }`.
+
+## makeNixvimWithModule
+
+`makeNixvimWithModule` is available at:
+
+```nix
+nixvim.legacyPackages.${system}.makeNixvimWithModule
+```
+
+It accepts an attribute set with the following fields:
+- `module`
+- `pkgs`
+- `extraSpecialArgs`
+
+The only required field is `module`.
+
+```nix
+nixvim.legacyPackages.${system}.makeNixvimWithModule {
+  module = ./config;
+}
+```
+
+## Test derivation helpers
+
+### check.mkTestDerivationFromNvim
+
+Available at:
+
+```nix
+nixvim.lib.${system}.check.mkTestDerivationFromNvim
+```
+
+Accepts:
+
+```nix
+{
+  name = "example";
+  nvim = myNvim;
+}
+```
+
+where `nvim` is a Nixvim package.
+
+### check.mkTestDerivationFromNixvimModule
+
+Available at:
+
+```nix
+nixvim.lib.${system}.check.mkTestDerivationFromNixvimModule
+```
+
+Accepts the same arguments as `makeNixvimWithModule` and produces a test derivation.
+
+## Extending an existing package
+
+Packages produced by the legacy APIs expose an `extend` function.
+
+```nix
+{ makeNixvim }:
+
+let
+  first = makeNixvim {
+    extraConfigLua = "-- first stage";
+  };
+
+  second = first.extend {
+    extraConfigLua = "-- second stage";
+  };
+
+  third = second.extend {
+    extraConfigLua = "-- third stage";
+  };
+in
+third
+```
+
+This produces:
+
+```lua
+-- first stage
+-- second stage
+-- third stage
+```
+
+The modern equivalent is `configuration.extendModules`.
+
+## Accessing configuration values
+
+Legacy packages expose the evaluated configuration through the `config` attribute.
+
+```nix
+nvim.config
+```
+
+## Accessing options
+
+Legacy packages expose module options through the `options` attribute.
+
+```nix
+nvim.options
+```
+
+## Migration
+
+| Legacy API                                                    | Modern equivalent                                              |
+| ------------------------------------------------------------- | -------------------------------------------------------------- |
+| `makeNixvim module`                                           | `(evalNixvim { modules = [ module ]; }).config.build.package`  |
+| `makeNixvimWithModule args`                                   | `(evalNixvim { ... }).config.build.package`                    |
+| `check.mkTestDerivationFromNixvimModule args`                 | `(evalNixvim { ... }).config.build.test`                       |
+| `check.mkTestDerivationFromNvim { name = ""; inherit nvim; }` | `nvim.config.build.test`                                       |
+| `package.extend module`                                       | `((evalNixvim { ... }).extendModules { modules = [ module ]; }).config.build.package` |
+

--- a/docs/platforms/standalone.md
+++ b/docs/platforms/standalone.md
@@ -1,70 +1,163 @@
 # Standalone Usage
 
+Standalone usage refers to using Nixvim directly as a package,
+rather than through the [NixOS], [Home Manager], or [nix-darwin] modules.
+
+In this mode, Nixvim configurations are evaluated explicitly using [`evalNixvim`][evalNixvim].
+
+[NixOS]: ./nixos.md
+[Home Manager]: ./hm.md
+[nix-darwin]: ./darwin.md
+[evalNixvim]: ../lib/nixvim/modules/index.md#lib.nixvim.modules.evalNixvim
+
 ## Options
 
-When used standalone, nixvim's options are available directly, without any prefix/namespace.
+When used standalone, Nixvim's options are available directly, without any prefix/namespace.
 This is unlike the other modules which typically use a `programs.nixvim.*` prefix.
 
 There are **no** standalone-specific options available.
 
-## Using in another configuration
+## Evaluating a configuration
 
-Here is an example on how to integrate into a NixOS or Home Manager configuration when using flakes.
+When used standalone, Nixvim configurations are evaluated using `nixvim.lib.evalNixvim`.
 
-The example assumes your standalone config is the `default` package of a flake, and you've named the input "`nixvim-config`".
 ```nix
-{ inputs, system, ... }:
+configuration = nixvim.lib.evalNixvim {
+  inherit system;
+  modules = [ ./config ];
+};
+```
+
+The result is a Nix module-system configuration.
+
+```
+modules
+  ↓
+evalNixvim
+  ↓
+configuration
+```
+
+Notable attributes include:
+- `config`: The nested attribute set of all merged option values.
+- `options`: The nested attribute set of all option declarations.
+- `type`: A module system type.
+  See [upstream docs][evalModules-type].
+- `extendModules`: Extends the current configuration with additional modules.
+  See [upstream docs][extendModules].
+
+For more information, see Nixpkgs' [`evalModules` output][evalModules-output] docs. \
+See the [lib.nixvim.modules] reference for complete API documentation.
+
+## Building a package
+
+Nixvim exposes build outputs through the evaluated configuration.
+The wrapped Neovim package is available as `configuration.config.build.package`.
+
+For example:
+
+```nix
 {
-  # NixOS
-  environment.systemPackages = [ inputs.nixvim-config.packages.${system}.default ];
-  # Home Manager
-  home.packages = [ inputs.nixvim-config.packages.${system}.default ];
+  packages.${system}.default = configuration.config.build.package;
 }
 ```
 
-## Extending an existing configuration
+## Building tests
 
-Given a `<nixvim>` derivation obtained from `makeNixvim` or `makeNixvimWithModule` it is possible to create a new derivation with additional options.
+A test derivation is available as `configuration.config.build.test`.
+It can be used to smoke-test your Nixvim configuration.
 
-This is done through the `<nixvim>.extend` function. This function takes a Nixvim module that is merged with the options used to build `<nixvim>`.
-
-This function is recursive, meaning that it can be applied an arbitrary number of times.
-
-### Example
+For example, as a flake check:
 
 ```nix
-{makeNixvim}: let
-  first = makeNixvim { extraConfigLua = "-- first stage"; };
-  second = first.extend {extraConfigLua = "-- second stage";};
-  third = second.extend {extraConfigLua = "-- third stage";};
+{
+  checks.${system}.default = configuration.config.build.test;
+}
+```
+
+## Extending a configuration
+
+Configurations can be extended using `extendModules`.
+
+```nix
+let
+  base = nixvim.lib.evalNixvim {
+    inherit system;
+
+    modules = [
+      {
+        extraConfigLua = "-- first stage";
+      }
+    ];
+  };
+
+  extended = base.extendModules {
+    modules = [
+      {
+        extraConfigLua = "-- second stage";
+      }
+    ];
+  };
 in
-third
+extended.config.build.package
 ```
 
-This will generate a `init.lua` that will contain the comments from each stages:
+See the upstream [`lib.evalModules` → `extendModules`][extendModules] documentation.
 
-```lua
--- first stage
--- second stage
--- third stage
+## Accessing configuration values
+
+Evaluated option values are available through `config`.
+
+For example:
+
+```nix
+configuration.config.colorschemes.gruvbox.enable
+⇒ true
 ```
 
-## Accessing options used in an existing configuration
+This can be useful when other parts of your NixOS, Home Manager, or nix-darwin configuration need access to values defined by Nixvim.
 
-The `config` used to produce a standalone Nixvim derivation can be accessed as an attribute on the derivation, similar to `<nixvim>.extend`.
+## Accessing options
 
-This may be useful if you want unrelated parts of your NixOS, Home Manager or nix-darwin configuration to use the same value as something in your Nixvim configuration.
+Module options are available through `options`.
 
-## Accessing Nixvim options
-
-Given a Nixvim derivation it is possible to access the module options using `<derivation>.options`.
-This can be useful to configure `nixd` for example:
+This can be useful when configuring `nixd`:
 
 ```nix
 {
   plugins.lsp.servers.nixd = {
     enable = true;
-    settings.options.nixvim.expr = ''(builtins.getFlake "/path/to/flake").packages.${system}.neovimNixvim.options'';
+
+    settings.options.nixvim.expr =
+      ''(builtins.getFlake "/path/to/flake").packages.${system}.default.options'';
   };
 }
 ```
+
+Package outputs also expose `config` and `options` through passthru attributes.
+
+## Using in another configuration
+
+Here is an example of integrating a standalone configuration into a NixOS or Home Manager configuration.
+
+The example assumes the standalone configuration is exported as the `default` package of a flake named `nixvim-config`.
+
+```nix
+{ inputs, system, ... }:
+{
+  # NixOS
+  environment.systemPackages = [
+    inputs.nixvim-config.packages.${system}.default
+  ];
+
+  # Home Manager
+  home.packages = [
+    inputs.nixvim-config.packages.${system}.default
+  ];
+}
+```
+
+[lib.nixvim.modules]: ../lib/nixvim/modules/index.md
+[evalModules-output]: https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules
+[evalModules-type]: https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-return-value-type
+[extendModules]: https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-return-value-extendModules

--- a/docs/platforms/standalone.md
+++ b/docs/platforms/standalone.md
@@ -157,6 +157,88 @@ The example assumes the standalone configuration is exported as the `default` pa
 }
 ```
 
+## Convenience functions
+
+For simple use cases, Nixvim provides helper functions that combine configuration evaluation and output selection.
+
+These are thin wrappers around `evalNixvim` selecting `config.build.package` or `config.build.test`.
+
+See the [reference docs][lib.nixvim.modules] for more detail.
+
+### buildNixvim
+
+Builds a Nixvim package from a module or list of modules.
+
+```nix
+buildNixvim {
+  imports = [ ./config ];
+  nixpkgs.hostPlatform = system;
+}
+```
+
+Equivalent to:
+
+```nix
+(evalNixvim {
+  inherit system;
+  modules = [ ./config ];
+}).config.build.package
+```
+
+### buildNixvimWith
+
+Like `buildNixvim`, but accepts the full set of arguments supported by `evalNixvim`.
+
+```nix
+buildNixvimWith {
+  inherit system;
+  modules = [ ./config ];
+}
+```
+
+Equivalent to:
+
+```nix
+(evalNixvim {
+  inherit system;
+  modules = [ ./config ];
+}).config.build.package
+```
+
+### testNixvim
+
+Produces a test derivation from an existing Nixvim package.
+
+```nix
+testNixvim myNvim
+```
+
+Equivalent to:
+
+```nix
+myNvim.config.build.test
+```
+
+### testNixvimWith
+
+Evaluates a configuration and returns its test derivation.
+
+```nix
+testNixvimWith {
+  inherit system;
+  modules = [ ./config ];
+}
+```
+
+Equivalent to:
+
+```nix
+(evalNixvim {
+  inherit system;
+  modules = [ ./config ];
+}).config.build.test
+```
+
 [lib.nixvim.modules]: ../lib/nixvim/modules/index.md
 [evalModules-output]: https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules
 [evalModules-type]: https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-return-value-type

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -119,3 +119,6 @@ The resulting configuration exposes several useful outputs:
 For a complete example, see our [standalone flake template](https://github.com/nix-community/nixvim/tree/main/templates/simple).
 
 For more information, including extending configurations and accessing configuration values, see [Standalone Usage](../platforms/standalone.md).
+
+> [!IMPORTANT]
+> If you are using the legacy standalone APIs (`makeNixvim`, `makeNixvimWithModule`, etc.), see [Legacy Standalone Functions](../platforms/standalone-legacy.md).

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -101,18 +101,21 @@ For more platform-specific options and information, see [Nixvim Platforms](../pl
 
 ### Standalone usage
 
-When using Nixvim as a standalone derivation you can use the following functions, located in `<nixvim>.legacyPackages.${system}`:
-- `makeNixvim`: A simplified version of `makeNixvimWithModule` for when you only need to specify `module` and the other options can be left as the defaults.
-  This function's only argument is a Nixvim module, e.g. `{ extraConfigLua = "print('hi')"; }`
-- `makeNixvimWithModule`: This function takes an attribute set of the form: `{pkgs, extraSpecialArgs, module}`.
-  The only required argument is `module`, being a Nixvim module. This gives access to the `imports`, `options`, `config` variables, and using functions like `{config, ...}: { ... }`.
+When using Nixvim standalone, start by evaluating a Nixvim configuration:
 
-There are also some helper functions in `<nixvim>.lib.${system}` like:
-- `check.mkTestDerivationFromNixvimModule`, taking the same arguments as `makeNixvimWithModule` and generates a check derivation.
-- `check.mkTestDerivationFromNvim`, taking an attribute set of the form `{name = "<derivation name>"; nvim = <nvim derivation>}`. The `nvim` is the standalone derivation provided by Nixvim.
+```nix
+configuration = nixvim.lib.evalNixvim {
+  inherit system;
+  modules = [ ./config ];
+};
+```
 
-The Nixvim derivation can then be used like any other package!
+The resulting configuration exposes several useful outputs:
+- `configuration.config.build.package`: builds the Neovim package.
+  The package output can be used like any other package.
+- `configuration.config.build.test`: builds a test derivation for the configuration.
+  The derivation will fail to build if the test fails.
 
-For an example, see the [nixvim standalone flake template](https://github.com/nix-community/nixvim/blob/main/templates/simple/flake.nix).
+For a complete example, see our [standalone flake template](https://github.com/nix-community/nixvim/tree/main/templates/simple).
 
-For more information see [Standalone Usage](../platforms/standalone.md).
+For more information, including extending configurations and accessing configuration values, see [Standalone Usage](../platforms/standalone.md).

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -16,7 +16,51 @@ let
   };
 in
 {
-  # Evaluate nixvim modules, checking warnings and assertions
+  /**
+    Evaluate Nixvim modules into a module system configuration.
+
+    # Input
+
+    An attribute set with the following fields:
+    : `modules`
+      : An optional list of modules.
+        These are merged together to form the final configuration.
+
+      `extraSpecialArgs`
+      : An optional AttrSet, appended to `specialArgs`.
+
+        `specialArgs` is an attribute set of module arguments that can be used in `imports`.
+        In contrast to `config._module.args`, which is only available after imports have been resolved.
+
+        **Caution:** relying on special args can make your modules less portable.
+
+      `system`
+      : An optional string, used to define `nixpkgs.hostPlatform`.
+
+    # Output
+
+    Returns a Nixvim configuration, as produced by `lib.evalModules`.
+
+    Notable attributes include:
+    : `config`
+      : The nested attribute set of all merged option values.
+
+      `options`
+      : The nested attribute set of all option declarations.
+
+      `type`
+      : A module system type.
+        See: <https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-return-value-type>
+
+      `extendModules`
+      : Extends the current configuration with additional modules.
+        See: <https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-return-value-extendModules>
+
+    # See Also
+
+    - Module System: <https://nixos.org/manual/nixpkgs/unstable/#module-system>
+    - `lib.evalModules`: <https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules>
+  */
   evalNixvim =
     {
       modules ? [ ],

--- a/templates/simple/README.md
+++ b/templates/simple/README.md
@@ -1,6 +1,9 @@
 # Nixvim template
 
 This template gives you a good starting point for configuring Nixvim standalone.
+See [Standalone Usage] for more detail.
+
+[Standalone Usage]: https://nix-community.github.io/nixvim/platforms/standalone.html
 
 ## Configuring
 

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -19,28 +19,26 @@
       perSystem =
         { system, ... }:
         let
-          nixvimLib = nixvim.lib.${system};
-          nixvim' = nixvim.legacyPackages.${system};
-          nixvimModule = {
-            inherit system; # or alternatively, set `pkgs`
-            module = import ./config; # import the module directly
+          configuration = nixvim.lib.evalNixvim {
+            # Specify the target system.
+            # Alternatively configure `nixpkgs` options in your modules.
+            inherit system;
+
+            # Import your Nixvim modules
+            modules = [ ./config ];
+
             # You can use `extraSpecialArgs` to pass additional arguments to your module files
             extraSpecialArgs = {
               # inherit (inputs) foo;
             };
           };
-          nvim = nixvim'.makeNixvimWithModule nixvimModule;
         in
         {
-          checks = {
-            # Run `nix flake check .` to verify that your config is not broken
-            default = nixvimLib.check.mkTestDerivationFromNixvimModule nixvimModule;
-          };
+          # Run `nix flake check .` to verify that your config is not broken
+          checks.default = configuration.config.build.test;
 
-          packages = {
-            # Lets you run `nix run .` to start nixvim
-            default = nvim;
-          };
+          # Lets you run `nix run .` to start nixvim
+          packages.default = configuration.config.build.package;
         };
     };
 }


### PR DESCRIPTION
### Summary

This soft-deprecates the legacy standalone functions, by updating all documentation to use the new `evalNixvim`-centric approach. No new warnings are added (hence "soft") and legacy documentation is preserved on a dedicated `standalone-legacy.md` page.

Updating our docs, templates, and guides is an important prerequisite before we can begin _actually_ deprecating and removing the legacy functions.

I'd been putting this off for a while, so I ended up using an LLM to help with much of the docs re-write. The final text is all manually reviewed/edited, of course.

### Next steps

With our docs updated, next we can:
- consider promoting the "experimental flake-parts template" to be a stable template.
- add warnings to the legacy functions
- (eventually) remove the legacy functions

### Reviewing

You can of course review the PR's diff and/or the individual commits.

If you clone this branch locally, e.g. using `gh --repo nix-community/nixvim pr checkout 4377`, then you can open the docs in your browser using `nix run .#docs`.

You can skip the clone by using:
```shell
nix run github:nix-community/nixvim/refs/pull/4377/merge#docs
```