### PR TITLE
lib/types: add missing nvim_set_hl attrs

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -89,9 +89,15 @@ rec {
     # :help nvim_set_hl()
     options = with types; {
       fg = mkNullOrOption (maybeRaw (either int str)) "Color for the foreground (color name, '#RRGGBB', or 24-bit RGB integer).";
+      fg_indexed = mkNullOrOption (maybeRaw bool) "Same as `bg_indexed`, for `fg` and `ctermfg`.";
       bg = mkNullOrOption (maybeRaw (either int str)) "Color for the background (color name, '#RRGGBB', or 24-bit RGB integer).";
+      bg_indexed = mkNullOrOption (maybeRaw bool) ''
+        If true, `bg` is an RGB approximation of `ctermbg` (a palette index).
+        UIs rendering cterm natively may prefer `ctermbg`.
+      '';
       sp = mkNullOrOption (maybeRaw (either int str)) "Special color (color name, '#RRGGBB', or 24-bit RGB integer).";
       blend = mkNullOrOption (maybeRaw (numbers.between 0 100)) "Integer between 0 and 100.";
+      blink = mkNullOrOption (maybeRaw bool) "";
       bold = mkNullOrOption (maybeRaw bool) "";
       standout = mkNullOrOption (maybeRaw bool) "";
       underline = mkNullOrOption (maybeRaw bool) "";
@@ -102,9 +108,36 @@ rec {
       strikethrough = mkNullOrOption (maybeRaw bool) "";
       italic = mkNullOrOption (maybeRaw bool) "";
       reverse = mkNullOrOption (maybeRaw bool) "";
+      overline = mkNullOrOption (maybeRaw bool) "";
       nocombine = mkNullOrOption (maybeRaw bool) "";
+      dim = mkNullOrOption (maybeRaw bool) "";
+      conceal = mkNullOrOption (maybeRaw bool) ''
+        Concealment at the UI level (terminal SGR), unrelated to |:syn-conceal|.
+      '';
+      altfont = mkNullOrOption (maybeRaw bool) "";
       link = mkNullOrOption (maybeRaw (either int str)) "Name or id of another highlight group to link to.";
+      link_global = mkNullOrOption (maybeRaw (either int str)) ''
+        Like `link`, but always resolved in the global namespace (`ns=0`).
+
+        Nixvim applies highlights at `ns=0`, so this behaves as `link` does
+        here. It matters for values handed to a plugin that uses its own
+        namespace.
+      '';
       default = mkNullOrOption (maybeRaw bool) "Don't override existing definition.";
+      force = mkNullOrOption (maybeRaw bool) ''
+        Update the highlight group even if it already exists (default false).
+
+        Only meaningful together with `default`, which is what makes a
+        definition yield to an existing one. Without `default`, `nvim_set_hl`
+        already replaces the group.
+      '';
+      update = mkNullOrOption (maybeRaw bool) ''
+        Update specified attributes only, leave others unchanged (default false).
+
+        Nixvim applies `highlight` before `colorscheme` and `highlightOverride`
+        after it. Since a colorscheme clears existing groups, use this from
+        `highlightOverride`, where the attributes it preserves still exist.
+      '';
       ctermfg = mkNullOrOption (maybeRaw (either int str)) "Sets foreground of cterm color (color name or palette index).";
       ctermbg = mkNullOrOption (maybeRaw (either int str)) "Sets background of cterm color (color name or palette index).";
       cterm = mkNullOrOption (either str attrs) ''

--- a/tests/test-sources/modules/highlight.nix
+++ b/tests/test-sources/modules/highlight.nix
@@ -1,9 +1,54 @@
 {
+  # The submodule is freeform, so exercising values cannot detect a removed
+  # declaration. Assert the declarations themselves.
+  declares-nvim-set-hl-attrs =
+    { lib, ... }:
+    {
+      # Pure eval, so no wrapped Neovim needs building.
+      test.buildNixvim = false;
+
+      assertions =
+        map
+          (name: {
+            assertion = lib.types.highlight.getSubOptions [ ] ? ${name};
+            message = "Expected `types.highlight` to declare `${name}`.";
+          })
+          [
+            "altfont"
+            "bg_indexed"
+            "blink"
+            "conceal"
+            "dim"
+            "fg_indexed"
+            "force"
+            "link_global"
+            "overline"
+            "update"
+          ];
+    };
+
   example = {
     opts.termguicolors = true;
 
     highlight = {
-      MacchiatoRed.fg = "#ed8796";
+      MacchiatoRed = {
+        fg = "#ed8796";
+        ctermfg = "red";
+        fg_indexed = true;
+      };
+      DiagnosticWarn = {
+        bg = "#f5a97f";
+        ctermbg = "yellow";
+        bg_indexed = true;
+        blink = true;
+        overline = true;
+      };
+      Conceal = {
+        altfont = true;
+        conceal = true;
+        dim = true;
+      };
+      LspReferenceText.link_global = "Normal";
       # These two pin the widened types: raw Lua on a boolean, and the
       # `integer|string` the keyset gives every color attribute.
       Todo.bold.__raw = "true";
@@ -11,6 +56,15 @@
     };
 
     highlightOverride = {
+      # `highlightOverride` runs after `colorscheme`, so `update` has an
+      # existing definition to merge into and `force` overrides `default`.
+      Search = {
+        bg = "#eed49f";
+        default = true;
+        force = true;
+        update = true;
+      };
+
       Normal.fg = "#ff0000";
 
       # With raw


### PR DESCRIPTION
Declares the ten `nvim_set_hl` attributes from 0.12.4's `api.txt` that the
highlight submodule lacked. The submodule is freeform so they already reached
Neovim; this puts them in the generated option reference.

Related https://github.com/nix-community/nixvim/pull/4538