### PR TITLE
docs: opts differences

### DIFF
--- a/docs/user-configs/list.toml
+++ b/docs/user-configs/list.toml
@@ -190,7 +190,7 @@ url = "https://github.com/literally-sai/vermvim"
 owner = "carl0xs"
 title = "nixcfg"
 description = "Nix configuration setup, including nixvim"
-url = "https://github.com/carl0xs/nixcfg/blob/main/modules/workstation/neovim.nix"
+url = "https://github.com/carl0xs/nixcfg/blob/main/modules/nvim/default.nix"
 
 [[config]]
 owner = "ar-at-localhost"

--- a/modules/opts.nix
+++ b/modules/opts.nix
@@ -5,21 +5,42 @@ let
       prettyName = "options";
       luaVariableName = "options";
       luaApi = "opt";
-      description = "The configuration options, e.g. line numbers (`vim.opt.*`)";
+      description = ''
+        The configuration options, e.g. line numbers (`vim.opt.*`)
+
+        These options are set as global and local.
+
+        See [:h option-list](https://neovim.io/doc/user/quickref/#option-list) for all available options.
+      '';
     };
 
     globalOpts = {
       prettyName = "global options";
       luaVariableName = "global_options";
       luaApi = "opt_global";
-      description = "The configuration global options (`vim.opt_global.*`)";
+      description = ''
+        The configuration global options (`vim.opt_global.*`)
+
+        These options are overridden for buffers that have the same option set as a local option.
+        If a configuration set in `globalOpts` seems to have no effect, check with `:setglobal <option>?`, `:setlocal <option>?`
+        and move the option declaration into `opts`.
+
+        See [:h option-list](https://neovim.io/doc/user/quickref/#option-list) for all available options.
+      '';
     };
 
     localOpts = {
       prettyName = "local options";
       luaVariableName = "local_options";
       luaApi = "opt_local";
-      description = "The configuration local options (`vim.opt_local.*`)";
+      description = ''
+        The configuration local options (`vim.opt_local.*`)
+
+        These options are applied to the buffer on startup of neovim with the global options (`opt_global`) as a fallback.
+        When opening a new buffer, e.g. with `:new`, the global options are used, making `localOpts` irrelevant for the new buffer.
+
+        See [:h option-list](https://neovim.io/doc/user/quickref/#option-list) for all available options.
+      '';
     };
 
     globals = {


### PR DESCRIPTION
While trying to create my nixvim setup, I will try to add the documentation to options that would have helped me to understand faster.

Since documentation does not depend a lot on other documentation, the commits can also be cherry-picked if only some of them are wanted.