### PR TITLE
modules/lsp/servers: support server-specific documentation

### DIFF
--- a/modules/lsp/servers/default.nix
+++ b/modules/lsp/servers/default.nix
@@ -11,6 +11,7 @@ let
 
   cfg = config.lsp;
   oldCfg = config.plugins.lsp;
+  serverData = import ./packages.nix;
 
   # Create a submodule type from `server.nix`
   # Used as the type for both the freeform `lsp.servers.<name>`
@@ -32,7 +33,11 @@ let
   # Create a server option
   # Used below for the `lsp.servers.*` options
   mkServerOption =
-    { name, ... }@args:
+    {
+      name,
+      description ? null,
+      ...
+    }@args:
     let
       homepage = lib.pipe options.lsp.servers [
         # Get suboptions of `lsp.servers`
@@ -53,10 +58,14 @@ let
       nameLink = if homepage == null then name else "[${name}](${homepage})";
     in
     lib.mkOption {
-      type = mkServerType args;
-      description = ''
-        The ${nameLink} language server.
-      '';
+      type = mkServerType (removeAttrs args [ "description" ]);
+      description =
+        if description == null then
+          ''
+            The ${nameLink} language server.
+          ''
+        else
+          description;
       default = { };
     };
 in
@@ -70,8 +79,14 @@ in
         {
           # Declare explicit options for each `packages.nix` entry with a known package
           options = builtins.mapAttrs (
-            name: package: mkServerOption { inherit name package; }
-          ) (import ./packages.nix).packages;
+            name: package:
+            mkServerOption (
+              {
+                inherit name package;
+              }
+              // (serverData.serverArgs or { }).${name} or { }
+            )
+          ) serverData.packages;
         }
         {
           # `*` is effectively a meta server, where shared config & defaults can be set.

--- a/modules/lsp/servers/packages.nix
+++ b/modules/lsp/servers/packages.nix
@@ -190,6 +190,20 @@
     # keep-sorted end
   ];
 
