### PR TITLE
wrappers: fix `_module.check` disablement

### DIFF
--- a/flake/wrappers.nix
+++ b/flake/wrappers.nix
@@ -19,6 +19,7 @@ let
   configuration = self.lib.evalNixvim {
     modules = [
       {
+        _file = __curPos.file;
         key = "<internal:nixvim-nocheck-base-eval>";
         config._module.check = false;
       }

--- a/tests/platforms/darwin.nix
+++ b/tests/platforms/darwin.nix
@@ -9,6 +9,9 @@ self.inputs.nix-darwin.lib.darwinSystem {
 
       programs.nixvim = {
         enable = true;
+        imports = [
+          ./module-check-enabled.nix
+        ];
       };
 
       system.stateVersion = 5;

--- a/tests/platforms/hm.nix
+++ b/tests/platforms/hm.nix
@@ -14,6 +14,9 @@ self.inputs.home-manager.lib.homeManagerConfiguration {
 
       programs.nixvim = {
         enable = true;
+        imports = [
+          ./module-check-enabled.nix
+        ];
       };
 
       programs.home-manager.enable = true;

--- a/tests/platforms/module-check-enabled.nix
+++ b/tests/platforms/module-check-enabled.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+{
+  assertions = [
+    {
+      assertion = config._module.check;
+      message = "Expected ${options._module.check} to be true. Definitions:${lib.options.showDefs options._module.check.definitionsWithLocations}";
+    }
+  ];
+}

--- a/tests/platforms/nixos.nix
+++ b/tests/platforms/nixos.nix
@@ -16,6 +16,9 @@ self.inputs.nixpkgs.lib.nixosSystem {
 
       programs.nixvim = {
         enable = true;
+        imports = [
+          ./module-check-enabled.nix
+        ];
       };
     }
     self.nixosModules.nixvim

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -52,7 +52,7 @@ let
   baseConfiguration = extendModules {
     modules = [
       nixpkgsModule
-      { disabledModules = [ "<internal:nixvim-nocheck-base-eval>" ]; }
+      { disabledModules = [ { key = "<internal:nixvim-nocheck-base-eval>"; } ]; }
     ];
   };
 


### PR DESCRIPTION
When passing a string to `disabledModules`, it is appended to `modulesPath`. To avoid this, explicitly pass a `{key}` module.

Adds an assertion module to the platform-wrapper integration tests, which prints the following error:

```
Failed assertions:
    - Expected programs.nixvim._module.check to be true. Definitions:
    - In `/nix/store/XXXX-source/flake/wrappers.nix': false
```

Fixes #4411
