### PR TITLE
modules/output: make vimPlugin assertions lazier

### DIFF
--- a/modules/output.nix
+++ b/modules/output.nix
@@ -28,22 +28,21 @@ let
 
   isVimPluginPackage = package: package.vimPlugin or false;
 
-  mkVimPluginPackageAssertion =
-    opt:
-    let
-      vimPluginDefs = lib.pipe opt.definitionsWithLocations [
-        # Flatten to [{file, package}]
-        (lib.concatMap ({ file, value }: map (package: { inherit file package; }) value))
-        # Select vimPlugins
-        (lib.filter (def: isVimPluginPackage def.package))
-        # Group definition files by plugin name
-        (lib.groupBy (def: lib.getName def.package))
-        (lib.mapAttrs (_: map (def: def.file)))
-      ];
-    in
-    {
-      assertion = vimPluginDefs == { };
-      message = ''
+  mkVimPluginPackageAssertion = opt: {
+    assertion = !(lib.any isVimPluginPackage opt.value);
+    message =
+      let
+        vimPluginDefs = lib.pipe opt.definitionsWithLocations [
+          # Flatten to [{file, package}]
+          (lib.concatMap ({ file, value }: map (package: { inherit file package; }) value))
+          # Select offending definitions
+          (lib.filter (def: isVimPluginPackage def.package))
+          # Group definition files by plugin name
+          (lib.groupBy (def: lib.getName def.package))
+          (lib.mapAttrs (_: map (def: def.file)))
+        ];
+      in
+      ''
         `${opt}` is for executable packages added to Neovim's PATH, but it contains Vim plugin package(s):
         ${lib.concatMapAttrsStringSep "\n" (
           name: files: "  - ${name} defined in ${lib.options.showFiles files}"
@@ -52,7 +51,7 @@ let
         Use `${options.extraPlugins}` for Vim plugin packages:
           ${options.extraPlugins} = [ pkgs.vimPlugins.<plugin> ];
       '';
-    };
+  };
 in
 {
   options = {

--- a/modules/output.nix
+++ b/modules/output.nix
@@ -40,6 +40,7 @@ let
           # Group definition files by plugin name
           (lib.groupBy (def: lib.getName def.package))
           (lib.mapAttrs (_: map (def: def.file)))
+          (lib.mapAttrs (_: lib.uniqueStrings))
         ];
       in
       ''


### PR DESCRIPTION
Yes, a second minor followup. Sorry...

1. We can make the "happy path" of the assertion a bit cheaper to evaluate.
   - This is more important than it sounds, as all assertions get evaluated by every Nixvim eval.
2. Avoid printing the same file multiple times on the same line, if one file defines multiple plugins with the same name
