### PR TITLE
plugins/web-devicons: drop auto-enable and back-compat

### DIFF
--- a/plugins/by-name/barbar/default.nix
+++ b/plugins/by-name/barbar/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
   inherit (lib.nixvim)
@@ -89,18 +89,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = cfg: {
-    # TODO: added 2024-09-20 remove after 24.11
-    plugins.web-devicons = lib.mkIf (
-      !(
-        (
-          config.plugins.mini.enable
-          && config.plugins.mini.modules ? icons
-          && config.plugins.mini.mockDevIcons
-        )
-        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
-      )
-    ) { enable = lib.mkOverride 1490 true; };
-
     keymaps = lib.filter (keymap: keymap != null) (
       # TODO: switch to `attrValues cfg.keymaps` when removing the deprecation warnings above:
       lib.attrValues (lib.filterAttrs (n: v: n != "silent") cfg.keymaps)

--- a/plugins/by-name/bufferline/default.nix
+++ b/plugins/by-name/bufferline/default.nix
@@ -1,4 +1,4 @@
-{ lib, config, ... }:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
@@ -208,18 +208,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
   };
 
   extraConfig = {
-    # TODO: added 2024-09-20 remove after 24.11
-    plugins.web-devicons = lib.mkIf (
-      !(
-        (
-          config.plugins.mini.enable
-          && config.plugins.mini.modules ? icons
-          && config.plugins.mini.mockDevIcons
-        )
-        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
-      )
-    ) { enable = lib.mkOverride 1490 true; };
-
     opts.termguicolors = true;
   };
 }

--- a/plugins/by-name/diffview/default.nix
+++ b/plugins/by-name/diffview/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  config,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts;
   inherit (lib) types;
@@ -97,22 +93,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
           );
       };
   };
-
-  extraConfig =
-    cfg:
-    lib.mkIf cfg.enable {
-      # TODO: added 2024-09-20 remove after 24.11
-      plugins.web-devicons = lib.mkIf (
-        !(
-          (
-            config.plugins.mini.enable
-            && config.plugins.mini.modules ? icons
-            && config.plugins.mini.mockDevIcons
-          )
-          || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
-        )
-      ) { enable = lib.mkOverride 1490 true; };
-    };
 
   # TODO: Deprecated 2025-10-04
   inherit (import ./deprecations.nix { inherit lib; })

--- a/plugins/by-name/lspsaga/deprecations.nix
+++ b/plugins/by-name/lspsaga/deprecations.nix
@@ -26,33 +26,6 @@ lib: {
           lib.nixvim.ifNonNull' oldFilter (lib.mapAttrs (_: lib.nixvim.mkRaw) oldFilter)
         )
     )
-
-    # TODO: added 2024-09-20 remove after 24.11
-    (
-      { config, ... }:
-      let
-        cfg = config.plugins.lspsaga;
-      in
-      {
-        plugins.web-devicons =
-          lib.mkIf
-            (
-              cfg.enable
-              && (cfg.settings.ui.devicon or true)
-              && !(
-                (
-                  config.plugins.mini.enable
-                  && config.plugins.mini.modules ? icons
-                  && config.plugins.mini.mockDevIcons
-                )
-                || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
-              )
-            )
-            {
-              enable = lib.mkOverride 1490 true;
-            };
-      }
-    )
   ];
 
   # TODO: introduced 2025-08-20: remove after 25.11

--- a/plugins/by-name/nvim-tree/default.nix
+++ b/plugins/by-name/nvim-tree/default.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  config,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
 in
@@ -129,18 +125,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
       '';
     in
     {
-      # TODO: added 2024-09-20 remove after 24.11
-      plugins.web-devicons = lib.mkIf (
-        !(
-          (
-            config.plugins.mini.enable
-            && config.plugins.mini.modules ? icons
-            && config.plugins.mini.mockDevIcons
-          )
-          || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
-        )
-      ) { enable = lib.mkOverride 1490 true; };
-
       autoCmd =
         (lib.optional autoOpenEnabled {
           event = "VimEnter";

--- a/plugins/by-name/telescope/default.nix
+++ b/plugins/by-name/telescope/default.nix
@@ -79,18 +79,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
   callSetup = false;
   extraConfig = cfg: {
-    # TODO: added 2024-09-20 remove after 24.11
-    plugins.web-devicons = lib.mkIf (
-      !(
-        (
-          config.plugins.mini.enable
-          && config.plugins.mini.modules ? icons
-          && config.plugins.mini.mockDevIcons
-        )
-        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
-      )
-    ) { enable = lib.mkOverride 1490 true; };
-
     extraConfigVim = lib.mkIf (cfg.highlightTheme != null) ''
       let $BAT_THEME = '${cfg.highlightTheme}'
     '';

--- a/plugins/by-name/trouble/default.nix
+++ b/plugins/by-name/trouble/default.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  lib,
-  ...
-}:
+{ lib, ... }:
 let
   inherit (lib.nixvim) defaultNullOpts;
 in
@@ -246,19 +242,5 @@ lib.nixvim.plugins.mkNeovimPlugin {
         Variable = "󰀫 ";
       };
     } "Define custom icons.";
-  };
-
-  extraConfig = {
-    # TODO: added 2024-09-20 remove after 24.11
-    plugins.web-devicons = lib.mkIf (
-      !(
-        (
-          config.plugins.mini.enable
-          && config.plugins.mini.modules ? icons
-          && config.plugins.mini.mockDevIcons
-        )
-        || (config.plugins.mini-icons.enable && config.plugins.mini-icons.mockDevIcons)
-      )
-    ) { enable = lib.mkOverride 1490 true; };
   };
 }

