### PR TITLE
treewide: bump stable 25.11 → 26.05

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -13,7 +13,7 @@ Deprecations should include a comment in the format of:
 
 where:
 
-- `n` is the current release; 25.11 at the time of writing
+- `n` is the current release; 26.05 at the time of writing
 - `n+1` is the next release; 26.05 at the time of writing
 - `n+2` is the release following `n+1`; 26.11 at the time of writing
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you have any question, please use the [discussions page](https://github.com/n
 > Nixvim needs to be installed with a compatible nixpkgs version.
 > This means that the `main` branch of Nixvim requires to be installed with `nixpkgs-unstable`.
 >
-> If you want to use Nixvim with nixpkgs 25.11 you should use the `nixos-25.11` branch.
+> If you want to use Nixvim with nixpkgs 26.05 you should use the `nixos-26.05` branch.
 
 For more detail, see the [Installation](https://nix-community.github.io/nixvim) section of our documentation.
 
@@ -108,7 +108,7 @@ let
   nixvim = import (builtins.fetchGit {
     url = "https://github.com/nix-community/nixvim";
     # If you are not running an unstable channel of nixpkgs, select the corresponding branch of Nixvim.
-    # ref = "nixos-25.11";
+    # ref = "nixos-26.05";
   });
 in
 {
@@ -151,7 +151,7 @@ flakes, just add the `nixvim` input:
   inputs.nixvim = {
     url = "github:nix-community/nixvim";
     # If you are not running an unstable channel of nixpkgs, select the corresponding branch of Nixvim.
-    # url = "github:nix-community/nixvim/nixos-25.11";
+    # url = "github:nix-community/nixvim/nixos-26.05";
 
     inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -261,7 +261,7 @@ For more information, see the [Standalone Usage](https://nix-community.github.io
 Documentation is available on this project's GitHub Pages page:
 [https://nix-community.github.io/nixvim](https://nix-community.github.io/nixvim)
 
-The stable documentation is also available at [https://nix-community.github.io/nixvim/25.11](https://nix-community.github.io/nixvim/25.11).
+The stable documentation is also available at [https://nix-community.github.io/nixvim/26.05](https://nix-community.github.io/nixvim/26.05).
 
 If the option `enableMan` is set to `true` (by default it is), man pages will also
 be installed containing the same information, they can be viewed with `man nixvim`.

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -88,7 +88,7 @@ When using Nixvim, it is possible to encounter errors about something not being 
 
 This usually means one of few things:
 - You are using `follows` on `inputs.nixvim` causing Nixvim to have an unexpected version of Nixpkgs.
-- The nixpkgs version is not in line with Nixvim (for example nixpkgs nixos-25.11 is used with Nixvim master)
+- The nixpkgs version is not in line with Nixvim (for example nixpkgs nixos-26.05 is used with Nixvim master)
 - The nixpkgs unstable version used with Nixvim is not recent enough.
 
 When building Nixvim using flakes, we usually recommend _not_ declaring a `follows` for `inputs.nixvim`.

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -5,7 +5,7 @@ You must use a `nixpkgs` version compatible with the Nixvim version you choose.
 The `main` branch requires to use a _very recent_ version of nixpkgs unstable.
 In order to guarantee the compatibility between Nixvim & nixpkgs it is recommended to always update both at the same time.
 
-When using a `stable` version you must use the corresponding Nixvim branch, for example `nixos-25.11` when using NixOS 25.11.
+When using a `stable` version you must use the corresponding Nixvim branch, for example `nixos-26.05` when using NixOS 26.05.
 
 Failure to use the correct branch, or an old revision of nixpkgs will likely result in errors of the form `vimPlugins.<name> attribute not found`.
 


### PR DESCRIPTION
Final step in releasing Nixvim for 26.05 stable; bump our docs/references to stable.
