### PR TITLE
plugins/hover: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -139,6 +139,13 @@
     name = "Jalil David Salamé Messina";
     keys = [ { fingerprint = "7D6B 4D8F EBC5 7CBC 09AC  331F DA33 17E7 5BE9 485C"; } ];
   };
+  libewa = {
+    email = "linus@libewa.xyz";
+    github = "libewa";
+    githubId = 67926131;
+    name = "Linus Warnatz";
+    keys = [ { fingerprint = "EBD0 29E0 73D2 959A 9DC1  A74A 7BCA 3874 C2A0 475C"; } ];
+  };
   phinze = {
     email = "phinze@phinze.com";
     github = "phinze";

--- a/plugins/by-name/hover/default.nix
+++ b/plugins/by-name/hover/default.nix
@@ -1,0 +1,36 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "hover";
+  package = "hover-nvim";
+  url = "https://github.com/lewis6991/hover.nvim";
+  setup = ".config";
+
+  description = /* markdown */ ''
+    General framework for context aware hover providers (similar to vim.lsp.buf.hover).
+    You should also create keybinds for:
+    - `require("hover").open()`
+    - `require("hover").enter()`
+    - `require("hover").switch()`
+    - `require("hover").switch("previous")`
+    - `require("hover").switch("next")`
+
+    Also, create a bind from `<MouseMove>` to `require("hover").mouse()` and set `opts.mousemoveevent = true`.
+  '';
+
+  maintainers = [ lib.maintainers.libewa ];
+
+  settingsExample = {
+    providers = [
+      "hover.providers.diagnostic"
+      "hover.providers.lsp"
+      "hover.providers.dap"
+      "hover.providers.man"
+      "hover.providers.dictionary"
+    ];
+    preview_opts.border = "single";
+    preview_window = false;
+    title = true;
+    mouse_providers = [ "hover.providers.lsp" ];
+    mouse_delay = 1000;
+  };
+}

--- a/plugins/by-name/hover/default.nix
+++ b/plugins/by-name/hover/default.nix
@@ -1,8 +1,42 @@
-{ lib, ... }:
+{ lib, config, ... }:
+let
+  keymapType = lib.nixvim.keymaps.mkMapOptionSubmodule { action = false; };
+  hoverKeymap =
+    { description, exampleKey }:
+    lib.mkOption {
+      type = lib.types.nullOr keymapType;
+      default = null;
+      inherit description;
+      example = {
+        key = exampleKey;
+        mode = "n";
+      };
+    };
+  hoverKeymapEntry =
+    {
+      action,
+      function ? "${action}()",
+    }:
+    let
+      mapping = config.plugins.hover.keymaps.${action};
+    in
+    lib.mkIf (mapping != null) (
+      lib.mkMerge [
+        mapping
+        {
+          action = lib.nixvim.mkRaw /* lua */ ''
+            function()
+              require('hover').${function}
+            end
+          '';
+          options.desc = lib.mkDefault "hover.nvim (${function})";
+        }
+      ]
+    );
+in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "hover";
   package = "hover-nvim";
-  url = "https://github.com/lewis6991/hover.nvim";
   setup = ".config";
 
   description = /* markdown */ ''
@@ -32,5 +66,49 @@ lib.nixvim.plugins.mkNeovimPlugin {
     title = true;
     mouse_providers = [ "hover.providers.lsp" ];
     mouse_delay = 1000;
+  };
+  extraOptions = {
+    keymaps = {
+      open = hoverKeymap {
+        description = "A keymap to open the hover window.";
+        exampleKey = "K";
+      };
+      enter = hoverKeymap {
+        description = "A keymap to enter the hover window for scrolling.";
+        exampleKey = "gK";
+      };
+      previous = hoverKeymap {
+        description = "A keymap to switch to the previous Hover provider.";
+        exampleKey = "<C-p";
+      };
+      next = hoverKeymap {
+        description = "A keymap to switch to the next Hover provider.";
+        exampleKey = "<C-n>";
+      };
+    };
+    enableMouse = lib.mkEnableOption "mouse hover support";
+  };
+  extraConfig = {
+    keymaps = [
+      (hoverKeymapEntry { action = "open"; })
+      (hoverKeymapEntry { action = "enter"; })
+      (hoverKeymapEntry {
+        action = "previous";
+        function = "switch('previous')";
+      })
+      (hoverKeymapEntry {
+        action = "next";
+        function = "switch('next')";
+      })
+      (lib.mkIf config.plugins.hover.enableMouse {
+        key = "<MouseMove>";
+        action = lib.nixvim.mkRaw "require('hover').mouse";
+        options.remap = true;
+        options.desc = "hover.nvim (mouse)";
+      })
+    ];
+    opts = lib.mkIf config.plugins.hover.enableMouse {
+      mousemoveevent = true;
+    };
   };
 }

--- a/tests/test-sources/plugins/by-name/hover/default.nix
+++ b/tests/test-sources/plugins/by-name/hover/default.nix
@@ -1,0 +1,25 @@
+{
+  empty = {
+    plugins.hover.enable = true;
+  };
+
+  defaults = {
+    plugins.hover = {
+      enable = true;
+      settings = {
+        providers = [
+          "hover.providers.diagnostic"
+          "hover.providers.lsp"
+          "hover.providers.dap"
+          "hover.providers.man"
+          "hover.providers.dictionary"
+        ];
+        preview_opts.border = "single";
+        preview_window = false;
+        title = true;
+        mouse_providers = [ "hover.providers.lsp" ];
+        mouse_delay = 1000;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add a simple module for [hover.nvim](https://github.com/lewis6991/hover.nvim).

## Questions

### Should there be an option to automatically set keybinds, e.g.:
```nix
{
  plugins.hover.keybinds.open.key = "K";
}
```
setting:
```nix
{
  keymaps = [{
    key = "K";
    action = lib.mkRaw "require('hover').open()";
    options.desc = "hover.nvim (open)";
  }];
}
```

### Should there be automatic setup of the mouse?
Either through some kind of global toggle (which should be coordinated with modules such as `scrollview`, or through `plugins.hover.enableMouse`.
Should this option just add a keybind for `<MouseMove>`, or should it also enable `opts.mousemoveevent`? `scrollview` does the former (or rather, the plugin does it), but not the latter.