### PR TITLE
ci/backport: specify `workflows` permission

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,6 +32,7 @@ jobs:
           app-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-workflows: write
           permission-pull-requests: write
 
       - uses: actions/checkout@v7


### PR DESCRIPTION
Needed to create branches that modify workflow files.

Fixes #3429 🤞
