### PR TITLE
modules/lps/servers/tinymist: add some more documentation

### DIFF
--- a/modules/lsp/servers/packages.nix
+++ b/modules/lsp/servers/packages.nix
@@ -274,6 +274,15 @@
         };
       };
     };
+
+    zuban = {
+      config = {
+        extraDescription = ''
+          As described in the [documentation](https://docs.zubanls.com/en/latest/usage.html#configuration) Zuban is configured in the mypy or `pyproject.toml` configuration file of the project, not globally.
+        '';
+        example = { };
+      };
+    };
     # keep-sorted end
   };
 

--- a/modules/lsp/servers/packages.nix
+++ b/modules/lsp/servers/packages.nix
@@ -247,13 +247,16 @@
     };
 
     tinymist = {
-      description = "Tinymist is a language server for the typesetting system Typst.";
+      description = "[Tinymist](https://myriad-dreamin.github.io/tinymist/) is a language server for the typesetting system [Typst](https://typst.app/docs/). This language server works well with the plugin [typst-preview](https://nix-community.github.io/nixvim/plugins/typst-preview/index.html), enabled by `plugins.typst-preview.enable = true;`";
       config = {
         extraDescription = ''
-          Configuration options are described in the [Tinymist documentation](https://myriad-dreamin.github.io/tinymist/).
+          Configuration options are described in the [Tinymist documentation](https://myriad-dreamin.github.io/tinymist/config/neovim.html) with some examples [for Neovim](https://myriad-dreamin.github.io/tinymist/frontend/neovim.html#label-Configuration/). Note the extra nesting level with `setting`.
         '';
         example = {
-          settings.formatterMode = "typstyle";
+          settings = {
+            formatterMode = "typstyle";
+            formatterProseWrap = true;
+          };
         };
       };
     };

--- a/tests/docs-options.nix
+++ b/tests/docs-options.nix
@@ -105,17 +105,18 @@ let
       };
       tinymist = {
         configDescription = ''
-          Configurations for tinymist. Configuration options are described in the [Tinymist documentation](https://myriad-dreamin.github.io/tinymist/).
+          Configurations for tinymist. Configuration options are described in the [Tinymist documentation](https://myriad-dreamin.github.io/tinymist/config/neovim.html) with some examples [for Neovim](https://myriad-dreamin.github.io/tinymist/frontend/neovim.html#label-Configuration/). Note the extra nesting level with `setting`.
 
         '';
         configExample = renderExample [
           "{"
           "  settings = {"
           "    formatterMode = \"typstyle\";"
+          "    formatterProseWrap = true;"
           "  };"
           "}"
         ];
-        description = "Tinymist is a language server for the typesetting system Typst.";
+        description = "[Tinymist](https://myriad-dreamin.github.io/tinymist/) is a language server for the typesetting system [Typst](https://typst.app/docs/). This language server works well with the plugin [typst-preview](https://nix-community.github.io/nixvim/plugins/typst-preview/index.html), enabled by `plugins.typst-preview.enable = true;`";
       };
       yamlls = {
         configDescription = ''


### PR DESCRIPTION
Based on the very helpful PR #4510 this adds some information about the tinymist language server that I would have found helpful when configuring my nixvim.

I wanted to reference the nixvim documentation of the plugin `tinymist-preview` that provides a preview for Typst documents and has tinymist as a dependency. Currently I just added the web url but this is surely not a desired way of linking the typst-preview documentation since it depends on the docs being hosted where they are currently hosted. Is there a good way or should the link just be removed and the user can navigate by themselves to the needed page?

# Testing

```
nix fmt
nix build '.#checks.x86_64-linux.docs-options' '#checks.x86_64-linux.generated' --no-link
nix develop --command tests modules-lsp
```

based on the testing in #4510 .