### PR TITLE
maintainers: update Fovir's GitHub username

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -41,7 +41,7 @@
   };
   Fovir = {
     email = "fovir@disroot.org";
-    github = "Fovir-GitHub";
+    github = "FovirDev";
     githubId = 175422207;
     name = "Fovir";
   };


### PR DESCRIPTION
This PR updated my GitHub username, from `Fovir-GitHub` to `FovirDev`.

Please let me know if any changes are needed.
