### PR TITLE
plugins/blink-pairs: add blink_pairs_parser lib to combinePlugins.pathsToLink

### DIFF
--- a/plugins/by-name/blink-pairs/default.nix
+++ b/plugins/by-name/blink-pairs/default.nix
@@ -28,4 +28,9 @@ lib.nixvim.plugins.mkNeovimPlugin {
       };
     };
   };
+
+  extraConfig = {
+    # Native library is in lib/libblink_pairs_parser.so
+    performance.combinePlugins.pathsToLink = [ "/lib" ];
+  };
 }


### PR DESCRIPTION
This PR adds `blink_pairs_parser` native lib to `pathsToLink`, which is required after https://github.com/NixOS/nixpkgs/pull/544711. Fixes this loading error for configurations using `performance.combinePlugins`:

```
blink.pairs  v0.6+ uses a new build/download system for the native library. Please add  build = function() require('blink.pairs').build():pwait(60000) end  OR  build = function()
 require('blink.pairs').download():pwait(60000) end  to your lazy.nvim config. For vim.pack, simply call either function before calling setup().
```