### PR TITLE
docs: fixed GaetanLepage nixconfig URL

### DIFF
--- a/docs/user-configs/list.toml
+++ b/docs/user-configs/list.toml
@@ -50,7 +50,7 @@ description = "NixVim config, with format/lsp/debug configurations for Rust, Go,
 owner = "GaetanLepage"
 title = "nix-config"
 description = "Home-manager"
-url = "https://github.com/GaetanLepage/nix-config/tree/master/modules/home/core/programs/neovim"
+url = "https://github.com/GaetanLepage/nix-config/tree/master/modules/home/dev/_dev/programs/neovim"
 
 [[config]]
 owner = "gwg313"


### PR DESCRIPTION
Hello, it is pretty sad to have a maintainer's configuration URL not working + this configuration helped me a lot (thank you very much)

The docs builds and the link now works (manually tested)
