### PR TITLE
flake: mark `systems` as `flake=false`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,6 +44,7 @@
       }
     },
     "systems": {
+      "flake": false,
       "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    systems.url = "github:nix-systems/default/future-26.11";
+    systems = {
+      url = "github:nix-systems/default/future-26.11";
+      flake = false;
+    };
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -261,6 +261,7 @@
       }
     },
     "systems": {
+      "flake": false,
       "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",


### PR DESCRIPTION
`inputs.systems` is imported directly to evaluate a list of systems; it has no flake inputs and we never evaluate its flake outputs, so we may as well declare `flake=false`.

```
flake/dev/flake.lock updates:

• Updated input 'nixvim':
    'path:../..'
  → 'path:../..'
```
