### PR TITLE
plugins/sidekick: Fix broken `nes` assertion

### DIFF
--- a/plugins/by-name/sidekick/default.nix
+++ b/plugins/by-name/sidekick/default.nix
@@ -27,7 +27,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
   extraConfig = cfg: {
     assertions = lib.nixvim.mkAssertions "plugins.sidekick" {
       assertion =
-        (cfg.settings.opts.nes.enabled or true)
+        cfg.settings.opts.nes.enabled
         -> (config.plugins.copilot-lua.enable || config.lsp.servers.copilot.enable);
       message = "sidekick requires either copilot-lua (${options.plugins.copilot-lua.enable}) or copilot LSP (${options.lsp.servers}.copilot.enable) to be enabled when NES is enabled";
     };


### PR DESCRIPTION
This assertion is supposed to ensure that either `copilot-lua` or the copilot LSP is enabled if the Next Edit Suggestion option is enabled, but the `or true` renders this equivalent to asserting one of these plugins is installed, regardless of the value of `nes.enabled`.