+  serverArgs = {
+    tinymist = {
+      description = "Tinymist is a language server for the typesetting system Typst.";
+      config = {
+        extraDescription = ''
+          Configuration options are described in the [Tinymist documentation](https://myriad-dreamin.github.io/tinymist/).
+        '';
+        example = {
+          settings.formatterMode = "typstyle";
+        };
+      };
+    };
+  };
+
   packages = {
     # keep-sorted start block=yes newline_separated=no
     aiken = "aiken";

--- a/modules/lsp/servers/packages.nix
+++ b/modules/lsp/servers/packages.nix
@@ -191,6 +191,61 @@
   ];
 
   serverArgs = {
+    # keep-sorted start block=yes newline_separated=yes
+    gopls = {
+      description = "gopls is the official language server for Go.";
+      config = {
+        extraDescription = ''
+          Server settings belong under `settings.gopls` and are described in the [gopls settings documentation](https://go.dev/gopls/settings).
+        '';
+        example = {
+          settings.gopls.gofumpt = true;
+        };
+      };
+    };
+
+    nixd = {
+      description = "nixd is a Nix language server based on Nix libraries.";
+      config = {
+        extraDescription = ''
+          Configuration options are described in the [nixd configuration documentation](https://github.com/nix-community/nixd/blob/main/nixd/docs/configuration.md).
+
+          Replace `hostname` in the example with the relevant `nixosConfigurations` output name.
+        '';
+        example = {
+          settings.nixd.options.nixos.expr =
+            "(builtins.getFlake (builtins.toString ./.)).nixosConfigurations.hostname.options";
+        };
+      };
+    };
+
+    rust_analyzer = {
+      description = "rust-analyzer is a language server that provides IDE functionality for Rust.";
+      config = {
+        extraDescription = ''
+          Server settings belong under `settings."rust-analyzer"` and are described in the [rust-analyzer configuration documentation](https://rust-analyzer.github.io/book/configuration.html).
+        '';
+        example = {
+          settings."rust-analyzer".check.command = "clippy";
+        };
+      };
+    };
+
+    terraformls = {
+      description = "Terraform Language Server provides language features for Terraform configuration.";
+      config = {
+        extraDescription = ''
+          Terraform Language Server reads static configuration from `init_options`; `settings` is not supported. See the [Terraform Language Server settings documentation](https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md).
+        '';
+        example = {
+          init_options = {
+            ignoreSingleFileWarning = true;
+            indexing.ignoreDirectoryNames = [ ".direnv" ];
+          };
+        };
+      };
+    };
+
     tinymist = {
       description = "Tinymist is a language server for the typesetting system Typst.";
       config = {
@@ -202,6 +257,21 @@
         };
       };
     };
+
+    yamlls = {
+      description = "YAML Language Server provides validation, completion, formatting, and schema-based intelligence for YAML.";
+      config = {
+        extraDescription = ''
+          Configuration options are described in the [YAML Language Server settings documentation](https://github.com/redhat-developer/yaml-language-server#language-server-settings).
+        '';
+        example = {
+          settings.yaml.schemas = {
+            "https://json.schemastore.org/github-workflow.json" = "/.github/workflows/*";
+          };
+        };
+      };
+    };
+    # keep-sorted end
   };
 
   packages = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -58,6 +58,7 @@ let
 
   docs = lib.optionalAttrs (selfPackages ? docs) {
     # Individual tests can be run using: nix build .#docs.user-configs.tests.<test>
+    docs-options = callTest ./docs-options.nix { inherit selfPackages; };
     docs-user-configs = linkFarm "user-configs-tests" selfPackages.docs.user-configs.tests;
   };
 

--- a/tests/docs-options.nix
+++ b/tests/docs-options.nix
@@ -5,19 +5,135 @@
   selfPackages,
 }:
 let
+  renderExample = builtins.concatStringsSep "\n";
+
   expected = pkgs.writeText "expected-lsp-server-docs.json" (
     builtins.toJSON {
       clangd = {
-        configExample = "{\n  cmd = [\n    \"clangd\"\n    \"--background-index\"\n  ];\n  filetypes = [\n    \"c\"\n    \"cpp\"\n  ];\n  root_markers = [\n    \"compile_commands.json\"\n    \"compile_flags.txt\"\n  ];\n}";
+        configExample = renderExample [
+          "{"
+          "  cmd = ["
+          "    \"clangd\""
+          "    \"--background-index\""
+          "  ];"
+          "  filetypes = ["
+          "    \"c\""
+          "    \"cpp\""
+          "  ];"
+          "  root_markers = ["
+          "    \"compile_commands.json\""
+          "    \"compile_flags.txt\""
+          "  ];"
+          "}"
+        ];
         description = "The clangd language server.\n";
+      };
+      gopls = {
+        configDescription = ''
+          Configurations for gopls. Server settings belong under `settings.gopls` and are described in the [gopls settings documentation](https://go.dev/gopls/settings).
+
+        '';
+        configExample = renderExample [
+          "{"
+          "  settings = {"
+          "    gopls = {"
+          "      gofumpt = true;"
+          "    };"
+          "  };"
+          "}"
+        ];
+        description = "gopls is the official language server for Go.";
+      };
+      nixd = {
+        configDescription = ''
+          Configurations for nixd. Configuration options are described in the [nixd configuration documentation](https://github.com/nix-community/nixd/blob/main/nixd/docs/configuration.md).
+
+          Replace `hostname` in the example with the relevant `nixosConfigurations` output name.
+
+        '';
+        configExample = renderExample [
+          "{"
+          "  settings = {"
+          "    nixd = {"
+          "      options = {"
+          "        nixos = {"
+          "          expr = \"(builtins.getFlake (builtins.toString ./.)).nixosConfigurations.hostname.options\";"
+          "        };"
+          "      };"
+          "    };"
+          "  };"
+          "}"
+        ];
+        description = "nixd is a Nix language server based on Nix libraries.";
+      };
+      rust_analyzer = {
+        configDescription = ''
+          Configurations for rust_analyzer. Server settings belong under `settings."rust-analyzer"` and are described in the [rust-analyzer configuration documentation](https://rust-analyzer.github.io/book/configuration.html).
+
+        '';
+        configExample = renderExample [
+          "{"
+          "  settings = {"
+          "    rust-analyzer = {"
+          "      check = {"
+          "        command = \"clippy\";"
+          "      };"
+          "    };"
+          "  };"
+          "}"
+        ];
+        description = "rust-analyzer is a language server that provides IDE functionality for Rust.";
+      };
+      terraformls = {
+        configDescription = ''
+          Configurations for terraformls. Terraform Language Server reads static configuration from `init_options`; `settings` is not supported. See the [Terraform Language Server settings documentation](https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md).
+
+        '';
+        configExample = renderExample [
+          "{"
+          "  init_options = {"
+          "    ignoreSingleFileWarning = true;"
+          "    indexing = {"
+          "      ignoreDirectoryNames = ["
+          "        \".direnv\""
+          "      ];"
+          "    };"
+          "  };"
+          "}"
+        ];
+        description = "Terraform Language Server provides language features for Terraform configuration.";
       };
       tinymist = {
         configDescription = ''
           Configurations for tinymist. Configuration options are described in the [Tinymist documentation](https://myriad-dreamin.github.io/tinymist/).
 
         '';
-        configExample = "{\n  settings = {\n    formatterMode = \"typstyle\";\n  };\n}";
+        configExample = renderExample [
+          "{"
+          "  settings = {"
+          "    formatterMode = \"typstyle\";"
+          "  };"
+          "}"
+        ];
         description = "Tinymist is a language server for the typesetting system Typst.";
+      };
+      yamlls = {
+        configDescription = ''
+          Configurations for yamlls. Configuration options are described in the [YAML Language Server settings documentation](https://github.com/redhat-developer/yaml-language-server#language-server-settings).
+
+        '';
+        configExample = renderExample [
+          "{"
+          "  settings = {"
+          "    yaml = {"
+          "      schemas = {"
+          "        \"https://json.schemastore.org/github-workflow.json\" = \"/.github/workflows/*\";"
+          "      };"
+          "    };"
+          "  };"
+          "}"
+        ];
+        description = "YAML Language Server provides validation, completion, formatting, and schema-based intelligence for YAML.";
       };
     }
     + "\n"
@@ -30,10 +146,35 @@ let
           description: .["lsp.servers.clangd"].description,
           configExample: .["lsp.servers.clangd.config"].example.text
         },
+        gopls: {
+          description: .["lsp.servers.gopls"].description,
+          configDescription: .["lsp.servers.gopls.config"].description,
+          configExample: .["lsp.servers.gopls.config"].example.text
+        },
+        nixd: {
+          description: .["lsp.servers.nixd"].description,
+          configDescription: .["lsp.servers.nixd.config"].description,
+          configExample: .["lsp.servers.nixd.config"].example.text
+        },
+        rust_analyzer: {
+          description: .["lsp.servers.rust_analyzer"].description,
+          configDescription: .["lsp.servers.rust_analyzer.config"].description,
+          configExample: .["lsp.servers.rust_analyzer.config"].example.text
+        },
+        terraformls: {
+          description: .["lsp.servers.terraformls"].description,
+          configDescription: .["lsp.servers.terraformls.config"].description,
+          configExample: .["lsp.servers.terraformls.config"].example.text
+        },
         tinymist: {
           description: .["lsp.servers.tinymist"].description,
           configDescription: .["lsp.servers.tinymist.config"].description,
           configExample: .["lsp.servers.tinymist.config"].example.text
+        },
+        yamlls: {
+          description: .["lsp.servers.yamlls"].description,
+          configDescription: .["lsp.servers.yamlls.config"].description,
+          configExample: .["lsp.servers.yamlls.config"].example.text
         }
       }
     ' ${selfPackages.options-json}/share/doc/nixos/options.json > "$out"

--- a/tests/docs-options.nix
+++ b/tests/docs-options.nix
@@ -1,0 +1,45 @@
+{
+  jq,
+  pkgs,
+  runCommandLocal,
+  selfPackages,
+}:
+let
+  expected = pkgs.writeText "expected-lsp-server-docs.json" (
+    builtins.toJSON {
+      clangd = {
+        configExample = "{\n  cmd = [\n    \"clangd\"\n    \"--background-index\"\n  ];\n  filetypes = [\n    \"c\"\n    \"cpp\"\n  ];\n  root_markers = [\n    \"compile_commands.json\"\n    \"compile_flags.txt\"\n  ];\n}";
+        description = "The clangd language server.\n";
+      };
+      tinymist = {
+        configDescription = ''
+          Configurations for tinymist. Configuration options are described in the [Tinymist documentation](https://myriad-dreamin.github.io/tinymist/).
+
+        '';
+        configExample = "{\n  settings = {\n    formatterMode = \"typstyle\";\n  };\n}";
+        description = "Tinymist is a language server for the typesetting system Typst.";
+      };
+    }
+    + "\n"
+  );
+
+  actual = runCommandLocal "actual-lsp-server-docs.json" { nativeBuildInputs = [ jq ]; } ''
+    jq --compact-output --sort-keys '
+      {
+        clangd: {
+          description: .["lsp.servers.clangd"].description,
+          configExample: .["lsp.servers.clangd.config"].example.text
+        },
+        tinymist: {
+          description: .["lsp.servers.tinymist"].description,
+          configDescription: .["lsp.servers.tinymist.config"].description,
+          configExample: .["lsp.servers.tinymist.config"].example.text
+        }
+      }
+    ' ${selfPackages.options-json}/share/doc/nixos/options.json > "$out"
+  '';
+in
+pkgs.testers.testEqualContents {
+  assertion = "generated LSP server documentation";
+  inherit actual expected;
+}


### PR DESCRIPTION
## What

Adds per-server documentation overrides for generated LSP options.

This fixes the Tinymist docs from #4505 and adds useful examples for a few other servers with non-obvious configuration shapes. Servers without overrides keep the existing generic docs.

## Testing

- `nix fmt`
- `nix build .#checks.aarch64-darwin.docs-options .#checks.aarch64-darwin.generated --no-link`
- `nix develop --command tests modules-lsp`

Closes #4505

*Not sure the generated-options test earns its weight just to prove the documentation plumbing. We could rely on manual spot checks instead, or keep a narrower version.*
