### PR TITLE
modules/nixvim-info: flatten and simplify

### DIFF
--- a/docs/mdbook/default.nix
+++ b/docs/mdbook/default.nix
@@ -96,7 +96,8 @@ let
       path = removeWhitespace (lib.concatStringsSep "/" path);
       docSummaryMD =
         let
-          info = lib.attrByPath path { } nixvimInfo;
+          pathstr = lib.showOption path;
+          info = nixvimInfo.${pathstr} or { };
           maintainers = lib.unique (configuration.config.meta.maintainers.${info.file} or [ ]);
           maintainersNames = map maintToMD maintainers;
           maintToMD = m: if m ? github then "[${m.name}](https://github.com/${m.github})" else m.name;

--- a/modules/misc/nixvim-info.nix
+++ b/modules/misc/nixvim-info.nix
@@ -21,22 +21,17 @@
       # }
       merge =
         _: defs:
-        lib.foldl'
-          (
-            acc: def:
-            lib.recursiveUpdate acc (
-              lib.setAttrByPath def.value.path {
-                inherit (def) file;
-                url = def.value.url or null;
-                description = def.value.description or null;
-              }
-            )
-          )
-          {
-            plugins = { };
-            colorschemes = { };
-          }
-          defs;
+        builtins.listToAttrs (
+          map ({ file, value }: {
+            name = lib.showOption value.path;
+            value = {
+              inherit file;
+              inherit (value) path;
+              url = value.url or null;
+              description = value.description or null;
+            };
+          }) defs
+        );
     };
     internal = true;
     default = null;


### PR DESCRIPTION
Instead of recursively merging a nested tree, construct a flat map of `"option-path" → {info}`.

This should be more efficient to eval, and simpler to introspect.

Needed this while working on some other docs improvements; replacing the custom docs-eval logic with something closer to Nixpkgs' option-docs tooling.
