### PR TITLE
wrappers/{nixos,hm}: add `programs.neovim` assertion

### DIFF
--- a/wrappers/hm.nix
+++ b/wrappers/hm.nix
@@ -3,8 +3,9 @@
   extendModules,
 }:
 {
-  config,
   lib,
+  config,
+  options,
   ...
 }:
 let
@@ -48,5 +49,12 @@ in
       fish.shellAliases.vimdiff = "nvim -d";
       zsh.shellAliases.vimdiff = "nvim -d";
     };
+
+    assertions = [
+      {
+        assertion = !config.programs.neovim.enable;
+        message = "`${options.programs.nixvim}.enable` and `${options.programs.neovim.enable}` are incompatible.";
+      }
+    ];
   };
 }

--- a/wrappers/nixos.nix
+++ b/wrappers/nixos.nix
@@ -3,8 +3,9 @@
   extendModules,
 }:
 {
-  config,
   lib,
+  config,
+  options,
   ...
 }:
 let
@@ -46,5 +47,12 @@ in
     };
 
     programs.neovim.defaultEditor = cfg.defaultEditor;
+
+    assertions = [
+      {
+        assertion = !config.programs.neovim.enable;
+        message = "`${options.programs.nixvim}.enable` and `${options.programs.neovim.enable}` are incompatible.";
+      }
+    ];
   };
 }


### PR DESCRIPTION
`programs.nixvim` and `programs.neovim` are incompatible; both install a `neovim` package onto the PATH in an arbitrary order.

Home Manager also installs config into `.config/nvim`, which conflicts with `wrapRc = false` used by default in our Home Manager module.
