### PR TITLE
modules/output: show defs in extraPlugins vimPlugins assertion

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -31,13 +31,23 @@ let
   mkVimPluginPackageAssertion =
     opt:
     let
-      vimPlugins = builtins.filter isVimPluginPackage opt.value;
+      vimPluginDefs = lib.pipe opt.definitionsWithLocations [
+        # Flatten to [{file, package}]
+        (lib.concatMap ({ file, value }: map (package: { inherit file package; }) value))
+        # Select vimPlugins
+        (lib.filter (def: isVimPluginPackage def.package))
+        # Group definition files by plugin name
+        (lib.groupBy (def: lib.getName def.package))
+        (lib.mapAttrs (_: map (def: def.file)))
+      ];
     in
     {
-      assertion = vimPlugins == [ ];
+      assertion = vimPluginDefs == { };
       message = ''
         `${opt}` is for executable packages added to Neovim's PATH, but it contains Vim plugin package(s):
-        ${lib.concatMapStringsSep "\n" (package: "  - ${lib.getName package}") vimPlugins}
+        ${lib.concatMapAttrsStringSep "\n" (
+          name: files: "  - ${name} defined in ${lib.options.showFiles files}"
+        ) vimPluginDefs}
 
         Use `${options.extraPlugins}` for Vim plugin packages:
           ${options.extraPlugins} = [ pkgs.vimPlugins.<plugin> ];

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -315,7 +315,7 @@
           (expect "any" "`extraPackages` is for executable packages added to Neovim's PATH")
           (expect "any" "`extraPackagesAfter` is for executable packages added to Neovim's PATH")
           (expect "all" "Use `extraPlugins` for Vim plugin packages:")
-          (expect "all" "nixvim-extra-packages-vim-plugin-test")
+          (expect "all" "- nixvim-extra-packages-vim-plugin-test defined in `${toString __curPos.file}'")
         ];
       };
     };

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -301,7 +301,7 @@
       plugin = pkgs.vimUtils.buildVimPlugin {
         pname = "nixvim-extra-packages-vim-plugin-test";
         version = "1";
-        src = pkgs.runCommandLocal "nixvim-extra-packages-vim-plugin-test-src" { } "mkdir -p $out";
+        src = pkgs.emptyDirectory;
       };
     in
     {
@@ -331,7 +331,7 @@
       plugin = pkgs.vimUtils.buildVimPlugin {
         pname = "nixvim-runtime-deps-test";
         version = "1";
-        src = pkgs.runCommandLocal "nixvim-runtime-deps-test-src" { } "mkdir -p $out";
+        src = pkgs.emptyDirectory;
         runtimeDeps = [ pkgs.hello ];
       };
     in
@@ -357,7 +357,7 @@
       plugin = pkgs.vimUtils.buildVimPlugin {
         pname = "nixvim-runtime-deps-disabled-test";
         version = "1";
-        src = pkgs.runCommandLocal "nixvim-runtime-deps-disabled-test-src" { } "mkdir -p $out";
+        src = pkgs.emptyDirectory;
         runtimeDeps = [ pkgs.hello ];
       };
     in


### PR DESCRIPTION
- **tests/modules/output: use `pkgs.emptyDirectory`**
- **modules/output: show defs in extraPlugins vimPlugins assertion**
- **modules/output: group extraPlugins assertion defs by vimPlugins**

@khaneliman I've included two different ways of rendering the assertion
1. full definitions (file, followed by `toPretty` of filtered definition)
   ```
   For assertions:
   - Nixvim (output): `extraPackages` is for executable packages added to Neovim's PATH, but it contains Vim plug>
   - In `/nix/store/c7jklfw376yi61chy2sch46q6vqqa0xq-source/tests/test-sources/modules/output.nix':
       [
         <derivation vimplugin-nixvim-extra-packages-vim-plugin-test-1>
       ]

   Use `extraPlugins` for Vim plugin packages:
     extraPlugins = [ pkgs.vimPlugins.<plugin> ];
   ```
2. plugins & files (plugin name, followed by its `showFiles`)
   ```
   - Nixvim (output): `extraPackages` is for executable packages added to Neovim's PATH, but it contains Vim plugin package(s):
     - nixvim-extra-packages-vim-plugin-test defined in `/nix/store/m4dj51mzivfp9x7lw5zl1qd23zip21b4-source/tests/test-sources/modules/output.nix'
	
   Use `extraPlugins` for Vim plugin packages:
     extraPlugins = [ pkgs.vimPlugins.<plugin> ];
   ```

LMK which you prefer (if any) and I'll squash/drop, then undraft.
