### PR TITLE
nixbot: build stable branches on push

### DIFF
--- a/nixbot.toml
+++ b/nixbot.toml
@@ -1,1 +1,4 @@
 attribute = "ci.nixbot"
+# Additional branches to build on push.
+# The default branch and merge-queue branches always build.
+build_branches = ["nixos-*"]


### PR DESCRIPTION
Nixbot [recently added](https://github.com/Mic92/nixbot/commit/87c9a409c2e8f91ebcb5069e177f3a045ddfbc1e) a `build_branches` config option, which allows specifying additional branches to be built on push. This replaces the old behaviour where all branches were built on push.

The default branch and merge-queue refs are always built on push and Pull Requests are considered their own non-push event.

I considered explicitly listing _supported_ stable branches `["nixos-26.05"]` instead of a glob-pattern `["nixos-*"]`, which would have the benefit of not running nixbot if an old branch gets pushed to accidentally. However, this adds maintenance complexity (ideally our update script would keep the list in sync with `version-info.toml`) and we already handle this by blocking pushes in our [archived branches](https://github.com/nix-community/nixvim/settings/rules/17034875) ruleset.

_Thanks @zowoq for the [ping](https://github.com/nix-community/nixvim/pull/4469#issuecomment-5126235216)._
