### PR TITLE
ci: run dependabot on GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`
     # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
-    directory: "/"
+    # You _do_ need to specify any non-workflow directories, such as actions, though.
+    directories:
+      - /
+      - /.github/actions/*
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Dependabot can find GHA workflows and actions in standard locations:
- `/.github/workflows/*`
- `/action.yml`

But non-standard locations like `.github/actions/**` must be specified explicitly.

See https://github.com/dependabot/dependabot-core/issues/6345
