### PR TITLE
modules/nixpkgs: use `version-info.toml` for `source` assertion

### DIFF
--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -10,6 +10,9 @@ let
   opt = options.nixpkgs;
 
   pinned = import ../../nixpkgs.nix;
+  # NOTE: `pinned.rev` is the same as `versionInfo.nixpkgs_rev`, but the latter is cheaper to eval.
+  # Evaluating `pinned` may cause some `fetchTree` implementations to fetch eagerly (unverified).
+  versionInfo = lib.importTOML ../../version-info.toml;
 
   optionDefaultPrio = (lib.mkOptionDefault null).priority;
 
@@ -277,11 +280,11 @@ in
           (
             constructedByMe
             && opt.source.highestPrio == optionDefaultPrio
-            && pinned.narHash != cfg.source.narHash or null
+            && versionInfo.nixpkgs_rev != cfg.source.rev or null
           )
           ''
             The `${opt.source}` default value has been affected by your flake input `follows`.
-            Nixvim's inputs pin Nixpkgs to `${pinned.rev}`.${
+            Nixvim's inputs pin Nixpkgs to `${versionInfo.nixpkgs_rev}`.${
               lib.optionalString (cfg.source ? rev) " Actual Nixpkgs is following `${cfg.source.rev}`."
             }
             Please remove your `inputs.nixvim.inputs.nixpkgs.follows` or explicitly define `${opt.source}` to suppress this warning.'';

--- a/tests/nixpkgs-fetch.nix
+++ b/tests/nixpkgs-fetch.nix
@@ -35,6 +35,7 @@
 #     nix-instantiate --eval nixpkgs.nix --attr outPath --option experimental-features ''
 
 let
+  version-info = lib.importTOML ../version-info.toml;
   flake-input = self.inputs.nixpkgs.sourceInfo;
   pinned-input = import ../nixpkgs.nix;
 in
@@ -47,6 +48,8 @@ linkFarmFromDrvs "nixpkgs-fetch-test" [
       strictDeps = true;
 
       hasPrimop = builtins ? fetchTree;
+      versionInfo = version-info;
+
       expected = flake-input;
       actual = pinned-input;
 
@@ -72,6 +75,13 @@ linkFarmFromDrvs "nixpkgs-fetch-test" [
         echo "Expected '$actual' to be '$expected'" >&2
         exit 1
       fi
+
+      expectedRev=$(jq --raw-output .expectedAttrs.rev "$NIX_ATTRS_JSON_FILE")
+      versionInfoRev=$(jq --raw-output .versionInfo.nixpkgs_rev "$NIX_ATTRS_JSON_FILE")
+      [ "$expectedRev" = "$versionInfoRev" ] || {
+        echo "Expected version-info nixpkgs_rev '$versionInfoRev' to be '$expectedRev'" >&2
+        exit 1
+      }
 
       mkdir "$out"
       jq --sort-keys .expectedAttrs "$NIX_ATTRS_JSON_FILE" > "$out/expected.json"


### PR DESCRIPTION

It may be cheaper to evaluate `(version-info.toml).nixpkgs_rev` instead of `(nixpkgs.nix).rev` in some scenarios.

I've seen [some reports](https://matrix.to/#/!WomvlAunmgpjaRLBzo:matrix.org/$Dj-do_10Wj8ZJ_odlbSUgScY0tWAf28VQGuOeWUAnNA?via=matrix.org&via=catgirl.cloud&via=tchncs.de) of `builtins.fetchTree` _eagerly_ fetching the FOD even without forcing `outPath`.

For sanity, cross-check with `version-info.toml` in the `nixpkgs-fetch` test.
