### PR TITLE
modules/output: restore plugin advised Lua

### DIFF
--- a/modules/top-level/output.nix
+++ b/modules/top-level/output.nix
@@ -8,11 +8,27 @@
 let
   inherit (lib) types mkOption mkPackageOption;
   inherit (lib) optional;
+  inherit (import ./plugins/utils.nix lib) normalizePlugins;
   builders = lib.nixvim.builders.withPkgs pkgs;
   inherit (pkgs.stdenv.hostPlatform) system;
 in
 {
   options = {
+    autoconfigure = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to apply the Lua snippets that Nixpkgs plugins advise through `passthru.initLua`.
+
+        Some Nixpkgs plugins need extra Lua to work from the nix store.
+        For example, `sqlite-lua` must be told where `libsqlite3` lives.
+
+        Off by default, because the snippets come from Nixpkgs rather than
+        from your configuration. When enabled, they run before every other
+        part of the config, so anything you set yourself overrides them.
+      '';
+    };
+
     autowrapRuntimeDeps = mkOption {
       type = types.bool;
       default = true;
@@ -210,6 +226,10 @@ in
 
       vimPackageInfo = pkgs.neovimUtils.makeVimPackageInfo config.build.plugins;
 
+      # Compare against Nixpkgs using the same pre-combine plugin list.
+      normalizedConfiguredPlugins = normalizePlugins config.extraPlugins;
+      configuredVimPackageInfo = pkgs.neovimUtils.makeVimPackageInfo normalizedConfiguredPlugins;
+
       luaPackagesForWrapper =
         ps:
         extraLuaPackages ps
@@ -220,6 +240,8 @@ in
       wrappedNeovim =
         (pkgs.wrapNeovimUnstable package {
           extraLuaPackages = luaPackagesForWrapper;
+          # Keep upstream `luaRcContent` free of advice; `customRC` owns it below.
+          autoconfigure = false;
           inherit (config)
             autowrapRuntimeDeps
             extraPython3Packages
@@ -259,7 +281,34 @@ in
         wrapRc = false;
       });
 
+      # Packaging transforms rewrite `build.plugins`; collect from `extraPlugins`
+      # to preserve advice membership and order.
+      pluginAdvisedLuaEntries = lib.optionals config.autoconfigure (
+        lib.concatMap (
+          normalizedPlugin:
+          lib.optional (normalizedPlugin.plugin.passthru ? initLua) {
+            pname = lib.getName normalizedPlugin.plugin;
+            inherit (normalizedPlugin.plugin.passthru) initLua;
+          }
+        ) normalizedConfiguredPlugins
+      );
+
+      # `stylua` parses the generated `init.lua`. Match malformed text exactly so
+      # a corrected upstream value flows through.
+      brokenPluginAdvice = {
+        "fzf-hoogle.vim" = "vim.g.hoogle_fzf_cache_file = vim.fn.stdpath('cache')..'/hoogle_cache.json";
+      };
+
+      pluginAdvisedLua = lib.nixvim.concatNonEmptyLines (
+        lib.pipe pluginAdvisedLuaEntries [
+          (builtins.filter (entry: brokenPluginAdvice.${entry.pname} or null != entry.initLua))
+          (builtins.catAttrs "initLua")
+        ]
+      );
+
       customRC = lib.nixvim.concatNonEmptyLines [
+        # Apply advice first so setup calls can use it and explicit configuration wins.
+        (lib.optionalString config.autoconfigure pluginAdvisedLua)
         (lib.nixvim.wrapVimscriptForLua wrappedNeovim.initRc)
         (nvimPackage.passthru.providerLuaRc or "")
         config.content
@@ -426,6 +475,16 @@ in
           message = "`impureRtp = false` requires `wrapRc = true` so Nixvim can suppress system/XDG startup config.";
         }
       ];
+
+      # Tests reject drift warnings at Nixpkgs bumps; user evaluation remains non-fatal.
+      warnings = lib.nixvim.mkWarnings "output" {
+        when =
+          config.autoconfigure
+          &&
+            builtins.catAttrs "initLua" pluginAdvisedLuaEntries
+            != (configuredVimPackageInfo.pluginAdvisedLua or null);
+        message = "Nixvim's plugin advised Lua no longer matches Nixpkgs `vimPackageInfo.pluginAdvisedLua`. Update the collection in `modules/top-level/output.nix`.";
+      };
 
       extraConfigLuaPre = lib.mkOrder 100 (
         lib.concatStringsSep "\n" (

--- a/tests/test-sources/modules/output.nix
+++ b/tests/test-sources/modules/output.nix
@@ -78,6 +78,170 @@
         ++ mkConfigAssertions "test.vim" config.files."test.vim".content;
     };
 
+  plugin-advised-lua =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    let
+      plugin = pkgs.vimUtils.buildVimPlugin {
+        pname = "nixvim-plugin-advised-lua-test";
+        version = "1";
+        src = pkgs.emptyDirectory;
+        passthru.initLua = ''
+          vim.g.nixvim_plugin_advised_lua = "advised1"
+        '';
+      };
+    in
+    {
+      autoconfigure = true;
+
+      extraPlugins = [
+        plugin
+
+        (pkgs.runCommandLocal "plugin-advised-lua-content-test" { } ''
+          if ! grep -qF 'vim.g.nixvim_plugin_advised_lua = "advised1"' "${config.build.initFile}"; then
+              echo "init.lua should contain the plugin's advised Lua snippet" >&2
+              exit 1
+          fi
+
+          touch $out
+        '')
+      ];
+
+      extraConfigLuaPre = ''
+        assert(
+          vim.g.nixvim_plugin_advised_lua == "advised1",
+          "advised Lua was not applied before the user config"
+        )
+      '';
+    };
+
+  # `extraPlugins[].config` follows advice, so the user's assignment must win.
+  plugin-advised-lua-user-override =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    let
+      plugin = pkgs.vimUtils.buildVimPlugin {
+        pname = "nixvim-plugin-advised-lua-override-test";
+        version = "1";
+        src = pkgs.emptyDirectory;
+        passthru.initLua = ''
+          vim.g.nixvim_advised_lua_override = "advised"
+        '';
+      };
+    in
+    {
+      autoconfigure = true;
+
+      extraPlugins = [
+        {
+          inherit plugin;
+          config = ''let g:nixvim_advised_lua_override = "user"'';
+        }
+
+        # A runtime assertion would miss trailing advice; compare source positions.
+        (pkgs.runCommandLocal "plugin-advised-lua-order-test" { } ''
+          advised=$(grep -n 'nixvim_advised_lua_override = "advised"' "${config.build.initFile}" | cut -d: -f1)
+          user=$(grep -n 'nixvim_advised_lua_override = "user"' "${config.build.initFile}" | cut -d: -f1)
+
+          if [ -z "$advised" ] || [ -z "$user" ]; then
+              echo "init.lua should contain both assignments, got advised='$advised' user='$user'" >&2
+              exit 1
+          fi
+
+          if [ "$advised" -ge "$user" ]; then
+              echo "advised Lua on line $advised should precede \`extraPlugins[].config\` on line $user" >&2
+              exit 1
+          fi
+
+          touch $out
+        '')
+      ];
+    };
+
+  plugin-advised-lua-default-off =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    let
+      plugin = pkgs.vimUtils.buildVimPlugin {
+        pname = "nixvim-plugin-advised-lua-default-off-test";
+        version = "1";
+        src = pkgs.emptyDirectory;
+        passthru.initLua = ''
+          vim.g.nixvim_plugin_advised_lua = "advised2"
+        '';
+      };
+    in
+    {
+      extraPlugins = [
+        plugin
+
+        (pkgs.runCommandLocal "plugin-advised-lua-default-off-content-test" { } ''
+          if grep -qF 'vim.g.nixvim_plugin_advised_lua = "advised2"' "${config.build.initFile}"; then
+              echo "init.lua should not contain advised Lua unless autoconfigure is on" >&2
+              exit 1
+          fi
+
+          touch $out
+        '')
+      ];
+    };
+
+  plugin-advised-lua-malformed =
+    { pkgs, ... }:
+    {
+      autoconfigure = true;
+
+      extraPlugins = [ pkgs.vimPlugins.fzf-hoogle-vim ];
+
+      # The plugin refuses to load without `hoogle` in `PATH`.
+      test.runNvim = false;
+    };
+
+  # Corrected advice from the same plugin must bypass the exclusion.
+  plugin-advised-lua-corrected =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    let
+      plugin = pkgs.vimPlugins.fzf-hoogle-vim.overrideAttrs (prev: {
+        passthru = prev.passthru // {
+          initLua = ''
+            vim.g.nixvim_corrected_advice = "corrected"
+          '';
+        };
+      });
+    in
+    {
+      autoconfigure = true;
+
+      extraPlugins = [
+        plugin
+
+        (pkgs.runCommandLocal "plugin-advised-lua-corrected-content-test" { } ''
+          if ! grep -qF 'vim.g.nixvim_corrected_advice = "corrected"' "${config.build.initFile}"; then
+              echo "a corrected snippet from an excluded plugin should still be applied" >&2
+              exit 1
+          fi
+
+          touch $out
+        '')
+      ];
+
+      # The plugin refuses to load without `hoogle` in `PATH`.
+      test.runNvim = false;
+    };
+
   files-default-empty =
     { config, lib, ... }:
     {

--- a/tests/test-sources/modules/performance/combine-plugins-advised-lua.nix
+++ b/tests/test-sources/modules/performance/combine-plugins-advised-lua.nix
@@ -1,0 +1,80 @@
+{ pkgs }:
+let
+  advising =
+    name:
+    pkgs.vimUtils.buildVimPlugin {
+      pname = "advising_${name}";
+      version = "1";
+      src = pkgs.emptyDirectory;
+      passthru.initLua = ''
+        vim.g.nixvim_advice_${name} = "${name}"
+      '';
+    };
+
+  dependent = pkgs.vimUtils.buildVimPlugin {
+    pname = "advising_dependent";
+    version = "1";
+    src = pkgs.emptyDirectory;
+    dependencies = [ (advising "dep") ];
+  };
+
+  # Advice is generated config, so packaging must not change it.
+  invariant =
+    label:
+    {
+      combine,
+      standalone ? [ ],
+    }:
+    { config, ... }:
+    {
+      autoconfigure = true;
+      performance.combinePlugins = {
+        enable = combine;
+        standalonePlugins = standalone;
+      };
+
+      extraPlugins = [
+        (advising "first")
+        (advising "middle")
+        (advising "third")
+        dependent
+      ];
+
+      # Avoid a cycle: an `extraPlugins` member cannot reference `build.initFile`.
+      test.extraInputs = [
+        (pkgs.runCommandLocal "advised-lua-invariants-${label}" { } ''
+          init=${config.build.initFile}
+
+          for name in first middle third; do
+              grep -qF "vim.g.nixvim_advice_$name = \"$name\"" "$init" || {
+                  echo "missing advice for $name" >&2
+                  exit 1
+              }
+          done
+
+          # Nixpkgs does not collect from dependencies, and neither do we.
+          if grep -qF 'nixvim_advice_dep' "$init"; then
+              echo "dependency advice should not be collected" >&2
+              exit 1
+          fi
+
+          order=$(grep -oE 'nixvim_advice_(first|middle|third)' "$init" | head -3 | tr '\n' ' ')
+          if [ "$order" != "nixvim_advice_first nixvim_advice_middle nixvim_advice_third " ]; then
+              echo "advice order changed: $order" >&2
+              exit 1
+          fi
+
+          touch $out
+        '')
+      ];
+    };
+in
+{
+  plain = invariant "plain" { combine = false; };
+  combined = invariant "combined" { combine = true; };
+  # Extract the middle plugin to verify standalone ordering.
+  combined-with-standalone = invariant "standalone" {
+    combine = true;
+    standalone = [ "advising_middle" ];
+  };
+}


### PR DESCRIPTION
Nixvim builds `init.lua` itself, which discards the nixpkgs wrapper rc and the
per-plugin `passthru.initLua` snippets it carries. Collect them and emit them
first, so user config still wins. Off by default via `autoconfigure`.

Advice comes only from plugins you list. Nixpkgs itself doesn't collect from
dependencies.
