### PR TITLE
plugins/coq-nvim: set Lua module name

### DIFF
--- a/plugins/by-name/coq-nvim/default.nix
+++ b/plugins/by-name/coq-nvim/default.nix
@@ -8,6 +8,7 @@ let
 in
 lib.nixvim.plugins.mkNeovimPlugin {
   name = "coq-nvim";
+  moduleName = "coq";
   package = "coq_nvim";
   description = "A fast nvim completion engine.";
 
@@ -44,7 +45,7 @@ lib.nixvim.plugins.mkNeovimPlugin {
       coq_settings = cfg.settings;
     };
 
-    plugins.coq-nvim.luaConfig.content = "require('coq')";
+    plugins.coq-nvim.luaConfig.content = lib.mkIf (!cfg.callSetup) "require('coq')";
 
     plugins.lsp = {
       preConfig = ''

--- a/tests/test-sources/plugins/by-name/coq-nvim/default.nix
+++ b/tests/test-sources/plugins/by-name/coq-nvim/default.nix
@@ -20,4 +20,21 @@
       installArtifacts = true;
     };
   };
+
+  call-setup =
+    { config, lib, ... }:
+    {
+      plugins.coq-nvim = {
+        enable = true;
+        callSetup = true;
+      };
+
+      assertions = [
+        {
+          assertion =
+            builtins.length (lib.splitString "require('coq')" config.plugins.coq-nvim.luaConfig.content) == 2;
+          message = "Forced coq-nvim setup should require the coq module once.";
+        }
+      ];
+    };
 }


### PR DESCRIPTION
## Summary

Set the coq-nvim Lua module name and avoid duplicate `require('coq')` calls when users force setup generation.

## Why

PR #4532 exposed `callSetup` for plugins that disable setup generation by default.

For coq-nvim, the helper defaulted the Lua module name to the plugin name. This generated `require('coq-nvim').setup({})` and caused startup to fail because the plugin exports its Lua API from `coq`.

After correcting the module name, forced setup also merged with the module's existing fallback `require('coq')`. The fallback is required when `callSetup = false`, but it is redundant when generated setup is enabled.

## What changed

- Set `moduleName = "coq"`.
- Emit the existing fallback require only when `callSetup = false`.
- Add a generated test that starts Neovim and verifies exactly one `require('coq')` occurrence.

## Testing

- `nix develop --command tests plugins-by-name-coq-nvim`
- `nix fmt -- --ci plugins/by-name/coq-nvim/default.nix tests/test-sources/plugins/by-name/coq-nvim/default.nix`
- Pre-commit hooks: deadnix, plugins-by-name, treefmt, and typos

## Related Issue(s)

- Follow-up to #4532
