### PR TITLE
wrappers: inherit platform config tuples

### DIFF
--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -168,6 +168,12 @@ in
         To cross-compile, also set `nixpkgs.buildPlatform`.
 
         Ignored when `nixpkgs.pkgs` is set.
+
+        > [!WARNING]
+        > Avoid passing a fully elaborated platform from another Nixpkgs instance,
+        > such as `pkgs.stdenv.hostPlatform`, when `nixpkgs.source` may point to a
+        > different Nixpkgs revision. Prefer a platform spec, such as
+        > `{ inherit (pkgs.stdenv.hostPlatform) config; }`, or a system string.
       '';
     };
 
@@ -195,6 +201,12 @@ in
         Setting this option will cause Nixvim to be cross-compiled.
 
         Ignored when `nixpkgs.pkgs` is set.
+
+        > [!WARNING]
+        > Avoid passing a fully elaborated platform from another Nixpkgs instance,
+        > such as `pkgs.stdenv.buildPlatform`, when `nixpkgs.source` may point to a
+        > different Nixpkgs revision. Prefer a platform spec, such as
+        > `{ inherit (pkgs.stdenv.buildPlatform) config; }`, or a system string.
       '';
     };
 

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -44,8 +44,8 @@ let
         pkgs = lib.mkIf config.nixpkgs.useGlobalPackages (lib.mkDefault pkgs);
 
         # Inherit platform spec
-        hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform;
-        buildPlatform = lib.mkOverride buildPlatformPrio pkgs.stdenv.buildPlatform;
+        hostPlatform = lib.mkOptionDefault { inherit (pkgs.stdenv.hostPlatform) config; };
+        buildPlatform = lib.mkOverride buildPlatformPrio { inherit (pkgs.stdenv.buildPlatform) config; };
       };
     };
 


### PR DESCRIPTION
Nixvim wrapper modules passed the host nixpkgs' fully elaborated stdenv.{host,build}Platform attrsets into Nixvim's own nixpkgs import.

When the host and Nixvim nixpkgs revisions disagreed, those platform attrsets could be re-elaborated by a different lib.systems, causing eval recursion or platform-schema errors.

Pass only { config = ...; } as the inherited platform spec instead. This keeps ABI/libc details while letting Nixvim's selected nixpkgs elaborate the platform itself.

Closes https://github.com/nix-community/nixvim/issues/4460
Closes https://github.com/nix-community/nixvim/issues/4426