### PR TITLE
modules/performance: match vimGenDocHook by name

### DIFF
--- a/modules/top-level/plugins/mk-plugin-pack.nix
+++ b/modules/top-level/plugins/mk-plugin-pack.nix
@@ -12,7 +12,9 @@ let
   overridePlugin =
     plugin:
     plugin.plugin.overrideAttrs (prev: {
-      nativeBuildInputs = lib.remove vimUtils.vimGenDocHook prev.nativeBuildInputs or [ ];
+      nativeBuildInputs = builtins.filter (
+        drv: lib.getName drv != "vim-gen-doc-hook"
+      ) prev.nativeBuildInputs or [ ];
       configurePhase = ''
         ${prev.configurePhase or ""}
         rm -vf doc/tags'';


### PR DESCRIPTION
Current implementation has a problem: if the user is using a plugin from
a different nixpkgs set, vimGenDocHook isn't filtered out correctly,
because it doesn't match literally. In order to handle this, match
vimGenDocHook by name.
