### PR TITLE
modules/output: reject vim plugins in extraPackages

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -1,4 +1,9 @@
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  options,
+  ...
+}:
 let
   inherit (lib) types mkOption;
 
@@ -20,6 +25,24 @@ let
       };
     };
   };
+
+  isVimPluginPackage = package: package.vimPlugin or false;
+
+  mkVimPluginPackageAssertion =
+    opt:
+    let
+      vimPlugins = builtins.filter isVimPluginPackage opt.value;
+    in
+    {
+      assertion = vimPlugins == [ ];
+      message = ''
+        `${opt}` is for executable packages added to Neovim's PATH, but it contains Vim plugin package(s):
+        ${lib.concatMapStringsSep "\n" (package: "  - ${lib.getName package}") vimPlugins}
+
+        Use `${options.extraPlugins}` for Vim plugin packages:
+          ${options.extraPlugins} = [ pkgs.vimPlugins.<plugin> ];
+      '';
+    };
 in
 {
   options = {
@@ -132,6 +155,11 @@ in
   };
 
   config = {
+    assertions = lib.nixvim.mkAssertions "output" [
+      (mkVimPluginPackageAssertion options.extraPackages)
+      (mkVimPluginPackageAssertion options.extraPackagesAfter)
+    ];
+
     content =
       if config.type == "lua" then
         # Lua

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -295,6 +295,31 @@
       '';
     };
 
+  extraPackages-rejects-vim-plugins =
+    { pkgs, ... }:
+    let
+      plugin = pkgs.vimUtils.buildVimPlugin {
+        pname = "nixvim-extra-packages-vim-plugin-test";
+        version = "1";
+        src = pkgs.runCommandLocal "nixvim-extra-packages-vim-plugin-test-src" { } "mkdir -p $out";
+      };
+    in
+    {
+      extraPackages = [ plugin ];
+      extraPackagesAfter = [ plugin ];
+
+      test = {
+        buildNixvim = false;
+        assertions = expect: [
+          (expect "count" 2)
+          (expect "any" "`extraPackages` is for executable packages added to Neovim's PATH")
+          (expect "any" "`extraPackagesAfter` is for executable packages added to Neovim's PATH")
+          (expect "all" "Use `extraPlugins` for Vim plugin packages:")
+          (expect "all" "nixvim-extra-packages-vim-plugin-test")
+        ];
+      };
+    };
+
   autowrapRuntimeDeps =
     {
       config,


### PR DESCRIPTION
Prevent Vim plugin derivations from being silently treated as PATH packages and point users to extraPlugins instead.

Saw this on matrix and thought it fit into our recent footgun assertions path. 