### PR TITLE
docs: take defaults from environment variables

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -1,3 +1,4 @@
+# NOTE: to use defaults from the environment, you must build with --impure
 {
   pkgs,
   callPackage,
@@ -9,10 +10,10 @@
   search,
   lib-docs,
   # The root directory of the site
-  baseHref ? "/",
+  baseHref ? lib.maybeEnv "NIXVIM_DOCS_BASE_HREF" "/",
   # A list of all available docs that should be linked to
   # Each element should contain { branch; nixpkgsBranch; baseHref; status; }
-  availableVersions ? [ ],
+  availableVersions ? builtins.fromJSON (lib.maybeEnv "NIXVIM_DOCS_AVAILABLE_VERSIONS" "[]"),
 }:
 let
   inherit (configuration.config.meta) nixvimInfo;


### PR DESCRIPTION
## Summary

When building with --impure, accept the following environment variables for docs inputs:
- `NIXVIM_DOCS_BASE_HREF` → `baseHref`
- `NIXVIM_DOCS_AVAILABLE_VERSIONS` → `availableVersions`

This is a no-op change when building without `--impure` or when the above environment variables are undefined.

## Motivation

With this change, we can simplify our `website.yml` CI to:
```sh
nix build "github:$GITHUB_REPOSITORY/$ref#docs" --impure --out-link "$outLink"
```

...dropping the checkout, composite action, and reliance on flake-compat.

The full change (with CI changes) was tested here: https://github.com/MattSturgeon/nixvim/actions/runs/27102800885
...which deployed to https://mattsturgeon.github.io/nixvim/ correctly.

This PR must be merged and backported _before_ the CI workflow can be refactored.