--- a/plugins/deprecation.nix
+++ b/plugins/deprecation.nix
@@ -46,21 +46,6 @@ let
     # Added 2026-01-24
     vscode-diff = "codediff";
   };
-  # Added 2024-09-21; remove after 24.11
-  # `iconsPackage` options were briefly available in the following plugins for ~3 weeks
-  iconsPackagePlugins = [
-    "telescope"
-    "lspsaga"
-    "nvim-tree"
-    "neo-tree"
-    "trouble"
-    "alpha"
-    "diffview"
-    "fzf-lua"
-    "bufferline"
-    "barbar"
-    "chadtree"
-  ];
 in
 {
 
@@ -84,43 +69,21 @@ in
       acc: scope: renamed':
       acc ++ lib.mapAttrsToList (old: new: lib.mkRenamedOptionModule [ scope old ] [ scope new ]) renamed'
     ) [ ] renamed
-    ++ map (
-      name:
-      lib.mkRemovedOptionModule [ "plugins" name "iconsPackage" ] ''
-        Please use `plugins.web-devicons` or `plugins.mini.modules.icons` with `plugins.mini.mockDevIcons`, or `plugins.mini-icons` with `plugins.mini-icons.mockDevIcons` instead.
-      ''
-    ) iconsPackagePlugins
     ++ [
       (
-        { config, options, ... }:
+        { config, ... }:
         {
-          config = {
-            warnings =
-              (lib.nixvim.mkWarnings "plugins.web-devicons" {
-                when = options.plugins.web-devicons.enable.highestPrio == 1490;
-
-                message = ''
-                  This plugin was enabled automatically because the following plugins are enabled.
-                  This behaviour is deprecated. Please explicitly define `plugins.web-devicons.enable` or alternatively
-                  enable `plugins.mini.enable` with `plugins.mini.modules.icons` and `plugins.mini.mockDevIcons`, or
-                  `plugins.mini-icons.enable` with `plugins.mini-icons.mockDevIcons`.
-                  ${lib.concatMapStringsSep "\n" (name: "plugins.${name}") (
-                    builtins.filter (name: config.plugins.${name}.enable) iconsPackagePlugins
-                  )}
-                '';
-              })
-              ++ lib.foldlAttrs (
-                warnings: plugin: msg:
-                warnings
-                ++ (lib.nixvim.mkWarnings "plugins.${plugin}" {
-                  when = config.plugins.${plugin}.enable;
-                  message = ''
-                    This plugin has been deprecated.
-                    ${msg}
-                  '';
-                })
-              ) [ ] deprecated;
-          };
+          warnings = lib.foldlAttrs (
+            warnings: plugin: msg:
+            warnings
+            ++ lib.nixvim.mkWarnings "plugins.${plugin}" {
+              when = config.plugins.${plugin}.enable;
+              message = ''
+                This plugin has been deprecated.
+                ${msg}
+              '';
+            }
+          ) [ ] deprecated;
         }
       )
     ];

