### PR TITLE
plugins/tiny-cmdline: init

### DIFF
--- a/plugins/by-name/tiny-cmdline/default.nix
+++ b/plugins/by-name/tiny-cmdline/default.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "tiny-cmdline";
+  package = "tiny-cmdline-nvim";
+
+  maintainers = [ lib.maintainers.zainkergaye ];
+
+  description = "A Neovim plugin that repositions the cmdline as a centered floating window, powered by Neovim's native ui2 system.";
+
+  callSetup = false;
+  extraConfig.plugins.tiny-cmdline.luaConfig.content = ''
+    	
+    		require('vim._core.ui2').enable({})
+    		require('tiny-cmdline')
+  '';
+
+}

--- a/tests/test-sources/plugins/by-name/tiny-cmdline/default.nix
+++ b/tests/test-sources/plugins/by-name/tiny-cmdline/default.nix
@@ -1,0 +1,3 @@
+{
+  empty.plugins.tiny-cmdline.enable = true;
+}


### PR DESCRIPTION
Fixes: #4422 

No AI was used to make this. 

Plugin was easy to implement. Requires `vim._core.ui2`. Not sure how to add that in. Any suggestions are appreciated. 