### PR TITLE
docs/man: simplify using structuredAttrs

### DIFF
--- a/docs/man/default.nix
+++ b/docs/man/default.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   options-json,
   lib-docs,
   runCommand,
@@ -8,48 +7,50 @@
   pandoc,
 }:
 let
-  markdownSections = [
-    ../user-guide/faq.md
-    ../user-guide/config-examples.md
-  ]
-  ++ lib-docs.pages;
-
   manHeader =
     runCommand "nixvim-general-doc-manpage"
       {
+        __structuredAttrs = true;
+        strictDeps = true;
         nativeBuildInputs = [ pandoc ];
+        markdownSections = [
+          ../user-guide/faq.md
+          ../user-guide/config-examples.md
+        ]
+        ++ lib-docs.pages;
       }
       ''
-        function mkMDSection {
-          file="$1"
-          pandoc --lua-filter ${./filter.lua} -f gfm -t man "$file"
-        }
         mkdir -p $out
-
-        (
+        {
           cat ${./nixvim-header-start.5}
 
-          ${lib.concatMapStringsSep "\n" (file: "mkMDSection ${file}") markdownSections}
+          for file in "''${markdownSections[@]}"; do
+            pandoc --lua-filter ${./filter.lua} -f gfm -t man "$file"
+          done
 
           cat ${./nixvim-header-end.5}
-        ) >$out/nixvim-header.5
+        } >$out/nixvim-header.5
       '';
 in
 # FIXME add platform specific docs to manpage
 runCommand "nixvim-configuration-reference-manpage"
   {
+    __structuredAttrs = true;
+    strictDeps = true;
     nativeBuildInputs = [
       installShellFiles
       nixos-render-docs
     ];
+    header = manHeader;
+    footer = ./nixvim-footer.5;
   }
   ''
     # Generate man-pages
     mkdir -p $out/share/man/man5
     nixos-render-docs -j $NIX_BUILD_CORES options manpage \
       --revision unstable \
-      --header ${manHeader}/nixvim-header.5 \
-      --footer ${./nixvim-footer.5} \
+      --header "$header"/nixvim-header.5 \
+      --footer "$footer" \
       ${options-json}/share/doc/nixos/options.json \
       $out/share/man/man5/nixvim.5
     compressManPages $out


### PR DESCRIPTION
Verified the output does not change:

```
$ nix build .#man-docs github:nix-community/nixvim#man-docs

$ sha256sum result{,-1}/share/man/man5/nixvim.5.gz
63177f4e1bff6db2ef01dfdb31c0674342ba9d9d27fe8e3d392bf86131fbc867  result/share/man/man5/nixvim.5.gz
63177f4e1bff6db2ef01dfdb31c0674342ba9d9d27fe8e3d392bf86131fbc867  result-1/share/man/man5/nixvim.5.gz
```
