### PR TITLE
lib/plugins: build callSetup description dynamically

### DIFF
--- a/lib/plugins/mk-neovim-plugin.nix
+++ b/lib/plugins/mk-neovim-plugin.nix
@@ -92,13 +92,24 @@ let
               description = ''
                 Whether to generate the standard `require('${moduleName}')${setup}(...)` call for this plugin.
 
-                The default follows the plugin's built-in behavior. Set `false` to
-                disable the generated call. Set `true` to force the call when the plugin
-                disables it or emits it conditionally.
+              ''
+              + (
+                if defaultCallSetup == "optional" then
+                  ''
+                    Explicitly set to `true` to call `${setup}()`, even when `settings` is undefined.
+                    Or set to `false` to disable calling `${setup}()` at all.
+                  ''
+                else if defaultCallSetup then
+                  "Explicitly set to `false` to disable calling `${setup}()`."
+                else
+                  ''
+                    Explicitly set to `true` to force calling `${setup}()`.
 
-                A forced call can emit a duplicate or invalid `setup()`. Some plugins
-                generate custom setup code or have no real `${moduleName}` Lua module.
-              '';
+                    > [!CAUTION]
+                    > A forced call can emit a duplicate or invalid setup.
+                    > Some plugins generate custom setup code or have no real `${moduleName}` Lua module.
+                  ''
+              );
             }
             // lib.optionalAttrs (defaultCallSetup == "optional") {
               defaultText = lib.literalMD "`true` when `settings` is explicitly defined, otherwise `false`.";


### PR DESCRIPTION
Followup to #4532 by @khaneliman 

Based on the default, the description should offer different advice and cautions for the given `plugins.<name>.callSetup` option.

<img width="1429" height="628" alt="image" src="https://github.com/user-attachments/assets/797b2d65-87d2-48bc-b899-8471b54d332b" />

<img width="1429" height="588" alt="image" src="https://github.com/user-attachments/assets/387c9498-eb62-41f7-8a80-407bc8028ce0" />

<img width="1429" height="847" alt="image" src="https://github.com/user-attachments/assets/5b4dc44d-ad37-4657-b694-3c4c710928db" />
