### PR TITLE
plugins/nvim-toggler: init

### DIFF
--- a/plugins/by-name/toggler/default.nix
+++ b/plugins/by-name/toggler/default.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+lib.nixvim.plugins.mkNeovimPlugin {
+  name = "toggler";
+  moduleName = "nvim-toggler";
+  package = "nvim-toggler";
+
+  maintainers = [ lib.maintainers.pierreborine ];
+
+  description = "Invert text in vim, purely with lua";
+
+  settingsExample = {
+    inverses = {
+      vim = "emacs";
+      enabled = "disabled";
+    };
+    remove_default_keybinds = true;
+    remove_default_inverses = true;
+    autoselect_longest_match = false;
+  };
+}

--- a/tests/test-sources/plugins/by-name/toggler/default.nix
+++ b/tests/test-sources/plugins/by-name/toggler/default.nix
@@ -1,0 +1,32 @@
+{
+  empty = {
+    plugins.toggler.enable = true;
+  };
+
+  defaults = {
+    plugins.toggler = {
+      enable = true;
+      settings = {
+        inverses = { };
+        remove_default_keybinds = false;
+        remove_default_inverses = false;
+        autoselect_longest_match = false;
+      };
+    };
+  };
+
+  example = {
+    plugins.toggler = {
+      enable = true;
+      settings = {
+        inverses = {
+          vim = "emacs";
+          enabled = "disabled";
+        };
+        remove_default_keybinds = true;
+        remove_default_inverses = true;
+        autoselect_longest_match = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add [nvim-toggler](https://github.com/nguyenvukhang/nvim-toggler), a plugin that inverts text under the cursor.

Depends on #4523 to add myself as a maintainer.