--- a/tests/test-sources/plugins/by-name/barbar/default.nix
+++ b/tests/test-sources/plugins/by-name/barbar/default.nix
@@ -1,13 +1,17 @@
 {
   empty = {
-    plugins.web-devicons.enable = true;
     plugins.barbar.enable = true;
+
+    # Defaults rely on icons
+    plugins.web-devicons.enable = true;
   };
 
   keymappings = {
-    plugins.web-devicons.enable = true;
     plugins.barbar = {
       enable = true;
+
+      # Disable icons
+      settings.icons.filetype.enabled = false;
 
       keymaps = {
         next.key = "<TAB>";
@@ -22,7 +26,9 @@
   };
 
   defaults = {
+    # Defaults rely on icons
     plugins.web-devicons.enable = true;
+
     plugins.barbar = {
       enable = true;
 
@@ -224,8 +230,7 @@
     };
   };
 
-  no-icons = {
-    plugins.web-devicons.enable = false;
+  no-icon = {
     plugins.barbar = {
       enable = true;
       settings.icons.filetype.enabled = false;

--- a/tests/test-sources/plugins/by-name/bufferline/default.nix
+++ b/tests/test-sources/plugins/by-name/bufferline/default.nix
@@ -1,11 +1,9 @@
 {
   empty = {
-    plugins.web-devicons.enable = true;
     plugins.bufferline.enable = true;
   };
 
   example = {
-    plugins.web-devicons.enable = true;
     plugins.bufferline = {
       enable = true;
       settings = {
@@ -60,7 +58,6 @@
   };
 
   defaults = {
-    plugins.web-devicons.enable = true;
     plugins.bufferline = {
       enable = true;
       settings = {
@@ -127,8 +124,8 @@
     };
   };
 
-  no-icons = {
-    plugins.web-devicons.enable = false;
+  with-icons = {
+    plugins.web-devicons.enable = true;
     plugins.bufferline = {
       enable = true;
     };

--- a/tests/test-sources/plugins/by-name/diffview/default.nix
+++ b/tests/test-sources/plugins/by-name/diffview/default.nix
@@ -1,11 +1,9 @@
 {
   empty = {
-    plugins.web-devicons.enable = true;
     plugins.diffview.enable = true;
   };
 
   example = {
-    plugins.web-devicons.enable = true;
     plugins.diffview = {
       enable = true;
 
@@ -166,8 +164,8 @@
     };
   };
 
-  no-icons = {
-    plugins.web-devicons.enable = false;
+  with-icons = {
+    plugins.web-devicons.enable = true;
     plugins.diffview = {
       enable = true;
     };

--- a/tests/test-sources/plugins/by-name/lspsaga/default.nix
+++ b/tests/test-sources/plugins/by-name/lspsaga/default.nix
@@ -1,11 +1,9 @@
 {
   empty = {
-    plugins.web-devicons.enable = true;
     plugins.lspsaga.enable = true;
   };
 
   defaults = {
-    plugins.web-devicons.enable = true;
     plugins.lspsaga = {
       enable = true;
       settings = {
@@ -187,8 +185,8 @@
     };
   };
 
-  no-icons = {
-    plugins.web-devicons.enable = false;
+  with-icons = {
+    plugins.web-devicons.enable = true;
     plugins.lspsaga = {
       enable = true;
     };

--- a/tests/test-sources/plugins/by-name/nvim-tree/default.nix
+++ b/tests/test-sources/plugins/by-name/nvim-tree/default.nix
@@ -1,11 +1,9 @@
 {
   empty = {
-    plugins.web-devicons.enable = true;
     plugins.nvim-tree.enable = true;
   };
 
   defaults = {
-    plugins.web-devicons.enable = true;
     plugins.nvim-tree = {
       openOnSetup = true;
       openOnSetupFile = true;
@@ -259,10 +257,14 @@
 
   no-packages = {
     plugins = {
-      web-devicons.enable = true;
       nvim-tree.enable = true;
     };
 
     dependencies.git.enable = false;
+  };
+
+  with-icon = {
+    plugins.web-devicons.enable = true;
+    plugins.nvim-tree.enable = true;
   };
 }

--- a/tests/test-sources/plugins/by-name/telescope/default.nix
+++ b/tests/test-sources/plugins/by-name/telescope/default.nix
@@ -1,6 +1,5 @@
 {
   empty = {
-    plugins.web-devicons.enable = true;
     plugins.telescope.enable = true;
   };
 
@@ -21,7 +20,6 @@
   };
 
   combine-plugins = {
-    plugins.web-devicons.enable = true;
     plugins.telescope.enable = true;
 
     performance.combinePlugins.enable = true;
@@ -36,7 +34,6 @@
 
   no-packages = {
     plugins = {
-      web-devicons.enable = false;
       telescope.enable = true;
     };
     dependencies.bat.enable = false;

--- a/tests/test-sources/plugins/by-name/trouble/default.nix
+++ b/tests/test-sources/plugins/by-name/trouble/default.nix
@@ -1,11 +1,9 @@
 {
   empty = {
-    plugins.web-devicons.enable = true;
     plugins.trouble.enable = true;
   };
 
   lsp = {
-    plugins.web-devicons.enable = true;
     plugins.lsp = {
       enable = true;
       servers.clangd.enable = true;
@@ -15,7 +13,6 @@
   };
 
   defaults = {
-    plugins.web-devicons.enable = true;
     plugins.trouble = {
       enable = true;
 
@@ -203,7 +200,6 @@
   };
 
   split-right-preview = {
-    plugins.web-devicons.enable = true;
     plugins.trouble = {
       enable = true;
 
@@ -224,7 +220,6 @@
   };
 
   top-right-preview = {
-    plugins.web-devicons.enable = true;
     plugins.trouble = {
       enable = true;
 
@@ -254,8 +249,8 @@
     };
   };
 
-  no-icons = {
-    plugins.web-devicons.enable = false;
+  with-icons = {
+    plugins.web-devicons.enable = true;
     plugins.trouble = {
       enable = true;
     };


### PR DESCRIPTION
The `plugins.<name>.iconsPackage` options only briefly existed before being removed, we can safely drop their removal assertions now.

The `plugins.web-devicons.enable` auto-enable has been deprecated since the same time-period, originally marked as "remove after 24.11". We never actually stated "it will be removed after x" in the warning, but I think it is fair to drop it after having had a warning this long.


