### PR TITLE
plugins/treesitter-modules: add treesitter-modules.nvim

### DIFF
--- a/plugins/by-name/treesitter-modules/default.nix
+++ b/plugins/by-name/treesitter-modules/default.nix
@@ -1,0 +1,37 @@
+{ lib, config, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "treesitter-modules";
+  package = "treesitter-modules-nvim";
+
+  maintainers = [ lib.maintainers.khaneliman ];
+
+  description = ''
+    A companion plugin to nvim-treesitter that re-implements modules that used to be
+    built into nvim-treesitter's `main` branch (such as `incremental_selection`,
+    `highlight`, `indent`, and `fold`), now that nvim-treesitter's `main` branch only
+    manages parsers/queries.
+  '';
+
+  settingsExample = lib.literalExpression ''
+    {
+      incremental_selection = {
+        enable = true;
+        keymaps = {
+          init_selection = "<A-o>";
+          node_incremental = "<A-o>";
+          scope_incremental = "<A-O>";
+          node_decremental = "<A-i>";
+        };
+      };
+    }
+  '';
+
+  extraConfig = {
+    assertions = lib.nixvim.mkAssertions "plugins.treesitter-modules" {
+      assertion = config.plugins.treesitter.enable;
+      message = ''
+        You have to enable `plugins.treesitter` to use `plugins.treesitter-modules`.
+      '';
+    };
+  };
+}

--- a/tests/test-sources/plugins/by-name/treesitter-modules/default.nix
+++ b/tests/test-sources/plugins/by-name/treesitter-modules/default.nix
@@ -1,0 +1,63 @@
+{
+  empty = {
+    plugins.treesitter.enable = true;
+    plugins.treesitter-modules.enable = true;
+  };
+
+  defaults = {
+    plugins.treesitter.enable = true;
+    plugins.treesitter-modules = {
+      enable = true;
+
+      settings = {
+        ensure_installed = [ ];
+        ignore_install = [ ];
+        sync_install = false;
+        install_options = { };
+        auto_install = false;
+        fold = {
+          enable = false;
+          disable = false;
+        };
+        highlight = {
+          enable = false;
+          disable = false;
+          additional_vim_regex_highlighting = false;
+        };
+        incremental_selection = {
+          enable = false;
+          disable = false;
+          keymaps = {
+            init_selection = "gnn";
+            node_incremental = "grn";
+            scope_incremental = "grc";
+            node_decremental = "grm";
+          };
+        };
+        indent = {
+          enable = false;
+          disable = false;
+        };
+      };
+    };
+  };
+
+  example = {
+    plugins.treesitter.enable = true;
+    plugins.treesitter-modules = {
+      enable = true;
+
+      settings = {
+        incremental_selection = {
+          enable = true;
+          keymaps = {
+            init_selection = "<A-o>";
+            node_incremental = "<A-o>";
+            scope_incremental = "<A-O>";
+            node_decremental = "<A-i>";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Upstreaming another module i've had locally defined in khanelivim

EDIT: I see the plugin’s “Do I Need This Plugin?” guidance was added after I switched to this. It recommends using native Neovim APIs directly on 0.12; the remaining plugin-specific gaps are scope-based incremental selection and parser auto-installation. Might prefer https://github.com/nix-community/nixvim/pull/4503 