### PR TITLE
[26.05] modules/nixpkgs: backport recent fixes

### DIFF
--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -16,6 +16,13 @@ let
 
   optionDefaultPrio = (lib.mkOptionDefault null).priority;
 
+  # lib.systems.elaborate is sensitive to Nixpkgs revision, so import a `lib` instance from the Nixpkgs revision we're constructing.
+  libForPkgs =
+    if opt.source.highestPrio == optionDefaultPrio then
+      lib
+    else
+      cfg.source.lib or (import cfg.source + "/lib");
+
   isConfig = x: builtins.isAttrs x || lib.isFunction x;
 
   mergeConfig =
@@ -156,7 +163,7 @@ in
       example = {
         system = "aarch64-linux";
       };
-      apply = lib.systems.elaborate;
+      apply = libForPkgs.systems.elaborate;
       defaultText = lib.literalMD ''
         - Inherited from the "host" configuration's `pkgs`
         - Or `evalNixvim`'s `system` argument
@@ -186,11 +193,11 @@ in
       apply =
         value:
         let
-          elaborated = lib.systems.elaborate value;
+          elaborated = libForPkgs.systems.elaborate value;
         in
         # If equivalent to `hostPlatform`, make it actually identical so that `==` can be used
         # See https://github.com/NixOS/nixpkgs/issues/278001
-        if lib.systems.equals elaborated cfg.hostPlatform then cfg.hostPlatform else elaborated;
+        if libForPkgs.systems.equals elaborated cfg.hostPlatform then cfg.hostPlatform else elaborated;
       defaultText = lib.literalMD ''
         Inherited from the "host" configuration's `pkgs`.
         Or `config.nixpkgs.hostPlatform` when building a standalone nixvim.

--- a/modules/top-level/nixpkgs.nix
+++ b/modules/top-level/nixpkgs.nix
@@ -168,6 +168,12 @@ in
         To cross-compile, also set `nixpkgs.buildPlatform`.
 
         Ignored when `nixpkgs.pkgs` is set.
+
+        > [!WARNING]
+        > Avoid passing a fully elaborated platform from another Nixpkgs instance,
+        > such as `pkgs.stdenv.hostPlatform`, when `nixpkgs.source` may point to a
+        > different Nixpkgs revision. Prefer a platform spec, such as
+        > `{ inherit (pkgs.stdenv.hostPlatform) config; }`, or a system string.
       '';
     };
 
@@ -195,6 +201,12 @@ in
         Setting this option will cause Nixvim to be cross-compiled.
 
         Ignored when `nixpkgs.pkgs` is set.
+
+        > [!WARNING]
+        > Avoid passing a fully elaborated platform from another Nixpkgs instance,
+        > such as `pkgs.stdenv.buildPlatform`, when `nixpkgs.source` may point to a
+        > different Nixpkgs revision. Prefer a platform spec, such as
+        > `{ inherit (pkgs.stdenv.buildPlatform) config; }`, or a system string.
       '';
     };
 

--- a/tests/nixpkgs-module.nix
+++ b/tests/nixpkgs-module.nix
@@ -10,6 +10,12 @@ let
 
   defaultPkgs = pkgs;
 
+  # A fake nixpkgs source that can be imported
+  mockNixpkgs = {
+    inherit lib;
+    outPath = ./nixpkgs-mock.nix;
+  };
+
   # Only imports the bare minimum modules, to ensure we are not accidentally evaluating `pkgs.*`
   evalModule =
     name: module:
@@ -109,7 +115,7 @@ linkFarmFromDrvs "nixpkgs-module-test" [
   (testModule "nixpkgs-source" (
     { pkgs, ... }:
     {
-      nixpkgs.source = ./nixpkgs-mock.nix;
+      nixpkgs.source = mockNixpkgs;
 
       nixpkgs.hostPlatform = {
         inherit (stdenv.hostPlatform) system;

--- a/wrappers/_shared.nix
+++ b/wrappers/_shared.nix
@@ -44,8 +44,8 @@ let
         pkgs = lib.mkIf config.nixpkgs.useGlobalPackages (lib.mkDefault pkgs);
 
         # Inherit platform spec
-        hostPlatform = lib.mkOptionDefault pkgs.stdenv.hostPlatform;
-        buildPlatform = lib.mkOverride buildPlatformPrio pkgs.stdenv.buildPlatform;
+        hostPlatform = lib.mkOptionDefault { inherit (pkgs.stdenv.hostPlatform) config; };
+        buildPlatform = lib.mkOverride buildPlatformPrio { inherit (pkgs.stdenv.buildPlatform) config; };
       };
     };
 


### PR DESCRIPTION
- #4467
  - cc3b773a
- #4461
  - c6a99bb4
  - adfa139f
