### PR TITLE
readme: remove nixpkgs follows recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,14 @@ flakes, just add the `nixvim` input:
     url = "github:nix-community/nixvim";
     # If you are not running an unstable channel of nixpkgs, select the corresponding branch of Nixvim.
     # url = "github:nix-community/nixvim/nixos-26.05";
-
-    inputs.nixpkgs.follows = "nixpkgs";
   };
 }
 ```
+
+Nixvim is tested against its own Nixpkgs revision. We recommend not overriding
+its `nixpkgs` input with `follows`; see the
+[installation guide](https://nix-community.github.io/nixvim/user-guide/install.html#accessing-nixvim)
+for details.
 
 You can now access the module using `inputs.nixvim.homeModules.nixvim`,
 for a Home Manager installation, `inputs.nixvim.nixosModules.nixvim`, for NixOS,


### PR DESCRIPTION
Closes #4367.

Removes the README example that makes Nixvim's Nixpkgs input follow the system input. Adds a short explanation and links to the installation guide, matching the project's tested-revision recommendation.

The standalone example is intentionally unchanged: it makes the top-level Nixpkgs input follow Nixvim's tested revision, which is the opposite direction.

Checks:
- git diff --check
- installation guide link returns HTTP 200

This is a documentation-only change. Nix-based checks were not run locally because Nix is not installed.