### PR TITLE
plugins/md-table-tidy: init

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -145,6 +145,12 @@
     githubId = 37534;
     name = "Paul Hinze";
   };
+  pierreborine = {
+    email = "nixpkgs@thecakeis.top";
+    github = "PierreBorine";
+    githubId = 85021467;
+    name = "Pierre Borine";
+  };
   psfloyd = {
     email = "peter.racoon@gmail.com";
     github = "psfloyd";

--- a/plugins/by-name/md-table-tidy/default.nix
+++ b/plugins/by-name/md-table-tidy/default.nix
@@ -1,0 +1,26 @@
+{ config, lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "md-table-tidy";
+  package = "md-table-tidy-nvim";
+
+  maintainers = [ lib.maintainers.pierreborine ];
+
+  description = "A lightweight Neovim plugin for formatting markdown tables.";
+
+  settingsExample = {
+    padding = 0;
+    keymap = {
+      table_tidy = "<leader>mt";
+      table_tidy_all = "<leader>ma";
+    };
+  };
+
+  extraConfig = {
+    warnings = lib.nixvim.mkWarnings "plugins.md-table-tidy" [
+      {
+        when = !config.plugins.treesitter.enable;
+        message = "This plugin needs treesitter to function as intended.";
+      }
+    ];
+  };
+}

--- a/tests/test-sources/plugins/by-name/md-table-tidy/default.nix
+++ b/tests/test-sources/plugins/by-name/md-table-tidy/default.nix
@@ -1,0 +1,49 @@
+{
+  empty = { config, ... }: {
+    plugins = {
+      treesitter = {
+        enable = true;
+        grammarPackages = [ config.plugins.treesitter.package.builtGrammars.markdown ];
+      };
+      md-table-tidy.enable = true;
+    };
+  };
+
+  defaults = { config, ... }: {
+    plugins = {
+      treesitter = {
+        enable = true;
+        grammarPackages = [ config.plugins.treesitter.package.builtGrammars.markdown ];
+      };
+      md-table-tidy = {
+        enable = true;
+        settings = {
+          padding = 1;
+          keymap = {
+            table_tidy = "<leader>tt";
+            table_tidy_all = "<leader>ta";
+          };
+        };
+      };
+    };
+  };
+
+  example = { config, ... }: {
+    plugins = {
+      treesitter = {
+        enable = true;
+        grammarPackages = [ config.plugins.treesitter.package.builtGrammars.markdown ];
+      };
+      md-table-tidy = {
+        enable = true;
+        settings = {
+          padding = 0;
+          keymap = {
+            table_tidy = "<leader>mt";
+            table_tidy_all = "<leader>ma";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [md-table-tidy](https://github.com/timantipov/md-table-tidy.nvim), "A lightweight Neovim plugin for formatting markdown tables".

Also adds myself to the maintainers list (been waiting for [a while](https://github.com/NixOS/nixpkgs/pull/504821) :)).