### PR TITLE
plugins/treesitter: improve Nixvim's native tree-sitter setup

### DIFF
--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -373,6 +373,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
                   return
                 end
                 local has_parser = vim.treesitter.language.add(lang)
+                if not has_parser then
+                  return
+                end
 
                 local function has_query(query_name)
                   return vim.treesitter.query.get(lang, query_name) ~= nil
@@ -398,7 +401,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
               ${optionalString highlightEnabled ''
                 local disabled_highlight = ${lib.nixvim.toLuaObject cfg.highlight.disable}
-                if has_parser and has_query('highlights') and not is_disabled(disabled_highlight) then
+                if has_query('highlights') and not is_disabled(disabled_highlight) then
                   vim.treesitter.start(buf, lang)
                   add_undo_ftplugin(("call v:lua.vim.treesitter.stop(%d)"):format(buf))
 
@@ -409,13 +412,13 @@ lib.nixvim.plugins.mkNeovimPlugin {
                 end
               ''}${optionalString indentEnabled ''
                 local disabled_indent = ${lib.nixvim.toLuaObject cfg.indent.disable}
-                if has_parser and has_query('indents') and not is_disabled(disabled_indent) then
+                if has_query('indents') and not is_disabled(disabled_indent) then
                   vim.bo[buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
                   add_undo_ftplugin('setlocal indentexpr<')
                 end
               ''}${optionalString cfg.folding.enable ''
                 local disabled_folding = ${lib.nixvim.toLuaObject cfg.folding.disable}
-                if has_parser and has_query('folds') and not is_disabled(disabled_folding) then
+                if has_query('folds') and not is_disabled(disabled_folding) then
                   vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
                   vim.wo[0][0].foldmethod = 'expr'
                   add_undo_ftplugin('setlocal foldexpr< foldmethod<')

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -162,6 +162,21 @@ lib.nixvim.plugins.mkNeovimPlugin {
           foldingSubmodule = types.submodule {
             options = {
               enable = lib.mkEnableOption "tree-sitter based folding";
+
+              disable = mkOption {
+                type = lib.types.maybeRaw (types.listOf types.str);
+                default = [ ];
+                example = [
+                  "markdown"
+                  "nix"
+                ];
+                description = ''
+                  Languages or filetypes for which tree-sitter based folding should not be enabled by
+                  Nixvim. A raw Lua function may be used for buffer-specific control; it receives the
+                  tree-sitter language, buffer number, and filetype, in that order, and should return
+                  `true` to disable folding.
+                '';
+              };
             };
           };
         in
@@ -180,6 +195,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
             "Passing a boolean to `${options.plugins.treesitter.folding}` is deprecated, use `${options.plugins.treesitter.folding}.enable`. Definitions: ${lib.options.showDefs options.plugins.treesitter.folding.definitionsWithLocations}"
             {
               enable = x;
+              disable = [ ];
             }
         else
           x;
@@ -189,25 +205,60 @@ lib.nixvim.plugins.mkNeovimPlugin {
       enable = lib.mkEnableOption "tree-sitter based syntax highlighting";
 
       disable = mkOption {
-        type = with types; listOf str;
+        type = lib.types.maybeRaw (types.listOf types.str);
         default = [ ];
         example = [
           "latex"
           "html"
         ];
         description = ''
-          List of languages or filetypes for which tree-sitter based syntax highlighting should not
-          be started by Nixvim.
+          Languages or filetypes for which tree-sitter based syntax highlighting should not be
+          started by Nixvim. A raw Lua function may be used for buffer-specific control; it receives
+          the tree-sitter language, buffer number, and filetype, in that order, and should return
+          `true` to disable highlighting.
 
           This option only applies to Nixvim's native tree-sitter highlighting setup for the modern
           nvim-treesitter main branch. Legacy nvim-treesitter configuration should continue using
           upstream settings under `plugins.treesitter.settings`.
         '';
       };
+
+      enableVimSyntax = mkOption {
+        type = with types; either bool (listOf str);
+        default = false;
+        example = [
+          "latex"
+          "html"
+        ];
+        description = ''
+          Whether to enable Vim's legacy regex syntax highlighting in addition to native tree-sitter
+          highlighting. Set this to `true` for all languages, or provide a list of languages or
+          filetypes for which it should be enabled.
+        '';
+      };
     };
 
     indent = {
       enable = lib.mkEnableOption "tree-sitter based indentation";
+
+      disable = mkOption {
+        type = lib.types.maybeRaw (types.listOf types.str);
+        default = [ ];
+        example = [
+          "python"
+          "yaml"
+        ];
+        description = ''
+          Languages or filetypes for which tree-sitter based indentation should not be enabled by
+          Nixvim. A raw Lua function may be used for buffer-specific control; it receives the
+          tree-sitter language, buffer number, and filetype, in that order, and should return `true`
+          to disable indentation.
+
+          This option only applies to Nixvim's native tree-sitter indentation setup for the modern
+          nvim-treesitter main branch. Legacy nvim-treesitter configuration should continue using
+          upstream settings under `plugins.treesitter.settings`.
+        '';
+      };
     };
 
     grammarPackages = mkOption {
@@ -309,34 +360,67 @@ lib.nixvim.plugins.mkNeovimPlugin {
           ${optionalString (mainBranchSettings != { }) ''
             require'nvim-treesitter'.setup(${lib.nixvim.toLuaObject mainBranchSettings})
           ''}
-          ${optionalString (highlightEnabled || indentEnabled) ''
-            -- Enable features via autocommands for modern nvim-treesitter
-            ${optionalString highlightEnabled ''
-              local disabled_highlight = ${lib.nixvim.toLuaObject cfg.highlight.disable}
-            ''}
-
+          ${optionalString (highlightEnabled || indentEnabled || cfg.folding.enable) ''
+            -- Enable features via an autocommand for modern nvim-treesitter
             vim.api.nvim_create_autocmd('FileType', {
               group = augroup,
               pattern = '*',
               callback = function(args)
-                ${optionalString highlightEnabled ''
-                  local filetype = vim.bo[args.buf].filetype
-                  local lang = vim.treesitter.language.get_lang(filetype) or filetype
-                  local start_highlight = true
+                local buf = args.buf
+                local filetype = vim.bo[buf].filetype
+                local lang = vim.treesitter.language.get_lang(filetype)
+                if not lang then
+                  return
+                end
+                local has_parser = vim.treesitter.language.add(lang)
 
-                  for _, disabled in ipairs(disabled_highlight) do
-                    if disabled == lang or disabled == filetype then
-                      start_highlight = false
-                      break
+                local function has_query(query_name)
+                  return vim.treesitter.query.get(lang, query_name) ~= nil
+                end
+
+                local function add_undo_ftplugin(command)
+                  vim.b.undo_ftplugin = (vim.b.undo_ftplugin and vim.b.undo_ftplugin .. " | " or "") .. command
+                end
+
+                local function is_disabled(disabled)
+                  if type(disabled) == 'function' then
+                    return disabled(lang, buf, filetype)
+                  elseif type(disabled) == 'table' then
+                    for _, disabled_language in ipairs(disabled) do
+                      if disabled_language == lang or disabled_language == filetype then
+                        return true
+                      end
                     end
                   end
 
-                  if start_highlight then
-                    pcall(vim.treesitter.start, args.buf, lang)
+                  return false
+                end
+
+              ${optionalString highlightEnabled ''
+                local disabled_highlight = ${lib.nixvim.toLuaObject cfg.highlight.disable}
+                if has_parser and has_query('highlights') and not is_disabled(disabled_highlight) then
+                  vim.treesitter.start(buf, lang)
+                  add_undo_ftplugin(("call v:lua.vim.treesitter.stop(%d)"):format(buf))
+
+                  local vim_syntax = ${lib.nixvim.toLuaObject cfg.highlight.enableVimSyntax}
+                  if vim_syntax == true or is_disabled(vim_syntax) then
+                    vim.bo[buf].syntax = 'ON'
                   end
-                ''}${optionalString indentEnabled ''
-                  vim.bo[args.buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
-                ''}
+                end
+              ''}${optionalString indentEnabled ''
+                local disabled_indent = ${lib.nixvim.toLuaObject cfg.indent.disable}
+                if has_parser and has_query('indents') and not is_disabled(disabled_indent) then
+                  vim.bo[buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+                  add_undo_ftplugin('setlocal indentexpr<')
+                end
+              ''}${optionalString cfg.folding.enable ''
+                local disabled_folding = ${lib.nixvim.toLuaObject cfg.folding.disable}
+                if has_parser and has_query('folds') and not is_disabled(disabled_folding) then
+                  vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+                  vim.wo[0][0].foldmethod = 'expr'
+                  add_undo_ftplugin('setlocal foldexpr< foldmethod<')
+                end
+              ''}
               end,
             })
           ''}
@@ -360,22 +444,6 @@ lib.nixvim.plugins.mkNeovimPlugin {
       pkg: pkg.withPlugins (_: cfg.grammarPackages)
     );
 
-    # NOTE: This autoCmd is declared outside of Lua while the autogroup is created in luaConfig.content.
-    # This is fragile - if module generation order changes, the autocmd might be created before the
-    # autogroup exists (causing failure), or the autogroup's clear=true might clear this autocmd.
-    # The current order happens to work, but changes to nixvim's module system could break this.
-    autoCmd = lib.optional cfg.folding.enable {
-      event = "FileType";
-      group = "nixvim_treesitter";
-      pattern = "*";
-      callback.__raw = ''
-        function()
-          vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
-          vim.wo[0][0].foldmethod = 'expr'
-        end
-      '';
-    };
-
     warnings = lib.nixvim.mkWarnings "plugins.treesitter" (
       [
         {
@@ -386,6 +454,16 @@ lib.nixvim.plugins.mkNeovimPlugin {
             `plugins.treesitter.settings.highlight.disable` is an upstream legacy nvim-treesitter
             option. For Nixvim's native highlighting support with the modern nvim-treesitter main
             branch, use `${opt.highlight.disable}` instead.
+          '';
+        }
+        {
+          when =
+            (cfg.settings.indent.disable or null) != null
+            && !(lib.hasInfix "nvim-treesitter-legacy" (lib.getName cfg.package));
+          message = ''
+            `plugins.treesitter.settings.indent.disable` is an upstream legacy nvim-treesitter
+            option. For Nixvim's native indentation support with the modern nvim-treesitter main
+            branch, use `${opt.indent.disable}` instead.
           '';
         }
       ]

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -356,6 +356,16 @@ lib.nixvim.plugins.mkNeovimPlugin {
 
         if has_configs_module then
           require('nvim-treesitter.configs').setup(${lib.nixvim.toLuaObject legacySettings})
+          ${optionalString cfg.folding.enable ''
+            vim.api.nvim_create_autocmd('FileType', {
+              group = augroup,
+              pattern = '*',
+              callback = function(args)
+                vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+                vim.wo[0][0].foldmethod = 'expr'
+              end,
+            })
+          ''}
         else
           ${optionalString (mainBranchSettings != { }) ''
             require'nvim-treesitter'.setup(${lib.nixvim.toLuaObject mainBranchSettings})

--- a/plugins/by-name/treesitter/default.nix
+++ b/plugins/by-name/treesitter/default.nix
@@ -361,6 +361,18 @@ lib.nixvim.plugins.mkNeovimPlugin {
               group = augroup,
               pattern = '*',
               callback = function(args)
+                local lang = vim.treesitter.language.get_lang(vim.bo[args.buf].filetype)
+                if not lang or not vim.treesitter.language.add(lang) or not vim.treesitter.query.get(lang, 'folds') then
+                  return
+                end
+
+                local disabled = ${lib.nixvim.toLuaObject cfg.folding.disable}
+                if type(disabled) == 'function' and disabled(lang, args.buf, vim.bo[args.buf].filetype) then
+                  return
+                elseif type(disabled) == 'table' and (vim.list_contains(disabled, lang) or vim.list_contains(disabled, vim.bo[args.buf].filetype)) then
+                  return
+                end
+
                 vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
                 vim.wo[0][0].foldmethod = 'expr'
               end,

--- a/tests/test-sources/plugins/by-name/treesitter/default.nix
+++ b/tests/test-sources/plugins/by-name/treesitter/default.nix
@@ -53,8 +53,8 @@
           message = "Treesitter highlight disable check should match language and filetype.";
         }
         {
-          assertion = lib.hasInfix "if has_parser and has_query('highlights') and not is_disabled(disabled_highlight) then" config.content;
-          message = "Treesitter highlight should be enabled only if there are parser and queries, and if not disabled.";
+          assertion = lib.hasInfix "if has_query('highlights') and not is_disabled(disabled_highlight) then" config.content;
+          message = "Treesitter highlight should be enabled only if there are queries, and if not disabled.";
         }
         {
           assertion = lib.hasInfix "vim.treesitter.start(buf, lang)" config.content;
@@ -100,8 +100,8 @@
           message = "Treesitter indentation disable list should be present in generated lua.";
         }
         {
-          assertion = lib.hasInfix "if has_parser and has_query('indents') and not is_disabled(disabled_indent) then" config.content;
-          message = "Treesitter indentation should be enabled only if there are parser and queries, and if not disabled.";
+          assertion = lib.hasInfix "if has_query('indents') and not is_disabled(disabled_indent) then" config.content;
+          message = "Treesitter indentation should be enabled only if there are queries, and if not disabled.";
         }
         {
           assertion = lib.hasInfix ''vim.bo[buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"'' config.content;
@@ -134,8 +134,8 @@
           message = "Treesitter folding disable list should be present in generated lua.";
         }
         {
-          assertion = lib.hasInfix "if has_parser and has_query('folds') and not is_disabled(disabled_folding) then" config.content;
-          message = "Treesitter folding should be enabled only if there are parser and queries, and if not disabled.";
+          assertion = lib.hasInfix "if has_query('folds') and not is_disabled(disabled_folding) then" config.content;
+          message = "Treesitter folding should be enabled only if there are queries, and if not disabled.";
         }
         {
           assertion = lib.hasInfix "vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'" config.content;

--- a/tests/test-sources/plugins/by-name/treesitter/default.nix
+++ b/tests/test-sources/plugins/by-name/treesitter/default.nix
@@ -49,12 +49,32 @@
           message = "Treesitter highlight disable list should be present in generated lua.";
         }
         {
-          assertion = lib.hasInfix "if disabled == lang or disabled == filetype then" config.content;
+          assertion = lib.hasInfix "if disabled_language == lang or disabled_language == filetype then" config.content;
           message = "Treesitter highlight disable check should match language and filetype.";
         }
         {
-          assertion = lib.hasInfix "pcall(vim.treesitter.start, args.buf, lang)" config.content;
+          assertion = lib.hasInfix "if has_parser and has_query('highlights') and not is_disabled(disabled_highlight) then" config.content;
+          message = "Treesitter highlight should be enabled only if there are parser and queries, and if not disabled.";
+        }
+        {
+          assertion = lib.hasInfix "vim.treesitter.start(buf, lang)" config.content;
           message = "Treesitter highlighting should start with the resolved language.";
+        }
+        {
+          assertion = lib.hasInfix ''add_undo_ftplugin(("call v:lua.vim.treesitter.stop(%d)"):format(buf))'' config.content;
+          message = "Treesitter highlighting should stop after changing filetype.";
+        }
+        {
+          assertion = lib.hasInfix ''local vim_syntax = { "jinja" }'' config.content;
+          message = "Vim syntax enable list should be present in generated lua.";
+        }
+        {
+          assertion = lib.hasInfix "if vim_syntax == true or is_disabled(vim_syntax) then" config.content;
+          message = "Vim syntax should be enabled based on settings only.";
+        }
+        {
+          assertion = lib.hasInfix "vim.bo[buf].syntax = 'ON'" config.content;
+          message = "Vim syntax should be enabled for the resolved languages.";
         }
       ];
 
@@ -66,6 +86,126 @@
             "latex"
             "html"
           ];
+          enableVimSyntax = [ "jinja" ];
+        };
+      };
+    };
+
+  disable-indent =
+    { config, lib, ... }:
+    {
+      assertions = [
+        {
+          assertion = lib.hasInfix ''local disabled_indent = { "latex", "html" }'' config.content;
+          message = "Treesitter indentation disable list should be present in generated lua.";
+        }
+        {
+          assertion = lib.hasInfix "if has_parser and has_query('indents') and not is_disabled(disabled_indent) then" config.content;
+          message = "Treesitter indentation should be enabled only if there are parser and queries, and if not disabled.";
+        }
+        {
+          assertion = lib.hasInfix ''vim.bo[buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"'' config.content;
+          message = "Treesitter indentation should start with the resolved language.";
+        }
+        {
+          assertion = lib.hasInfix "add_undo_ftplugin('setlocal indentexpr<')" config.content;
+          message = "Treesitter indentation should be disabled after changing filetype.";
+        }
+      ];
+
+      plugins.treesitter = {
+        enable = true;
+        indent = {
+          enable = true;
+          disable = [
+            "latex"
+            "html"
+          ];
+        };
+      };
+    };
+
+  disable-folding =
+    { config, lib, ... }:
+    {
+      assertions = [
+        {
+          assertion = lib.hasInfix ''local disabled_folding = { "latex", "html" }'' config.content;
+          message = "Treesitter folding disable list should be present in generated lua.";
+        }
+        {
+          assertion = lib.hasInfix "if has_parser and has_query('folds') and not is_disabled(disabled_folding) then" config.content;
+          message = "Treesitter folding should be enabled only if there are parser and queries, and if not disabled.";
+        }
+        {
+          assertion = lib.hasInfix "vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'" config.content;
+          message = "Treesitter folding should be enabled the resolved language.";
+        }
+        {
+          assertion = lib.hasInfix "vim.wo[0][0].foldmethod = 'expr'" config.content;
+          message = "Foldmethod should be expr.";
+        }
+        {
+          assertion = lib.hasInfix "add_undo_ftplugin('setlocal foldexpr< foldmethod<')" config.content;
+          message = "Treesitter folding should be disabled after changing filetype.";
+        }
+      ];
+
+      plugins.treesitter = {
+        enable = true;
+        folding = {
+          enable = true;
+          disable = [
+            "latex"
+            "html"
+          ];
+        };
+      };
+    };
+
+  disable-functions =
+    { config, lib, ... }:
+    {
+      assertions = [
+        {
+          assertion = lib.hasInfix ''return lang == "highlight" and vim.api.nvim_buf_line_count(bufnr) > 50000'' config.content;
+          message = "Treesitter highlight disable function should be present in generated lua.";
+        }
+        {
+          assertion = lib.hasInfix ''return lang == "indent" and vim.api.nvim_buf_line_count(bufnr) > 50000'' config.content;
+          message = "Treesitter indentation disable function should be present in generated lua.";
+        }
+        {
+          assertion = lib.hasInfix ''return lang == "folding" and vim.api.nvim_buf_line_count(bufnr) > 50000'' config.content;
+          message = "Treesitter folding disable function should be present in generated lua.";
+        }
+      ];
+
+      plugins.treesitter = {
+        enable = true;
+        highlight = {
+          enable = true;
+          disable = lib.nixvim.mkRaw ''
+            function(lang, bufnr, filetype)
+              return lang == "highlight" and vim.api.nvim_buf_line_count(bufnr) > 50000
+            end
+          '';
+        };
+        indent = {
+          enable = true;
+          disable = lib.nixvim.mkRaw ''
+            function(lang, bufnr, filetype)
+              return lang == "indent" and vim.api.nvim_buf_line_count(bufnr) > 50000
+            end
+          '';
+        };
+        folding = {
+          enable = true;
+          disable = lib.nixvim.mkRaw ''
+            function(lang, bufnr, filetype)
+              return lang == "folding" and vim.api.nvim_buf_line_count(bufnr) > 50000
+            end
+          '';
         };
       };
     };
@@ -136,14 +276,23 @@
     test.runNvim = false;
     test.buildNixvim = false;
     test.warnings = expect: [
-      (expect "count" 1)
+      (expect "count" 2)
       (expect "any" "`plugins.treesitter.settings.highlight.disable` is an upstream legacy nvim-treesitter")
       (expect "any" "use `plugins.treesitter.highlight.disable` instead.")
+      (expect "any" "`plugins.treesitter.settings.indent.disable` is an upstream legacy nvim-treesitter")
+      (expect "any" "use `plugins.treesitter.indent.disable` instead.")
     ];
 
     plugins.treesitter = {
       enable = true;
       settings.highlight = {
+        enable = true;
+        disable = [
+          "latex"
+          "html"
+        ];
+      };
+      settings.indent = {
         enable = true;
         disable = [
           "latex"


### PR DESCRIPTION
Recently I switched from NixOS 25.11 to 26.05 and noticed significant limitations due to switching to nvim-treesitter's main branch.

This PR tries to lift these limitations. The intent was to bring more customizations
that were lost after switching from master branch. In particular:

- `highlight.disable` option now accepts a raw function compatible with
  disable parameter from master branch. Additionally it accepts a third
  filetype parameter
- add `highlight.enableVimSyntax` option to enable :h syntax for chosen
  filetypes. Syntax is sometimes needed for indent files, some vim
  scripts, or to improve highlighting for compopund filetypes
- `indent` and `folding` now also have `disable` support
- all features are now enabled only when the parser and queries are
  available for current filetype. This avoids setting 'indentexpr' and
  'foldexpr' when they cannot work because of missing parser or queries
- adds commands to `b:undo_ftplugin` variable to undo options set. The
  content of this variable is automatically executed by Nvim when
  switching filetype (by ftplugin). This is needed so that options were
  reset if the filetype is changed. Previously stale options were left.

Development was done in my dotfiles, and not in Nixvim repo, so there is no dev history. Everything is in one commit. I didn't done a thorough functional tests (like I did with performance modules), but added a couple of assertions based on tests that are already here. They test only the presence of relevant config lines, not absence or actual functionality. But I tested it in my dotfiles.

I think it can close #4458 too.

Technically I think `disable` now compatible enough with the old option from settings that old option can be used directly. Previous behavior was to only show a warning, but the value isn't used. I didn't change that behavior.