### PR TITLE
modules/ui_two: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -52,6 +52,12 @@
     githubId = 51029895;
     name = "GGORG";
   };
+  guelakais = {
+    email = "koroyeldiores@gmail.com";
+    github = "Guelakais";
+    githubId = 76840985;
+    name = "GueLaKais";
+  };
   JanKremer = {
     email = "mail@jankremer.eu";
     matrix = "@jankremer:matrix.org";

--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -52,12 +52,6 @@
     githubId = 51029895;
     name = "GGORG";
   };
-  guelakais = {
-    email = "koroyeldiores@gmail.com";
-    github = "Guelakais";
-    githubId = 76840985;
-    name = "GueLaKais";
-  };
   JanKremer = {
     email = "mail@jankremer.eu";
     matrix = "@jankremer:matrix.org";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -24,6 +24,7 @@
     ./output.nix
     ./performance.nix
     ./plugins.nix
+    ./ui_two.nix
     ./wrappers.nix
   ];
 }

--- a/modules/ui_two.nix
+++ b/modules/ui_two.nix
@@ -9,7 +9,7 @@ in
 {
   options.ui2.enable = lib.mkEnableOption "Neovim's [experimental UI2](https://neovim.io/doc/user/lua/#ui2)";
 
-  config = lib.mkIf (config.ui_two.enable) {
+  config = lib.mkIf cfg.enable {
     extraConfigLua = ''
       require('vim._core.ui2').enable(${lib.nixvim.toLuaObject cfg.settings})
     '';

--- a/modules/ui_two.nix
+++ b/modules/ui_two.nix
@@ -3,6 +3,9 @@
   config,
   ...
 }:
+let
+  cfg = config.ui2;
+in
 {
   options.ui_two.enable = lib.mkOption {
     type = lib.types.bool;

--- a/modules/ui_two.nix
+++ b/modules/ui_two.nix
@@ -13,7 +13,7 @@
 
   config = lib.mkIf (config.ui_two.enable) {
     extraConfigLua = ''
-      require('vim._core.ui2').enable()
+      require('vim._core.ui2').enable(${lib.nixvim.toLuaObject cfg.settings})
     '';
   };
 }

--- a/modules/ui_two.nix
+++ b/modules/ui_two.nix
@@ -7,12 +7,7 @@ let
   cfg = config.ui2;
 in
 {
-  options.ui_two.enable = lib.mkOption {
-    type = lib.types.bool;
-    description = "enables neovim ui2 features";
-    default = false;
-    example = true;
-  };
+  options.ui2.enable = lib.mkEnableOption "Neovim's [experimental UI2](https://neovim.io/doc/user/lua/#ui2)";
 
   config = lib.mkIf (config.ui_two.enable) {
     extraConfigLua = ''

--- a/modules/ui_two.nix
+++ b/modules/ui_two.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  options.ui_two.enable = lib.mkOption {
+    type = lib.types.bool;
+    description = "enables neovim ui2 features";
+    default = false;
+    example = true;
+  };
+
+  config = lib.mkIf (config.ui_two.enable) {
+    extraConfigLua = ''
+      require('vim._core.ui2').enable()
+    '';
+  };
+}


### PR DESCRIPTION
I've added `modules/ui_two.nix` to enable the neovim ui_two features through the nixvim declaration. That's my first Pull request and according to the contribution guidelines it seems fine.

Closes https://github.com/nix-community/nixvim/discussions/4477