### PR TITLE
modules/opts: drop rename aliases

### DIFF
--- a/modules/opts.nix
+++ b/modules/opts.nix
@@ -41,13 +41,6 @@ in
     }
   ) optionsAttrs;
 
-  # Added 2024-03-29 (do not remove)
-  imports = lib.mapAttrsToList (old: new: lib.mkRenamedOptionModule [ old ] [ new ]) {
-    options = "opts";
-    globalOptions = "globalOpts";
-    localOptions = "localOpts";
-  };
-
   config = {
     extraConfigLuaPre =
       let


### PR DESCRIPTION
I originally marked this as "do not remove", but it's probably been around long enough now that it _is_ safe to remove?
