### PR TITLE
modules/lsp: add native LSP feature toggles

### DIFF
--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -1,6 +1,12 @@
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  options,
+  ...
+}:
 let
   cfg = config.lsp;
+  opts = options.lsp;
 in
 {
   options.lsp = {
@@ -30,6 +36,106 @@ in
         '';
       };
     };
+    # Completion is enabled per buffer in `on-attach.nix`; the others are global.
+    completion = {
+      enable = lib.mkEnableOption null // {
+        description = ''
+          Whether to enable LSP completion for each attached client that
+          supports `textDocument/completion`.
+
+          See [`:h lsp-completion`](https://neovim.io/doc/user/lsp/#lsp-completion)
+        '';
+      };
+      settings = lib.nixvim.mkSettingsOption {
+        description = ''
+          Options passed to `vim.lsp.completion.enable()`, such as `autotrigger`.
+
+          See [`:h lsp-completion`](https://neovim.io/doc/user/lsp/#lsp-completion)
+        '';
+        example = {
+          autotrigger = true;
+        };
+      };
+    };
+    semanticTokens = {
+      enable = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Whether to enable semantic tokens globally.
+
+          Neovim enables semantic tokens by default. Use `null` to keep that
+          default, or `false` to turn them off.
+
+          See [`:h lsp-semantic_tokens`](https://neovim.io/doc/user/lsp/#lsp-semantic_tokens)
+        '';
+      };
+    };
+    documentColor = {
+      enable = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Whether to enable document color highlighting globally.
+
+          Neovim enables document color highlighting by default. Use `null` to
+          keep that default, or `false` to turn it off. `${opts.documentColor.settings}`
+          only applies when this is set.
+
+          Requires Neovim 0.12 or later.
+
+          See [`:h lsp-document_color`](https://neovim.io/doc/user/lsp/#lsp-document_color)
+        '';
+      };
+      settings = lib.nixvim.mkSettingsOption {
+        description = ''
+          Options passed to `vim.lsp.document_color.enable()`, such as `style`.
+
+          > [!important]
+          > Neovim enables document color highlighting by default, but nixvim
+          > only applies these settings when `${opts.documentColor.enable}` is
+          > set explicitly.
+
+          See [`:h lsp-document_color`](https://neovim.io/doc/user/lsp/#lsp-document_color)
+        '';
+        example = {
+          style = "virtual";
+        };
+      };
+    };
+    linkedEditingRange = {
+      enable = lib.mkEnableOption null // {
+        description = ''
+          Whether to enable linked editing ranges globally.
+
+          Requires Neovim 0.12 or later.
+
+          See [`:h lsp-linked_editing_range`](https://neovim.io/doc/user/lsp/#lsp-linked_editing_range)
+        '';
+      };
+    };
+    onTypeFormatting = {
+      enable = lib.mkEnableOption null // {
+        description = ''
+          Whether to enable on-type formatting globally.
+
+          Requires Neovim 0.12 or later.
+
+          See [`:h lsp-on_type_formatting`](https://neovim.io/doc/user/lsp/#lsp-on_type_formatting)
+        '';
+      };
+    };
+    inlineCompletion = {
+      enable = lib.mkEnableOption null // {
+        description = ''
+          Whether to enable inline completion globally.
+
+          Requires Neovim 0.12 or later.
+
+          See [`:h lsp-inline_completion`](https://neovim.io/doc/user/lsp/#lsp-inline_completion)
+        '';
+      };
+    };
   };
 
   imports = [
@@ -42,6 +148,24 @@ in
     lsp.luaConfig.content = lib.mkMerge [
       (lib.mkIf cfg.inlayHints.enable "vim.lsp.inlay_hint.enable(true)")
       (lib.mkIf cfg.codelens.enable "vim.lsp.codelens.enable(true)")
+      (lib.mkIf (
+        cfg.semanticTokens.enable != null
+      ) "vim.lsp.semantic_tokens.enable(${lib.boolToString cfg.semanticTokens.enable})")
+      (
+        let
+          inherit (cfg.documentColor) settings;
+          # `opts` is the third argument, so pass `nil` for `filter`. Neovim
+          # stores `opts` before applying `enable`, so settings survive an
+          # explicit disable and apply on a later manual enable.
+          opts = lib.optionalString (settings != { }) ", nil, ${lib.nixvim.toLuaObject settings}";
+        in
+        lib.mkIf (
+          cfg.documentColor.enable != null
+        ) "vim.lsp.document_color.enable(${lib.boolToString cfg.documentColor.enable}${opts})"
+      )
+      (lib.mkIf cfg.linkedEditingRange.enable "vim.lsp.linked_editing_range.enable(true)")
+      (lib.mkIf cfg.onTypeFormatting.enable "vim.lsp.on_type_formatting.enable(true)")
+      (lib.mkIf cfg.inlineCompletion.enable "vim.lsp.inline_completion.enable(true)")
     ];
 
     extraConfigLua = lib.mkIf (cfg.luaConfig.content != "") ''

--- a/modules/lsp/on-attach.nix
+++ b/modules/lsp/on-attach.nix
@@ -1,6 +1,19 @@
 { lib, config, ... }:
 let
   cfg = config.lsp;
+
+  # Completion is per client and buffer, so configure it here instead of the
+  # global Lua block. Pass `bufnr` to `supports_method`; otherwise it checks the
+  # current buffer, which is wrong for dynamic registrations.
+  #
+  # Run this after `onAttach`. `enable` snapshots
+  # `completionProvider.triggerCharacters`, so users must extend that list first.
+  # See `:h lsp-attach` and `:h lsp-autocompletion`.
+  completionLua = lib.optionalString cfg.completion.enable ''
+    if client:supports_method('textDocument/completion', bufnr) then
+      vim.lsp.completion.enable(true, client.id, bufnr, ${lib.nixvim.toLuaObject cfg.completion.settings})
+    end
+  '';
 in
 {
   options.lsp = {
@@ -22,7 +35,7 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.onAttach != "") {
+  config = lib.mkIf (cfg.onAttach != "" || cfg.completion.enable) {
     autoGroups.nixvim_lsp_on_attach.clear = false;
 
     autoCmd = [
@@ -62,6 +75,7 @@ in
     extraConfigLua = ''
       local function __nixvim_lsp_on_attach(client, bufnr, event)
         ${cfg.onAttach}
+        ${completionLua}
       end
 
       vim.lsp.handlers["client/registerCapability"] = (function(overridden)

--- a/tests/test-sources/modules/lsp.nix
+++ b/tests/test-sources/modules/lsp.nix
@@ -30,6 +30,224 @@
     };
   };
 
+  feature-toggles-defaults =
+    { config, lib, ... }:
+    {
+      assertions = [
+        {
+          assertion = config.lsp.inlayHints.enable == false;
+          message = "Expected lsp.inlayHints.enable to default to false.";
+        }
+        {
+          assertion = config.lsp.codelens.enable == false;
+          message = "Expected lsp.codelens.enable to default to false.";
+        }
+        {
+          assertion = config.lsp.completion.enable == false;
+          message = "Expected lsp.completion.enable to default to false.";
+        }
+        {
+          assertion = config.lsp.completion.settings == { };
+          message = "Expected lsp.completion.settings to default to an empty attrs.";
+        }
+        {
+          assertion = config.lsp.semanticTokens.enable == null;
+          message = "Expected lsp.semanticTokens.enable to default to null.";
+        }
+        {
+          assertion = config.lsp.documentColor.enable == null;
+          message = "Expected lsp.documentColor.enable to default to null.";
+        }
+        {
+          assertion = config.lsp.documentColor.settings == { };
+          message = "Expected lsp.documentColor.settings to default to an empty attrs.";
+        }
+        {
+          assertion = config.lsp.linkedEditingRange.enable == false;
+          message = "Expected lsp.linkedEditingRange.enable to default to false.";
+        }
+        {
+          assertion = config.lsp.onTypeFormatting.enable == false;
+          message = "Expected lsp.onTypeFormatting.enable to default to false.";
+        }
+        {
+          assertion = config.lsp.inlineCompletion.enable == false;
+          message = "Expected lsp.inlineCompletion.enable to default to false.";
+        }
+        {
+          assertion = config.lsp.luaConfig.content == "";
+          message = "Expected LSP feature toggles to emit no global Lua by default.";
+        }
+        {
+          assertion = !lib.hasInfix "__nixvim_lsp_on_attach" config.extraConfigLua;
+          message = "Expected no LSP on-attach handler by default.";
+        }
+      ];
+    };
+
+  feature-toggles-example =
+    { config, lib, ... }:
+    let
+      attachLua = config.extraConfigLua;
+      globalLua = config.lsp.luaConfig.content;
+    in
+    {
+      lsp = {
+        onAttach = "local __nixvim_on_attach_order_probe = true";
+        inlayHints.enable = true;
+        codelens.enable = true;
+        completion = {
+          enable = true;
+          settings.autotrigger = true;
+        };
+        semanticTokens.enable = true;
+        documentColor = {
+          enable = true;
+          settings.style = "virtual";
+        };
+        linkedEditingRange.enable = true;
+        onTypeFormatting.enable = true;
+        inlineCompletion.enable = true;
+      };
+
+      assertions = [
+        {
+          assertion = lib.hasInfix "vim.lsp.inlay_hint.enable(true)" globalLua;
+          message = "Expected inlay hint Lua when enabled.";
+        }
+        {
+          assertion = lib.hasInfix "vim.lsp.codelens.enable(true)" globalLua;
+          message = "Expected codelens Lua when enabled.";
+        }
+        {
+          assertion = lib.hasInfix "vim.lsp.semantic_tokens.enable(true)" globalLua;
+          message = "Expected semantic token Lua when enabled.";
+        }
+        {
+          assertion = lib.hasInfix ''vim.lsp.document_color.enable(true, nil, { style = "virtual" })'' globalLua;
+          message = "Expected document color Lua with settings when enabled.";
+        }
+        {
+          assertion = lib.hasInfix "vim.lsp.linked_editing_range.enable(true)" globalLua;
+          message = "Expected linked editing range Lua when enabled.";
+        }
+        {
+          assertion = lib.hasInfix "vim.lsp.on_type_formatting.enable(true)" globalLua;
+          message = "Expected on-type formatting Lua when enabled.";
+        }
+        {
+          assertion = lib.hasInfix "vim.lsp.inline_completion.enable(true)" globalLua;
+          message = "Expected inline completion Lua when enabled.";
+        }
+        {
+          assertion = lib.hasInfix "client:supports_method('textDocument/completion', bufnr)" attachLua;
+          message = "Expected the completion capability check in the LspAttach callback.";
+        }
+        {
+          assertion = lib.hasInfix "vim.lsp.completion.enable(true, client.id, bufnr, { autotrigger = true })" attachLua;
+          message = "Expected completion Lua with settings in the LspAttach callback.";
+        }
+        {
+          # `enable` snapshots `triggerCharacters`, so `onAttach` must run first.
+          assertion =
+            let
+              beforeEnable = builtins.head (lib.splitString "vim.lsp.completion.enable" attachLua);
+            in
+            lib.hasInfix "__nixvim_on_attach_order_probe" beforeEnable;
+          message = "Expected `onAttach` to run before the completion enable call.";
+        }
+      ];
+    };
+
+  feature-toggles-disabled =
+    { config, lib, ... }:
+    let
+      globalLua = config.lsp.luaConfig.content;
+    in
+    {
+      lsp = {
+        semanticTokens.enable = false;
+        documentColor.enable = false;
+      };
+
+      assertions = [
+        {
+          assertion = lib.hasInfix "vim.lsp.semantic_tokens.enable(false)" globalLua;
+          message = "Expected semantic token Lua when disabled explicitly.";
+        }
+        {
+          assertion = lib.hasInfix "vim.lsp.document_color.enable(false)" globalLua;
+          message = "Expected document color Lua when disabled explicitly.";
+        }
+      ];
+    };
+
+  document-color-settings-need-explicit-enable =
+    { config, lib, ... }:
+    let
+      globalLua = config.lsp.luaConfig.content;
+    in
+    {
+      lsp.documentColor.settings.style = "virtual";
+
+      assertions = [
+        {
+          assertion = !lib.hasInfix "vim.lsp.document_color" globalLua;
+          message = "Expected no document color Lua until `enable` is set.";
+        }
+      ];
+    };
+
+  # Neovim stores `opts` before applying `enable`, so settings survive an
+  # explicit disable for a later manual enable.
+  document-color-disabled-keeps-settings =
+    { config, lib, ... }:
+    let
+      globalLua = config.lsp.luaConfig.content;
+    in
+    {
+      lsp.documentColor = {
+        enable = false;
+        settings.style = "virtual";
+      };
+
+      assertions = [
+        {
+          assertion = lib.hasInfix ''vim.lsp.document_color.enable(false, nil, { style = "virtual" })'' globalLua;
+          message = "Expected document color settings to be kept when disabled.";
+        }
+      ];
+    };
+
+  document-color-enabled-no-settings =
+    { config, lib, ... }:
+    let
+      globalLua = config.lsp.luaConfig.content;
+    in
+    {
+      lsp.documentColor.enable = true;
+
+      assertions = [
+        {
+          assertion = lib.hasInfix "vim.lsp.document_color.enable(true)" globalLua;
+          message = "Expected a bare enable call when document color has no settings.";
+        }
+      ];
+    };
+
+  completion-empty =
+    { config, lib, ... }:
+    {
+      lsp.completion.enable = true;
+
+      assertions = [
+        {
+          assertion = lib.hasInfix "vim.lsp.completion.enable(true, client.id, bufnr, { })" config.extraConfigLua;
+          message = "Expected completion Lua with an empty opts table when no settings are defined.";
+        }
+      ];
+    };
+
   keymaps =
     {
       lib,


### PR DESCRIPTION
Adds toggles for the native `vim.lsp` features Neovim 0.12 exposes: completion, semantic tokens, document color, linked editing range, on-type formatting, and inline completion. Follows the existing `inlayHints` and `codelens` options.

Superseded by #4542, which keeps `enable` out of the generated Lua instead of
making it nullable. Only one of these two should land. Merging this closes
#4542.
