### PR TITLE
ci: buildbot-nix → nixbot

### DIFF
--- a/buildbot-nix.toml
+++ b/buildbot-nix.toml
@@ -1,1 +1,0 @@
-attribute = "ci.buildbot"

--- a/flake/ci.nix
+++ b/flake/ci.nix
@@ -8,13 +8,13 @@ in
   perSystem = {
     # per-system CI options
     options.ci = {
-      buildbot = lib.mkOption {
+      nixbot = lib.mkOption {
         type = types.lazyAttrsOf types.raw;
         default = { };
         description = ''
-          A set of tests for [buildbot] to run.
+          A set of tests for [nixbot] to run.
 
-          [buildbot]: https://buildbot.nix-community.org
+          [nixbot]: https://nixbot.nix-community.org/repos/github/nix-community/nixvim
         '';
       };
     };
@@ -38,7 +38,7 @@ in
 
     # Transpose per-system definitions to the top-level
     config.ci = {
-      buildbot = builtins.mapAttrs (_: sysCfg: sysCfg.ci.buildbot) config.allSystems;
+      nixbot = builtins.mapAttrs (_: sysCfg: sysCfg.ci.nixbot) config.allSystems;
     };
   };
 }

--- a/flake/dev/package-tests.nix
+++ b/flake/dev/package-tests.nix
@@ -6,11 +6,11 @@
       # Test that all packages build fine when running `nix flake check`.
       checks = config.packages;
 
-      # Test that all packages build when running buildbot
+      # Test that all packages build when running nixbot
       # FIXME: we want to build most platforms on all systems,
       # but building the docs is often too expensive.
       # For now, we restrict the whole packages output to one platform.
       # TODO: move building the docs to GHA
-      ci.buildbot = lib.mkIf (system == "x86_64-linux") config.packages;
+      ci.nixbot = lib.mkIf (system == "x86_64-linux") config.packages;
     };
 }

--- a/flake/dev/tests.nix
+++ b/flake/dev/tests.nix
@@ -9,6 +9,6 @@
     in
     {
       checks = tests.flakeCheck;
-      ci.buildbot = tests.buildbot;
+      ci.nixbot = tests.nixbot;
     };
 }

--- a/nixbot.toml
+++ b/nixbot.toml
@@ -1,0 +1,1 @@
+attribute = "ci.nixbot"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -92,7 +92,7 @@ in
   # TODO: consider whether all these tests are needed in the `checks` output
   flakeCheck = misc // docs // platforms // packages // mainDrv;
 
-  # TODO: consider whether all these tests are needed to be built by buildbot
-  buildbot =
+  # TODO: consider whether all these tests are needed to be built by nixbot
+  nixbot =
     lib.optionalAttrs (system == "x86_64-linux") (misc // docs // mainGrouped) // platforms // packages;
 }


### PR DESCRIPTION
Migrate flake outputs, config files, etc from buildbot-nix to nixbot.

This is not urgent, because nixbot falls back to `buildbot-nix.toml` when `nixbot.toml` is missing.

This is a draft until we drop buildbot-nix; currently we are running _both_ nixbot _and_ buildbot-nix against PRs...
