### PR TITLE
modules/nixpkgs: use `libForPkgs` for `elaborate`

### DIFF
--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -16,6 +16,13 @@ let
 
   optionDefaultPrio = (lib.mkOptionDefault null).priority;
 
+  # lib.systems.elaborate is sensitive to Nixpkgs revision, so import a `lib` instance from the Nixpkgs revision we're constructing.
+  libForPkgs =
+    if opt.source.highestPrio == optionDefaultPrio then
+      lib
+    else
+      cfg.source.lib or (import cfg.source + "/lib");
+
   isConfig = x: builtins.isAttrs x || lib.isFunction x;
 
   mergeConfig =
@@ -156,7 +163,7 @@ in
       example = {
         system = "aarch64-linux";
       };
-      apply = lib.systems.elaborate;
+      apply = libForPkgs.systems.elaborate;
       defaultText = lib.literalMD ''
         - Inherited from the "host" configuration's `pkgs`
         - Or `evalNixvim`'s `system` argument
@@ -186,11 +193,11 @@ in
       apply =
         value:
         let
-          elaborated = lib.systems.elaborate value;
+          elaborated = libForPkgs.systems.elaborate value;
         in
         # If equivalent to `hostPlatform`, make it actually identical so that `==` can be used
         # See https://github.com/NixOS/nixpkgs/issues/278001
-        if lib.systems.equals elaborated cfg.hostPlatform then cfg.hostPlatform else elaborated;
+        if libForPkgs.systems.equals elaborated cfg.hostPlatform then cfg.hostPlatform else elaborated;
       defaultText = lib.literalMD ''
         Inherited from the "host" configuration's `pkgs`.
         Or `config.nixpkgs.hostPlatform` when building a standalone nixvim.

--- a/tests/nixpkgs-module.nix
+++ b/tests/nixpkgs-module.nix
@@ -10,6 +10,12 @@ let
 
   defaultPkgs = pkgs;
 
+  # A fake nixpkgs source that can be imported
+  mockNixpkgs = {
+    inherit lib;
+    outPath = ./nixpkgs-mock.nix;
+  };
+
   # Only imports the bare minimum modules, to ensure we are not accidentally evaluating `pkgs.*`
   evalModule =
     name: module:
@@ -109,7 +115,7 @@ linkFarmFromDrvs "nixpkgs-module-test" [
   (testModule "nixpkgs-source" (
     { pkgs, ... }:
     {
-      nixpkgs.source = ./nixpkgs-mock.nix;
+      nixpkgs.source = mockNixpkgs;
 
       nixpkgs.hostPlatform = {
         inherit (stdenv.hostPlatform) system;


### PR DESCRIPTION
Followup to #4461

While all of `lib` is _technically_ coupled to its Nixpkgs revision and should ideally be kept in sync with any `pkgs` instances it'll be exposed to, `lib.systems.elaborate` is particularly sensitive to differences in Nixpkgs revision. We can mitigate that by importing a `lib` instance from the Nixpkgs revision we're constructing (`nixpkgs.source`).

This means when our Nixpkgs module constructs a Nixpkgs instance (`constructedByMe == true`), it'll instantiate `nixpkgs.source` with platforms elaborated by a `lib` from that same Nixpkgs revision.

For efficiency in the happy path, we only do this when `nixpkgs.source` has been overridden (`highestPrio != 1500`). The default value should already be aligned with our `lib`, as both are derived from our `nixpkgs` flake input.[^1]

[^1]: there's a case to be made that our `sepcialArgs.lib` normalization could also be problematic in the nested module scenario, as we're then mixing lib revisions with outer/inner module evaluations.
