### PR TITLE
Remove GFM alert patches

### DIFF
--- a/docs/pkgs.nix
+++ b/docs/pkgs.nix
@@ -17,17 +17,6 @@ let
 
   overlay = final: prev: {
     lib = prev.lib.extend libOverlay;
-
-    nixos-render-docs = prev.nixos-render-docs.overrideAttrs (old: {
-      patches = old.patches or [ ] ++ [
-        (final.fetchpatch {
-          name = "extend-admonition-support.patch";
-          url = "https://github.com/NixOS/nixpkgs/pull/538502.patch";
-          hash = "sha256-rhAp95lH5fPvdtylIDx+LazoCtgfhs4AOaq8CagTfZ8=";
-          stripLen = 5;
-        })
-      ];
-    });
   };
 
 in

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783279667,
-        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "lastModified": 1783791668,
+        "narHash": "sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "rev": "716c7a2664ca8325617b8a7fbb609273f2c4cae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
PR #4485 added an overlay applying GFM alerts patches from NixOS/nixpkgs#538502 to `nix-render-docs`. With the `nixpkgs` PR merged and propagated to `nixpkgs-unstable`, this fails due to trying to apply the patches twice.

Therefore, this change updates the `nixpkgs` input to get the updated `nix-render-docs` and drops the patches from the overlay.