### PR TITLE
modules/performance: keep plugin runtimeDeps when combining

### DIFF
--- a/modules/top-level/plugins/mk-plugin-pack.nix
+++ b/modules/top-level/plugins/mk-plugin-pack.nix
@@ -34,6 +34,15 @@ let
       (builtins.concatMap (f: f ps))
     ];
 
+  # nixpkgs reads `plugin.runtimeDeps` in plugin-submodule.nix to suffix PATH
+  # in the neovim wrapper when `autowrapRuntimeDeps` is enabled.
+  runtimeDeps = lib.pipe pluginsToCombine [
+    (builtins.catAttrs "plugin")
+    (builtins.catAttrs "runtimeDeps")
+    builtins.concatLists
+    lib.unique
+  ];
+
   requiredLuaModules = lib.pipe pluginsToCombine [
     (builtins.catAttrs "plugin")
     (builtins.catAttrs "requiredLuaModules")
@@ -65,7 +74,11 @@ let
           fixupPhase
         '';
         passthru = {
-          inherit python3Dependencies;
+          # The wrapper reads these, not the pack build. `python3Dependencies`
+          # is a function, which a derivation attribute cannot hold.
+          # `runtimeDeps` as one would pull every dependency into the pack's
+          # build closure.
+          inherit python3Dependencies runtimeDeps;
         };
       }
       [

--- a/tests/test-sources/modules/performance/combine-plugins-runtime-deps.nix
+++ b/tests/test-sources/modules/performance/combine-plugins-runtime-deps.nix
@@ -1,0 +1,44 @@
+{ pkgs, ... }:
+let
+  pluginStubs = pkgs.callPackage ../../../utils/plugin-stubs.nix { };
+
+  pluginWithRuntimeDep = pluginStubs.mkPlugin "plugin_with_runtime_dep" {
+    runtimeDeps = [ pkgs.hello ];
+  };
+
+  # With `autowrapRuntimeDeps`, `hello` reaches the wrapper's PATH only through
+  # this plugin's `runtimeDeps`.
+  runtimeDepCheck = # lua
+    ''
+      assert(
+        vim.fn.executable("hello") == 1,
+        "'hello' is not in PATH, expected the plugin runtimeDeps to be wrapped"
+      )
+    '';
+in
+{
+  combined =
+    { config, lib, ... }:
+    {
+      performance.combinePlugins.enable = true;
+      extraPlugins = [ pluginWithRuntimeDep ];
+      extraConfigLuaPost = runtimeDepCheck;
+
+      # The test runner checks assertions before it launches nvim, so a
+      # regression names the missing dependency instead of failing in Lua.
+      assertions = [
+        {
+          assertion = lib.elem pkgs.hello config.build.nvimPackage.runtimeDeps;
+          message = "`combinePlugins` should keep plugin runtime dependencies.";
+        }
+      ];
+    };
+
+  # Control case: the same stub without combining, so a `combined` failure
+  # points at the pack code.
+  not-combined = {
+    performance.combinePlugins.enable = false;
+    extraPlugins = [ pluginWithRuntimeDep ];
+    extraConfigLuaPost = runtimeDepCheck;
+  };
+}


### PR DESCRIPTION
`combinePlugins` collapses its members into a single pack derivation, which dropped their `runtimeDeps`, so `autowrapRuntimeDeps` had nothing to add to the wrapper's PATH.